### PR TITLE
Add PQC support

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -1998,10 +1998,66 @@ jobs:
             build-reports.zip
           retention-days: 7
 
+  pqc-tests:
+    name: "PQC Tests"
+    runs-on: ubuntu-latest
+    container: ubuntu:26.04
+    needs: [configure]
+    if: needs.configure.outputs.run-ci-build == 'true'
+    timeout-minutes: 60
+    env:
+      COMMON_MAVEN_ARGS: ${{ needs.configure.outputs.common-maven-args }}
+    steps:
+      - name: Install container dependencies
+        run: |
+          apt-get update && apt-get install -y git curl unzip openssl libssl-dev libapr1t64 p7zip-full
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Verify OpenSSL version
+        run: openssl version
+      - name: Build Quarkus
+        run: |
+          ./mvnw $COMMON_MAVEN_ARGS install -Dquickly -T1C
+      - name: Run PQC tests Vertx-http
+        run: |
+          ./mvnw $COMMON_MAVEN_ARGS -Dtest-containers -Dstart-containers -Dtest=HybridKeyExchangeTest,HybridKeyExchangeMtlsTest,HybridKeyExchangeClientNegotiatedTest -f extensions/vertx-http/deployment test
+      - name: Run PQC tests resteasy-reactive
+        run: |
+          ./mvnw $COMMON_MAVEN_ARGS -Dtest-containers -Dstart-containers -Dtest=PqcKeyExchangeTest -f extensions/resteasy-reactive/rest-client/deployment test
+      - name: Prepare failure archive (if maven failed)
+        if: failure()
+        run: find . -name '*-reports' -type d -o -name '*.log' | tar -czf test-reports.tgz -T -
+      - name: Upload failure Archive (if maven failed)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: test-reports-pqc-tests
+          path: 'test-reports.tgz'
+          retention-days: 7
+      - name: Prepare build reports archive
+        if: always()
+        run: |
+          7z a -tzip build-reports.zip -r \
+              '**/target/*-reports/TEST-*.xml' \
+              'target/build-report.json' \
+              LICENSE
+      - name: Upload build reports
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: "build-reports-${{ github.run_attempt }}-PQC Tests"
+          path: |
+            build-reports.zip
+          retention-days: 7
+
   build-report:
     runs-on: ubuntu-latest
     name: Build report
-    needs: [configure,build-jdk17,jvm-tests,maven-tests,gradle-tests,devtools-tests,kubernetes-tests,quickstarts-tests,platform-tests,tcks-test,native-tests,virtual-thread-native-tests,oracle-test-pilot-jvm-tests,oracle-test-pilot-native-tests]
+    needs: [configure,build-jdk17,jvm-tests,maven-tests,gradle-tests,devtools-tests,kubernetes-tests,quickstarts-tests,platform-tests,tcks-test,native-tests,virtual-thread-native-tests,oracle-test-pilot-jvm-tests,oracle-test-pilot-native-tests,pqc-tests]
     if: always() && needs.configure.outputs.run-ci-build == 'true'
     steps:
       - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60 # v2.1.2

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -2024,7 +2024,13 @@ jobs:
           ./mvnw $COMMON_MAVEN_ARGS install -Dquickly -T1C
       - name: Run PQC tests Vertx-http
         run: |
-          ./mvnw $COMMON_MAVEN_ARGS -Dtest-containers -Dstart-containers -Dtest=HybridKeyExchangeTest,HybridKeyExchangeMtlsTest,HybridKeyExchangeClientNegotiatedTest -f extensions/vertx-http/deployment test
+          ./mvnw $COMMON_MAVEN_ARGS -Dtest-containers -Dstart-containers -Dtest=HybridKeyExchangeTest,\
+          HybridKeyExchangeMtlsTest,HybridKeyExchangeClientNegotiatedTest,HybridKeyExchangeStrictNoGroupsTest,\
+          HybridKeyExchangeStrictIllGroupsTest,HybridKeyExchangeClientNegotiatedNoGroupsTest,\
+          HybridKeyExchangeClientNegotiatedIllGroupsTest,HybridKeyExchangeRelaxedTest,\
+          HybridKeyExchangeRelaxedNoGroupsTest,HybridKeyExchangeJdkSslStrictInvalidTest,\
+          HybridKeyExchangeJdkSslClientNegotiatedInvalidTest,HybridKeyExchangeNamedBucketTest\
+          -f extensions/vertx-http/deployment test
       - name: Run PQC tests resteasy-reactive
         run: |
           ./mvnw $COMMON_MAVEN_ARGS -Dtest-containers -Dstart-containers -Dtest=PqcKeyExchangeTest -f extensions/resteasy-reactive/rest-client/deployment test

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -2029,7 +2029,7 @@ jobs:
           HybridKeyExchangeStrictIllGroupsTest,HybridKeyExchangeClientNegotiatedNoGroupsTest,\
           HybridKeyExchangeClientNegotiatedIllGroupsTest,HybridKeyExchangeRelaxedTest,\
           HybridKeyExchangeRelaxedNoGroupsTest,HybridKeyExchangeJdkSslStrictInvalidTest,\
-          HybridKeyExchangeJdkSslClientNegotiatedInvalidTest,HybridKeyExchangeNamedBucketTest\
+          HybridKeyExchangeJdkSslClientNegotiatedInvalidTest,HybridKeyExchangeNamedBucketTest \
           -f extensions/vertx-http/deployment test
       - name: Run PQC tests resteasy-reactive
         run: |

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -113,7 +113,7 @@
         <wildfly-elytron.version>2.9.2.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.3.0</jboss-marshalling.version>
         <jboss-threads.version>3.9.2</jboss-threads.version>
-        <vertx.version>4.5.30</vertx.version>
+        <vertx.version>4.5.31</vertx.version>
         <httpclient5.version>5.6.1</httpclient5.version>
         <httpcore5.version>5.4.3</httpcore5.version>
         <httpclient.version>4.5.14</httpclient.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -365,6 +365,12 @@
                 <classifier>linux-x86_64</classifier>
                 <version>${smallrye-openssl.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-openssl</artifactId>
+                <classifier>linux-aarch_64</classifier>
+                <version>${smallrye-openssl.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>io.smallrye.certs</groupId>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -57,6 +57,7 @@
         <smallrye-context-propagation.version>2.3.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
+        <smallrye-openssl.version>0.1.4</smallrye-openssl.version>
         <smallrye-mutiny-vertx-binding.version>3.23.0</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.36.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.7.10</smallrye-stork.version>
@@ -135,6 +136,7 @@
         <infinispan.version>16.0.13</infinispan.version>
         <infinispan.protostream.version>6.0.7</infinispan.protostream.version>
         <caffeine.version>3.2.4</caffeine.version>
+        <netty-tcnative.version>2.0.76.Final</netty-tcnative.version>
         <netty.version>4.1.136.Final</netty.version>
         <brotli4j.version>1.23.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
@@ -297,6 +299,11 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-tcnative-classes</artifactId>
+                <version>${netty-tcnative.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.aayushatharva.brotli4j</groupId>
                 <artifactId>brotli4j</artifactId>
                 <version>${brotli4j.version}</version>
@@ -350,6 +357,13 @@
                 <groupId>com.aayushatharva.brotli4j</groupId>
                 <artifactId>native-osx-aarch64</artifactId>
                 <version>${brotli4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-openssl</artifactId>
+                <classifier>linux-x86_64</classifier>
+                <version>${smallrye-openssl.version}</version>
             </dependency>
 
             <dependency>

--- a/docs/src/main/asciidoc/tls-registry-reference.adoc
+++ b/docs/src/main/asciidoc/tls-registry-reference.adoc
@@ -763,6 +763,60 @@ Disabling ALPN is not recommended for non-experts, as it can lead to performance
 However, disabling ALPN can be useful for diagnosing native inconsistencies or testing performance in specific edge cases where protocol negotiation causes conflicts.
 ====
 
+==== Post-Quantum Cryptography (PQC)
+
+Post-Quantum Cryptography (PQC) protects TLS connections against attacks from quantum computers.
+Quarkus exposes two properties to control PQC key exchange, both of which apply to the HTTP server, HTTP client, REST client, and mailer.
+
+===== Key exchange groups
+
+The key exchange groups (also called _supported groups_) are the elliptic-curve or post-quantum algorithms the TLS engine advertises during the handshake.
+When not set, the engine uses its built-in defaults.
+
+To advertise the hybrid post-quantum group `X25519MLKEM768` (combining X25519 with ML-KEM-768):
+
+[source,properties]
+----
+quarkus.tls.key-exchange-groups=X25519MLKEM768
+----
+
+You can specify multiple groups as a comma-separated list.
+Groups are tried in the order listed; the first one the peer also supports is used.
+
+===== PQC enforcement policy
+
+The enforcement policy controls how strictly the server requires post-quantum key exchange from clients.
+
+[source,properties]
+----
+quarkus.tls.pqc-enforcement-policy=relaxed # Default
+----
+
+The available values are:
+
+`relaxed`:: No enforcement.
+Standard TLS negotiation applies, and no post-quantum groups are required.
+This is the default.
+
+`client-negotiated`:: The server advertises PQC groups and prefers them, but accepts connections from clients that do not support them, falling back to classical key exchange.
+Use this when you want PQC where available without breaking existing clients.
+
+`strict`:: The server only accepts connections that use a post-quantum key exchange group.
+Clients that do not negotiate a PQC group are rejected.
+Use this when all clients are known to support PQC.
+
+[NOTE]
+====
+When using `client-negotiated` or `strict`, `quarkus.tls.key-exchange-groups` must include at least one PQC-capable group such as `X25519MLKEM768`.
+Vert.x validates this at startup and throws an exception if no compatible engine or group is configured.
+====
+
+[WARNING]
+====
+`strict` enforcement will reject any client that does not support the configured PQC group, including standard browsers and TLS clients that have not yet adopted post-quantum extensions.
+Ensure all clients are upgraded before enabling this mode.
+====
+
 ==== Certificate Revocation List (CRL)
 
 A Certificate Revocation List (CRL) is a list of certificates that the issuing Certificate Authority (CA) revoked before their scheduled expiration date.

--- a/docs/src/main/asciidoc/tls-registry-reference.adoc
+++ b/docs/src/main/asciidoc/tls-registry-reference.adoc
@@ -817,6 +817,13 @@ Vert.x validates this at startup and throws an exception if no compatible engine
 Ensure all clients are upgraded before enabling this mode.
 ====
 
+[NOTE]
+====
+Policy enforcement (`strict` and `client-negotiated`) is not supported when using the JDK SSL engine.
+If you are running on JDK 27+, or on JDK 25+ once the PQC backport ships (expected October 2026), you can still enable PQC key exchange by setting `quarkus.tls.key-exchange-groups` — the negotiation will work correctly without policy enforcement.
+For full enforcement, OpenSSL 3.5+ via the native SSL engine is required.
+====
+
 ==== Certificate Revocation List (CRL)
 
 A Certificate Revocation List (CRL) is a list of certificates that the issuing Certificate Authority (CA) revoked before their scheduled expiration date.

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/Mailers.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/Mailers.java
@@ -318,7 +318,10 @@ public class Mailers {
                     cfg.addCrlValue(buffer);
                 }
                 cfg.setEnabledSecureTransportProtocols(sslOptions.getEnabledSecureTransportProtocols());
-
+                if (sslOptions.getKeyExchangeGroups() != null && !sslOptions.getKeyExchangeGroups().isEmpty()) {
+                    cfg.getSslOptions().setKeyExchangeGroups(sslOptions.getKeyExchangeGroups());
+                }
+                cfg.getSslOptions().setPqcEnforcementPolicy(sslOptions.getPqcEnforcementPolicy());
             }
 
         } else {

--- a/extensions/resteasy-reactive/rest-client/deployment/pom.xml
+++ b/extensions/resteasy-reactive/rest-client/deployment/pom.xml
@@ -131,6 +131,17 @@
             <artifactId>apache-mime4j-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-classes</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-openssl</artifactId>
+            <classifier>linux-x86_64</classifier>
+            <scope>test</scope>
+        </dependency>
    </dependencies>
 
     <build>

--- a/extensions/resteasy-reactive/rest-client/deployment/pom.xml
+++ b/extensions/resteasy-reactive/rest-client/deployment/pom.xml
@@ -142,6 +142,12 @@
             <classifier>linux-x86_64</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-openssl</artifactId>
+            <classifier>linux-aarch_64</classifier>
+            <scope>test</scope>
+        </dependency>
    </dependencies>
 
     <build>

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/tls/PqcKeyExchangeTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/tls/PqcKeyExchangeTest.java
@@ -1,0 +1,81 @@
+package io.quarkus.rest.client.reactive.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.netty.handler.ssl.OpenSsl;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+
+/**
+ * Verifies that PQC key-exchange-groups configured via the TLS registry are propagated to
+ * the REST client's HttpClientOptions (via ClientBuilderImpl). The server is configured with
+ * strict PQC enforcement, so a successful connection proves the groups were propagated.
+ */
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "tls-pqc-rc-test", password = "secret", formats = {
+        Format.PEM }))
+@EnabledIf("isOpenSsl35Available")
+public class PqcKeyExchangeTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Client.class, Resource.class)
+                    .addAsResource(new File("target/certs/tls-pqc-rc-test.key"), "server-key.pem")
+                    .addAsResource(new File("target/certs/tls-pqc-rc-test.crt"), "server-cert.pem")
+                    .addAsResource(new File("target/certs/tls-pqc-rc-test-ca.crt"), "server-ca.pem"))
+            // Server: strict PQC, only accepts connections that negotiate X25519MLKEM768
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.cert", "server-cert.pem")
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.key", "server-key.pem")
+            .overrideConfigKey("quarkus.tls.pqc-enforcement-policy", "strict")
+            .overrideConfigKey("quarkus.tls.key-exchange-groups", "x25519mlkem768")
+            // REST client: named TLS bucket with trust store and matching PQC config.
+            // pqc-enforcement-policy=client-negotiated is required to trigger Vert.x's
+            // OpenSSL auto-selection (RELAXED uses JDK SSL, which cannot negotiate PQC groups).
+            .overrideConfigKey("quarkus.tls.rest-client.trust-store.pem.certs", "server-ca.pem")
+            .overrideConfigKey("quarkus.tls.rest-client.key-exchange-groups", "x25519mlkem768")
+            .overrideConfigKey("quarkus.tls.rest-client.pqc-enforcement-policy", "client-negotiated")
+            .overrideConfigKey("quarkus.rest-client.rc.url", "https://localhost:${quarkus.http.test-ssl-port:8444}")
+            .overrideConfigKey("quarkus.rest-client.rc.tls-configuration-name", "rest-client");
+
+    @RestClient
+    Client client;
+
+    @Test
+    void restClientConnectsToStrictPqcServer() {
+        // A non-PQC client would fail the STRICT server handshake.
+        // Success proves key-exchange-groups propagated from TLS registry to HttpClientOptions.
+        assertThat(client.ping()).isEqualTo("pong");
+    }
+
+    static boolean isOpenSsl35Available() {
+        return OpenSsl.isAvailable() && OpenSsl.version() >= 0x30500000L;
+    }
+
+    @Path("/pqc-ping")
+    @RegisterRestClient(configKey = "rc")
+    public interface Client {
+        @GET
+        String ping();
+    }
+
+    @Path("/pqc-ping")
+    public static class Resource {
+        @GET
+        public String ping() {
+            return "pong";
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/tls/PqcKeyExchangeTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/tls/PqcKeyExchangeTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.rest.client.reactive.tls;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 
@@ -32,7 +33,7 @@ public class PqcKeyExchangeTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar
-                    .addClasses(Client.class, Resource.class)
+                    .addClasses(Client.class, DefaultClient.class, Resource.class)
                     .addAsResource(new File("target/certs/tls-pqc-rc-test.key"), "server-key.pem")
                     .addAsResource(new File("target/certs/tls-pqc-rc-test.crt"), "server-cert.pem")
                     .addAsResource(new File("target/certs/tls-pqc-rc-test-ca.crt"), "server-ca.pem"))
@@ -41,23 +42,39 @@ public class PqcKeyExchangeTest {
             .overrideConfigKey("quarkus.tls.key-store.pem.0.key", "server-key.pem")
             .overrideConfigKey("quarkus.tls.pqc-enforcement-policy", "strict")
             .overrideConfigKey("quarkus.tls.key-exchange-groups", "x25519mlkem768")
-            // REST client: named TLS bucket with trust store and matching PQC config.
+            // PQC REST client: named TLS bucket with trust store and matching PQC config.
             // pqc-enforcement-policy=client-negotiated is required to trigger Vert.x's
             // OpenSSL auto-selection (RELAXED uses JDK SSL, which cannot negotiate PQC groups).
             .overrideConfigKey("quarkus.tls.rest-client.trust-store.pem.certs", "server-ca.pem")
             .overrideConfigKey("quarkus.tls.rest-client.key-exchange-groups", "x25519mlkem768")
             .overrideConfigKey("quarkus.tls.rest-client.pqc-enforcement-policy", "client-negotiated")
             .overrideConfigKey("quarkus.rest-client.rc.url", "https://localhost:${quarkus.http.test-ssl-port:8444}")
-            .overrideConfigKey("quarkus.rest-client.rc.tls-configuration-name", "rest-client");
+            .overrideConfigKey("quarkus.rest-client.rc.tls-configuration-name", "rest-client")
+            // Default REST client: trust store only, no PQC groups configured
+            .overrideConfigKey("quarkus.tls.no-pqc.trust-store.pem.certs", "server-ca.pem")
+            .overrideConfigKey("quarkus.rest-client.rc-no-pqc.url",
+                    "https://localhost:${quarkus.http.test-ssl-port:8444}")
+            .overrideConfigKey("quarkus.rest-client.rc-no-pqc.tls-configuration-name", "no-pqc");
 
     @RestClient
     Client client;
+
+    @RestClient
+    DefaultClient defaultClient;
 
     @Test
     void restClientConnectsToStrictPqcServer() {
         // A non-PQC client would fail the STRICT server handshake.
         // Success proves key-exchange-groups propagated from TLS registry to HttpClientOptions.
         assertThat(client.ping()).isEqualTo("pong");
+    }
+
+    @Test
+    void restClientWithoutPqcConfigFailsToConnectToStrictServer() {
+        // A REST client with no PQC groups (JDK SSL engine, classical groups only) cannot
+        // negotiate a PQC group with the strict server — the handshake fails.
+        assertThatThrownBy(() -> defaultClient.ping())
+                .isNotNull();
     }
 
     static boolean isOpenSsl35Available() {
@@ -67,6 +84,13 @@ public class PqcKeyExchangeTest {
     @Path("/pqc-ping")
     @RegisterRestClient(configKey = "rc")
     public interface Client {
+        @GET
+        String ping();
+    }
+
+    @Path("/pqc-ping")
+    @RegisterRestClient(configKey = "rc-no-pqc")
+    public interface DefaultClient {
         @GET
         String ping();
     }

--- a/extensions/tls-registry/runtime/pom.xml
+++ b/extensions/tls-registry/runtime/pom.xml
@@ -32,6 +32,7 @@
         </dependency>
 
         <!-- To register the let's encrypt routes -->
+
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
@@ -26,7 +26,10 @@ import io.quarkus.tls.runtime.config.TlsBucketConfig;
 import io.quarkus.tls.runtime.config.TlsConfigUtils;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.JdkSSLEngineOptions;
 import io.vertx.core.net.KeyCertOptions;
+import io.vertx.core.net.OpenSSLEngineOptions;
+import io.vertx.core.net.SSLEngineOptions;
 import io.vertx.core.net.SSLOptions;
 import io.vertx.core.net.TrustOptions;
 
@@ -302,6 +305,14 @@ public class VertxCertificateHolder implements TlsConfiguration {
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public Optional<SSLEngineOptions> getSslEngineOptions() {
+        return config().sslEngine().map(e -> switch (e) {
+            case OPENSSL -> (SSLEngineOptions) new OpenSSLEngineOptions();
+            case JDKSSL -> new JdkSSLEngineOptions();
+        });
     }
 
     public TlsBucketConfig config() {

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
@@ -21,11 +21,13 @@ import org.jboss.logging.Logger;
 import io.quarkus.tls.KeyStoreAndKeyCertOptions;
 import io.quarkus.tls.TlsConfiguration;
 import io.quarkus.tls.TrustStoreAndTrustOptions;
+import io.quarkus.tls.runtime.config.PqcEnforcePolicyEnum;
 import io.quarkus.tls.runtime.config.TlsBucketConfig;
 import io.quarkus.tls.runtime.config.TlsConfigUtils;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.net.KeyCertOptions;
+import io.vertx.core.net.PqcEnforcementPolicy;
 import io.vertx.core.net.SSLOptions;
 import io.vertx.core.net.TrustOptions;
 
@@ -111,12 +113,24 @@ public class VertxCertificateHolder implements TlsConfiguration {
         return sslContext;
     }
 
+    private static PqcEnforcementPolicy toVertxPqcPolicy(PqcEnforcePolicyEnum policy) {
+        return switch (policy) {
+            case STRICT -> PqcEnforcementPolicy.STRICT;
+            case CLIENT_NEGOTIATED -> PqcEnforcementPolicy.CLIENT_NEGOTIATED;
+            case RELAXED -> PqcEnforcementPolicy.RELAXED;
+        };
+    }
+
     @Override
     public synchronized SSLOptions getSSLOptions() {
         SSLOptions options = new SSLOptions();
         options.setKeyCertOptions(getKeyStoreOptions());
         options.setTrustOptions(getTrustStoreOptions());
         options.setUseAlpn(config().alpn());
+        if (config().keyExchangeGroups().isPresent()) {
+            options.setKeyExchangeGroups(config().keyExchangeGroups().get());
+        }
+        options.setPqcEnforcementPolicy(toVertxPqcPolicy(config().pqcEnforcementPolicy()));
         options.setSslHandshakeTimeoutUnit(TimeUnit.SECONDS);
         options.setSslHandshakeTimeout(config().handshakeTimeout().toSeconds());
         options.setEnabledSecureTransportProtocols(config().protocols());

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
@@ -21,13 +21,12 @@ import org.jboss.logging.Logger;
 import io.quarkus.tls.KeyStoreAndKeyCertOptions;
 import io.quarkus.tls.TlsConfiguration;
 import io.quarkus.tls.TrustStoreAndTrustOptions;
-import io.quarkus.tls.runtime.config.PqcEnforcePolicyEnum;
+import io.quarkus.tls.runtime.config.PqcEnforcementPolicy;
 import io.quarkus.tls.runtime.config.TlsBucketConfig;
 import io.quarkus.tls.runtime.config.TlsConfigUtils;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.net.KeyCertOptions;
-import io.vertx.core.net.PqcEnforcementPolicy;
 import io.vertx.core.net.SSLOptions;
 import io.vertx.core.net.TrustOptions;
 
@@ -113,11 +112,11 @@ public class VertxCertificateHolder implements TlsConfiguration {
         return sslContext;
     }
 
-    private static PqcEnforcementPolicy toVertxPqcPolicy(PqcEnforcePolicyEnum policy) {
+    private static io.vertx.core.net.PqcEnforcementPolicy toVertxPqcPolicy(PqcEnforcementPolicy policy) {
         return switch (policy) {
-            case STRICT -> PqcEnforcementPolicy.STRICT;
-            case CLIENT_NEGOTIATED -> PqcEnforcementPolicy.CLIENT_NEGOTIATED;
-            case RELAXED -> PqcEnforcementPolicy.RELAXED;
+            case STRICT -> io.vertx.core.net.PqcEnforcementPolicy.STRICT;
+            case CLIENT_NEGOTIATED -> io.vertx.core.net.PqcEnforcementPolicy.CLIENT_NEGOTIATED;
+            case RELAXED -> io.vertx.core.net.PqcEnforcementPolicy.RELAXED;
         };
     }
 

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/PqcEnforcePolicyEnum.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/PqcEnforcePolicyEnum.java
@@ -1,0 +1,7 @@
+package io.quarkus.tls.runtime.config;
+
+public enum PqcEnforcePolicyEnum {
+    STRICT,
+    CLIENT_NEGOTIATED,
+    RELAXED
+}

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/PqcEnforcePolicyEnum.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/PqcEnforcePolicyEnum.java
@@ -1,7 +1,0 @@
-package io.quarkus.tls.runtime.config;
-
-public enum PqcEnforcePolicyEnum {
-    STRICT,
-    CLIENT_NEGOTIATED,
-    RELAXED
-}

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/PqcEnforcementPolicy.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/PqcEnforcementPolicy.java
@@ -4,7 +4,8 @@ public enum PqcEnforcementPolicy {
 
     /**
      * A connection is refused unless both the client and the server negotiate a PQC key exchange
-     * ({@code X25519MLKEM768}). Clients that do not advertise PQC support are rejected during the TLS handshake.
+     * ({@code X25519MLKEM768}, {@code SecP256r1MLKEM768}, {@code SecP384r1MLKEM1024}).
+     * Clients that do not advertise PQC support are rejected during the TLS handshake.
      */
     STRICT,
 

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/PqcEnforcementPolicy.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/PqcEnforcementPolicy.java
@@ -1,0 +1,22 @@
+package io.quarkus.tls.runtime.config;
+
+public enum PqcEnforcementPolicy {
+
+    /**
+     * A connection is refused unless both the client and the server negotiate a PQC key exchange
+     * ({@code X25519MLKEM768}). Clients that do not advertise PQC support are rejected during the TLS handshake.
+     */
+    STRICT,
+
+    /**
+     * The server advertises PQC key exchange groups but does not require the client to support them.
+     * If the client does not support PQC, the handshake falls back to classical key exchange.
+     */
+    CLIENT_NEGOTIATED,
+
+    /**
+     * No PQC enforcement; standard TLS key exchange negotiation applies.
+     * The server neither advertises nor requires PQC groups.
+     */
+    RELAXED
+}

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/SslEngineType.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/SslEngineType.java
@@ -1,0 +1,12 @@
+package io.quarkus.tls.runtime.config;
+
+public enum SslEngineType {
+    /**
+     * Use the OpenSsl Engine, requires netty-tcnative.
+     */
+    OPENSSL,
+    /**
+     * Use the default JdkSsl Engine.
+     */
+    JDKSSL
+}

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsBucketConfig.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsBucketConfig.java
@@ -76,8 +76,9 @@ public interface TlsBucketConfig {
     /**
      * Sets the PQC enforcement policy.
      * <p>
-     * {@code STRICT}: a connection will be refused unless both the client and the server support PQC
-     * ({@code X25519MLKEM768}). The server requires PQC-capable clients.
+     * {@code STRICT}: a connection will be refused unless both the client and the server support a PQC-capable group
+     * ({@code X25519MLKEM768}, {@code SecP256r1MLKEM768}, {@code SecP384r1MLKEM1024}).
+     * The server requires PQC-capable clients.
      * <p>
      * {@code CLIENT_NEGOTIATED}: the server advertises PQC groups but will not refuse a connection if the client
      * does not support them, allowing fallback to classical key exchange.
@@ -85,7 +86,7 @@ public interface TlsBucketConfig {
      * {@code RELAXED}: no PQC enforcement; standard TLS key exchange negotiation applies.
      */
     @WithDefault("relaxed")
-    PqcEnforcePolicyEnum pqcEnforcementPolicy();
+    PqcEnforcementPolicy pqcEnforcementPolicy();
 
     /**
      * Sets the ordered list of enabled TLS key exchange groups (supported groups).

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsBucketConfig.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsBucketConfig.java
@@ -74,6 +74,29 @@ public interface TlsBucketConfig {
     boolean alpn();
 
     /**
+     * Sets the PQC enforcement policy.
+     * <p>
+     * {@code STRICT}: a connection will be refused unless both the client and the server support PQC
+     * ({@code X25519MLKEM768}). The server requires PQC-capable clients.
+     * <p>
+     * {@code CLIENT_NEGOTIATED}: the server advertises PQC groups but will not refuse a connection if the client
+     * does not support them, allowing fallback to classical key exchange.
+     * <p>
+     * {@code RELAXED}: no PQC enforcement; standard TLS key exchange negotiation applies.
+     */
+    @WithDefault("relaxed")
+    PqcEnforcePolicyEnum pqcEnforcementPolicy();
+
+    /**
+     * Sets the ordered list of enabled TLS key exchange groups (supported groups).
+     * If not set, the default groups defined by the {@code SSLEngineOptions} in use are used.
+     * <p>
+     * Example values: {@code X25519MLKEM768}, {@code X25519}, {@code P-256}.
+     * When set, these groups take precedence over the engine defaults.
+     */
+    Optional<List<String>> keyExchangeGroups();
+
+    /**
      * Sets the list of revoked certificates (paths to files).
      * <p>
      * A Certificate Revocation List (CRL) is a list of digital certificates that have been revoked by the issuing

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsBucketConfig.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsBucketConfig.java
@@ -98,6 +98,14 @@ public interface TlsBucketConfig {
     Optional<List<String>> keyExchangeGroups();
 
     /**
+     * Sets the SSL engine that the application should use.
+     * If not set, Vert.x selects the engine automatically — choosing OpenSSL when the PQC
+     * enforcement policy requires it and OpenSSL 3.5+ is available.
+     * If set explicitly, the chosen engine must support all configured features (e.g. PQC groups).
+     */
+    Optional<SslEngineType> sslEngine();
+
+    /**
      * Sets the list of revoked certificates (paths to files).
      * <p>
      * A Certificate Revocation List (CRL) is a list of digital certificates that have been revoked by the issuing

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsConfigUtils.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsConfigUtils.java
@@ -91,6 +91,10 @@ public class TlsConfigUtils {
                         "ALPN configuration not supported by implementation: %s. ALPN setting will be ignored.",
                         options.getClass().getName());
             }
+            if (sslOptions.getKeyExchangeGroups() != null && !sslOptions.getKeyExchangeGroups().isEmpty()) {
+                options.getSslOptions().setKeyExchangeGroups(sslOptions.getKeyExchangeGroups());
+            }
+            options.getSslOptions().setPqcEnforcementPolicy(sslOptions.getPqcEnforcementPolicy());
         }
     }
 

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsConfigUtils.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsConfigUtils.java
@@ -96,6 +96,7 @@ public class TlsConfigUtils {
             }
             options.getSslOptions().setPqcEnforcementPolicy(sslOptions.getPqcEnforcementPolicy());
         }
+        configuration.getSslEngineOptions().ifPresent(options::setSslEngineOptions);
     }
 
     /**

--- a/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/VertxCertificateHolderTest.java
+++ b/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/VertxCertificateHolderTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.tls.runtime.config.KeyStoreConfig;
 import io.quarkus.tls.runtime.config.PqcEnforcementPolicy;
+import io.quarkus.tls.runtime.config.SslEngineType;
 import io.quarkus.tls.runtime.config.TlsBucketConfig;
 import io.quarkus.tls.runtime.config.TrustStoreConfig;
 
@@ -73,6 +74,11 @@ class VertxCertificateHolderTest {
             @Override
             public Optional<List<String>> keyExchangeGroups() {
                 return Optional.of(List.of("x25519mlkem768"));
+            }
+
+            @Override
+            public Optional<SslEngineType> sslEngine() {
+                return Optional.empty();
             }
 
             @Override

--- a/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/VertxCertificateHolderTest.java
+++ b/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/VertxCertificateHolderTest.java
@@ -112,6 +112,11 @@ class VertxCertificateHolderTest {
     }
 
     @Test
+    void testSslEngine() {
+        assertEquals(Optional.empty(), holder.getSslEngineOptions());
+    }
+
+    @Test
     void testWarnIfOldProtocols_withSSL() {
         assertTrue(holder.warnIfOldProtocols(Set.of("SSLv3"), "test"));
         assertTrue(holder.warnIfOldProtocols(Set.of("SSLv2", "TLSv1.3"), "test"));

--- a/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/VertxCertificateHolderTest.java
+++ b/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/VertxCertificateHolderTest.java
@@ -2,6 +2,7 @@ package io.quarkus.tls.runtime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
@@ -13,6 +14,8 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.vertx.core.net.JdkSSLEngineOptions;
+import io.vertx.core.net.OpenSSLEngineOptions;
 import io.quarkus.tls.runtime.config.KeyStoreConfig;
 import io.quarkus.tls.runtime.config.PqcEnforcementPolicy;
 import io.quarkus.tls.runtime.config.SslEngineType;
@@ -25,6 +28,7 @@ class VertxCertificateHolderTest {
 
     @BeforeEach
     void setUp() {
+        // Create a minimal test config with only the required methods implemented
         TlsBucketConfig config = new TlsBucketConfig() {
             @Override
             public Optional<KeyStoreConfig> keyStore() {
@@ -113,7 +117,35 @@ class VertxCertificateHolderTest {
 
     @Test
     void testSslEngine() {
-        assertEquals(Optional.empty(), holder.getSslEngineOptions());
+        assertTrue(holder.getSslEngineOptions().isEmpty());
+    }
+
+    @Test
+    void testSslEngineOptionsOpenssl() {
+        assertInstanceOf(OpenSSLEngineOptions.class, holderWithEngine(SslEngineType.OPENSSL).getSslEngineOptions().get());
+    }
+
+    @Test
+    void testSslEngineOptionsJdkssl() {
+        assertInstanceOf(JdkSSLEngineOptions.class, holderWithEngine(SslEngineType.JDKSSL).getSslEngineOptions().get());
+    }
+
+    private VertxCertificateHolder holderWithEngine(SslEngineType engine) {
+        return new VertxCertificateHolder(null, "test", new TlsBucketConfig() {
+            @Override public Optional<KeyStoreConfig> keyStore() { return Optional.empty(); }
+            @Override public Optional<TrustStoreConfig> trustStore() { return Optional.empty(); }
+            @Override public Optional<List<String>> cipherSuites() { return Optional.empty(); }
+            @Override public Set<String> protocols() { return Set.of(); }
+            @Override public Optional<List<Path>> certificateRevocationList() { return Optional.empty(); }
+            @Override public boolean trustAll() { return false; }
+            @Override public Optional<String> hostnameVerificationAlgorithm() { return Optional.empty(); }
+            @Override public boolean alpn() { return false; }
+            @Override public PqcEnforcementPolicy pqcEnforcementPolicy() { return PqcEnforcementPolicy.RELAXED; }
+            @Override public Optional<List<String>> keyExchangeGroups() { return Optional.empty(); }
+            @Override public Duration handshakeTimeout() { return Duration.ofSeconds(10); }
+            @Override public Optional<Duration> reloadPeriod() { return Optional.empty(); }
+            @Override public Optional<SslEngineType> sslEngine() { return Optional.of(engine); }
+        }, null, null);
     }
 
     @Test

--- a/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/VertxCertificateHolderTest.java
+++ b/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/VertxCertificateHolderTest.java
@@ -14,13 +14,13 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.vertx.core.net.JdkSSLEngineOptions;
-import io.vertx.core.net.OpenSSLEngineOptions;
 import io.quarkus.tls.runtime.config.KeyStoreConfig;
 import io.quarkus.tls.runtime.config.PqcEnforcementPolicy;
 import io.quarkus.tls.runtime.config.SslEngineType;
 import io.quarkus.tls.runtime.config.TlsBucketConfig;
 import io.quarkus.tls.runtime.config.TrustStoreConfig;
+import io.vertx.core.net.JdkSSLEngineOptions;
+import io.vertx.core.net.OpenSSLEngineOptions;
 
 class VertxCertificateHolderTest {
 
@@ -132,19 +132,70 @@ class VertxCertificateHolderTest {
 
     private VertxCertificateHolder holderWithEngine(SslEngineType engine) {
         return new VertxCertificateHolder(null, "test", new TlsBucketConfig() {
-            @Override public Optional<KeyStoreConfig> keyStore() { return Optional.empty(); }
-            @Override public Optional<TrustStoreConfig> trustStore() { return Optional.empty(); }
-            @Override public Optional<List<String>> cipherSuites() { return Optional.empty(); }
-            @Override public Set<String> protocols() { return Set.of(); }
-            @Override public Optional<List<Path>> certificateRevocationList() { return Optional.empty(); }
-            @Override public boolean trustAll() { return false; }
-            @Override public Optional<String> hostnameVerificationAlgorithm() { return Optional.empty(); }
-            @Override public boolean alpn() { return false; }
-            @Override public PqcEnforcementPolicy pqcEnforcementPolicy() { return PqcEnforcementPolicy.RELAXED; }
-            @Override public Optional<List<String>> keyExchangeGroups() { return Optional.empty(); }
-            @Override public Duration handshakeTimeout() { return Duration.ofSeconds(10); }
-            @Override public Optional<Duration> reloadPeriod() { return Optional.empty(); }
-            @Override public Optional<SslEngineType> sslEngine() { return Optional.of(engine); }
+            @Override
+            public Optional<KeyStoreConfig> keyStore() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<TrustStoreConfig> trustStore() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<List<String>> cipherSuites() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Set<String> protocols() {
+                return Set.of();
+            }
+
+            @Override
+            public Optional<List<Path>> certificateRevocationList() {
+                return Optional.empty();
+            }
+
+            @Override
+            public boolean trustAll() {
+                return false;
+            }
+
+            @Override
+            public Optional<String> hostnameVerificationAlgorithm() {
+                return Optional.empty();
+            }
+
+            @Override
+            public boolean alpn() {
+                return false;
+            }
+
+            @Override
+            public PqcEnforcementPolicy pqcEnforcementPolicy() {
+                return PqcEnforcementPolicy.RELAXED;
+            }
+
+            @Override
+            public Optional<List<String>> keyExchangeGroups() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Duration handshakeTimeout() {
+                return Duration.ofSeconds(10);
+            }
+
+            @Override
+            public Optional<Duration> reloadPeriod() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<SslEngineType> sslEngine() {
+                return Optional.of(engine);
+            }
         }, null, null);
     }
 

--- a/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/VertxCertificateHolderTest.java
+++ b/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/VertxCertificateHolderTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.tls.runtime;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -13,8 +14,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.tls.runtime.config.KeyStoreConfig;
+import io.quarkus.tls.runtime.config.PqcEnforcePolicyEnum;
 import io.quarkus.tls.runtime.config.TlsBucketConfig;
 import io.quarkus.tls.runtime.config.TrustStoreConfig;
+import io.vertx.core.net.PqcEnforcementPolicy;
 
 class VertxCertificateHolderTest {
 
@@ -22,7 +25,6 @@ class VertxCertificateHolderTest {
 
     @BeforeEach
     void setUp() {
-        // Create a minimal test config with only the required methods implemented
         TlsBucketConfig config = new TlsBucketConfig() {
             @Override
             public Optional<KeyStoreConfig> keyStore() {
@@ -65,6 +67,16 @@ class VertxCertificateHolderTest {
             }
 
             @Override
+            public PqcEnforcePolicyEnum pqcEnforcementPolicy() {
+                return PqcEnforcePolicyEnum.STRICT;
+            }
+
+            @Override
+            public Optional<List<String>> keyExchangeGroups() {
+                return Optional.of(List.of("x25519mlkem768"));
+            }
+
+            @Override
             public Duration handshakeTimeout() {
                 return Duration.ofSeconds(10);
             }
@@ -81,6 +93,17 @@ class VertxCertificateHolderTest {
     void testDefault() {
         assertFalse(holder.warnIfOldProtocols(Set.of(TlsBucketConfig.DEFAULT_TLS_PROTOCOLS), "test"));
         assertFalse(holder.warnIfOldProtocols(Set.of(TlsBucketConfig.DEFAULT_TLS_PROTOCOLS.toLowerCase()), "test"));
+    }
+
+    @Test
+    void testKeyExchangeGroups() {
+        assertEquals(1, holder.getSSLOptions().getKeyExchangeGroups().size());
+        assertTrue(holder.getSSLOptions().getKeyExchangeGroups().contains("x25519mlkem768"));
+    }
+
+    @Test
+    void testPqcEnforcementPolicy() {
+        assertEquals(PqcEnforcementPolicy.STRICT, holder.getSSLOptions().getPqcEnforcementPolicy());
     }
 
     @Test

--- a/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/VertxCertificateHolderTest.java
+++ b/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/VertxCertificateHolderTest.java
@@ -14,10 +14,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.tls.runtime.config.KeyStoreConfig;
-import io.quarkus.tls.runtime.config.PqcEnforcePolicyEnum;
+import io.quarkus.tls.runtime.config.PqcEnforcementPolicy;
 import io.quarkus.tls.runtime.config.TlsBucketConfig;
 import io.quarkus.tls.runtime.config.TrustStoreConfig;
-import io.vertx.core.net.PqcEnforcementPolicy;
 
 class VertxCertificateHolderTest {
 
@@ -67,8 +66,8 @@ class VertxCertificateHolderTest {
             }
 
             @Override
-            public PqcEnforcePolicyEnum pqcEnforcementPolicy() {
-                return PqcEnforcePolicyEnum.STRICT;
+            public PqcEnforcementPolicy pqcEnforcementPolicy() {
+                return PqcEnforcementPolicy.STRICT;
             }
 
             @Override
@@ -103,7 +102,7 @@ class VertxCertificateHolderTest {
 
     @Test
     void testPqcEnforcementPolicy() {
-        assertEquals(PqcEnforcementPolicy.STRICT, holder.getSSLOptions().getPqcEnforcementPolicy());
+        assertEquals(io.vertx.core.net.PqcEnforcementPolicy.STRICT, holder.getSSLOptions().getPqcEnforcementPolicy());
     }
 
     @Test

--- a/extensions/tls-registry/spi/src/main/java/io/quarkus/tls/TlsConfiguration.java
+++ b/extensions/tls-registry/spi/src/main/java/io/quarkus/tls/TlsConfiguration.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import javax.net.ssl.SSLContext;
 
 import io.vertx.core.net.KeyCertOptions;
+import io.vertx.core.net.SSLEngineOptions;
 import io.vertx.core.net.SSLOptions;
 import io.vertx.core.net.TrustOptions;
 
@@ -108,6 +109,16 @@ public interface TlsConfiguration {
      */
     default String getName() {
         return "unset";
+    }
+
+    /**
+     * Returns the SSL engine options to use, if explicitly configured.
+     * When present, the returned options override the default SSL engine selection.
+     *
+     * @return the SSL engine options, or an empty Optional to use the default
+     */
+    default Optional<SSLEngineOptions> getSslEngineOptions() {
+        return Optional.empty();
     }
 
 }

--- a/extensions/vertx-http/deployment/pom.xml
+++ b/extensions/vertx-http/deployment/pom.xml
@@ -100,6 +100,17 @@
             <artifactId>vertx-web-client</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-classes</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-openssl</artifactId>
+            <classifier>linux-x86_64</classifier>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.smallrye.certs</groupId>

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/AbstractHybridKeyExchangeTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/AbstractHybridKeyExchangeTest.java
@@ -1,0 +1,17 @@
+package io.quarkus.vertx.http.tls;
+
+import jakarta.inject.Inject;
+
+import io.netty.handler.ssl.OpenSsl;
+import io.vertx.core.Vertx;
+
+public abstract class AbstractHybridKeyExchangeTest {
+
+    @Inject
+    Vertx vertx;
+
+    static boolean isOpenSsl35Available() {
+        return OpenSsl.isAvailable() && OpenSsl.version() >= 0x30500000L;
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/AbstractHybridKeyExchangeTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/AbstractHybridKeyExchangeTest.java
@@ -14,4 +14,8 @@ public abstract class AbstractHybridKeyExchangeTest {
         return OpenSsl.isAvailable() && OpenSsl.version() >= 0x30500000L;
     }
 
+    static boolean isJdk27OrLater() {
+        return Runtime.version().feature() >= 27;
+    }
+
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeClientNegotiatedIllGroupsTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeClientNegotiatedIllGroupsTest.java
@@ -1,0 +1,99 @@
+package io.quarkus.vertx.http.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+
+import javax.net.ssl.SSLException;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.OpenSSLEngineOptions;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-hybrid-client-neg-ill-groups-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }))
+@EnabledIf("isOpenSsl35Available")
+public class HybridKeyExchangeClientNegotiatedIllGroupsTest extends AbstractHybridKeyExchangeTest {
+
+    @TestHTTPResource(value = "/client-neg-ill-groups", tls = true)
+    URL url;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class)
+                    .addAsResource(new File("target/certs/ssl-hybrid-client-neg-ill-groups-test.key"), "server-key.pem")
+                    .addAsResource(new File("target/certs/ssl-hybrid-client-neg-ill-groups-test.crt"), "server-cert.pem"))
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.cert", "server-cert.pem")
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.key", "server-key.pem")
+            .overrideConfigKey("quarkus.tls.pqc-enforcement-policy", "client-negotiated")
+            // PQC-only group — unlike the no-groups case, explicitly-set groups are not overridden;
+            // classical clients will fail because X25519 is not in the advertised group list
+            .overrideConfigKey("quarkus.tls.key-exchange-groups", "X25519MLKEM768")
+            .overrideConfigKey("quarkus.http.insecure-requests", "disabled");
+
+    @Test
+    void testPqcClientConnects() {
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setSslEngineOptions(new OpenSSLEngineOptions());
+        options.getSslOptions().setKeyExchangeGroups(List.of("X25519MLKEM768"));
+        options.setTrustAll(true);
+
+        WebClient client = WebClient.create(vertx, options);
+        try {
+            HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join();
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.bodyAsString()).isEqualTo("client-neg-ill-groups-ok");
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void testClassicClientRejectedWhenGroupsExplicitlyPqcOnly() {
+        // Explicitly-set groups are not overridden — X25519 is absent from the server's group list,
+        // so a non-PQC client has no common group and the handshake fails.
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setTrustAll(true);
+        options.getSslOptions().setKeyExchangeGroups(List.of("x25519"));
+
+        WebClient client = WebClient.create(vertx, options);
+        try {
+            assertThatThrownBy(() -> client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join())
+                    .hasRootCauseInstanceOf(SSLException.class);
+        } finally {
+            client.close();
+        }
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/client-neg-ill-groups").handler(rc -> rc.response().end("client-neg-ill-groups-ok"));
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeClientNegotiatedNoGroupsTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeClientNegotiatedNoGroupsTest.java
@@ -1,0 +1,92 @@
+package io.quarkus.vertx.http.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.OpenSSLEngineOptions;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-hybrid-client-neg-no-groups-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }))
+@EnabledIf("isOpenSsl35Available")
+public class HybridKeyExchangeClientNegotiatedNoGroupsTest extends AbstractHybridKeyExchangeTest {
+
+    @TestHTTPResource(value = "/client-neg-no-groups", tls = true)
+    URL url;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class)
+                    .addAsResource(new File("target/certs/ssl-hybrid-client-neg-no-groups-test.key"), "server-key.pem")
+                    .addAsResource(new File("target/certs/ssl-hybrid-client-neg-no-groups-test.crt"), "server-cert.pem"))
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.cert", "server-cert.pem")
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.key", "server-key.pem")
+            .overrideConfigKey("quarkus.tls.pqc-enforcement-policy", "client-negotiated")
+            // key-exchange-groups intentionally omitted — Vert.x overrides to PQC + classical defaults
+            .overrideConfigKey("quarkus.http.insecure-requests", "disabled");
+
+    @Test
+    void testPqcClientConnects() {
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setSslEngineOptions(new OpenSSLEngineOptions());
+        options.getSslOptions().setKeyExchangeGroups(List.of("X25519MLKEM768"));
+        options.setTrustAll(true);
+
+        WebClient client = WebClient.create(vertx, options);
+        try {
+            HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join();
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.bodyAsString()).isEqualTo("client-neg-no-groups-ok");
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void testClassicClientAlsoConnects() {
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setTrustAll(true);
+
+        WebClient client = WebClient.create(vertx, options);
+        try {
+            HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join();
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.bodyAsString()).isEqualTo("client-neg-no-groups-ok");
+        } finally {
+            client.close();
+        }
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/client-neg-no-groups").handler(rc -> rc.response().end("client-neg-no-groups-ok"));
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeClientNegotiatedTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeClientNegotiatedTest.java
@@ -19,6 +19,7 @@ import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.OpenSSLEngineOptions;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
@@ -50,6 +51,7 @@ public class HybridKeyExchangeClientNegotiatedTest extends AbstractHybridKeyExch
     void testPqcClientConnects() {
         WebClientOptions options = new WebClientOptions();
         options.setSsl(true);
+        options.setSslEngineOptions(new OpenSSLEngineOptions());
         options.getSslOptions().setKeyExchangeGroups(List.of("X25519MLKEM768"));
         options.setTrustAll(true);
 

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeClientNegotiatedTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeClientNegotiatedTest.java
@@ -1,0 +1,88 @@
+package io.quarkus.vertx.http.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-hybrid-client-negotiated-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }))
+@EnabledIf("isOpenSsl35Available")
+public class HybridKeyExchangeClientNegotiatedTest extends AbstractHybridKeyExchangeTest {
+
+    @TestHTTPResource(value = "/client-negotiated", tls = true)
+    URL url;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class)
+                    .addAsResource(new File("target/certs/ssl-hybrid-client-negotiated-test.key"), "server-key.pem")
+                    .addAsResource(new File("target/certs/ssl-hybrid-client-negotiated-test.crt"), "server-cert.pem"))
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.cert", "server-cert.pem")
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.key", "server-key.pem")
+            .overrideConfigKey("quarkus.tls.pqc-enforcement-policy", "client-negotiated")
+            // Advertise both PQC and classical groups so non-PQC clients have a fallback (x25519).
+            // With STRICT, x25519 alone would be rejected; CLIENT_NEGOTIATED allows it.
+            .overrideConfigKey("quarkus.tls.key-exchange-groups", "x25519mlkem768,x25519")
+            .overrideConfigKey("quarkus.http.insecure-requests", "disabled");
+
+    @Test
+    void testPqcClientConnects() {
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.getSslOptions().setKeyExchangeGroups(List.of("X25519MLKEM768"));
+        options.setTrustAll(true);
+
+        WebClient client = WebClient.create(vertx, options);
+        HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                .send().toCompletionStage().toCompletableFuture().join();
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.bodyAsString()).isEqualTo("client-negotiated-ok");
+    }
+
+    @Test
+    void testClassicClientAlsoConnects() {
+        // CLIENT_NEGOTIATED must not reject clients that don't support PQC
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setTrustAll(true);
+
+        WebClient client = WebClient.create(vertx, options);
+        HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                .send().toCompletionStage().toCompletableFuture().join();
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.bodyAsString()).isEqualTo("client-negotiated-ok");
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/client-negotiated").handler(rc -> {
+                assertThat(rc.request().connection().isSsl()).isTrue();
+                rc.response().end("client-negotiated-ok");
+            });
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeClientNegotiatedTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeClientNegotiatedTest.java
@@ -1,10 +1,13 @@
 package io.quarkus.vertx.http.tls;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import java.io.File;
 import java.net.URL;
 import java.util.List;
+
+import javax.net.ssl.SSLException;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
@@ -44,7 +47,7 @@ public class HybridKeyExchangeClientNegotiatedTest extends AbstractHybridKeyExch
             .overrideConfigKey("quarkus.tls.pqc-enforcement-policy", "client-negotiated")
             // Advertise both PQC and classical groups so non-PQC clients have a fallback (x25519).
             // With STRICT, x25519 alone would be rejected; CLIENT_NEGOTIATED allows it.
-            .overrideConfigKey("quarkus.tls.key-exchange-groups", "x25519mlkem768,x25519")
+            .overrideConfigKey("quarkus.tls.key-exchange-groups", "X25519MLKEM768,X25519")
             .overrideConfigKey("quarkus.http.insecure-requests", "disabled");
 
     @Test
@@ -56,10 +59,75 @@ public class HybridKeyExchangeClientNegotiatedTest extends AbstractHybridKeyExch
         options.setTrustAll(true);
 
         WebClient client = WebClient.create(vertx, options);
-        HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
-                .send().toCompletionStage().toCompletableFuture().join();
-        assertThat(response.statusCode()).isEqualTo(200);
-        assertThat(response.bodyAsString()).isEqualTo("client-negotiated-ok");
+        try {
+            HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join();
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.bodyAsString()).isEqualTo("client-negotiated-ok");
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void testClientWithOnlyUnadvertisedPqcGroupFails() {
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setSslEngineOptions(new OpenSSLEngineOptions());
+        options.setTrustAll(true);
+        options.getSslOptions().setKeyExchangeGroups(List.of("SecP256r1MLKEM768"));
+
+        WebClient client = WebClient.create(vertx, options);
+        try {
+            assertThatThrownBy(() -> client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join())
+                    .hasRootCauseInstanceOf(SSLException.class);
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void testClientWithUnadvertisedPqcGroupFallsBackToClassical() {
+        // Client prefers SecP256r1MLKEM768 (not in server's group list) but also supports X25519.
+        // TLS negotiates X25519 as a common group; CLIENT_NEGOTIATED allows the classical fallback
+        // whereas STRICT would reject it.
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setSslEngineOptions(new OpenSSLEngineOptions());
+        options.setTrustAll(true);
+        options.getSslOptions().setKeyExchangeGroups(List.of("SecP256r1MLKEM768", "X25519"));
+
+        WebClient client = WebClient.create(vertx, options);
+        try {
+            HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join();
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.bodyAsString()).isEqualTo("client-negotiated-ok");
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    @EnabledIf("isJdk27OrLater")
+    void testJdkSslClientConnectsToClientNegotiatedServer() {
+        // JDK 27+ supports X25519MLKEM768 natively — no OpenSSL engine needed on the client side.
+        // The server still requires OpenSSL 3.5 for client-negotiated enforcement (class-level @EnabledIf).
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setTrustAll(true);
+        options.getSslOptions().setKeyExchangeGroups(List.of("X25519MLKEM768"));
+
+        WebClient client = WebClient.create(vertx, options);
+        try {
+            HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join();
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.bodyAsString()).isEqualTo("client-negotiated-ok");
+        } finally {
+            client.close();
+        }
     }
 
     @Test
@@ -70,10 +138,14 @@ public class HybridKeyExchangeClientNegotiatedTest extends AbstractHybridKeyExch
         options.setTrustAll(true);
 
         WebClient client = WebClient.create(vertx, options);
-        HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
-                .send().toCompletionStage().toCompletableFuture().join();
-        assertThat(response.statusCode()).isEqualTo(200);
-        assertThat(response.bodyAsString()).isEqualTo("client-negotiated-ok");
+        try {
+            HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join();
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.bodyAsString()).isEqualTo("client-negotiated-ok");
+        } finally {
+            client.close();
+        }
     }
 
     @ApplicationScoped
@@ -87,4 +159,5 @@ public class HybridKeyExchangeClientNegotiatedTest extends AbstractHybridKeyExch
         }
 
     }
+
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeJdkSslClientNegotiatedInvalidTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeJdkSslClientNegotiatedInvalidTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.vertx.http.tls;
+
+import static org.assertj.core.api.Fail.fail;
+
+import java.io.File;
+import java.net.URL;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.vertx.ext.web.Router;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-hybrid-jdkssl-client-neg-invalid-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }))
+@DisabledIf("isJdk27OrLater")
+public class HybridKeyExchangeJdkSslClientNegotiatedInvalidTest extends AbstractHybridKeyExchangeTest {
+
+    @TestHTTPResource(value = "/jdkssl-client-neg-invalid", tls = true)
+    URL url;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class)
+                    .addAsResource(new File("target/certs/ssl-hybrid-jdkssl-client-neg-invalid-test.key"), "server-key.pem")
+                    .addAsResource(new File("target/certs/ssl-hybrid-jdkssl-client-neg-invalid-test.crt"), "server-cert.pem"))
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.cert", "server-cert.pem")
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.key", "server-key.pem")
+            .overrideConfigKey("quarkus.tls.pqc-enforcement-policy", "client-negotiated")
+            .overrideConfigKey("quarkus.tls.ssl-engine", "jdkssl")
+            .overrideConfigKey("quarkus.http.insecure-requests", "disabled")
+            .assertException(t -> {
+            });
+
+    /*
+     * On jdk < 27, no pq-compliant groups are available. As such, vertx doesn't accept to start a server with a
+     * client-negotiated policy when jdkssl is forced on jdk < 27.
+     * TODO when pqc is backported to java 25, update condition
+     */
+    @Test
+    void test() {
+        fail("Should not be called, server startup should have failed.");
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/jdkssl-client-neg-invalid").handler(rc -> rc.response().end("jdkssl-client-neg-invalid-ok"));
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeJdkSslStrictInvalidTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeJdkSslStrictInvalidTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.vertx.http.tls;
+
+import static org.assertj.core.api.Fail.fail;
+
+import java.io.File;
+import java.net.URL;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.vertx.ext.web.Router;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-hybrid-jdkssl-strict-invalid-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }))
+@DisabledIf("isJdk27OrLater")
+public class HybridKeyExchangeJdkSslStrictInvalidTest extends AbstractHybridKeyExchangeTest {
+
+    @TestHTTPResource(value = "/jdkssl-strict-invalid", tls = true)
+    URL url;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class)
+                    .addAsResource(new File("target/certs/ssl-hybrid-jdkssl-strict-invalid-test.key"), "server-key.pem")
+                    .addAsResource(new File("target/certs/ssl-hybrid-jdkssl-strict-invalid-test.crt"), "server-cert.pem"))
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.cert", "server-cert.pem")
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.key", "server-key.pem")
+            .overrideConfigKey("quarkus.tls.pqc-enforcement-policy", "strict")
+            .overrideConfigKey("quarkus.tls.ssl-engine", "jdkssl")
+            .overrideConfigKey("quarkus.http.insecure-requests", "disabled")
+            .assertException(t -> {
+            });
+
+    /*
+     * On jdk < 27, no pq-compliant groups are available. As such, vertx doesn't accept to start a server with a strict
+     * policy when jdkssl is forced on jdk < 27.
+     * TODO when pqc is backported to java 25, update condition
+     */
+    @Test
+    void test() {
+        fail("Should not be called, server startup should have failed.");
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/jdkssl-strict-invalid").handler(rc -> rc.response().end("jdkssl-strict-invalid-ok"));
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeMtlsTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeMtlsTest.java
@@ -1,0 +1,90 @@
+package io.quarkus.vertx.http.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.JksOptions;
+import io.vertx.core.net.OpenSSLEngineOptions;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "mtls-hybrid-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }, client = true))
+@EnabledIf("isOpenSsl35Available")
+public class HybridKeyExchangeMtlsTest extends AbstractHybridKeyExchangeTest {
+
+    @TestHTTPResource(value = "/hybrid-mtls", tls = true)
+    URL url;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class)
+                    .addAsResource(new File("target/certs/mtls-hybrid-test-keystore.jks"), "server-keystore.jks")
+                    .addAsResource(new File("target/certs/mtls-hybrid-test-server-truststore.jks"),
+                            "server-truststore.jks"))
+            .overrideConfigKey("quarkus.tls.key-store.jks.path", "server-keystore.jks")
+            .overrideConfigKey("quarkus.tls.key-store.jks.password", "secret")
+            .overrideConfigKey("quarkus.tls.trust-store.jks.path", "server-truststore.jks")
+            .overrideConfigKey("quarkus.tls.trust-store.jks.password", "secret")
+            .overrideConfigKey("quarkus.tls.pqc-enforcement-policy", "strict")
+            .overrideConfigKey("quarkus.http.ssl.client-auth", "REQUIRED")
+            .overrideConfigKey("quarkus.tls.key-exchange-groups", "x25519mlkem768")
+            .overrideConfigKey("quarkus.http.insecure-requests", "disabled");
+
+    @Test
+    void testHybridKeyExchangeWithMtls() {
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setSslEngineOptions(new OpenSSLEngineOptions());
+        options.getSslOptions().setKeyExchangeGroups(List.of("X25519MLKEM768"));
+        options.setTrustAll(true);
+        options.setKeyCertOptions(new JksOptions()
+                .setPath("target/certs/mtls-hybrid-test-client-keystore.jks")
+                .setPassword("secret"));
+
+        WebClient client = WebClient.create(vertx, options);
+        HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                .send().toCompletionStage().toCompletableFuture().join();
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.bodyAsString()).isEqualTo("mtls-hybrid-ok");
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/hybrid-mtls").handler(rc -> {
+                assertThat(rc.request().connection().isSsl()).isTrue();
+                assertThat(rc.request().isSSL()).isTrue();
+                assertThat(rc.request().connection().sslSession()).isNotNull();
+                assertThat(rc.request().connection().sslSession().getProtocol()).isEqualTo("TLSv1.3");
+                try {
+                    assertThat(rc.request().connection().sslSession().getPeerCertificates()).isNotEmpty();
+                } catch (javax.net.ssl.SSLPeerUnverifiedException e) {
+                    throw new RuntimeException(e);
+                }
+                rc.response().end("mtls-hybrid-ok");
+            });
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeMtlsTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeMtlsTest.java
@@ -62,10 +62,14 @@ public class HybridKeyExchangeMtlsTest extends AbstractHybridKeyExchangeTest {
                 .setPassword("secret"));
 
         WebClient client = WebClient.create(vertx, options);
-        HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
-                .send().toCompletionStage().toCompletableFuture().join();
-        assertThat(response.statusCode()).isEqualTo(200);
-        assertThat(response.bodyAsString()).isEqualTo("mtls-hybrid-ok");
+        try {
+            HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join();
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.bodyAsString()).isEqualTo("mtls-hybrid-ok");
+        } finally {
+            client.close();
+        }
     }
 
     @ApplicationScoped

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeNamedBucketTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeNamedBucketTest.java
@@ -1,0 +1,101 @@
+package io.quarkus.vertx.http.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+
+import javax.net.ssl.SSLException;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.OpenSSLEngineOptions;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+
+/**
+ * Smoke test for PQC enforcement with a named TLS bucket. The policy/groups logic is already
+ * thoroughly covered by the default bucket tests — this just verifies the named bucket code path
+ * is wired correctly end-to-end.
+ */
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-hybrid-named-bucket-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }))
+@EnabledIf("isOpenSsl35Available")
+public class HybridKeyExchangeNamedBucketTest extends AbstractHybridKeyExchangeTest {
+
+    @TestHTTPResource(value = "/named-bucket", tls = true)
+    URL url;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class)
+                    .addAsResource(new File("target/certs/ssl-hybrid-named-bucket-test.key"), "server-key.pem")
+                    .addAsResource(new File("target/certs/ssl-hybrid-named-bucket-test.crt"), "server-cert.pem"))
+            .overrideConfigKey("quarkus.tls.pqc.key-store.pem.0.cert", "server-cert.pem")
+            .overrideConfigKey("quarkus.tls.pqc.key-store.pem.0.key", "server-key.pem")
+            .overrideConfigKey("quarkus.tls.pqc.pqc-enforcement-policy", "strict")
+            .overrideConfigKey("quarkus.tls.pqc.key-exchange-groups", "X25519MLKEM768")
+            .overrideConfigKey("quarkus.http.tls-configuration-name", "pqc")
+            .overrideConfigKey("quarkus.http.insecure-requests", "disabled");
+
+    @Test
+    void testPqcClientConnects() {
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setSslEngineOptions(new OpenSSLEngineOptions());
+        options.getSslOptions().setKeyExchangeGroups(List.of("X25519MLKEM768"));
+        options.setTrustAll(true);
+
+        WebClient client = WebClient.create(vertx, options);
+        try {
+            HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join();
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.bodyAsString()).isEqualTo("named-bucket-ok");
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void testNonHybridClientRejected() {
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setTrustAll(true);
+        options.getSslOptions().setKeyExchangeGroups(List.of("x25519"));
+
+        WebClient client = WebClient.create(vertx, options);
+        try {
+            assertThatThrownBy(() -> client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join())
+                    .hasRootCauseInstanceOf(SSLException.class);
+        } finally {
+            client.close();
+        }
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/named-bucket").handler(rc -> rc.response().end("named-bucket-ok"));
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeRelaxedNoGroupsTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeRelaxedNoGroupsTest.java
@@ -1,0 +1,99 @@
+package io.quarkus.vertx.http.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+
+import javax.net.ssl.SSLException;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.OpenSSLEngineOptions;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-hybrid-relaxed-no-groups-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }))
+public class HybridKeyExchangeRelaxedNoGroupsTest extends AbstractHybridKeyExchangeTest {
+
+    @TestHTTPResource(value = "/relaxed-no-groups", tls = true)
+    URL url;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class)
+                    .addAsResource(new File("target/certs/ssl-hybrid-relaxed-no-groups-test.key"), "server-key.pem")
+                    .addAsResource(new File("target/certs/ssl-hybrid-relaxed-no-groups-test.crt"), "server-cert.pem"))
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.cert", "server-cert.pem")
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.key", "server-key.pem")
+            .overrideConfigKey("quarkus.tls.pqc-enforcement-policy", "relaxed")
+            // no key-exchange-groups — server uses TLS defaults (classical groups only)
+            .overrideConfigKey("quarkus.http.insecure-requests", "disabled");
+
+    @Test
+    void testClassicClientConnects() {
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setTrustAll(true);
+
+        WebClient client = WebClient.create(vertx, options);
+        try {
+            HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join();
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.bodyAsString()).isEqualTo("relaxed-no-groups-ok");
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    @EnabledIf("isOpenSsl35Available")
+    //if jdk is 27 or later, server will have pqc groups by default
+    @DisabledIf("isJdk27OrLater")
+    void testPqcClientFails() {
+        // Server uses classical TLS defaults — no PQC groups advertised.
+        // A client that only offers X25519MLKEM768 has no common group and the handshake fails.
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setSslEngineOptions(new OpenSSLEngineOptions());
+        options.getSslOptions().setKeyExchangeGroups(List.of("X25519MLKEM768"));
+        options.setTrustAll(true);
+
+        WebClient client = WebClient.create(vertx, options);
+        try {
+            assertThatThrownBy(() -> client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join())
+                    .hasRootCauseInstanceOf(SSLException.class);
+        } finally {
+            client.close();
+        }
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/relaxed-no-groups").handler(rc -> rc.response().end("relaxed-no-groups-ok"));
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeRelaxedTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeRelaxedTest.java
@@ -1,0 +1,94 @@
+package io.quarkus.vertx.http.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.OpenSSLEngineOptions;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-hybrid-relaxed-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }))
+@EnabledIf("isOpenSsl35Available")
+public class HybridKeyExchangeRelaxedTest extends AbstractHybridKeyExchangeTest {
+
+    @TestHTTPResource(value = "/relaxed", tls = true)
+    URL url;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class)
+                    .addAsResource(new File("target/certs/ssl-hybrid-relaxed-test.key"), "server-key.pem")
+                    .addAsResource(new File("target/certs/ssl-hybrid-relaxed-test.crt"), "server-cert.pem"))
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.cert", "server-cert.pem")
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.key", "server-key.pem")
+            .overrideConfigKey("quarkus.tls.pqc-enforcement-policy", "relaxed")
+            .overrideConfigKey("quarkus.tls.ssl-engine", "openssl")
+            .overrideConfigKey("quarkus.tls.key-exchange-groups", "X25519MLKEM768,X25519")
+            .overrideConfigKey("quarkus.http.insecure-requests", "disabled");
+
+    @Test
+    void testPqcClientConnects() {
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setSslEngineOptions(new OpenSSLEngineOptions());
+        options.getSslOptions().setKeyExchangeGroups(List.of("X25519MLKEM768"));
+        options.setTrustAll(true);
+
+        WebClient client = WebClient.create(vertx, options);
+        try {
+            HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join();
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.bodyAsString()).isEqualTo("relaxed-ok");
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void testClassicClientAlsoConnects() {
+        // RELAXED imposes no enforcement — a classical client connects even though PQC groups are advertised.
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setTrustAll(true);
+
+        WebClient client = WebClient.create(vertx, options);
+        try {
+            HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join();
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.bodyAsString()).isEqualTo("relaxed-ok");
+        } finally {
+            client.close();
+        }
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/relaxed").handler(rc -> rc.response().end("relaxed-ok"));
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeStrictIllGroupsTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeStrictIllGroupsTest.java
@@ -1,0 +1,96 @@
+package io.quarkus.vertx.http.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+
+import javax.net.ssl.SSLException;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.OpenSSLEngineOptions;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-hybrid-strict-ill-groups-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }))
+@EnabledIf("isOpenSsl35Available")
+public class HybridKeyExchangeStrictIllGroupsTest extends AbstractHybridKeyExchangeTest {
+
+    @TestHTTPResource(value = "/strict-ill-groups", tls = true)
+    URL url;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class)
+                    .addAsResource(new File("target/certs/ssl-hybrid-strict-ill-groups-test.key"), "server-key.pem")
+                    .addAsResource(new File("target/certs/ssl-hybrid-strict-ill-groups-test.crt"), "server-cert.pem"))
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.cert", "server-cert.pem")
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.key", "server-key.pem")
+            .overrideConfigKey("quarkus.tls.pqc-enforcement-policy", "strict")
+            // classical-only group — Vert.x overrides to PQC defaults for strict
+            .overrideConfigKey("quarkus.tls.key-exchange-groups", "X25519")
+            .overrideConfigKey("quarkus.http.insecure-requests", "disabled");
+
+    @Test
+    void testPqcClientConnects() {
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setSslEngineOptions(new OpenSSLEngineOptions());
+        options.getSslOptions().setKeyExchangeGroups(List.of("X25519MLKEM768"));
+        options.setTrustAll(true);
+
+        WebClient client = WebClient.create(vertx, options);
+        try {
+            HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join();
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.bodyAsString()).isEqualTo("strict-ill-groups-ok");
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void testNonHybridClientRejected() {
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setTrustAll(true);
+        options.getSslOptions().setKeyExchangeGroups(List.of("x25519"));
+
+        WebClient client = WebClient.create(vertx, options);
+        try {
+            assertThatThrownBy(() -> client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join())
+                    .hasRootCauseInstanceOf(SSLException.class);
+        } finally {
+            client.close();
+        }
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/strict-ill-groups").handler(rc -> rc.response().end("strict-ill-groups-ok"));
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeStrictNoGroupsTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeStrictNoGroupsTest.java
@@ -1,0 +1,95 @@
+package io.quarkus.vertx.http.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+
+import javax.net.ssl.SSLException;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.OpenSSLEngineOptions;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-hybrid-strict-no-groups-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }))
+@EnabledIf("isOpenSsl35Available")
+public class HybridKeyExchangeStrictNoGroupsTest extends AbstractHybridKeyExchangeTest {
+
+    @TestHTTPResource(value = "/strict-no-groups", tls = true)
+    URL url;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class)
+                    .addAsResource(new File("target/certs/ssl-hybrid-strict-no-groups-test.key"), "server-key.pem")
+                    .addAsResource(new File("target/certs/ssl-hybrid-strict-no-groups-test.crt"), "server-cert.pem"))
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.cert", "server-cert.pem")
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.key", "server-key.pem")
+            .overrideConfigKey("quarkus.tls.pqc-enforcement-policy", "strict")
+            // key-exchange-groups intentionally omitted — Vert.x overrides to PQC defaults
+            .overrideConfigKey("quarkus.http.insecure-requests", "disabled");
+
+    @Test
+    void testPqcClientConnects() {
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setSslEngineOptions(new OpenSSLEngineOptions());
+        options.getSslOptions().setKeyExchangeGroups(List.of("X25519MLKEM768"));
+        options.setTrustAll(true);
+
+        WebClient client = WebClient.create(vertx, options);
+        try {
+            HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join();
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.bodyAsString()).isEqualTo("strict-no-groups-ok");
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void testNonHybridClientRejected() {
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setTrustAll(true);
+        options.getSslOptions().setKeyExchangeGroups(List.of("x25519"));
+
+        WebClient client = WebClient.create(vertx, options);
+        try {
+            assertThatThrownBy(() -> client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join())
+                    .hasRootCauseInstanceOf(SSLException.class);
+        } finally {
+            client.close();
+        }
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/strict-no-groups").handler(rc -> rc.response().end("strict-no-groups-ok"));
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeTest.java
@@ -22,7 +22,6 @@ import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.net.OpenSSLEngineOptions;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
@@ -52,7 +51,7 @@ public class HybridKeyExchangeTest extends AbstractHybridKeyExchangeTest {
     void testHybridKeyExchangeHandshake() {
         WebClientOptions options = new WebClientOptions();
         options.setSsl(true);
-        options.setSslEngineOptions(new OpenSSLEngineOptions());
+        //        options.setSslEngineOptions(new OpenSSLEngineOptions());
         options.getSslOptions().setKeyExchangeGroups(List.of("X25519MLKEM768"));
         options.setTrustAll(true);
 

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeTest.java
@@ -57,10 +57,67 @@ public class HybridKeyExchangeTest extends AbstractHybridKeyExchangeTest {
         options.setTrustAll(true);
 
         WebClient client = WebClient.create(vertx, options);
-        HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
-                .send().toCompletionStage().toCompletableFuture().join();
-        assertThat(response.statusCode()).isEqualTo(200);
-        assertThat(response.bodyAsString()).isEqualTo("hybrid-ok");
+        try {
+            HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join();
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.bodyAsString()).isEqualTo("hybrid-ok");
+        } finally {
+            client.close();
+        }
+    }
+
+    // TODO should work when vertx SslEngineUtils.resolveKeyExchangeGroups(...) is fixed
+    //    @Test
+    //    void testClientWithOnlyUnadvertisedPqcGroupFails() {
+    //        WebClientOptions options = new WebClientOptions();
+    //        options.setSsl(true);
+    //        options.setSslEngineOptions(new OpenSSLEngineOptions());
+    //        options.setTrustAll(true);
+    //        options.getSslOptions().setKeyExchangeGroups(List.of("SecP256r1MLKEM768"));
+    //
+    //        WebClient client = WebClient.create(vertx, options);
+    //        assertThatThrownBy(() -> client.getAbs(url.toExternalForm())
+    //                .send().toCompletionStage().toCompletableFuture().join())
+    //                .hasRootCauseInstanceOf(SSLException.class);
+    //    }
+
+    // TODO should work when vertx SslEngineUtils.resolveKeyExchangeGroups(...) is fixed
+    //    @Test
+    //    void testClientWithUnadvertisedPqcGroupFailsInStrictMode() {
+    //        // Client offers SecP256r1MLKEM768 (not advertised by the server) with X25519 as a fallback.
+    //        // Strict mode only advertises X25519MLKEM768, so there is no common group — handshake fails.
+    //        WebClientOptions options = new WebClientOptions();
+    //        options.setSsl(true);
+    //        options.setSslEngineOptions(new OpenSSLEngineOptions());
+    //        options.setTrustAll(true);
+    //        options.getSslOptions().setKeyExchangeGroups(List.of("SecP256r1MLKEM768", "X25519"));
+    //
+    //        WebClient client = WebClient.create(vertx, options);
+    //        assertThatThrownBy(() -> client.getAbs(url.toExternalForm())
+    //                .send().toCompletionStage().toCompletableFuture().join())
+    //                .hasRootCauseInstanceOf(SSLException.class);
+    //    }
+
+    @Test
+    @EnabledIf("isJdk27OrLater")
+    void testJdkSslClientConnectsToStrictServer() {
+        // JDK 27+ supports X25519MLKEM768 natively — no OpenSSL engine needed on the client side.
+        // The server still requires OpenSSL 3.5 for strict enforcement (class-level @EnabledIf).
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setTrustAll(true);
+        options.getSslOptions().setKeyExchangeGroups(List.of("X25519MLKEM768"));
+
+        WebClient client = WebClient.create(vertx, options);
+        try {
+            HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join();
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.bodyAsString()).isEqualTo("hybrid-ok");
+        } finally {
+            client.close();
+        }
     }
 
     @Test
@@ -68,11 +125,16 @@ public class HybridKeyExchangeTest extends AbstractHybridKeyExchangeTest {
         WebClientOptions options = new WebClientOptions();
         options.setSsl(true);
         options.setTrustAll(true);
+        options.getSslOptions().setKeyExchangeGroups(List.of("x25519"));
 
         WebClient client = WebClient.create(vertx, options);
-        assertThatThrownBy(() -> client.getAbs(url.toExternalForm())
-                .send().toCompletionStage().toCompletableFuture().join())
-                .hasRootCauseInstanceOf(SSLException.class);
+        try {
+            assertThatThrownBy(() -> client.getAbs(url.toExternalForm())
+                    .send().toCompletionStage().toCompletableFuture().join())
+                    .hasRootCauseInstanceOf(SSLException.class);
+        } finally {
+            client.close();
+        }
     }
 
     @ApplicationScoped
@@ -89,4 +151,5 @@ public class HybridKeyExchangeTest extends AbstractHybridKeyExchangeTest {
         }
 
     }
+
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeTest.java
@@ -1,0 +1,92 @@
+package io.quarkus.vertx.http.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+
+import javax.net.ssl.SSLException;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.OpenSSLEngineOptions;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-hybrid-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }))
+@EnabledIf("isOpenSsl35Available")
+public class HybridKeyExchangeTest extends AbstractHybridKeyExchangeTest {
+
+    @TestHTTPResource(value = "/hybrid", tls = true)
+    URL url;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class)
+                    .addAsResource(new File("target/certs/ssl-hybrid-test.key"), "server-key.pem")
+                    .addAsResource(new File("target/certs/ssl-hybrid-test.crt"), "server-cert.pem"))
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.cert", "server-cert.pem")
+            .overrideConfigKey("quarkus.tls.key-store.pem.0.key", "server-key.pem")
+            .overrideConfigKey("quarkus.tls.pqc-enforcement-policy", "strict")
+            .overrideConfigKey("quarkus.tls.key-exchange-groups", "x25519mlkem768")
+            .overrideConfigKey("quarkus.http.insecure-requests", "disabled");
+
+    @Test
+    void testHybridKeyExchangeHandshake() {
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setSslEngineOptions(new OpenSSLEngineOptions());
+        options.getSslOptions().setKeyExchangeGroups(List.of("X25519MLKEM768"));
+        options.setTrustAll(true);
+
+        WebClient client = WebClient.create(vertx, options);
+        HttpResponse<Buffer> response = client.getAbs(url.toExternalForm())
+                .send().toCompletionStage().toCompletableFuture().join();
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.bodyAsString()).isEqualTo("hybrid-ok");
+    }
+
+    @Test
+    void testNonHybridClientRejected() {
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setTrustAll(true);
+
+        WebClient client = WebClient.create(vertx, options);
+        assertThatThrownBy(() -> client.getAbs(url.toExternalForm())
+                .send().toCompletionStage().toCompletableFuture().join())
+                .hasRootCauseInstanceOf(SSLException.class);
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/hybrid").handler(rc -> {
+                assertThat(rc.request().connection().isSsl()).isTrue();
+                assertThat(rc.request().isSSL()).isTrue();
+                assertThat(rc.request().connection().sslSession()).isNotNull();
+                assertThat(rc.request().connection().sslSession().getProtocol()).isEqualTo("TLSv1.3");
+                rc.response().end("hybrid-ok");
+            });
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeTest.java
@@ -22,6 +22,7 @@ import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.OpenSSLEngineOptions;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
@@ -51,7 +52,7 @@ public class HybridKeyExchangeTest extends AbstractHybridKeyExchangeTest {
     void testHybridKeyExchangeHandshake() {
         WebClientOptions options = new WebClientOptions();
         options.setSsl(true);
-        //        options.setSslEngineOptions(new OpenSSLEngineOptions());
+        options.setSslEngineOptions(new OpenSSLEngineOptions());
         options.getSslOptions().setKeyExchangeGroups(List.of("X25519MLKEM768"));
         options.setTrustAll(true);
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
@@ -253,6 +253,10 @@ public class HttpServerOptionsUtils {
         if (!other.isUseAlpn()) {
             serverOptions.setUseAlpn(false);
         }
+        if (other.getKeyExchangeGroups() != null && !other.getKeyExchangeGroups().isEmpty()) {
+            serverOptions.getSslOptions().setKeyExchangeGroups(other.getKeyExchangeGroups());
+        }
+        serverOptions.getSslOptions().setPqcEnforcementPolicy(other.getPqcEnforcementPolicy());
         serverOptions.setEnabledSecureTransportProtocols(other.getEnabledSecureTransportProtocols());
     }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
@@ -229,6 +229,7 @@ public class HttpServerOptionsUtils {
 
     public static void applyTlsConfigurationToHttpServerOptions(TlsConfiguration bucket, HttpServerOptions serverOptions) {
         serverOptions.setSsl(true);
+        bucket.getSslEngineOptions().ifPresent(serverOptions::setSslEngineOptions);
         setJdkHeapBufferPooling(serverOptions);
 
         KeyCertOptions keyStoreOptions = bucket.getKeyStoreOptions();

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
@@ -395,6 +395,10 @@ public class ClientBuilderImpl extends ClientBuilder {
             }
             options.setEnabledSecureTransportProtocols(sslOptions.getEnabledSecureTransportProtocols());
             options.setUseAlpn(sslOptions.isUseAlpn());
+            if (sslOptions.getKeyExchangeGroups() != null && !sslOptions.getKeyExchangeGroups().isEmpty()) {
+                options.getSslOptions().setKeyExchangeGroups(sslOptions.getKeyExchangeGroups());
+            }
+            options.getSslOptions().setPqcEnforcementPolicy(sslOptions.getPqcEnforcementPolicy());
         }
     }
 

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -58,7 +58,7 @@
         <mutiny.version>3.3.0</mutiny.version>
         <smallrye-mutiny-vertx-core.version>3.23.0</smallrye-mutiny-vertx-core.version>
         <smallrye-common.version>2.19.0</smallrye-common.version>
-        <vertx.version>4.5.30</vertx.version>
+        <vertx.version>4.5.31</vertx.version>
         <rest-assured.version>6.0.0</rest-assured.version>
         <commons-logging-jboss-logging.version>2.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.22.0</jackson-bom.version>


### PR DESCRIPTION
The rise of quantum computers threatens traditional asymmetric key exchange protocol due to their ability to break private keys. Post-quantum cryptography must use problems that quantum computers can't solve as quickly. Module-lattice-based problems have been found to resist quantum computers. ML-KEM, for module-lattice-based key encapsulation mechanism, is an instance of a key exchange protocol resistant to quantum computers. Due to its relative short existence, it has been recommended to use it alongside traditional Diffie-Hellman with elliptic curve. 

Thus, the new hybrid key exchange protocol `x25519mlkem768` uses both Diffie-Hellman with elliptic curve 25519 and ML-KEM. Its has been integrated in OpenSsl starting with version 3.5.

This commit wires the new Vert.x API introduced in https://github.com/eclipse-vertx/vert.x/pull/6239 through the Quarkus TLS registry stack (HTTP server, HTTP client, REST client, Mailer).

Two new configuration properties are exposed:

- `quarkus.tls.key-exchange-groups`: TLS 1.3 key exchange groups to advertise (e.g. `x25519mlkem768,x25519`)
- `quarkus.tls.pqc-enforcement-policy`: one of `strict`, `client-negotiated`, or `relaxed` (default)

PQC requires OpenSSL 3.5+, provided at runtime by `smallrye-openssl` (bound to `netty-tcnative-openssl-dynamic`). `netty-tcnative-classes` is needed at build time.