### PR TITLE
Update Redpanda devservice version to v26.1.12

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -156,7 +156,7 @@
         <redis.image>docker.io/library/redis:8</redis.image>
         <infinispan.image>quay.io/infinispan/server:latest</infinispan.image>
         <mailpit.image>docker.io/axllent/mailpit:latest</mailpit.image>
-        <kafka.redpanda.image>docker.io/redpandadata/redpanda:v24.1.2</kafka.redpanda.image>
+        <kafka.redpanda.image>docker.io/redpandadata/redpanda:v26.1.12</kafka.redpanda.image>
         <kafka.strimzi.image>quay.io/strimzi-test-container/test-container:0.115.0-kafka-4.2.0</kafka.strimzi.image>
         <kafka.native.image>quay.io/ogunalp/kafka-native:latest</kafka.native.image>
         <kafka.upstream.image>docker.io/apache/kafka:4.2.0</kafka.upstream.image>


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
and the AI/LLM usage policy at https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md
-->
Bumping RedPanda image to v26.1.12

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

