### PR TITLE
Fall back to reflection-based deserialization when a @JsonCreator parameter cannot be handled

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
@@ -335,8 +335,14 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
                 missingBranch.throwException(exception);
             }
 
-            params[i++] = readValueFromJson(deserData.classCreator, deserData.methodCreator,
+            ResultHandle paramValue = readValueFromJson(deserData.classCreator, deserData.methodCreator,
                     deserData.methodCreator.getMethodParam(1), fieldSpecs, deserData.typeParametersIndex, fieldValue);
+            if (paramValue == null) {
+                // the value of this parameter cannot be deserialized in a reflection-free way (e.g. its
+                // type is polymorphic), so give up generating the deserializer for the whole class
+                return null;
+            }
+            params[i++] = paramValue;
         }
         return deserData.methodCreator.newInstance(deserData.constructor, params);
     }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
@@ -1397,6 +1397,32 @@ public abstract class AbstractSimpleJsonTest {
     }
 
     @Test
+    void testJsonCreatorWithPolymorphicProperty() {
+        // A @JsonCreator parameter with a polymorphic (@JsonTypeInfo) type cannot be handled by the
+        // generated reflection-free deserializer and must fall back to the reflection-based one
+        RestAssured
+                .with()
+                .body("{\"item\":{\"type\":\"type_a\",\"value\":\"hello\"}}")
+                .contentType("application/json")
+                .post("/simple/polymorphic-creator-property")
+                .then()
+                .statusCode(200)
+                .body("item.value", CoreMatchers.is("hello"));
+    }
+
+    @Test
+    void testJsonCreatorWithPolymorphicPropertyMissing() {
+        // Omit the required polymorphic "item" property — should fail with 400
+        RestAssured
+                .with()
+                .body("{}")
+                .contentType("application/json")
+                .post("/simple/polymorphic-creator-property")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
     void sensor_metadata_shouldDeserialize() {
         given()
                 .when()

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/PolymorphicCreatorProperty.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/PolymorphicCreatorProperty.java
@@ -1,0 +1,25 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PolymorphicCreatorProperty {
+
+    private PolymorphicItem item;
+
+    public PolymorphicCreatorProperty() {
+    }
+
+    @JsonCreator
+    public PolymorphicCreatorProperty(@JsonProperty(value = "item", required = true) PolymorphicItem item) {
+        this.item = item;
+    }
+
+    public PolymorphicItem getItem() {
+        return item;
+    }
+
+    public void setItem(PolymorphicItem item) {
+        this.item = item;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
@@ -775,6 +775,14 @@ public class SimpleJsonResource extends SuperClass<Person> {
         return obj;
     }
 
+    @POST
+    @Path("/polymorphic-creator-property")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public PolymorphicCreatorProperty echoPolymorphicCreatorProperty(PolymorphicCreatorProperty obj) {
+        return obj;
+    }
+
     @GET
     @Path("/sensor-metadata")
     public SensorMetadata sensorMetadata() {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
@@ -38,7 +38,8 @@ public class SimpleJsonTest extends AbstractSimpleJsonTest {
                                     UnwrappedResult.class, UnwrappedResultsResponse.class, Detail.class, ErrorInfo.class,
                                     PolymorphicItemResponse.class, PolymorphicItem.class,
                                     SensorMetadata.class, SensorMetadata.ComponentMetadata.class, SensorUnit.class,
-                                    FinalCollectionHolder.class, RequiredCreatorProperty.class)
+                                    FinalCollectionHolder.class, RequiredCreatorProperty.class,
+                                    PolymorphicCreatorProperty.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +
                                     "birth-date-roles=alice,bob\n" +

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
@@ -41,7 +41,8 @@ public class SimpleJsonWithReflectionFreeSerializersTest extends AbstractSimpleJ
                                     UnwrappedResult.class, UnwrappedResultsResponse.class, Detail.class, ErrorInfo.class,
                                     PolymorphicItemResponse.class, PolymorphicItem.class,
                                     SensorMetadata.class, SensorMetadata.ComponentMetadata.class, SensorUnit.class,
-                                    FinalCollectionHolder.class, RequiredCreatorProperty.class)
+                                    FinalCollectionHolder.class, RequiredCreatorProperty.class,
+                                    PolymorphicCreatorProperty.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +
                                     "birth-date-roles=alice,bob\n" +


### PR DESCRIPTION
The reflection-free Jackson deserializer generator cannot create a deserializer for a polymorphic (`@JsonTypeInfo`) type, so `readValueFromJson` returns `null` for such a type. The setter-based path already handles this by bailing on the generated deserializer, falling back to the reflection-based one.

Give up on the generated deserializer in this case too, so the class falls back to the reflection-based one.

- Fixes: #55487

_P.S. I used Claude Code to analyze and develop this fix._

