### PR TITLE
Add opt-in histogram buckets for gRPC Micrometer metrics

### DIFF
--- a/docs/src/main/asciidoc/grpc-service-consumption.adoc
+++ b/docs/src/main/asciidoc/grpc-service-consumption.adoc
@@ -462,6 +462,23 @@ grpc_client_processing_duration_seconds_max{method="SayHello",methodType="UNARY"
 
 The service name, method and type can be found in the _tags_.
 
+By default, processing duration is exported as a Prometheus summary (`_count`, `_sum`, `_max`).
+To publish aggregatable histogram buckets (for example for `histogram_quantile`), enable:
+
+[source, properties]
+----
+quarkus.micrometer.binder.grpc-client.histogram=true
+----
+
+Optional custom bucket boundaries (defaults are `5ms,10ms,25ms,50ms,100ms,250ms,500ms,1s,5s`):
+
+[source, properties]
+----
+quarkus.micrometer.binder.grpc-client.slos=5ms,10ms,25ms,50ms,100ms,1s
+----
+
+Histograms are disabled by default because they increase memory usage and metric cardinality.
+
 === Disabling metrics collection
 
 To disable the gRPC client metrics when `quarkus-micrometer` is used, add the following property to the application configuration:

--- a/docs/src/main/asciidoc/grpc-service-consumption.adoc
+++ b/docs/src/main/asciidoc/grpc-service-consumption.adoc
@@ -470,11 +470,14 @@ To publish aggregatable histogram buckets (for example for `histogram_quantile`)
 quarkus.micrometer.binder.grpc-client.histogram=true
 ----
 
-This uses Micrometer's default percentile histogram buckets. Optionally add extra SLO boundaries:
+This uses Micrometer's default percentile histogram buckets (about `1ms` to `30s`).
+Optionally add extra SLO boundaries and/or clamp the published bucket range to reduce cardinality:
 
 [source, properties]
 ----
 quarkus.micrometer.binder.grpc-client.slos=5ms,10ms,25ms,50ms,100ms,1s
+quarkus.micrometer.binder.grpc-client.minimum-expected-value=1ms
+quarkus.micrometer.binder.grpc-client.maximum-expected-value=10s
 ----
 
 Histograms are disabled by default because they increase memory usage and metric cardinality.

--- a/docs/src/main/asciidoc/grpc-service-consumption.adoc
+++ b/docs/src/main/asciidoc/grpc-service-consumption.adoc
@@ -470,7 +470,7 @@ To publish aggregatable histogram buckets (for example for `histogram_quantile`)
 quarkus.micrometer.binder.grpc-client.histogram=true
 ----
 
-Optional custom bucket boundaries (defaults are `5ms,10ms,25ms,50ms,100ms,250ms,500ms,1s,5s`):
+This uses Micrometer's default percentile histogram buckets. Optionally add extra SLO boundaries:
 
 [source, properties]
 ----

--- a/docs/src/main/asciidoc/grpc-service-implementation.adoc
+++ b/docs/src/main/asciidoc/grpc-service-implementation.adoc
@@ -471,6 +471,23 @@ grpc_server_requests_received_messages_total{method="SayHello",methodType="UNARY
 
 The service name, method and type can be found in the _tags_.
 
+By default, processing duration is exported as a Prometheus summary (`_count`, `_sum`, `_max`).
+To publish aggregatable histogram buckets (for example for `histogram_quantile`), enable:
+
+[source, properties]
+----
+quarkus.micrometer.binder.grpc-server.histogram=true
+----
+
+Optional custom bucket boundaries (defaults are `5ms,10ms,25ms,50ms,100ms,250ms,500ms,1s,5s`):
+
+[source, properties]
+----
+quarkus.micrometer.binder.grpc-server.slos=5ms,10ms,25ms,50ms,100ms,1s
+----
+
+Histograms are disabled by default because they increase memory usage and metric cardinality.
+
 === Disabling metrics collection
 
 To disable the gRPC server metrics when `quarkus-micrometer` is used, add the following property to the application configuration:

--- a/docs/src/main/asciidoc/grpc-service-implementation.adoc
+++ b/docs/src/main/asciidoc/grpc-service-implementation.adoc
@@ -479,7 +479,7 @@ To publish aggregatable histogram buckets (for example for `histogram_quantile`)
 quarkus.micrometer.binder.grpc-server.histogram=true
 ----
 
-Optional custom bucket boundaries (defaults are `5ms,10ms,25ms,50ms,100ms,250ms,500ms,1s,5s`):
+This uses Micrometer's default percentile histogram buckets. Optionally add extra SLO boundaries:
 
 [source, properties]
 ----

--- a/docs/src/main/asciidoc/grpc-service-implementation.adoc
+++ b/docs/src/main/asciidoc/grpc-service-implementation.adoc
@@ -479,11 +479,14 @@ To publish aggregatable histogram buckets (for example for `histogram_quantile`)
 quarkus.micrometer.binder.grpc-server.histogram=true
 ----
 
-This uses Micrometer's default percentile histogram buckets. Optionally add extra SLO boundaries:
+This uses Micrometer's default percentile histogram buckets (about `1ms` to `30s`).
+Optionally add extra SLO boundaries and/or clamp the published bucket range to reduce cardinality:
 
 [source, properties]
 ----
 quarkus.micrometer.binder.grpc-server.slos=5ms,10ms,25ms,50ms,100ms,1s
+quarkus.micrometer.binder.grpc-server.minimum-expected-value=1ms
+quarkus.micrometer.binder.grpc-server.maximum-expected-value=10s
 ----
 
 Histograms are disabled by default because they increase memory usage and metric cardinality.

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricTimerCustomizer.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricTimerCustomizer.java
@@ -1,0 +1,30 @@
+package io.quarkus.micrometer.runtime.binder.grpc;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+import io.micrometer.core.instrument.Timer;
+
+/**
+ * Builds Micrometer {@link Timer.Builder} customizers for gRPC metrics interceptors.
+ */
+public final class GrpcMetricTimerCustomizer {
+
+    private GrpcMetricTimerCustomizer() {
+    }
+
+    /**
+     * Creates a timer customizer that optionally publishes fixed SLO histogram buckets.
+     *
+     * @param histogram whether histogram buckets should be published
+     * @param slos bucket boundaries used when {@code histogram} is {@code true}
+     */
+    public static UnaryOperator<Timer.Builder> create(boolean histogram, List<Duration> slos) {
+        if (!histogram) {
+            return UnaryOperator.identity();
+        }
+        Duration[] buckets = slos.toArray(Duration[]::new);
+        return timer -> timer.serviceLevelObjectives(buckets);
+    }
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricTimerCustomizer.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricTimerCustomizer.java
@@ -19,19 +19,25 @@ public final class GrpcMetricTimerCustomizer {
      * Creates a timer customizer that optionally publishes Micrometer percentile histogram buckets.
      * <p>
      * When {@code histogram} is {@code true}, Micrometer's default percentile histogram is enabled
-     * via {@link Timer.Builder#publishPercentileHistogram()}. Optional SLO boundaries can be
-     * supplied to add extra buckets; {@link Timer.Builder#publishPercentiles(double...)} is never
-     * used.
+     * via {@link Timer.Builder#publishPercentileHistogram()}. Optional minimum/maximum expected
+     * values clamp which buckets are shipped (Micrometer timer defaults are {@code 1ms}..{@code 30s}
+     * when unset). Optional SLO boundaries can be supplied to add extra buckets;
+     * {@link Timer.Builder#publishPercentiles(double...)} is never used.
      *
      * @param histogram whether histogram buckets should be published
-     * @param slos optional extra SLO bucket boundaries; empty means Micrometer defaults only
+     * @param slos optional extra SLO bucket boundaries
+     * @param minimumExpectedValue optional lower bound for published histogram buckets
+     * @param maximumExpectedValue optional upper bound for published histogram buckets
      */
-    public static UnaryOperator<Timer.Builder> create(boolean histogram, Optional<List<Duration>> slos) {
+    public static UnaryOperator<Timer.Builder> create(boolean histogram, Optional<List<Duration>> slos,
+            Optional<Duration> minimumExpectedValue, Optional<Duration> maximumExpectedValue) {
         if (!histogram) {
             return UnaryOperator.identity();
         }
         return timer -> {
             Timer.Builder builder = timer.publishPercentileHistogram();
+            minimumExpectedValue.ifPresent(builder::minimumExpectedValue);
+            maximumExpectedValue.ifPresent(builder::maximumExpectedValue);
             if (slos.isPresent() && !slos.get().isEmpty()) {
                 builder.serviceLevelObjectives(slos.get().toArray(Duration[]::new));
             }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricTimerCustomizer.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricTimerCustomizer.java
@@ -2,6 +2,7 @@ package io.quarkus.micrometer.runtime.binder.grpc;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.UnaryOperator;
 
 import io.micrometer.core.instrument.Timer;
@@ -15,16 +16,26 @@ public final class GrpcMetricTimerCustomizer {
     }
 
     /**
-     * Creates a timer customizer that optionally publishes fixed SLO histogram buckets.
+     * Creates a timer customizer that optionally publishes Micrometer percentile histogram buckets.
+     * <p>
+     * When {@code histogram} is {@code true}, Micrometer's default percentile histogram is enabled
+     * via {@link Timer.Builder#publishPercentileHistogram()}. Optional SLO boundaries can be
+     * supplied to add extra buckets; {@link Timer.Builder#publishPercentiles(double...)} is never
+     * used.
      *
      * @param histogram whether histogram buckets should be published
-     * @param slos bucket boundaries used when {@code histogram} is {@code true}
+     * @param slos optional extra SLO bucket boundaries; empty means Micrometer defaults only
      */
-    public static UnaryOperator<Timer.Builder> create(boolean histogram, List<Duration> slos) {
+    public static UnaryOperator<Timer.Builder> create(boolean histogram, Optional<List<Duration>> slos) {
         if (!histogram) {
             return UnaryOperator.identity();
         }
-        Duration[] buckets = slos.toArray(Duration[]::new);
-        return timer -> timer.serviceLevelObjectives(buckets);
+        return timer -> {
+            Timer.Builder builder = timer.publishPercentileHistogram();
+            if (slos.isPresent() && !slos.get().isEmpty()) {
+                builder.serviceLevelObjectives(slos.get().toArray(Duration[]::new));
+            }
+            return builder;
+        };
     }
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricsClientInterceptor.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricsClientInterceptor.java
@@ -1,21 +1,28 @@
 package io.quarkus.micrometer.runtime.binder.grpc;
 
+import java.util.function.UnaryOperator;
+
 import jakarta.enterprise.inject.spi.Prioritized;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.interceptor.Interceptor.Priority;
 
+import io.grpc.Status;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.grpc.MetricCollectingClientInterceptor;
 import io.quarkus.grpc.GlobalInterceptor;
+import io.quarkus.micrometer.runtime.config.MicrometerConfig;
 
 @Singleton
 @GlobalInterceptor
 public class GrpcMetricsClientInterceptor extends MetricCollectingClientInterceptor implements Prioritized {
 
     @Inject
-    public GrpcMetricsClientInterceptor(MeterRegistry registry) {
-        super(registry);
+    public GrpcMetricsClientInterceptor(MeterRegistry registry, MicrometerConfig config) {
+        super(registry, UnaryOperator.identity(),
+                GrpcMetricTimerCustomizer.create(config.binder().grpcClient().histogram(),
+                        config.binder().grpcClient().slos()),
+                Status.Code.OK);
     }
 
     @Override

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricsClientInterceptor.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricsClientInterceptor.java
@@ -21,7 +21,9 @@ public class GrpcMetricsClientInterceptor extends MetricCollectingClientIntercep
     public GrpcMetricsClientInterceptor(MeterRegistry registry, MicrometerConfig config) {
         super(registry, UnaryOperator.identity(),
                 GrpcMetricTimerCustomizer.create(config.binder().grpcClient().histogram(),
-                        config.binder().grpcClient().slos()),
+                        config.binder().grpcClient().slos(),
+                        config.binder().grpcClient().minimumExpectedValue(),
+                        config.binder().grpcClient().maximumExpectedValue()),
                 Status.Code.OK);
     }
 

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricsServerInterceptor.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricsServerInterceptor.java
@@ -1,21 +1,28 @@
 package io.quarkus.micrometer.runtime.binder.grpc;
 
+import java.util.function.UnaryOperator;
+
 import jakarta.enterprise.inject.spi.Prioritized;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.interceptor.Interceptor.Priority;
 
+import io.grpc.Status;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.grpc.MetricCollectingServerInterceptor;
 import io.quarkus.grpc.GlobalInterceptor;
+import io.quarkus.micrometer.runtime.config.MicrometerConfig;
 
 @Singleton
 @GlobalInterceptor
 public class GrpcMetricsServerInterceptor extends MetricCollectingServerInterceptor implements Prioritized {
 
     @Inject
-    public GrpcMetricsServerInterceptor(MeterRegistry registry) {
-        super(registry);
+    public GrpcMetricsServerInterceptor(MeterRegistry registry, MicrometerConfig config) {
+        super(registry, UnaryOperator.identity(),
+                GrpcMetricTimerCustomizer.create(config.binder().grpcServer().histogram(),
+                        config.binder().grpcServer().slos()),
+                Status.Code.OK);
     }
 
     @Override

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricsServerInterceptor.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricsServerInterceptor.java
@@ -21,7 +21,9 @@ public class GrpcMetricsServerInterceptor extends MetricCollectingServerIntercep
     public GrpcMetricsServerInterceptor(MeterRegistry registry, MicrometerConfig config) {
         super(registry, UnaryOperator.identity(),
                 GrpcMetricTimerCustomizer.create(config.binder().grpcServer().histogram(),
-                        config.binder().grpcServer().slos()),
+                        config.binder().grpcServer().slos(),
+                        config.binder().grpcServer().minimumExpectedValue(),
+                        config.binder().grpcServer().maximumExpectedValue()),
                 Status.Code.OK);
     }
 

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/GrpcClientConfigGroup.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/GrpcClientConfigGroup.java
@@ -1,8 +1,11 @@
 package io.quarkus.micrometer.runtime.config;
 
+import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
 
 /**
  * Build / static runtime config for gRPC Client.
@@ -19,4 +22,24 @@ public interface GrpcClientConfigGroup extends MicrometerConfig.CapabilityEnable
      */
     @Override
     Optional<Boolean> enabled();
+
+    /**
+     * Whether to publish histogram buckets for gRPC client processing duration timers.
+     * <p>
+     * Disabled by default because histograms increase memory usage and metric cardinality.
+     * When enabled, aggregatable latency buckets are published (suitable for
+     * {@code histogram_quantile} in Prometheus).
+     */
+    @WithDefault("false")
+    boolean histogram();
+
+    /**
+     * Service level objective (bucket) boundaries for the processing duration histogram.
+     * <p>
+     * Only applied when {@link #histogram()} is {@code true}. Using a fixed set of buckets
+     * keeps metric cardinality bounded compared to Micrometer's full percentile histogram
+     * generator.
+     */
+    @WithDefault("5ms,10ms,25ms,50ms,100ms,250ms,500ms,1s,5s")
+    List<Duration> slos();
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/GrpcClientConfigGroup.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/GrpcClientConfigGroup.java
@@ -29,7 +29,8 @@ public interface GrpcClientConfigGroup extends MicrometerConfig.CapabilityEnable
      * Disabled by default because histograms increase memory usage and metric cardinality.
      * When enabled, Micrometer's default percentile histogram buckets are published (suitable
      * for {@code histogram_quantile} in Prometheus). Optional SLO boundaries can be added via
-     * {@link #slos()}.
+     * {@link #slos()}, and the published bucket range can be clamped via
+     * {@link #minimumExpectedValue()} / {@link #maximumExpectedValue()}.
      */
     @WithDefault("false")
     boolean histogram();
@@ -42,4 +43,22 @@ public interface GrpcClientConfigGroup extends MicrometerConfig.CapabilityEnable
      * histogram.
      */
     Optional<List<Duration>> slos();
+
+    /**
+     * Minimum expected duration observed by the processing duration timer.
+     * <p>
+     * Only applied when {@link #histogram()} is {@code true}. Sets a lower bound on which
+     * Micrometer percentile-histogram buckets are published. When unset, Micrometer's timer
+     * default ({@code 1ms}) is used.
+     */
+    Optional<Duration> minimumExpectedValue();
+
+    /**
+     * Maximum expected duration observed by the processing duration timer.
+     * <p>
+     * Only applied when {@link #histogram()} is {@code true}. Sets an upper bound on which
+     * Micrometer percentile-histogram buckets are published. Narrowing this value reduces
+     * metric cardinality. When unset, Micrometer's timer default ({@code 30s}) is used.
+     */
+    Optional<Duration> maximumExpectedValue();
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/GrpcClientConfigGroup.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/GrpcClientConfigGroup.java
@@ -27,19 +27,19 @@ public interface GrpcClientConfigGroup extends MicrometerConfig.CapabilityEnable
      * Whether to publish histogram buckets for gRPC client processing duration timers.
      * <p>
      * Disabled by default because histograms increase memory usage and metric cardinality.
-     * When enabled, aggregatable latency buckets are published (suitable for
-     * {@code histogram_quantile} in Prometheus).
+     * When enabled, Micrometer's default percentile histogram buckets are published (suitable
+     * for {@code histogram_quantile} in Prometheus). Optional SLO boundaries can be added via
+     * {@link #slos()}.
      */
     @WithDefault("false")
     boolean histogram();
 
     /**
-     * Service level objective (bucket) boundaries for the processing duration histogram.
+     * Optional service level objective (bucket) boundaries for the processing duration histogram.
      * <p>
-     * Only applied when {@link #histogram()} is {@code true}. Using a fixed set of buckets
-     * keeps metric cardinality bounded compared to Micrometer's full percentile histogram
-     * generator.
+     * Only applied when {@link #histogram()} is {@code true}. When unset, Micrometer's default
+     * percentile histogram buckets are used. When set, these SLO boundaries are added to that
+     * histogram.
      */
-    @WithDefault("5ms,10ms,25ms,50ms,100ms,250ms,500ms,1s,5s")
-    List<Duration> slos();
+    Optional<List<Duration>> slos();
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/GrpcServerConfigGroup.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/GrpcServerConfigGroup.java
@@ -1,8 +1,11 @@
 package io.quarkus.micrometer.runtime.config;
 
+import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
 
 /**
  * Build / static runtime config for gRPC Server.
@@ -19,4 +22,24 @@ public interface GrpcServerConfigGroup extends MicrometerConfig.CapabilityEnable
      */
     @Override
     Optional<Boolean> enabled();
+
+    /**
+     * Whether to publish histogram buckets for gRPC server processing duration timers.
+     * <p>
+     * Disabled by default because histograms increase memory usage and metric cardinality.
+     * When enabled, aggregatable latency buckets are published (suitable for
+     * {@code histogram_quantile} in Prometheus).
+     */
+    @WithDefault("false")
+    boolean histogram();
+
+    /**
+     * Service level objective (bucket) boundaries for the processing duration histogram.
+     * <p>
+     * Only applied when {@link #histogram()} is {@code true}. Using a fixed set of buckets
+     * keeps metric cardinality bounded compared to Micrometer's full percentile histogram
+     * generator.
+     */
+    @WithDefault("5ms,10ms,25ms,50ms,100ms,250ms,500ms,1s,5s")
+    List<Duration> slos();
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/GrpcServerConfigGroup.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/GrpcServerConfigGroup.java
@@ -29,7 +29,8 @@ public interface GrpcServerConfigGroup extends MicrometerConfig.CapabilityEnable
      * Disabled by default because histograms increase memory usage and metric cardinality.
      * When enabled, Micrometer's default percentile histogram buckets are published (suitable
      * for {@code histogram_quantile} in Prometheus). Optional SLO boundaries can be added via
-     * {@link #slos()}.
+     * {@link #slos()}, and the published bucket range can be clamped via
+     * {@link #minimumExpectedValue()} / {@link #maximumExpectedValue()}.
      */
     @WithDefault("false")
     boolean histogram();
@@ -42,4 +43,22 @@ public interface GrpcServerConfigGroup extends MicrometerConfig.CapabilityEnable
      * histogram.
      */
     Optional<List<Duration>> slos();
+
+    /**
+     * Minimum expected duration observed by the processing duration timer.
+     * <p>
+     * Only applied when {@link #histogram()} is {@code true}. Sets a lower bound on which
+     * Micrometer percentile-histogram buckets are published. When unset, Micrometer's timer
+     * default ({@code 1ms}) is used.
+     */
+    Optional<Duration> minimumExpectedValue();
+
+    /**
+     * Maximum expected duration observed by the processing duration timer.
+     * <p>
+     * Only applied when {@link #histogram()} is {@code true}. Sets an upper bound on which
+     * Micrometer percentile-histogram buckets are published. Narrowing this value reduces
+     * metric cardinality. When unset, Micrometer's timer default ({@code 30s}) is used.
+     */
+    Optional<Duration> maximumExpectedValue();
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/GrpcServerConfigGroup.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/GrpcServerConfigGroup.java
@@ -27,19 +27,19 @@ public interface GrpcServerConfigGroup extends MicrometerConfig.CapabilityEnable
      * Whether to publish histogram buckets for gRPC server processing duration timers.
      * <p>
      * Disabled by default because histograms increase memory usage and metric cardinality.
-     * When enabled, aggregatable latency buckets are published (suitable for
-     * {@code histogram_quantile} in Prometheus).
+     * When enabled, Micrometer's default percentile histogram buckets are published (suitable
+     * for {@code histogram_quantile} in Prometheus). Optional SLO boundaries can be added via
+     * {@link #slos()}.
      */
     @WithDefault("false")
     boolean histogram();
 
     /**
-     * Service level objective (bucket) boundaries for the processing duration histogram.
+     * Optional service level objective (bucket) boundaries for the processing duration histogram.
      * <p>
-     * Only applied when {@link #histogram()} is {@code true}. Using a fixed set of buckets
-     * keeps metric cardinality bounded compared to Micrometer's full percentile histogram
-     * generator.
+     * Only applied when {@link #histogram()} is {@code true}. When unset, Micrometer's default
+     * percentile histogram buckets are used. When set, these SLO boundaries are added to that
+     * histogram.
      */
-    @WithDefault("5ms,10ms,25ms,50ms,100ms,250ms,500ms,1s,5s")
-    List<Duration> slos();
+    Optional<List<Duration>> slos();
 }

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricTimerCustomizerTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricTimerCustomizerTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.micrometer.runtime.binder.grpc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.UnaryOperator;
+
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.distribution.CountAtBucket;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+class GrpcMetricTimerCustomizerTest {
+
+    @Test
+    void histogramDisabledDoesNotPublishBuckets() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+        UnaryOperator<Timer.Builder> customizer = GrpcMetricTimerCustomizer.create(false,
+                List.of(Duration.ofMillis(10), Duration.ofMillis(100)));
+
+        Timer timer = customizer.apply(Timer.builder("grpc.server.processing.duration")).register(registry);
+        timer.record(Duration.ofMillis(15));
+
+        assertEquals(0, timer.takeSnapshot().histogramCounts().length);
+    }
+
+    @Test
+    void histogramEnabledPublishesConfiguredSloBuckets() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+        List<Duration> slos = List.of(Duration.ofMillis(10), Duration.ofMillis(100), Duration.ofSeconds(1));
+        UnaryOperator<Timer.Builder> customizer = GrpcMetricTimerCustomizer.create(true, slos);
+
+        Timer timer = customizer.apply(Timer.builder("grpc.server.processing.duration")).register(registry);
+        timer.record(Duration.ofMillis(15));
+
+        CountAtBucket[] buckets = timer.takeSnapshot().histogramCounts();
+        assertTrue(buckets.length > 0);
+        assertTrue(Arrays.stream(buckets).anyMatch(bucket -> bucket.bucket(TimeUnit.MILLISECONDS) == 10));
+        assertTrue(Arrays.stream(buckets).anyMatch(bucket -> bucket.bucket(TimeUnit.MILLISECONDS) == 100));
+        assertTrue(Arrays.stream(buckets).anyMatch(bucket -> bucket.bucket(TimeUnit.SECONDS) == 1));
+    }
+}

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricTimerCustomizerTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricTimerCustomizerTest.java
@@ -1,59 +1,80 @@
 package io.quarkus.micrometer.runtime.binder.grpc;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.prometheus.PrometheusConfig;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
 
 class GrpcMetricTimerCustomizerTest {
 
+    Timer.Builder builder;
+
+    @BeforeEach
+    void setUp() {
+        builder = mock(Timer.Builder.class);
+        when(builder.publishPercentileHistogram()).thenReturn(builder);
+        when(builder.minimumExpectedValue(any())).thenReturn(builder);
+        when(builder.maximumExpectedValue(any())).thenReturn(builder);
+        when(builder.serviceLevelObjectives(any(Duration[].class))).thenReturn(builder);
+    }
+
     @Test
-    void histogramDisabledDoesNotPublishBuckets() {
-        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+    void histogramDisabledDoesNotCustomizeTimer() {
         UnaryOperator<Timer.Builder> customizer = GrpcMetricTimerCustomizer.create(false,
-                Optional.of(List.of(Duration.ofMillis(10), Duration.ofMillis(100))));
+                Optional.of(List.of(Duration.ofMillis(10))),
+                Optional.of(Duration.ofMillis(1)),
+                Optional.of(Duration.ofSeconds(1)));
 
-        Timer timer = customizer.apply(Timer.builder("grpc.server.processing.duration")).register(registry);
-        timer.record(Duration.ofMillis(15));
-
-        assertFalse(registry.scrape().contains("grpc_server_processing_duration_seconds_bucket"));
+        assertSame(builder, customizer.apply(builder));
+        verifyNoInteractions(builder);
     }
 
     @Test
     void histogramEnabledUsesMicrometerPercentileHistogramDefaults() {
-        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
-        UnaryOperator<Timer.Builder> customizer = GrpcMetricTimerCustomizer.create(true, Optional.empty());
+        UnaryOperator<Timer.Builder> customizer = GrpcMetricTimerCustomizer.create(true, Optional.empty(),
+                Optional.empty(), Optional.empty());
 
-        Timer timer = customizer.apply(Timer.builder("grpc.server.processing.duration")).register(registry);
-        timer.record(Duration.ofMillis(15));
-
-        String scrape = registry.scrape();
-        assertTrue(scrape.contains("# TYPE grpc_server_processing_duration_seconds histogram"), scrape);
-        assertTrue(scrape.contains("grpc_server_processing_duration_seconds_bucket{"), scrape);
-        assertTrue(scrape.contains("le=\"+Inf\""), scrape);
+        assertSame(builder, customizer.apply(builder));
+        verify(builder).publishPercentileHistogram();
+        verify(builder, never()).minimumExpectedValue(any());
+        verify(builder, never()).maximumExpectedValue(any());
+        verify(builder, never()).serviceLevelObjectives(any(Duration[].class));
     }
 
     @Test
     void histogramEnabledAddsOptionalSloBuckets() {
-        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
         List<Duration> slos = List.of(Duration.ofMillis(10), Duration.ofMillis(100), Duration.ofSeconds(1));
-        UnaryOperator<Timer.Builder> customizer = GrpcMetricTimerCustomizer.create(true, Optional.of(slos));
+        UnaryOperator<Timer.Builder> customizer = GrpcMetricTimerCustomizer.create(true, Optional.of(slos),
+                Optional.empty(), Optional.empty());
 
-        Timer timer = customizer.apply(Timer.builder("grpc.server.processing.duration")).register(registry);
-        timer.record(Duration.ofMillis(15));
+        assertSame(builder, customizer.apply(builder));
+        verify(builder).publishPercentileHistogram();
+        verify(builder).serviceLevelObjectives(slos.toArray(Duration[]::new));
+    }
 
-        String scrape = registry.scrape();
-        assertTrue(scrape.contains("le=\"0.01\""), scrape);
-        assertTrue(scrape.contains("le=\"0.1\""), scrape);
-        assertTrue(scrape.contains("le=\"1.0\""), scrape);
+    @Test
+    void histogramEnabledAppliesExpectedValueOverrides() {
+        Duration min = Duration.ofMillis(5);
+        Duration max = Duration.ofMillis(100);
+        UnaryOperator<Timer.Builder> customizer = GrpcMetricTimerCustomizer.create(true, Optional.empty(),
+                Optional.of(min), Optional.of(max));
+
+        assertSame(builder, customizer.apply(builder));
+        verify(builder).publishPercentileHistogram();
+        verify(builder).minimumExpectedValue(min);
+        verify(builder).maximumExpectedValue(max);
     }
 }

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricTimerCustomizerTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/grpc/GrpcMetricTimerCustomizerTest.java
@@ -1,48 +1,59 @@
 package io.quarkus.micrometer.runtime.binder.grpc;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.util.Optional;
 import java.util.function.UnaryOperator;
 
 import org.junit.jupiter.api.Test;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.core.instrument.distribution.CountAtBucket;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
 
 class GrpcMetricTimerCustomizerTest {
 
     @Test
     void histogramDisabledDoesNotPublishBuckets() {
-        MeterRegistry registry = new SimpleMeterRegistry();
+        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
         UnaryOperator<Timer.Builder> customizer = GrpcMetricTimerCustomizer.create(false,
-                List.of(Duration.ofMillis(10), Duration.ofMillis(100)));
+                Optional.of(List.of(Duration.ofMillis(10), Duration.ofMillis(100))));
 
         Timer timer = customizer.apply(Timer.builder("grpc.server.processing.duration")).register(registry);
         timer.record(Duration.ofMillis(15));
 
-        assertEquals(0, timer.takeSnapshot().histogramCounts().length);
+        assertFalse(registry.scrape().contains("grpc_server_processing_duration_seconds_bucket"));
     }
 
     @Test
-    void histogramEnabledPublishesConfiguredSloBuckets() {
-        MeterRegistry registry = new SimpleMeterRegistry();
-        List<Duration> slos = List.of(Duration.ofMillis(10), Duration.ofMillis(100), Duration.ofSeconds(1));
-        UnaryOperator<Timer.Builder> customizer = GrpcMetricTimerCustomizer.create(true, slos);
+    void histogramEnabledUsesMicrometerPercentileHistogramDefaults() {
+        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        UnaryOperator<Timer.Builder> customizer = GrpcMetricTimerCustomizer.create(true, Optional.empty());
 
         Timer timer = customizer.apply(Timer.builder("grpc.server.processing.duration")).register(registry);
         timer.record(Duration.ofMillis(15));
 
-        CountAtBucket[] buckets = timer.takeSnapshot().histogramCounts();
-        assertTrue(buckets.length > 0);
-        assertTrue(Arrays.stream(buckets).anyMatch(bucket -> bucket.bucket(TimeUnit.MILLISECONDS) == 10));
-        assertTrue(Arrays.stream(buckets).anyMatch(bucket -> bucket.bucket(TimeUnit.MILLISECONDS) == 100));
-        assertTrue(Arrays.stream(buckets).anyMatch(bucket -> bucket.bucket(TimeUnit.SECONDS) == 1));
+        String scrape = registry.scrape();
+        assertTrue(scrape.contains("# TYPE grpc_server_processing_duration_seconds histogram"), scrape);
+        assertTrue(scrape.contains("grpc_server_processing_duration_seconds_bucket{"), scrape);
+        assertTrue(scrape.contains("le=\"+Inf\""), scrape);
+    }
+
+    @Test
+    void histogramEnabledAddsOptionalSloBuckets() {
+        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        List<Duration> slos = List.of(Duration.ofMillis(10), Duration.ofMillis(100), Duration.ofSeconds(1));
+        UnaryOperator<Timer.Builder> customizer = GrpcMetricTimerCustomizer.create(true, Optional.of(slos));
+
+        Timer timer = customizer.apply(Timer.builder("grpc.server.processing.duration")).register(registry);
+        timer.record(Duration.ofMillis(15));
+
+        String scrape = registry.scrape();
+        assertTrue(scrape.contains("le=\"0.01\""), scrape);
+        assertTrue(scrape.contains("le=\"0.1\""), scrape);
+        assertTrue(scrape.contains("le=\"1.0\""), scrape);
     }
 }

--- a/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/GrpcMetricsHistogramCustomBucketsTest.java
+++ b/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/GrpcMetricsHistogramCustomBucketsTest.java
@@ -1,0 +1,63 @@
+package io.quarkus.grpc.example.interceptors;
+
+import static io.restassured.RestAssured.get;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(GrpcMetricsHistogramCustomBucketsTestProfile.class)
+class GrpcMetricsHistogramCustomBucketsTest {
+
+    private static final Pattern SERVER_BUCKETS = Pattern
+            .compile("grpc_server_processing_duration_seconds_bucket\\{[^}]*le=\"([^\"]+)\"");
+    private static final Pattern CLIENT_BUCKETS = Pattern
+            .compile("grpc_client_processing_duration_seconds_bucket\\{[^}]*le=\"([^\"]+)\"");
+
+    @Test
+    void serverHistogramRespectsMinMaxAndCustomSlos() {
+        get("/hello/blocking/neo").then().statusCode(200);
+
+        String metrics = get("/q/metrics").then().statusCode(200).extract().asString();
+
+        assertCustomBuckets(metrics, SERVER_BUCKETS, "grpc_server_processing_duration_seconds");
+    }
+
+    @Test
+    void clientHistogramRespectsMinMaxAndCustomSlos() {
+        get("/hello/blocking/neo").then().statusCode(200);
+
+        String metrics = get("/q/metrics").then().statusCode(200).extract().asString();
+
+        assertCustomBuckets(metrics, CLIENT_BUCKETS, "grpc_client_processing_duration_seconds");
+    }
+
+    private static void assertCustomBuckets(String metrics, Pattern bucketPattern, String metricName) {
+        assertThat(metrics)
+                .contains("# TYPE " + metricName + " histogram")
+                .contains(metricName + "_bucket{");
+
+        var bucketBounds = bucketPattern.matcher(metrics).results()
+                .map(match -> match.group(1))
+                .toList();
+
+        assertThat(bucketBounds)
+                .as("custom SLO buckets for %s", metricName)
+                .contains("0.025", "0.05", "+Inf");
+
+        // Micrometer's default percentile-histogram range is ~1ms..30s. With min=10ms / max=100ms,
+        // buckets outside that clamped range (except +Inf and explicit SLOs) must not appear.
+        assertThat(bucketBounds)
+                .as("clamped bucket range for %s", metricName)
+                .doesNotContain("0.001", "1.0", "10.0", "30.0");
+
+        assertThat(bucketBounds.stream().filter(bound -> !"+Inf".equals(bound)).map(Double::parseDouble))
+                .as("finite buckets for %s stay within the configured min/max window", metricName)
+                .allSatisfy(bound -> assertThat(bound).isBetween(0.01, 0.1));
+    }
+}

--- a/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/GrpcMetricsHistogramCustomBucketsTestProfile.java
+++ b/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/GrpcMetricsHistogramCustomBucketsTestProfile.java
@@ -1,0 +1,20 @@
+package io.quarkus.grpc.example.interceptors;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class GrpcMetricsHistogramCustomBucketsTestProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "quarkus.micrometer.binder.grpc-server.histogram", "true",
+                "quarkus.micrometer.binder.grpc-server.slos", "25ms,50ms",
+                "quarkus.micrometer.binder.grpc-server.minimum-expected-value", "10ms",
+                "quarkus.micrometer.binder.grpc-server.maximum-expected-value", "100ms",
+                "quarkus.micrometer.binder.grpc-client.histogram", "true",
+                "quarkus.micrometer.binder.grpc-client.slos", "25ms,50ms",
+                "quarkus.micrometer.binder.grpc-client.minimum-expected-value", "10ms",
+                "quarkus.micrometer.binder.grpc-client.maximum-expected-value", "100ms");
+    }
+}

--- a/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/GrpcMetricsHistogramTest.java
+++ b/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/GrpcMetricsHistogramTest.java
@@ -1,0 +1,30 @@
+package io.quarkus.grpc.example.interceptors;
+
+import static io.restassured.RestAssured.get;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(GrpcMetricsHistogramTestProfile.class)
+class GrpcMetricsHistogramTest {
+
+    @Test
+    void processingDurationPublishesHistogramBuckets() {
+        get("/hello/blocking/neo").then().statusCode(200);
+
+        String metrics = get("/q/metrics").then().statusCode(200).extract().asString();
+
+        assertThat(metrics)
+                .contains("# TYPE grpc_server_processing_duration_seconds histogram")
+                .contains("grpc_server_processing_duration_seconds_bucket{")
+                .contains("le=\"0.005\"")
+                .contains("le=\"0.1\"")
+                .contains("le=\"1.0\"")
+                .contains("# TYPE grpc_client_processing_duration_seconds histogram")
+                .contains("grpc_client_processing_duration_seconds_bucket{");
+    }
+}

--- a/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/GrpcMetricsHistogramTest.java
+++ b/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/GrpcMetricsHistogramTest.java
@@ -21,9 +21,7 @@ class GrpcMetricsHistogramTest {
         assertThat(metrics)
                 .contains("# TYPE grpc_server_processing_duration_seconds histogram")
                 .contains("grpc_server_processing_duration_seconds_bucket{")
-                .contains("le=\"0.005\"")
-                .contains("le=\"0.1\"")
-                .contains("le=\"1.0\"")
+                .contains("le=\"+Inf\"")
                 .contains("# TYPE grpc_client_processing_duration_seconds histogram")
                 .contains("grpc_client_processing_duration_seconds_bucket{");
     }

--- a/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/GrpcMetricsHistogramTest.java
+++ b/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/GrpcMetricsHistogramTest.java
@@ -13,7 +13,7 @@ import io.quarkus.test.junit.TestProfile;
 class GrpcMetricsHistogramTest {
 
     @Test
-    void processingDurationPublishesHistogramBuckets() {
+    void serverProcessingDurationPublishesHistogramBuckets() {
         get("/hello/blocking/neo").then().statusCode(200);
 
         String metrics = get("/q/metrics").then().statusCode(200).extract().asString();
@@ -21,8 +21,18 @@ class GrpcMetricsHistogramTest {
         assertThat(metrics)
                 .contains("# TYPE grpc_server_processing_duration_seconds histogram")
                 .contains("grpc_server_processing_duration_seconds_bucket{")
-                .contains("le=\"+Inf\"")
+                .contains("le=\"+Inf\"");
+    }
+
+    @Test
+    void clientProcessingDurationPublishesHistogramBuckets() {
+        get("/hello/blocking/neo").then().statusCode(200);
+
+        String metrics = get("/q/metrics").then().statusCode(200).extract().asString();
+
+        assertThat(metrics)
                 .contains("# TYPE grpc_client_processing_duration_seconds histogram")
-                .contains("grpc_client_processing_duration_seconds_bucket{");
+                .contains("grpc_client_processing_duration_seconds_bucket{")
+                .contains("le=\"+Inf\"");
     }
 }

--- a/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/GrpcMetricsHistogramTestProfile.java
+++ b/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/GrpcMetricsHistogramTestProfile.java
@@ -1,0 +1,16 @@
+package io.quarkus.grpc.example.interceptors;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class GrpcMetricsHistogramTestProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "quarkus.micrometer.binder.grpc-server.histogram", "true",
+                "quarkus.micrometer.binder.grpc-client.histogram", "true",
+                "quarkus.micrometer.binder.grpc-server.slos", "5ms,10ms,25ms,50ms,100ms,1s",
+                "quarkus.micrometer.binder.grpc-client.slos", "5ms,10ms,25ms,50ms,100ms,1s");
+    }
+}

--- a/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/GrpcMetricsHistogramTestProfile.java
+++ b/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/GrpcMetricsHistogramTestProfile.java
@@ -9,8 +9,6 @@ public class GrpcMetricsHistogramTestProfile implements QuarkusTestProfile {
     public Map<String, String> getConfigOverrides() {
         return Map.of(
                 "quarkus.micrometer.binder.grpc-server.histogram", "true",
-                "quarkus.micrometer.binder.grpc-client.histogram", "true",
-                "quarkus.micrometer.binder.grpc-server.slos", "5ms,10ms,25ms,50ms,100ms,1s",
-                "quarkus.micrometer.binder.grpc-client.slos", "5ms,10ms,25ms,50ms,100ms,1s");
+                "quarkus.micrometer.binder.grpc-client.histogram", "true");
     }
 }


### PR DESCRIPTION
gRPC processing duration metrics currently export only summary-style `_count`/`_sum`/`_max`, which is not enough for aggregatable latency analysis across instances. This adds an opt-in Micrometer percentile histogram (`publishPercentileHistogram()`) so Prometheus `histogram_quantile` works. Histograms stay off by default because of memory and cardinality cost.

When enabled, Micrometer's default timer bucket range is used (`1ms`..`30s`). Optional `slos` can add extra boundaries, and optional `minimum-expected-value` / `maximum-expected-value` can clamp the published range to reduce cardinality — addressing incomplete histograms seen with large tag combinations (service/method/statusCode).

Fixes: #45855

Release note: Opt-in aggregatable histogram buckets for gRPC Micrometer processing-duration metrics, with optional SLO and min/max expected-value controls