### PR TITLE
Fix Lambda poll loop shutdown SocketException logging

### DIFF
--- a/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AbstractLambdaPollLoop.java
+++ b/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AbstractLambdaPollLoop.java
@@ -151,6 +151,10 @@ public abstract class AbstractLambdaPollLoop {
                                     }
                                 }
                             } catch (Exception e) {
+                                if (!running.get()) {
+                                    // shutdown disconnected the request while we were processing it
+                                    return;
+                                }
                                 if (abortGracefully(e)) {
                                     return;
                                 }
@@ -164,6 +168,11 @@ public abstract class AbstractLambdaPollLoop {
                             }
 
                         } catch (Exception e) {
+                            if (!running.get()) {
+                                // shutdown task set running=false and disconnected the long-poll;
+                                // SocketException here is expected (e.g. with Lambda extension layers)
+                                return;
+                            }
                             if (!abortGracefully(e))
                                 log.error("Error running lambda (" + launchMode + ")", e);
                             Application app = Application.currentApplication();

--- a/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AbstractLambdaPollLoop.java
+++ b/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AbstractLambdaPollLoop.java
@@ -150,6 +150,10 @@ public abstract class AbstractLambdaPollLoop {
                                     }
                                 }
                             } catch (Exception e) {
+                                if (!running.get()) {
+                                    // shutdown disconnected the request while we were processing it
+                                    return;
+                                }
                                 if (abortGracefully(e)) {
                                     return;
                                 }
@@ -163,6 +167,11 @@ public abstract class AbstractLambdaPollLoop {
                             }
 
                         } catch (Exception e) {
+                            if (!running.get()) {
+                                // shutdown task set running=false and disconnected the long-poll;
+                                // SocketException here is expected (e.g. with Lambda extension layers)
+                                return;
+                            }
                             if (!abortGracefully(e))
                                 log.error("Error running lambda (" + launchMode + ")", e);
                             Application app = Application.currentApplication();


### PR DESCRIPTION
When a Quarkus Lambda function shuts down while long-polling the Runtime API,
disconnecting the HTTP connection can surface as SocketException. With
extension layers (AppConfig, OTel) this race is more likely and produced
noisy ERROR logs during the SHUTDOWN phase even though invocation succeeded.

This change mirrors the existing graceful shutdown handling used for
openConnection failures: if running is already false, exit quietly
instead of logging Error running lambda.

- Fixes: #49962

