### PR TITLE
Fix `@QuarkusIntegrationTest` Dev Services result handling

### DIFF
--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -40,6 +40,7 @@ import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.utils.BuildToolHelper;
 import io.quarkus.bootstrap.workspace.ArtifactSources;
 import io.quarkus.bootstrap.workspace.SourceDir;
+import io.quarkus.deployment.builditem.DevServicesAdditionalConfigBuildItem;
 import io.quarkus.deployment.builditem.DevServicesCustomizerBuildItem;
 import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesNetworkIdBuildItem;
@@ -249,7 +250,8 @@ public final class IntegrationTestUtil {
                 propertyMap.put(s, s2);
             }
         }, DevServicesLauncherConfigResultBuildItem.class.getName(), DevServicesNetworkIdBuildItem.class.getName(),
-                DevServicesRegistryBuildItem.class.getName(), DevServicesCustomizerBuildItem.class.getName());
+                DevServicesRegistryBuildItem.class.getName(), DevServicesCustomizerBuildItem.class.getName(),
+                DevServicesAdditionalConfigBuildItem.class.getName());
 
         networkId = propertyMap.get("quarkus.test.container.network");
         boolean manageNetwork = false;

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/NativeDevServicesHandler.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/NativeDevServicesHandler.java
@@ -1,43 +1,92 @@
 package io.quarkus.test.junit;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
-import io.quarkus.builder.BuildResult;
-import io.quarkus.deployment.builditem.DevServicesAdditionalConfigBuildItem;
-import io.quarkus.deployment.builditem.DevServicesCustomizerBuildItem;
-import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
-import io.quarkus.deployment.builditem.DevServicesNetworkIdBuildItem;
-import io.quarkus.deployment.builditem.DevServicesRegistryBuildItem;
-import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+public class NativeDevServicesHandler implements BiConsumer<Object, Object> {
 
-public class NativeDevServicesHandler implements BiConsumer<Object, BuildResult> {
+    private static final String DEV_SERVICES_ADDITIONAL_CONFIG = "io.quarkus.deployment.builditem.DevServicesAdditionalConfigBuildItem";
+    private static final String DEV_SERVICES_CUSTOMIZER = "io.quarkus.deployment.builditem.DevServicesCustomizerBuildItem";
+    private static final String DEV_SERVICES_LAUNCHER_CONFIG = "io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem";
+    private static final String DEV_SERVICES_NETWORK_ID = "io.quarkus.deployment.builditem.DevServicesNetworkIdBuildItem";
+    private static final String DEV_SERVICES_REGISTRY = "io.quarkus.deployment.builditem.DevServicesRegistryBuildItem";
+    private static final String DEV_SERVICES_RESULT = "io.quarkus.deployment.builditem.DevServicesResultBuildItem";
+
     @Override
-    public void accept(Object o, BuildResult buildResult) {
+    @SuppressWarnings("unchecked")
+    public void accept(Object o, Object buildResult) {
         BiConsumer<String, String> propertyConsumer = (BiConsumer<String, String>) o;
 
-        DevServicesNetworkIdBuildItem compose = buildResult.consumeOptional(DevServicesNetworkIdBuildItem.class);
-        DevServicesLauncherConfigResultBuildItem devServicesProperties = buildResult
-                .consume(DevServicesLauncherConfigResultBuildItem.class);
-        for (var entry : devServicesProperties.getConfig().entrySet()) {
+        Object compose = consumeOptional(buildResult, DEV_SERVICES_NETWORK_ID);
+        Object devServicesProperties = consume(buildResult, DEV_SERVICES_LAUNCHER_CONFIG);
+        for (var entry : ((Map<String, String>) invoke(devServicesProperties, "getConfig")).entrySet()) {
             propertyConsumer.accept(entry.getKey(), entry.getValue());
         }
-        if (compose != null && compose.getNetworkId() != null) {
-            propertyConsumer.accept("quarkus.test.container.network", compose.getNetworkId());
+        if (compose != null && invoke(compose, "getNetworkId") != null) {
+            propertyConsumer.accept("quarkus.test.container.network", (String) invoke(compose, "getNetworkId"));
         }
 
-        List<DevServicesResultBuildItem> devServices = buildResult.consumeMulti(DevServicesResultBuildItem.class);
-        DevServicesRegistryBuildItem devServicesRegistry = buildResult.consumeOptional(DevServicesRegistryBuildItem.class);
-        List<DevServicesCustomizerBuildItem> customizers = buildResult.consumeMulti(DevServicesCustomizerBuildItem.class);
-        List<DevServicesAdditionalConfigBuildItem> additionalConfigBuildItems = buildResult
-                .consumeMulti(DevServicesAdditionalConfigBuildItem.class);
+        List<?> devServices = consumeMulti(buildResult, DEV_SERVICES_RESULT);
+        Object devServicesRegistry = consumeOptional(buildResult, DEV_SERVICES_REGISTRY);
+        List<?> customizers = consumeMulti(buildResult, DEV_SERVICES_CUSTOMIZER);
+        List<?> additionalConfigBuildItems = consumeMulti(buildResult, DEV_SERVICES_ADDITIONAL_CONFIG);
         if (devServicesRegistry != null) {
-            DevServicesRegistryBuildItem.DevServicesStartResult startResult = devServicesRegistry.startAll(devServices,
-                    customizers, additionalConfigBuildItems, null);
-            for (Map.Entry<String, String> entry : startResult.configs().entrySet()) {
+            Object startResult = invoke(devServicesRegistry, "startAll",
+                    new Class<?>[] { Collection.class, List.class, List.class, ClassLoader.class },
+                    devServices, customizers, additionalConfigBuildItems, null);
+            for (Map.Entry<String, String> entry : ((Map<String, String>) invoke(startResult, "configs")).entrySet()) {
                 propertyConsumer.accept(entry.getKey(), entry.getValue());
             }
+        }
+    }
+
+    private static Object consume(Object buildResult, String className) {
+        return invoke(buildResult, "consume", new Class<?>[] { Class.class }, deploymentClass(buildResult, className));
+    }
+
+    private static Object consumeOptional(Object buildResult, String className) {
+        return invoke(buildResult, "consumeOptional", new Class<?>[] { Class.class },
+                deploymentClass(buildResult, className));
+    }
+
+    private static List<?> consumeMulti(Object buildResult, String className) {
+        return (List<?>) invoke(buildResult, "consumeMulti", new Class<?>[] { Class.class },
+                deploymentClass(buildResult, className));
+    }
+
+    private static Class<?> deploymentClass(Object buildResult, String className) {
+        try {
+            return Class.forName(className, false, buildResult.getClass().getClassLoader());
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Failed to load Quarkus build item class " + className, e);
+        }
+    }
+
+    private static Object invoke(Object target, String methodName, Object... arguments) {
+        Class<?>[] parameterTypes = new Class<?>[arguments.length];
+        for (int i = 0; i < arguments.length; i++) {
+            parameterTypes[i] = arguments[i].getClass();
+        }
+        return invoke(target, methodName, parameterTypes, arguments);
+    }
+
+    private static Object invoke(Object target, String methodName, Class<?>[] parameterTypes, Object... arguments) {
+        try {
+            return target.getClass().getMethod(methodName, parameterTypes).invoke(target, arguments);
+        } catch (IllegalAccessException | NoSuchMethodException e) {
+            throw new RuntimeException("Failed to invoke " + target.getClass().getName() + "." + methodName, e);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw new RuntimeException("Failed to invoke " + target.getClass().getName() + "." + methodName, cause);
         }
     }
 }


### PR DESCRIPTION
`@QuarkusIntegrationTest` runs a custom augmentation step to collect Dev Services launch properties before starting the packaged application. The custom build result is produced inside the augmentation classloader, but `NativeDevServicesHandler` accepted `BuildResult` and deployment build item types from the test framework classloader.

That can fail with `ClassCastException` when the same Quarkus classes are loaded by both classloaders.

Change `NativeDevServicesHandler` to consume the custom build result via reflection using the result object's classloader, matching the classloader boundary used by the augmentation step. Also request `DevServicesAdditionalConfigBuildItem` from `IntegrationTestUtil` because the handler consumes it when starting registered Dev Services.

This keeps `@QuarkusIntegrationTest` Dev Services setup working when custom augmentation results cross the augmentation/test-framework classloader boundary.