### PR TITLE
Require Gradle 9.6 for Quarkus Gradle plugins

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -60,6 +60,9 @@
         <!-- These 2 properties are used by CreateProjectMojo to add the Maven Wrapper -->
         <proposed-maven-version>3.9.16</proposed-maven-version>
         <maven-wrapper.version>3.3.4</maven-wrapper.version>
+        <!-- Supported Gradle versions, interpreted as a version range -->
+        <minimum-gradle-version>9.6</minimum-gradle-version>
+        <supported-gradle-versions>[9.6,)</supported-gradle-versions>
         <gradle-wrapper.version>9.6.0</gradle-wrapper.version>
         <quarkus-gradle-plugin.version>${project.version}</quarkus-gradle-plugin.version>
         <quarkus-maven-plugin.version>${project.version}</quarkus-maven-plugin.version>

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -40,7 +40,6 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry;
-import org.gradle.util.GradleVersion;
 
 import io.quarkus.gradle.actions.BeforeTestAction;
 import io.quarkus.gradle.dependency.ApplicationDeploymentClasspathBuilder;
@@ -144,7 +143,7 @@ public class QuarkusPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        verifyGradleVersion();
+        GradleVersionSupport.requireMinimumGradleVersion();
 
         // Apply the `java` plugin
         project.getPluginManager().apply(JavaPlugin.class);
@@ -724,13 +723,6 @@ public class QuarkusPlugin implements Plugin<Project> {
 
     private void registerModel() {
         registry.register(new GradleApplicationModelBuilder());
-    }
-
-    private void verifyGradleVersion() {
-        if (GradleVersion.current().compareTo(GradleVersion.version("6.1")) < 0) {
-            throw new GradleException("Quarkus plugin requires Gradle 6.1 or later. Current version is: " +
-                    GradleVersion.current());
-        }
     }
 
     private void configureBuildNativeTask(Project project) {

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionPlugin.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionPlugin.java
@@ -23,6 +23,7 @@ import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.extension.gradle.dependency.DeploymentClasspathBuilder;
 import io.quarkus.extension.gradle.tasks.ExtensionDescriptorTask;
 import io.quarkus.extension.gradle.tasks.ValidateExtensionTask;
+import io.quarkus.gradle.GradleVersionSupport;
 import io.quarkus.gradle.dependency.ApplicationDeploymentClasspathBuilder;
 import io.quarkus.gradle.extension.ExtensionConstants;
 import io.quarkus.gradle.tooling.ToolingUtils;
@@ -45,6 +46,8 @@ public class QuarkusExtensionPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        GradleVersionSupport.requireMinimumGradleVersion();
+
         final QuarkusExtensionConfiguration quarkusExt = project.getExtensions().create(EXTENSION_CONFIGURATION_NAME,
                 QuarkusExtensionConfiguration.class);
 

--- a/devtools/gradle/gradle-model/build.gradle.kts
+++ b/devtools/gradle/gradle-model/build.gradle.kts
@@ -1,3 +1,7 @@
+import java.util.Locale
+import javax.xml.XMLConstants
+import javax.xml.parsers.DocumentBuilderFactory
+
 plugins {
     id("io.quarkus.devtools.java-library")
 }
@@ -15,6 +19,15 @@ java {
     withJavadocJar()
 }
 
+val generateGradleVersionSupport = tasks.register<GenerateGradleVersionSupport>("generateGradleVersionSupport") {
+    buildParentPom.set(layout.projectDirectory.file("../../../build-parent/pom.xml"))
+    outputDirectory.set(layout.buildDirectory.dir("generated/sources/gradle-version-support/java/main"))
+}
+
+sourceSets.named("main") {
+    java.srcDir(generateGradleVersionSupport)
+}
+
 // to generate reproducible jars
 tasks.withType<Jar>().configureEach {
     isPreserveFileTimestamps = false
@@ -26,4 +39,81 @@ publishing {
         artifactId = "quarkus-gradle-model"
         from(components["java"])
     }
+}
+
+@CacheableTask
+abstract class GenerateGradleVersionSupport : DefaultTask() {
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val buildParentPom: RegularFileProperty
+
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    @TaskAction
+    fun generate() {
+        val properties = readProperties()
+        val minimumGradleVersion = required(properties, "minimum-gradle-version")
+        val supportedGradleVersions = required(properties, "supported-gradle-versions")
+        val packageDirectory = outputDirectory.dir("io/quarkus/gradle").get().asFile
+        packageDirectory.mkdirs()
+        packageDirectory.resolve("GeneratedGradleVersionSupport.java").writeText(
+            """
+            package io.quarkus.gradle;
+
+            final class GeneratedGradleVersionSupport {
+
+                static final String MINIMUM_GRADLE_VERSION = "${javaString(minimumGradleVersion)}";
+                static final String SUPPORTED_GRADLE_VERSIONS = "${javaString(supportedGradleVersions)}";
+
+                private GeneratedGradleVersionSupport() {
+                }
+            }
+            """.trimIndent() + "\n"
+        )
+    }
+
+    private fun readProperties(): Map<String, String> {
+        val factory = DocumentBuilderFactory.newInstance()
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+        factory.isNamespaceAware = true
+        val document = factory.newDocumentBuilder().parse(buildParentPom.get().asFile)
+        val nodes = document.getElementsByTagNameNS("*", "properties")
+        val result = linkedMapOf<String, String>()
+        for (i in 0 until nodes.length) {
+            val properties = nodes.item(i).childNodes
+            for (j in 0 until properties.length) {
+                val property = properties.item(j)
+                val name = property.localName ?: property.nodeName
+                val value = property.textContent?.trim()
+                if (name != null && !value.isNullOrEmpty()) {
+                    result[name] = value
+                }
+            }
+        }
+        return result
+    }
+
+    private fun required(properties: Map<String, String>, name: String): String =
+        properties[name] ?: throw GradleException(
+            "Required property '$name' is missing from ${buildParentPom.get().asFile}"
+        )
+
+    private fun javaString(value: String): String =
+        value.flatMap { character ->
+            when (character) {
+                '\\' -> "\\\\".toList()
+                '"' -> "\\\"".toList()
+                '\n' -> "\\n".toList()
+                '\r' -> "\\r".toList()
+                '\t' -> "\\t".toList()
+                else -> if (character.code < 0x20) {
+                    "\\u%04x".format(Locale.ROOT, character.code).toList()
+                } else {
+                    listOf(character)
+                }
+            }
+        }.joinToString("")
 }

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/GradleVersionSupport.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/GradleVersionSupport.java
@@ -1,0 +1,27 @@
+package io.quarkus.gradle;
+
+import org.gradle.api.GradleException;
+import org.gradle.util.GradleVersion;
+
+public final class GradleVersionSupport {
+
+    public static final String MINIMUM_GRADLE_VERSION = GeneratedGradleVersionSupport.MINIMUM_GRADLE_VERSION;
+
+    public static final String SUPPORTED_GRADLE_VERSIONS = GeneratedGradleVersionSupport.SUPPORTED_GRADLE_VERSIONS;
+
+    private static final GradleVersion MINIMUM_GRADLE = GradleVersion.version(MINIMUM_GRADLE_VERSION);
+
+    private GradleVersionSupport() {
+    }
+
+    public static void requireMinimumGradleVersion() {
+        requireMinimumGradleVersion(GradleVersion.current());
+    }
+
+    static void requireMinimumGradleVersion(GradleVersion currentVersion) {
+        if (currentVersion.compareTo(MINIMUM_GRADLE) < 0) {
+            throw new GradleException("Quarkus Gradle plugins require Gradle " + MINIMUM_GRADLE_VERSION
+                    + " or later. Current version is: " + currentVersion);
+        }
+    }
+}

--- a/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/GradleVersionSupportTest.java
+++ b/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/GradleVersionSupportTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.gradle.api.GradleException;
+import org.gradle.util.GradleVersion;
+import org.junit.jupiter.api.Test;
+
+public class GradleVersionSupportTest {
+
+    @Test
+    public void shouldExposeSupportedGradleVersions() {
+        assertThat(GradleVersionSupport.MINIMUM_GRADLE_VERSION).isEqualTo("9.6");
+        assertThat(GradleVersionSupport.SUPPORTED_GRADLE_VERSIONS).isEqualTo("[9.6,)");
+    }
+
+    @Test
+    public void shouldAcceptMinimumGradleVersion() {
+        GradleVersionSupport.requireMinimumGradleVersion(GradleVersion.version("9.6"));
+    }
+
+    @Test
+    public void shouldAcceptLaterGradleVersion() {
+        GradleVersionSupport.requireMinimumGradleVersion(GradleVersion.version("10.0"));
+    }
+
+    @Test
+    public void shouldRejectOlderGradleVersion() {
+        assertThatThrownBy(() -> GradleVersionSupport.requireMinimumGradleVersion(GradleVersion.version("9.5.1")))
+                .isInstanceOf(GradleException.class)
+                .hasMessageContaining("Quarkus Gradle plugins require Gradle 9.6 or later")
+                .hasMessageContaining("Current version is: Gradle 9.5.1");
+    }
+}

--- a/integration-tests/gradle/pom.xml
+++ b/integration-tests/gradle/pom.xml
@@ -664,41 +664,6 @@
             </properties>
         </profile>
         <profile>
-            <id>gradle-8</id>
-            <activation>
-                <jdk>[17,25)</jdk>
-            </activation>
-            <!-- Adds an execution to the surefire plugin that runs selected tests with Gradle 8, only for Java < 25 -->
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-surefire-plugin</artifactId>
-                            <executions>
-                                <execution>
-                                    <id>gradle-wrapper-8.14</id>
-                                    <phase>test</phase>
-                                    <goals>
-                                        <goal>test</goal>
-                                    </goals>
-                                    <configuration>
-                                        <systemPropertyVariables>
-                                            <quarkus-test-gradle-wrapper-version>8.14</quarkus-test-gradle-wrapper-version>
-                                        </systemPropertyVariables>
-                                        <includes>
-                                            <include>BasicMultiModuleQuarkusBuildTest</include>
-                                            <include>MultiModuleConfigIsolationTest</include>
-                                        </includes>
-                                    </configuration>
-                                </execution>
-                            </executions>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-        <profile>
             <id>native-image</id>
             <!-- Since there is no quarkus-maven-plugin build goal in this pom,
                  this profile will not directly yield a native image like in the other modules.


### PR DESCRIPTION
Quarkus 4 development should target Gradle 9.6, dropping support for the EOL-ish Gradle 8. Enforce that minimum consistently from each Quarkus Gradle plugin entry point instead of keeping the application plugin's older Gradle 8.14-only check.

The shared check lives in gradle-model so the application, extension, and extension deployment plugins fail with the same diagnostic before doing plugin setup. The Gradle 8 integration-test profile is removed because those tests now only exercise the supported Gradle 9.6 wrapper path.

The minimum version is now tracked in `build-parent/pom.xml` and from there propagated into the Gradle plugin code for the minimum-version runtime assertion.