### PR TITLE
Remove the CI job that runs k8s tests on Windows

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -1091,14 +1091,6 @@ jobs:
             runs-on: true
           }
           - {
-            name: "17 Windows",
-            java-version: 17,
-            java-distribution: "temurin",
-            os-name: "windows-latest",
-            tag: "kubernetes-jdk-25-windows",
-            runs-on: false
-          }
-          - {
             name: "25 Semeru",
             java-version: 25,
             java-distribution: "semeru",


### PR DESCRIPTION
This is done because this job keeps getting canceled At some point we need to figure out why, but
the priority now is to make CI more stable
for more important things