### PR TITLE
Implement `@JsonAnyGetter` and `@JsonAnySetter` on fields in reflection-free Jackson serializers

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -458,8 +458,18 @@ public abstract class JacksonCodeGenerator {
         for (MethodInfo method : classMethods(classInfo)) {
             if (method.hasAnnotation(JsonAnyGetter.class)
                     && method.parametersCount() == 0
-                    && !java.lang.reflect.Modifier.isStatic(method.flags())) {
+                    && !Modifier.isStatic(method.flags())) {
                 return method;
+            }
+        }
+        return null;
+    }
+
+    protected FieldInfo findAnyGetterField(ClassInfo classInfo) {
+        for (FieldInfo field : classFields(classInfo)) {
+            if (field.hasAnnotation(JsonAnyGetter.class)
+                    && !Modifier.isStatic(field.flags())) {
+                return field;
             }
         }
         return null;

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
@@ -420,6 +420,11 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
         MethodInfo anyGetterMethod = findAnyGetterMethod(deserData.classInfo);
         if (anyGetterMethod != null) {
             ignoredProperties.add(anyGetterBackingFieldName(anyGetterMethod));
+        } else {
+            FieldInfo anyGetterField = findAnyGetterField(deserData.classInfo);
+            if (anyGetterField != null) {
+                ignoredProperties.add(anyGetterField.name());
+            }
         }
         deserData.constructorFields.addAll(ignoredProperties);
 
@@ -434,8 +439,9 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
         }
 
         MethodInfo anySetterMethod = findAnySetterMethod(deserData.classInfo);
+        FieldInfo anySetterField = anySetterMethod == null ? findAnySetterField(deserData.classInfo) : null;
         handleUnknownFields(deserData, ignoredProperties, ctorFields, strSwitch, deserializationContext, fieldName,
-                fieldValue, objHandle, anySetterMethod);
+                fieldValue, objHandle, anySetterMethod, anySetterField);
         return result;
     }
 
@@ -522,9 +528,10 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
         }
     }
 
-    private static void handleUnknownFields(DeserializationData deserData, Set<String> ignoredProperties,
+    private void handleUnknownFields(DeserializationData deserData, Set<String> ignoredProperties,
             Set<String> ctorFields, Switch.StringSwitch strSwitch, ResultHandle deserializationContext,
-            ResultHandle fieldName, ResultHandle fieldValue, ResultHandle objHandle, MethodInfo anySetterMethod) {
+            ResultHandle fieldName, ResultHandle fieldValue, ResultHandle objHandle, MethodInfo anySetterMethod,
+            FieldInfo anySetterField) {
         // add no-op cases for explicitly ignored properties
         for (String ignoredProp : ignoredProperties) {
             if (!ctorFields.contains(ignoredProp)) {
@@ -545,6 +552,25 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
                 } else {
                     bytecode.invokeVirtualMethod(anySetterMethod, objHandle, castedFieldName, deserializedValue);
                 }
+            });
+        } else if (anySetterField != null) {
+            ClassInfo classInfo = deserData.classInfo;
+            strSwitch.defaultCase(bytecode -> {
+                ResultHandle deserializedValue = bytecode.invokeVirtualMethod(
+                        ofMethod(DeserializationContext.class, "readTreeAsValue", Object.class, JsonNode.class, Class.class),
+                        deserializationContext, fieldValue,
+                        bytecode.loadClass(Object.class));
+                ResultHandle castedFieldName = bytecode.checkCast(fieldName, String.class);
+                MethodInfo getter = findMethod(classInfo, "get" + ucFirst(anySetterField.name()));
+                ResultHandle map;
+                if (getter != null) {
+                    map = bytecode.invokeVirtualMethod(MethodDescriptor.of(getter), objHandle);
+                } else {
+                    map = bytecode.readInstanceField(FieldDescriptor.of(anySetterField), objHandle);
+                }
+                bytecode.invokeInterfaceMethod(
+                        ofMethod(Map.class, "put", Object.class, Object.class, Object.class),
+                        map, castedFieldName, deserializedValue);
             });
         } else if (shouldIgnoreUnknownProperties(deserData.classInfo)) {
             strSwitch.defaultCase(bytecode -> {
@@ -793,6 +819,16 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
                     && method.parametersCount() == 2
                     && !Modifier.isStatic(method.flags())) {
                 return method;
+            }
+        }
+        return null;
+    }
+
+    private FieldInfo findAnySetterField(ClassInfo classInfo) {
+        for (FieldInfo field : classFields(classInfo)) {
+            if (field.hasAnnotation(JsonAnySetter.class)
+                    && !Modifier.isStatic(field.flags())) {
+                return field;
             }
         }
         return null;

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
@@ -406,8 +406,14 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
         String classInclude = getClassIncludeValue(classInfo);
 
         MethodInfo anyGetterMethod = findAnyGetterMethod(classInfo);
+        FieldInfo anyGetterField = null;
         if (anyGetterMethod != null) {
             ignoredProperties.add(anyGetterBackingFieldName(anyGetterMethod));
+        } else {
+            anyGetterField = findAnyGetterField(classInfo);
+            if (anyGetterField != null) {
+                ignoredProperties.add(anyGetterField.name());
+            }
         }
 
         List<FieldSpecs> allFieldSpecs = collectAllFieldSpecs(classInfo, namingStrategy);
@@ -457,7 +463,7 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
         }
 
         if (pkgName != null) {
-            serializeAnyGetter(anyGetterMethod, bytecode, ctx);
+            serializeAnyGetter(classInfo, anyGetterMethod, anyGetterField, bytecode, ctx);
         }
     }
 
@@ -514,13 +520,24 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
         return fieldSpecs;
     }
 
-    private void serializeAnyGetter(MethodInfo anyGetterMethod, MethodCreator bytecode, SerializationContext ctx) {
-        if (anyGetterMethod == null) {
+    private void serializeAnyGetter(ClassInfo classInfo, MethodInfo anyGetterMethod, FieldInfo anyGetterField,
+            MethodCreator bytecode, SerializationContext ctx) {
+        ResultHandle map;
+        if (anyGetterMethod != null) {
+            map = anyGetterMethod.declaringClass().isInterface()
+                    ? bytecode.invokeInterfaceMethod(MethodDescriptor.of(anyGetterMethod), ctx.valueHandle)
+                    : bytecode.invokeVirtualMethod(MethodDescriptor.of(anyGetterMethod), ctx.valueHandle);
+        } else if (anyGetterField != null) {
+            MethodInfo getter = findMethod(classInfo,
+                    "get" + ucFirst(anyGetterField.name()));
+            if (getter != null) {
+                map = bytecode.invokeVirtualMethod(MethodDescriptor.of(getter), ctx.valueHandle);
+            } else {
+                map = bytecode.readInstanceField(FieldDescriptor.of(anyGetterField), ctx.valueHandle);
+            }
+        } else {
             return;
         }
-        ResultHandle map = anyGetterMethod.declaringClass().isInterface()
-                ? bytecode.invokeInterfaceMethod(MethodDescriptor.of(anyGetterMethod), ctx.valueHandle)
-                : bytecode.invokeVirtualMethod(MethodDescriptor.of(anyGetterMethod), ctx.valueHandle);
         bytecode.invokeStaticMethod(
                 MethodDescriptor.ofMethod(JacksonMapperUtil.class, "serializeAnyGetterMap", void.class,
                         Map.class, JsonGenerator.class, SerializerProvider.class),

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
@@ -578,6 +578,36 @@ public abstract class AbstractGeneratedAnnotationTest {
                 .body("props_size", CoreMatchers.is(2));
     }
 
+    // --- @JsonAnySetter on field ---
+
+    @Test
+    public void testFieldAnySetterDeserialization() {
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"test\",\"extra1\":\"a\",\"extra2\":\"b\"}")
+                .when()
+                .post("/generated/field-any-setter")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", CoreMatchers.is("test"))
+                .body("extras_size", CoreMatchers.is(2));
+    }
+
+    // --- @JsonAnyGetter on field ---
+
+    @Test
+    public void testFieldAnyGetterSerialization() {
+        RestAssured.get("/generated/field-any-getter")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("test"))
+                .body("color", Matchers.is("red"))
+                .body("size", Matchers.is("large"))
+                .body(not(containsString("additionalProperties")));
+    }
+
     // --- @JsonManagedReference + @JsonBackReference ---
 
     @Test

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/FieldAnyGetterBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/FieldAnyGetterBean.java
@@ -1,0 +1,38 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public class FieldAnyGetterBean {
+
+    private String name;
+
+    @JsonIgnore
+    @JsonAnyGetter
+    private Map<String, Object> additionalProperties = new LinkedHashMap<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return additionalProperties;
+    }
+
+    public void setAdditionalProperties(Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void addProperty(String key, Object value) {
+        additionalProperties.put(key, value);
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/FieldAnySetterBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/FieldAnySetterBean.java
@@ -1,0 +1,26 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+public class FieldAnySetterBean {
+
+    private String name;
+
+    @JsonAnySetter
+    private Map<String, Object> extras = new LinkedHashMap<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Map<String, Object> getExtras() {
+        return extras;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
@@ -304,6 +304,29 @@ public class GeneratedAnnotationResource {
                 + "\",\"props_size\":" + bean.getProperties().size() + "}";
     }
 
+    // --- FieldAnySetterBean: @JsonAnySetter on field ---
+
+    @POST
+    @Path("/field-any-setter")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public String echoFieldAnySetter(FieldAnySetterBean bean) {
+        return "{\"name\":\"" + bean.getName()
+                + "\",\"extras_size\":" + bean.getExtras().size() + "}";
+    }
+
+    // --- FieldAnyGetterBean: @JsonAnyGetter on field ---
+
+    @GET
+    @Path("/field-any-getter")
+    public FieldAnyGetterBean getFieldAnyGetter() {
+        FieldAnyGetterBean bean = new FieldAnyGetterBean();
+        bean.setName("test");
+        bean.addProperty("color", "red");
+        bean.addProperty("size", "large");
+        return bean;
+    }
+
     // --- ManagedReferenceParent/Child: @JsonManagedReference + @JsonBackReference ---
 
     @GET

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
@@ -38,6 +38,8 @@ public class GeneratedAnnotationTest extends AbstractGeneratedAnnotationTest {
                                     IgnorePropertiesCreatorRecord.class,
                                     IgnoreAnySetterBean.class,
                                     AnyGetterBean.class,
+                                    FieldAnyGetterBean.class,
+                                    FieldAnySetterBean.class,
                                     ManagedReferenceParent.class,
                                     ManagedReferenceChild.class,
                                     DateFormatBean.class,

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
@@ -41,6 +41,8 @@ public class GeneratedAnnotationWithReflectionFreeSerializersTest extends Abstra
                                     IgnorePropertiesCreatorRecord.class,
                                     IgnoreAnySetterBean.class,
                                     AnyGetterBean.class,
+                                    FieldAnyGetterBean.class,
+                                    FieldAnySetterBean.class,
                                     ManagedReferenceParent.class,
                                     ManagedReferenceChild.class,
                                     DateFormatBean.class,


### PR DESCRIPTION
When `@JsonAnyGetter` is placed on a field (rather than a getter method), the reflection-free serializer does not serialize the map entries. Standard Jackson handles both placements, but the Quarkus code generator only looks at methods.

- Fixes: #55497
