### PR TITLE
Gradle: Add Gradle-version dependent warnings

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -40,7 +40,6 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry;
-import org.gradle.util.GradleVersion;
 
 import io.quarkus.gradle.actions.BeforeTestAction;
 import io.quarkus.gradle.dependency.ApplicationDeploymentClasspathBuilder;
@@ -75,6 +74,7 @@ import io.quarkus.gradle.tasks.QuarkusUpdate;
 import io.quarkus.gradle.tasks.services.ForcedPropertieBuildService;
 import io.quarkus.gradle.tooling.DefaultProjectDescriptor;
 import io.quarkus.gradle.tooling.GradleApplicationModelBuilder;
+import io.quarkus.gradle.tooling.GradleVersionEnforcer;
 import io.quarkus.gradle.tooling.ProjectDescriptorBuilder;
 import io.quarkus.gradle.tooling.ToolingUtils;
 import io.quarkus.gradle.tooling.dependency.DependencyDataCollector;
@@ -144,7 +144,7 @@ public class QuarkusPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        verifyGradleVersion();
+        GradleVersionEnforcer.verifyGradleVersion(project.getLogger());
 
         // Apply the `java` plugin
         project.getPluginManager().apply(JavaPlugin.class);
@@ -720,13 +720,6 @@ public class QuarkusPlugin implements Plugin<Project> {
 
     private void registerModel() {
         registry.register(new GradleApplicationModelBuilder());
-    }
-
-    private void verifyGradleVersion() {
-        if (GradleVersion.current().compareTo(GradleVersion.version("6.1")) < 0) {
-            throw new GradleException("Quarkus plugin requires Gradle 6.1 or later. Current version is: " +
-                    GradleVersion.current());
-        }
     }
 
     private void configureBuildNativeTask(Project project) {

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionPlugin.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionPlugin.java
@@ -25,6 +25,7 @@ import io.quarkus.extension.gradle.tasks.ExtensionDescriptorTask;
 import io.quarkus.extension.gradle.tasks.ValidateExtensionTask;
 import io.quarkus.gradle.dependency.ApplicationDeploymentClasspathBuilder;
 import io.quarkus.gradle.extension.ExtensionConstants;
+import io.quarkus.gradle.tooling.GradleVersionEnforcer;
 import io.quarkus.gradle.tooling.ToolingUtils;
 import io.quarkus.gradle.tooling.dependency.DependencyUtils;
 import io.quarkus.runtime.LaunchMode;
@@ -45,6 +46,8 @@ public class QuarkusExtensionPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        GradleVersionEnforcer.verifyGradleVersion(project.getLogger());
+
         final QuarkusExtensionConfiguration quarkusExt = project.getExtensions().create(EXTENSION_CONFIGURATION_NAME,
                 QuarkusExtensionConfiguration.class);
 

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleVersionEnforcer.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleVersionEnforcer.java
@@ -1,0 +1,43 @@
+package io.quarkus.gradle.tooling;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.logging.Logger;
+import org.gradle.util.GradleVersion;
+
+public final class GradleVersionEnforcer {
+
+    private static final GradleVersion MINIMUM_GRADLE_VERSION = GradleVersion.version("6.1");
+    private static final GradleVersion TESTED_GRADLE_VERSION = GradleVersion.version("8.14");
+    private static final GradleVersion QUARKUS_4_MINIMUM_GRADLE_VERSION = GradleVersion.version("9.6");
+
+    private GradleVersionEnforcer() {
+    }
+
+    public static void verifyGradleVersion(Logger logger) {
+        verifyGradleVersion(GradleVersion.current(), logger);
+    }
+
+    static void verifyGradleVersion(GradleVersion current, Logger logger) {
+        if (current.compareTo(MINIMUM_GRADLE_VERSION) < 0) {
+            throw new GradleException("Quarkus plugin requires Gradle 6.1 or later. Current version is: " + current);
+        }
+
+        warningsFor(current).forEach(logger::warn);
+    }
+
+    static List<String> warningsFor(GradleVersion current) {
+        List<String> warnings = new ArrayList<>();
+        if (current.compareTo(TESTED_GRADLE_VERSION) < 0) {
+            warnings.add("This version of Quarkus is tested with Gradle 8.14 or later. This build is using Gradle "
+                    + current.getVersion() + ". Please upgrade the Gradle wrapper.");
+        }
+        if (current.compareTo(QUARKUS_4_MINIMUM_GRADLE_VERSION) < 0) {
+            warnings.add("Quarkus 4 will require Gradle 9.6 or later. This build is using Gradle "
+                    + current.getVersion() + ". Please upgrade the Gradle wrapper before upgrading to Quarkus 4.");
+        }
+        return warnings;
+    }
+}

--- a/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/tooling/GradleVersionEnforcerTest.java
+++ b/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/tooling/GradleVersionEnforcerTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.gradle.tooling;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.gradle.api.GradleException;
+import org.gradle.util.GradleVersion;
+import org.junit.jupiter.api.Test;
+
+class GradleVersionEnforcerTest {
+
+    @Test
+    void shouldFailForGradleOlderThanMinimumVersion() {
+        assertThatThrownBy(() -> GradleVersionEnforcer.verifyGradleVersion(GradleVersion.version("6.0"), null))
+                .isInstanceOf(GradleException.class)
+                .hasMessage("Quarkus plugin requires Gradle 6.1 or later. Current version is: Gradle 6.0");
+    }
+
+    @Test
+    void shouldWarnForGradleVersionsOlderThanTestedVersionAndQuarkus4MinimumVersion() {
+        assertThat(GradleVersionEnforcer.warningsFor(GradleVersion.version("7.6.4")))
+                .containsExactly(
+                        "This version of Quarkus is tested with Gradle 8.14 or later. This build is using Gradle 7.6.4. Please upgrade the Gradle wrapper.",
+                        "Quarkus 4 will require Gradle 9.6 or later. This build is using Gradle 7.6.4. Please upgrade the Gradle wrapper before upgrading to Quarkus 4.");
+    }
+
+    @Test
+    void shouldWarnForGradleVersionsOlderThanTestedVersion() {
+        assertThat(GradleVersionEnforcer.warningsFor(GradleVersion.version("8.13")))
+                .containsExactly(
+                        "This version of Quarkus is tested with Gradle 8.14 or later. This build is using Gradle 8.13. Please upgrade the Gradle wrapper.",
+                        "Quarkus 4 will require Gradle 9.6 or later. This build is using Gradle 8.13. Please upgrade the Gradle wrapper before upgrading to Quarkus 4.");
+    }
+
+    @Test
+    void shouldWarnForGradleVersionsOlderThanQuarkus4MinimumVersion() {
+        assertThat(GradleVersionEnforcer.warningsFor(GradleVersion.version("8.14")))
+                .containsExactly(
+                        "Quarkus 4 will require Gradle 9.6 or later. This build is using Gradle 8.14. Please upgrade the Gradle wrapper before upgrading to Quarkus 4.");
+    }
+
+    @Test
+    void shouldNotWarnForGradleVersionsSupportedByQuarkus4() {
+        assertThat(GradleVersionEnforcer.warningsFor(GradleVersion.version("9.6"))).isEmpty();
+        assertThat(GradleVersionEnforcer.warningsFor(GradleVersion.version("10.0"))).isEmpty();
+    }
+}


### PR DESCRIPTION
This change preserves the existing Gradle-minimum-version check for `< 6.1`.

Added warnings:
* For Gradle < 8.14, emit a warning saying the Gradle version is untested and to update Gradle
* For Gradle < 9.6, emit a Quarkus 4 specific warning to update to >= 9.6 before upgrading to Quarkus 4.
