### PR TITLE
HTTP: Document and test compression configuration

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -100,17 +100,67 @@ Quarkus validates these values at build time.
 
 This feature can be used in both development and production environments.
 
+[[http-compression]]
 === HTTP Compression
 
-The response body of a static resource is not compressed by default.
-You can enable the HTTP compression support by means of `quarkus.http.enable-compression=true`.
-If compression support is enabled then the response body is compressed if the `Content-Type` header derived from the file name of a resource is a compressed media type as configured via `quarkus.http.compress-media-types`.
+The response body of an HTTP response is not compressed by default.
+You can enable HTTP compression support by setting `quarkus.http.enable-compression=true`.
 
-TIP: By default, the following list of media types is compressed: `text/html`, `text/plain`, `text/xml`, `text/css`, `text/javascript`, `application/javascript`, `application/json`, `application/graphql+json` and `application/xhtml+xml`.
+If compression is enabled, the response body is compressed when the `Content-Type` header matches one of the media types configured via `quarkus.http.compress-media-types`.
 
-NOTE: If the client does not indicate its support for HTTP compression in a request header, e.g. `Accept-Encoding: deflate, gzip, br`, then the response body is not compressed.
+TIP: By default, the following media types are compressed: `text/html`, `text/plain`, `text/xml`, `text/css`, `text/javascript`, `application/javascript`, `application/json`, `application/graphql+json`, and `application/xhtml+xml`.
 
-TIP: Brotli compression is not available by default. You can enable it by setting `quarkus.http.compressors=deflate,gzip,br`. In case of building native image, it adds around 1MB to your executable size.
+NOTE: If the client does not indicate support for HTTP compression in the request (e.g., `Accept-Encoding: deflate, gzip, br`), the response body is not compressed.
+
+==== Minimum response size
+
+By default, all responses matching the configured media types are compressed regardless of their size.
+Use `quarkus.http.compression-content-size-threshold` to set a minimum response body size (in bytes) that triggers compression.
+Responses smaller than this threshold are sent uncompressed, avoiding the CPU overhead of compressing small payloads.
+
+[source,properties]
+----
+quarkus.http.enable-compression=true
+# Only compress responses larger than 1KB
+quarkus.http.compression-content-size-threshold=1024
+----
+
+NOTE: The threshold only applies when the response `Content-Length` is known. Chunked responses (where the total size is not known upfront) are always eligible for compression when compression is enabled.
+
+==== Compression level
+
+Use `quarkus.http.compression-level` to control the compression level for gzip and deflate.
+Higher values produce smaller output at the cost of more CPU usage.
+When not set, the compressor's default level is used.
+
+[source,properties]
+----
+quarkus.http.enable-compression=true
+quarkus.http.compression-level=6
+----
+
+==== Brotli compression
+
+Brotli compression is not available by default.
+Enable it by adding `br` to the compressors list:
+
+[source,properties]
+----
+quarkus.http.compressors=deflate,gzip,br
+----
+
+TIP: Enabling Brotli adds approximately 1MB to native executable size because it requires bundling the Brotli4J native library.
+
+==== Per-endpoint control
+
+The RESTEasy Reactive and Reactive Routes extensions allow enabling or disabling compression on individual endpoints using the `@io.quarkus.vertx.http.Compressed` and `@io.quarkus.vertx.http.Uncompressed` annotations.
+See the xref:rest.adoc#http-compression[Quarkus REST] and xref:reactive-routes.adoc#http-compression[Reactive Routes] guides for details.
+
+==== Request decompression
+
+Quarkus can also decompress incoming request bodies.
+Enable this with `quarkus.http.enable-decompression=true`.
+The client must indicate the compression format in the `Content-Encoding` request header (e.g., `gzip`, `deflate`, or `br`).
 
 [[static-resources-config]]
 === Other Configurations

--- a/docs/src/main/asciidoc/reactive-routes.adoc
+++ b/docs/src/main/asciidoc/reactive-routes.adoc
@@ -702,6 +702,7 @@ public class MyFilters {
 <1> The `RouteFilter#value()` defines the priority used to sort the filters - filters with higher priority are called first.
 <2> The filter is likely required to call the `next()` method to continue the chain.
 
+[[http-compression]]
 == HTTP Compression
 
 The body of an HTTP response is not compressed by default.
@@ -720,6 +721,10 @@ The response body is never compressed if:
 TIP: By default, the following list of media types is compressed: `text/html`, `text/plain`, `text/xml`, `text/css`, `text/javascript`, `application/javascript`, `application/json`, `application/graphql+json` and `application/xhtml+xml`.
 
 NOTE: If the client does not support HTTP compression then the response body is not compressed.
+
+You can also set a minimum response body size (in bytes) for compression using `quarkus.http.compression-content-size-threshold`, control the compression level with `quarkus.http.compression-level`, and enable Brotli by adding `br` to `quarkus.http.compressors`.
+
+TIP: See the xref:http-reference.adoc#http-compression[HTTP reference guide] for the full list of compression configuration options including minimum response size, compression level, Brotli, and request decompression.
 
 
 == Adding OpenAPI and Swagger UI

--- a/docs/src/main/asciidoc/rest.adoc
+++ b/docs/src/main/asciidoc/rest.adoc
@@ -3429,6 +3429,7 @@ Or plain text:
 < {"name":"roquefort"}
 ----
 
+[[http-compression]]
 === HTTP Compression
 
 The body of an HTTP response is not compressed by default.
@@ -3447,6 +3448,10 @@ The response body is never compressed if:
 TIP: By default, the following list of media types is compressed: `text/html`, `text/plain`, `text/xml`, `text/css`, `text/javascript`, `application/javascript`, `application/json`, `application/graphql+json` and `application/xhtml+xml`.
 
 NOTE: If the client does not support HTTP compression then the response body is not compressed.
+
+You can also set a minimum response body size (in bytes) for compression using `quarkus.http.compression-content-size-threshold`, control the compression level with `quarkus.http.compression-level`, and enable Brotli by adding `br` to `quarkus.http.compressors`.
+
+TIP: See the xref:http-reference.adoc#http-compression[HTTP reference guide] for the full list of compression configuration options including minimum response size, compression level, Brotli, and request decompression.
 
 
 == Include/Exclude Jakarta REST classes

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/CompressionContentSizeThresholdTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/CompressionContentSizeThresholdTest.java
@@ -1,0 +1,82 @@
+package io.quarkus.vertx.http;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.nullValue;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.Router;
+
+public class CompressionContentSizeThresholdTest {
+
+    private static final String APP_PROPS = ""
+            + "quarkus.http.enable-compression=true\n"
+            + "quarkus.http.compression-content-size-threshold=1024\n";
+
+    // 1200 bytes — above the 1024-byte threshold
+    private static final String LARGE_BODY;
+    static {
+        StringBuilder sb = new StringBuilder(1200);
+        while (sb.length() < 1200) {
+            sb.append("Lorem ipsum dolor sit amet, consectetur adipiscing elit. ");
+        }
+        LARGE_BODY = sb.substring(0, 1200);
+    }
+
+    // 100 bytes — below the 1024-byte threshold
+    private static final String SMALL_BODY;
+    static {
+        StringBuilder sb = new StringBuilder(100);
+        while (sb.length() < 100) {
+            sb.append("Small. ");
+        }
+        SMALL_BODY = sb.substring(0, 100);
+    }
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties")
+                    .addClasses(BeanRegisteringRoutes.class));
+
+    @Test
+    public void testAboveThresholdIsCompressed() {
+        given().get("/above-threshold").then().statusCode(200)
+                .header("content-encoding", is("gzip"))
+                .header("content-length", Integer::parseInt, lessThan(LARGE_BODY.length()))
+                .body(equalTo(LARGE_BODY));
+    }
+
+    @Test
+    public void testBelowThresholdIsNotCompressed() {
+        given().get("/below-threshold").then().statusCode(200)
+                .header("content-encoding", is(nullValue()))
+                .header("content-length", Integer::parseInt, equalTo(SMALL_BODY.length()))
+                .body(equalTo(SMALL_BODY));
+    }
+
+    @ApplicationScoped
+    static class BeanRegisteringRoutes {
+
+        public void register(@Observes Router router) {
+            router.route("/above-threshold").handler(rc -> {
+                rc.response().headers().remove(HttpHeaders.CONTENT_ENCODING);
+                rc.response().end(LARGE_BODY);
+            });
+            router.route("/below-threshold").handler(rc -> {
+                rc.response().headers().remove(HttpHeaders.CONTENT_ENCODING);
+                rc.response().end(SMALL_BODY);
+            });
+        }
+    }
+}


### PR DESCRIPTION
Cover compression-content-size-threshold, compression-level, decompression, Brotli, and per-endpoint annotations.

- Fixes: https://github.com/quarkusio/quarkus/issues/46498
