### PR TITLE
Clear/reset integration-test boot failure state after class change and failed start

### DIFF
--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -172,9 +172,12 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
         boolean wrongProfile = !Objects.equals(selectedProfile, quarkusTestProfile);
         // we reset the failed state if we changed test class
         boolean isNewTestClass = !Objects.equals(extensionContext.getRequiredTestClass(), currentJUnitTestClass);
-        if (isNewTestClass && state != null) {
-            state.setTestFailed(null);
+        if (isNewTestClass) {
+            clearBootFailure();
             currentJUnitTestClass = extensionContext.getRequiredTestClass();
+            if (state != null) {
+                state.setTestFailed(null);
+            }
         }
         // we reload the test resources if we changed test class and if we had or will have per-test test resources
         boolean reloadTestResources = false;
@@ -210,6 +213,7 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
 
                 failedBoot = true;
                 firstException = e;
+                getStoreFromContext(extensionContext).put(FailedCleanup.class.getName(), new FailedCleanup());
             }
         }
         return state;
@@ -421,6 +425,18 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
             throw new RuntimeException(throwable);
         } else {
             throw new TestAbortedException("Boot failed");
+        }
+    }
+
+    static void clearBootFailure() {
+        firstException = null;
+        failedBoot = false;
+    }
+
+    static final class FailedCleanup implements AutoCloseable {
+        @Override
+        public void close() {
+            clearBootFailure();
         }
     }
 

--- a/test-framework/junit/src/test/java/io/quarkus/test/junit/QuarkusIntegrationTestExtensionTest.java
+++ b/test-framework/junit/src/test/java/io/quarkus/test/junit/QuarkusIntegrationTestExtensionTest.java
@@ -2,6 +2,7 @@ package io.quarkus.test.junit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -37,5 +38,20 @@ public class QuarkusIntegrationTestExtensionTest {
     @Test
     public void tailReturnsEmptyForEmptyLog() {
         assertThat(QuarkusIntegrationTestExtension.applicationLogTail(List.of(), 50, "quarkus.log")).isEmpty();
+    }
+
+    @Test
+    public void clearBootFailureClearsStaticBootFailureState() throws Exception {
+        Field failedBoot = QuarkusIntegrationTestExtension.class.getDeclaredField("failedBoot");
+        failedBoot.setAccessible(true);
+        failedBoot.setBoolean(null, true);
+        Field firstException = QuarkusIntegrationTestExtension.class.getDeclaredField("firstException");
+        firstException.setAccessible(true);
+        firstException.set(null, new RuntimeException("boom"));
+
+        QuarkusIntegrationTestExtension.clearBootFailure();
+
+        assertThat(failedBoot.getBoolean(null)).isFalse();
+        assertThat(firstException.get(null)).isNull();
     }
 }


### PR DESCRIPTION
`QuarkusIntegrationTestExtension` has long kept boot failures in static state so that the first failing test reports the real exception and the remaining tests in the same class are aborted as Boot failed. Unlike `QuarkusTestExtension`, it did not register cleanup for that state when startup failed.

This was latent for old integration-test paths. A single test-resource startup failure could then poison later integration-test classes in the same JVM, causing unrelated tests to be skipped as `Boot failed` even when their application started successfully.

* Register a root-store cleanup hook for failed integration-test starts and cover the static-state reset with a focused test.
* Clear stale boot-failure state when the extension observes a new test class, before deciding whether a new application should be started. This preserves the per-class abort behavior while allowing later classes to start independently.
