### PR TITLE
Capture management port for integration-test launches

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
@@ -246,6 +246,8 @@ public final class LauncherUtil {
         private final CountDownLatch signal;
         private final AtomicReference<ListeningAddress> resultReference;
         private final Pattern listeningRegex = Pattern.compile("Listening on:\\s+(https?)://[^:]*:(\\d+)");
+        private final Pattern managementListeningRegex = Pattern
+                .compile("Management interface listening on\\s+(https?)://[^:]*:(\\d+)");
         private final Pattern startedRegex = Pattern.compile(".*Quarkus .* started in \\d+.*s.*");
 
         public CaptureListeningDataReader(Path processOutput, Duration waitTime, CountDownLatch signal,
@@ -281,7 +283,13 @@ public final class LauncherUtil {
 
                         Matcher regexMatcher = listeningRegex.matcher(line);
                         if (regexMatcher.find()) {
-                            dataDetermined(regexMatcher.group(1), Integer.valueOf(regexMatcher.group(2)));
+                            Matcher managementRegexMatcher = managementListeningRegex.matcher(line);
+                            if (managementRegexMatcher.find()) {
+                                dataDetermined(regexMatcher.group(1), Integer.valueOf(regexMatcher.group(2)),
+                                        managementRegexMatcher.group(1), Integer.valueOf(managementRegexMatcher.group(2)));
+                            } else {
+                                dataDetermined(regexMatcher.group(1), Integer.valueOf(regexMatcher.group(2)), null, null);
+                            }
                             return;
                         } else {
                             if (line.contains("Failed to start application (with profile")) {
@@ -297,7 +305,7 @@ public final class LauncherUtil {
                         // or waiting the next check interval will exceed the bailout time, it's time to finish waiting:
                         if (now + LOG_CHECK_INTERVAL > bailoutTime || now - 2 * LOG_CHECK_INTERVAL > timeStarted) {
                             if (started) {
-                                dataDetermined(null, null); // no http, all is null
+                                dataDetermined(null, null, null, null); // no http, all is null
                             } else {
                                 unableToDetermineData("Waited " + waitTime.getSeconds() + " seconds for " + processOutput
                                         + " to contain info about the listening port and protocol but no such info was found. "
@@ -339,8 +347,10 @@ public final class LauncherUtil {
             return false;
         }
 
-        private void dataDetermined(String protocolValue, Integer portValue) {
-            this.resultReference.set(new ListeningAddress(portValue, protocolValue));
+        private void dataDetermined(String protocolValue, Integer portValue, String managementProtocolValue,
+                Integer managementPortValue) {
+            this.resultReference
+                    .set(new ListeningAddress(portValue, protocolValue, managementPortValue, managementProtocolValue));
             signal.countDown();
         }
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/ListeningAddress.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/ListeningAddress.java
@@ -10,7 +10,11 @@ import io.quarkus.value.registry.ValueRegistry;
 import io.quarkus.value.registry.ValueRegistry.RuntimeKey;
 import io.smallrye.config.Config;
 
-public record ListeningAddress(Integer port, String protocol) {
+public record ListeningAddress(Integer port, String protocol, Integer managementPort, String managementProtocol) {
+
+    public ListeningAddress(Integer port, String protocol) {
+        this(port, protocol, null, null);
+    }
 
     public boolean isSsl() {
         return "https".equals(protocol);
@@ -21,6 +25,10 @@ public record ListeningAddress(Integer port, String protocol) {
         valueRegistry.register(isSsl() ? HTTPS_TEST_PORT : HTTP_TEST_PORT, port);
         valueRegistry.register(LOCAL_BASE_URI,
                 URI.create(isSsl() ? testUrlSsl(valueRegistry, config) : testUrl(valueRegistry, config)));
+        if (managementPort != null) {
+            valueRegistry.register(MANAGEMENT_PORT, managementPort);
+            valueRegistry.register(MANAGEMENT_TEST_PORT, managementPort);
+        }
     }
 
     // Compatibility with Config and io.quarkus.vertx.http.HttpServer
@@ -28,6 +36,8 @@ public record ListeningAddress(Integer port, String protocol) {
     public static final RuntimeKey<Integer> HTTP_TEST_PORT = RuntimeKey.intKey("quarkus.http.test-port");
     public static final RuntimeKey<Integer> HTTPS_PORT = RuntimeKey.intKey("quarkus.http.ssl-port");
     public static final RuntimeKey<Integer> HTTPS_TEST_PORT = RuntimeKey.intKey("quarkus.http.test-ssl-port");
+    public static final RuntimeKey<Integer> MANAGEMENT_PORT = RuntimeKey.intKey("quarkus.management.port");
+    public static final RuntimeKey<Integer> MANAGEMENT_TEST_PORT = RuntimeKey.intKey("quarkus.management.test-port");
     public static final RuntimeKey<URI> LOCAL_BASE_URI = RuntimeKey.key("quarkus.http.local-base-uri");
     public static final RuntimeKey<Optional<ListeningAddress>> LISTENING_ADDRESS = RuntimeKey
             .key("quarkus.http.listening-address");

--- a/test-framework/common/src/test/java/io/quarkus/test/common/TestLauncherUtil.java
+++ b/test-framework/common/src/test/java/io/quarkus/test/common/TestLauncherUtil.java
@@ -3,6 +3,8 @@ package io.quarkus.test.common;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.file.Path;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.api.SoftAssertions;
@@ -12,12 +14,20 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkus.runtime.ValueRegistryImpl;
+import io.smallrye.config.Config;
+import io.smallrye.config.SmallRyeConfigBuilder;
 
 @EnabledOnOs({ OS.LINUX, OS.MAC })
 @ExtendWith(SoftAssertionsExtension.class)
 public class TestLauncherUtil {
     @InjectSoftAssertions
     protected SoftAssertions soft;
+
+    @TempDir
+    Path tempDir;
 
     @Test
     public void lastLineNoEOL() throws Exception {
@@ -114,5 +124,37 @@ public class TestLauncherUtil {
         soft.assertThatCode(proc::exitValue).doesNotThrowAnyException();
         soft.assertThat(outCapture.toString()).isEmpty();
         soft.assertThat(errCapture.toString()).isEmpty();
+    }
+
+    @Test
+    public void waitForCapturedListeningDataCapturesManagementPort() throws Exception {
+        Path logFile = tempDir.resolve("quarkus.log");
+        var proc = new ProcessBuilder("/bin/bash", "-c",
+                "printf '%s\\n' '2026-07-16 10:00:00,000 INFO  [io.quarkus] (main) started in 1.000s. Listening on: http://0.0.0.0:38133. Management interface listening on http://0.0.0.0:37247.' > "
+                        + logFile + "; sleep 120")
+                .start();
+
+        try {
+            Optional<ListeningAddress> listeningAddress = LauncherUtil.waitForCapturedListeningData(proc, logFile, 5);
+
+            soft.assertThat(listeningAddress).isPresent();
+            soft.assertThat(listeningAddress.get().port()).isEqualTo(38133);
+            soft.assertThat(listeningAddress.get().protocol()).isEqualTo("http");
+            soft.assertThat(listeningAddress.get().managementPort()).isEqualTo(37247);
+            soft.assertThat(listeningAddress.get().managementProtocol()).isEqualTo("http");
+        } finally {
+            proc.destroyForcibly();
+        }
+    }
+
+    @Test
+    public void listeningAddressRegistersManagementPort() {
+        var valueRegistry = ValueRegistryImpl.builder().build();
+
+        Config config = new SmallRyeConfigBuilder().build();
+        new ListeningAddress(38133, "http", 37247, "http").register(valueRegistry, config);
+
+        soft.assertThat(valueRegistry.getOrDefault(ListeningAddress.HTTP_TEST_PORT, -1)).isEqualTo(38133);
+        soft.assertThat(valueRegistry.getOrDefault(ListeningAddress.MANAGEMENT_TEST_PORT, -1)).isEqualTo(37247);
     }
 }


### PR DESCRIPTION
Commits 95da2a79da6 and 198c41febd3 moved integration-test runtime URL propagation away from system properties and into `ValueRegistry`-backed `ListeningAddress` data, including the local base URI used by RestAssured. That model captured the main HTTP listener only.

`@QuarkusIntegrationTest`s with `quarkus.management.port=0` may need to know the allocated management-port.

Extend `LauncherUtil` to parse the management listener from Quarkus startup logs, carry it through `ListeningAddress`, and register the actual management port in `ValueRegistry`.