### PR TITLE
Preserve manual line wrapping in annotation arguments

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/Substitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/Substitutions.java
@@ -118,7 +118,8 @@ final class Substitutions {
      * This Substitution provides a delegate to the GraalVM lazy implementation, expanding the lazy check to each
      * individual method of {@link Properties}.
      */
-    @TargetClass(className = "com.oracle.svm.core.jdk.SystemPropertiesSupport", onlyWith = Target_SystemPropertiesSupport.SystemPropertiesSupportGetPropertiesPresent.class)
+    @TargetClass(className = "com.oracle.svm.core.jdk.SystemPropertiesSupport",
+            onlyWith = Target_SystemPropertiesSupport.SystemPropertiesSupportGetPropertiesPresent.class)
     static final class Target_SystemPropertiesSupport {
         @Alias
         private Properties properties;
@@ -450,7 +451,8 @@ final class Substitutions {
         }
     }
 
-    @TargetClass(className = "com.oracle.svm.core.jdk.SystemPropertiesSupport", onlyWith = Target_SystemPropertiesSupport_post_21.SystemPropertiesSupportGetCurrentPropertiesPresent.class)
+    @TargetClass(className = "com.oracle.svm.core.jdk.SystemPropertiesSupport",
+            onlyWith = Target_SystemPropertiesSupport_post_21.SystemPropertiesSupportGetCurrentPropertiesPresent.class)
     static final class Target_SystemPropertiesSupport_post_21 {
 
         @Alias

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/BuildOptions.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/BuildOptions.java
@@ -22,7 +22,8 @@ public class BuildOptions {
     public boolean generateBuildReport = false;
 
     @CommandLine.Option(order = 8, names = {
-            "--ext-capture" }, description = "Enable extended capture for build metrics.", negatable = true, defaultValue = "false")
+            "--ext-capture" }, description = "Enable extended capture for build metrics.", negatable = true,
+            defaultValue = "false")
     public boolean buildExtendedCapture = false;
 
     public boolean skipTests() {

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/DebugOptions.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/DebugOptions.java
@@ -22,7 +22,9 @@ public class DebugOptions {
     public String host = LOCALHOST;
 
     @CommandLine.Option(order = 9, names = {
-            "--debug-mode" }, description = "Valid values: ${COMPLETION-CANDIDATES}.%nEither connect to or listen on <host>:<port>.", defaultValue = "listen")
+            "--debug-mode" },
+            description = "Valid values: ${COMPLETION-CANDIDATES}.%nEither connect to or listen on <host>:<port>.",
+            defaultValue = "listen")
     public DebugMode mode = DebugMode.listen;
 
     @CommandLine.Option(order = 10, names = {
@@ -30,7 +32,8 @@ public class DebugOptions {
     public int port = DEFAULT_PORT;
 
     @CommandLine.Option(order = 11, names = {
-            "--suspend" }, description = "In listen mode, suspend until a debugger is attached. Disabled by default.", negatable = true)
+            "--suspend" }, description = "In listen mode, suspend until a debugger is attached. Disabled by default.",
+            negatable = true)
     public boolean suspend = false;
 
     public String getJvmDebugParameter() {

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/ListFormatOptions.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/ListFormatOptions.java
@@ -14,7 +14,8 @@ public class ListFormatOptions {
     boolean concise = false;
 
     @CommandLine.Option(names = {
-            "--full" }, order = 6, description = "Display extension artifactId, name, version, platform origin, and other information.")
+            "--full" }, order = 6,
+            description = "Display extension artifactId, name, version, platform origin, and other information.")
     boolean full = false;
 
     @CommandLine.Option(names = {
@@ -22,7 +23,8 @@ public class ListFormatOptions {
     boolean origins = false;
 
     @CommandLine.Option(names = {
-            "--support-scope" }, order = 7, description = "Display extension artifactId, name, version, and support scope in case it's associated with an extension.")
+            "--support-scope" }, order = 7,
+            description = "Display extension artifactId, name, version, and support scope in case it's associated with an extension.")
     boolean supportScope = false;
 
     /**

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/TargetQuarkusPlatformGroup.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/TargetQuarkusPlatformGroup.java
@@ -35,7 +35,8 @@ public class TargetQuarkusPlatformGroup {
     }
 
     @CommandLine.Option(paramLabel = "groupId:artifactId:version", names = { "-P",
-            "--platform-bom" }, description = "A specific Quarkus platform BOM, for example:%n"
+            "--platform-bom" },
+            description = "A specific Quarkus platform BOM, for example:%n"
                     + "  " + FULL_EXAMPLE + "%n"
                     + "  io.quarkus::999-SNAPSHOT"
                     + "  3.15.2%n"

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/TargetQuarkusVersionGroup.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/TargetQuarkusVersionGroup.java
@@ -9,7 +9,8 @@ public class TargetQuarkusVersionGroup {
     public String streamId;
 
     @CommandLine.Option(paramLabel = "targetPlatformVersion", names = { "-P",
-            "--platform-version" }, description = "A specific target Quarkus platform version, for example:%n"
+            "--platform-version" },
+            description = "A specific target Quarkus platform version, for example:%n"
                     + "  3.15.2%n")
     public String platformVersion;
 

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/update/RewriteGroup.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/update/RewriteGroup.java
@@ -8,7 +8,8 @@ public class RewriteGroup {
     public RewriteRun run;
 
     @CommandLine.Option(order = 0, names = {
-            "--quarkus-update-recipes" }, description = "Use custom io.quarkus:quarkus-update-recipes:LATEST artifact (GAV) or just provide the version. This artifact should contain the base Quarkus update recipes to update a project.")
+            "--quarkus-update-recipes" },
+            description = "Use custom io.quarkus:quarkus-update-recipes:LATEST artifact (GAV) or just provide the version. This artifact should contain the base Quarkus update recipes to update a project.")
     public String quarkusUpdateRecipes;
 
     @CommandLine.Option(order = 1, names = {
@@ -16,7 +17,8 @@ public class RewriteGroup {
     public String pluginVersion;
 
     @CommandLine.Option(order = 2, names = {
-            "--additional-update-recipes" }, description = "Specify a list of additional artifacts (GAV) containing rewrite recipes.")
+            "--additional-update-recipes" },
+            description = "Specify a list of additional artifacts (GAV) containing rewrite recipes.")
     public String additionalUpdateRecipes;
 
     public static class RewriteRun {
@@ -28,7 +30,8 @@ public class RewriteGroup {
         @CommandLine.Option(order = 5, names = {
                 "--dry-run",
                 "-n"
-        }, description = "Do a dry run of the suggested update recipe for this project and create a patch file.", defaultValue = "false")
+        }, description = "Do a dry run of the suggested update recipe for this project and create a patch file.",
+                defaultValue = "false")
         public boolean dryRun = false;
 
         @CommandLine.Option(order = 4, names = {

--- a/devtools/cli/src/main/java/io/quarkus/cli/Completion.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Completion.java
@@ -4,7 +4,9 @@ import picocli.AutoComplete.GenerateCompletion;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "completion", version = "generate-completion "
-        + CommandLine.VERSION, header = "bash/zsh completion:  source <(${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} ${COMMAND-NAME})", helpCommand = true)
+        + CommandLine.VERSION,
+        header = "bash/zsh completion:  source <(${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} ${COMMAND-NAME})",
+        helpCommand = true)
 public class Completion extends GenerateCompletion {
 
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateApp.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateApp.java
@@ -20,7 +20,8 @@ import io.quarkus.devtools.project.SourceType;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "app", header = "Create a Quarkus application project.", description = "%n"
-        + "This command will create a Java project in a new ARTIFACT-ID directory", footer = { "%n"
+        + "This command will create a Java project in a new ARTIFACT-ID directory",
+        footer = { "%n"
                 + "For example (using default values), a new Java project will be created in a 'code-with-quarkus' directory; "
                 + "it will use Maven to build an artifact with GROUP-ID='org.acme', ARTIFACT-ID='code-with-quarkus', and VERSION='1.0.0-SNAPSHOT'."
                 + "%n" })

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateCli.java
@@ -20,7 +20,8 @@ import io.quarkus.devtools.project.SourceType;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "cli", header = "Create a Quarkus command-line project.", description = "%n"
-        + "This command will create a Java project in a new ARTIFACT-ID directory.", footer = { "%n"
+        + "This command will create a Java project in a new ARTIFACT-ID directory.",
+        footer = { "%n"
                 + "For example (using default values), a new Java project will be created in a 'code-with-quarkus' directory; "
                 + "it will use Maven to build an artifact with GROUP-ID='org.acme', ARTIFACT-ID='code-with-quarkus', and VERSION='1.0.0-SNAPSHOT'."
                 + "%n" })

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateExtension.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateExtension.java
@@ -24,7 +24,8 @@ import picocli.CommandLine;
 @CommandLine.Command(name = "extension", header = "Create a Quarkus extension project", description = "%n"
         + "Quarkus extensions are built from multiple modules: runtime, deployment, integration-test and "
         + "docs. This command will generate a Maven multi-module project in a directory called EXTENSION-ID "
-        + "by applying naming conventions to the specified EXTENSION-ID.", footer = { "%nDefault Naming conventions%n",
+        + "by applying naming conventions to the specified EXTENSION-ID.",
+        footer = { "%nDefault Naming conventions%n",
                 " GROUP-ID: io.quarkiverse.<EXTENSION-ID>",
                 " EXTENSION-NAME: EXTENSION-ID converted to Capitalized Words",
                 " NAMESPACE-NAME: NAMESPACE-ID converted to Capitalized Words",
@@ -88,7 +89,8 @@ public class CreateExtension extends BaseCreateCommand {
 
     // Ideally we should use TargetLanguageGroup once we support creating extensions with Kotlin
     @CommandLine.Option(names = {
-            "--java" }, description = "Target Java version.\n  Valid values: ${COMPLETION-CANDIDATES}", completionCandidates = VersionCandidates.class, defaultValue = JavaVersion.DEFAULT_JAVA_VERSION_FOR_EXTENSION)
+            "--java" }, description = "Target Java version.\n  Valid values: ${COMPLETION-CANDIDATES}",
+            completionCandidates = VersionCandidates.class, defaultValue = JavaVersion.DEFAULT_JAVA_VERSION_FOR_EXTENSION)
     String javaVersion;
 
     @CommandLine.ArgGroup(order = 2, exclusive = false, heading = "%nGenerated artifacts%n")

--- a/devtools/cli/src/main/java/io/quarkus/cli/Deploy.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Deploy.java
@@ -11,9 +11,11 @@ import io.quarkus.cli.deploy.Openshift;
 import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "deploy", sortOptions = false, mixinStandardHelpOptions = false, header = "Deploy application.", subcommands = {
-        Kubernetes.class, Openshift.class, Knative.class, Kind.class, Minikube.class,
-}, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "%nOptions:%n")
+@CommandLine.Command(name = "deploy", sortOptions = false, mixinStandardHelpOptions = false, header = "Deploy application.",
+        subcommands = {
+                Kubernetes.class, Openshift.class, Knative.class, Kind.class, Minikube.class,
+        }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ",
+        optionListHeading = "%nOptions:%n")
 public class Deploy extends BuildToolDelegatingCommand {
 
     private static final Map<BuildTool, String> ACTION_MAPPING = Map.of(BuildTool.MAVEN, "quarkus:deploy",

--- a/devtools/cli/src/main/java/io/quarkus/cli/Dev.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Dev.java
@@ -14,7 +14,8 @@ import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
 import picocli.CommandLine.Parameters;
 
-@CommandLine.Command(name = "dev", showEndOfOptionsDelimiterInUsageHelp = true, header = "Run the current project in dev (live coding) mode.")
+@CommandLine.Command(name = "dev", showEndOfOptionsDelimiterInUsageHelp = true,
+        header = "Run the current project in dev (live coding) mode.")
 public class Dev extends BaseBuildCommand implements Callable<Integer> {
 
     @CommandLine.ArgGroup(order = 1, exclusive = false, heading = "%nDev Mode options:%n")

--- a/devtools/cli/src/main/java/io/quarkus/cli/Image.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Image.java
@@ -11,9 +11,11 @@ import picocli.CommandLine;
 import picocli.CommandLine.ParseResult;
 import picocli.CommandLine.Unmatched;
 
-@CommandLine.Command(name = "image", sortOptions = false, mixinStandardHelpOptions = false, header = "Build or push project container image.", subcommands = {
-        Build.class, Push.class
-}, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "%nOptions:%n")
+@CommandLine.Command(name = "image", sortOptions = false, mixinStandardHelpOptions = false,
+        header = "Build or push project container image.", subcommands = {
+                Build.class, Push.class
+        }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ",
+        optionListHeading = "%nOptions:%n")
 public class Image implements Callable<Integer> {
 
     @CommandLine.Mixin(name = "output")

--- a/devtools/cli/src/main/java/io/quarkus/cli/Info.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Info.java
@@ -5,7 +5,10 @@ import java.util.concurrent.Callable;
 import io.quarkus.cli.common.build.BuildSystemRunner;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "info", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Display project information and verify versions health (platform and extensions).", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "%nOptions:%n")
+@CommandLine.Command(name = "info", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false,
+        header = "Display project information and verify versions health (platform and extensions).", headerHeading = "%n",
+        commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n",
+        optionListHeading = "%nOptions:%n")
 public class Info extends BaseBuildCommand implements Callable<Integer> {
 
     @CommandLine.Option(names = { "--per-module" }, description = "Display information per project module.")

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensions.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensions.java
@@ -10,7 +10,8 @@ import picocli.CommandLine.ParseResult;
 import picocli.CommandLine.Unmatched;
 
 @CommandLine.Command(name = "extension", aliases = {
-        "ext" }, header = "Configure extensions of an existing project.", subcommands = {
+        "ext" }, header = "Configure extensions of an existing project.",
+        subcommands = {
                 ProjectExtensionsList.class,
                 ProjectExtensionsCategories.class,
                 ProjectExtensionsAdd.class,

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsAdd.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsAdd.java
@@ -16,7 +16,8 @@ public class ProjectExtensionsAdd extends BaseBuildCommand implements Callable<I
     @CommandLine.Mixin
     RunModeOption runMode;
 
-    @CommandLine.Parameters(arity = "1", paramLabel = "EXTENSION", description = "extensions to add to this project", split = ",")
+    @CommandLine.Parameters(arity = "1", paramLabel = "EXTENSION", description = "extensions to add to this project",
+            split = ",")
     Set<String> extensions;
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsList.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsList.java
@@ -34,15 +34,18 @@ public class ProjectExtensionsList extends BaseBuildCommand implements Callable<
     TargetQuarkusPlatformGroup targetQuarkusVersion = new TargetQuarkusPlatformGroup();
 
     @CommandLine.Option(names = { "-i",
-            "--installable" }, defaultValue = "false", order = 2, description = "List extensions that can be installed (relative)")
+            "--installable" }, defaultValue = "false", order = 2,
+            description = "List extensions that can be installed (relative)")
     boolean installable = false;
 
     @CommandLine.Option(names = { "-s",
-            "--search" }, defaultValue = "*", paramLabel = "PATTERN", order = 3, description = "Search for matching extensions (simple glob using '*' and '?').")
+            "--search" }, defaultValue = "*", paramLabel = "PATTERN", order = 3,
+            description = "Search for matching extensions (simple glob using '*' and '?').")
     String searchPattern;
 
     @CommandLine.Option(names = { "-c",
-            "--category" }, defaultValue = "", paramLabel = "CATEGORY_ID", order = 4, description = "Only list extensions from the specified category.")
+            "--category" }, defaultValue = "", paramLabel = "CATEGORY_ID", order = 4,
+            description = "Only list extensions from the specified category.")
     String category;
 
     @CommandLine.ArgGroup(heading = "%nOutput format:%n")

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsRemove.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsRemove.java
@@ -16,7 +16,8 @@ public class ProjectExtensionsRemove extends BaseBuildCommand implements Callabl
     @CommandLine.Mixin
     RunModeOption runMode;
 
-    @CommandLine.Parameters(arity = "1", paramLabel = "EXTENSION", description = "Extension(s) to remove from this project.", split = ",")
+    @CommandLine.Parameters(arity = "1", paramLabel = "EXTENSION", description = "Extension(s) to remove from this project.",
+            split = ",")
     Set<String> extensions;
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -63,7 +63,10 @@ import picocli.CommandLine.UnmatchedArgumentException;
         Update.class,
         Version.class,
         CliPlugins.class,
-        Completion.class }, scope = ScopeType.INHERIT, sortOptions = false, showDefaultValues = true, versionProvider = Version.class, subcommandsRepeatable = false, mixinStandardHelpOptions = false, commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "Options:%n", headerHeading = "%n", parameterListHeading = "%n")
+        Completion.class }, scope = ScopeType.INHERIT, sortOptions = false, showDefaultValues = true,
+        versionProvider = Version.class, subcommandsRepeatable = false, mixinStandardHelpOptions = false,
+        commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "Options:%n",
+        headerHeading = "%n", parameterListHeading = "%n")
 public class QuarkusCli implements QuarkusApplication, OutputProvider, Callable<Integer> {
     static {
         System.setProperty("picocli.endofoptions.description", "End of command line options.");

--- a/devtools/cli/src/main/java/io/quarkus/cli/RegistryAddCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/RegistryAddCommand.java
@@ -16,10 +16,11 @@ import picocli.CommandLine;
         + "This command will add a Quarkus extension registry to the registry client configuration unless it's already present.")
 public class RegistryAddCommand extends BaseRegistryCommand {
 
-    @CommandLine.Parameters(arity = "1..*", split = ",", paramLabel = "REGISTRY-ID[,REGISTRY-ID]", description = "Registry ID to add to the registry client configuration%n"
-            + "  Example:%n"
-            + "    registry.quarkus.io%n"
-            + "    registry.quarkus.acme.com,registry.quarkus.io%n")
+    @CommandLine.Parameters(arity = "1..*", split = ",", paramLabel = "REGISTRY-ID[,REGISTRY-ID]",
+            description = "Registry ID to add to the registry client configuration%n"
+                    + "  Example:%n"
+                    + "    registry.quarkus.io%n"
+                    + "    registry.quarkus.acme.com,registry.quarkus.io%n")
     List<String> registryIds;
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/RegistryRemoveCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/RegistryRemoveCommand.java
@@ -14,10 +14,11 @@ import picocli.CommandLine;
         + "This command will remove a Quarkus extension registry from the registry client configuration.")
 public class RegistryRemoveCommand extends BaseRegistryCommand {
 
-    @CommandLine.Parameters(arity = "1..*", split = ",", paramLabel = "REGISTRY-ID[,REGISTRY-ID]", description = "Registry ID to remove from the registry client configuration%n"
-            + "  Example:%n"
-            + "    registry.quarkus.io%n"
-            + "    registry.quarkus.acme.com,registry.quarkus.io%n")
+    @CommandLine.Parameters(arity = "1..*", split = ",", paramLabel = "REGISTRY-ID[,REGISTRY-ID]",
+            description = "Registry ID to remove from the registry client configuration%n"
+                    + "  Example:%n"
+                    + "    registry.quarkus.io%n"
+                    + "    registry.quarkus.acme.com,registry.quarkus.io%n")
     List<String> registryIds;
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/Test.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Test.java
@@ -17,7 +17,8 @@ import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
 import picocli.CommandLine.Parameters;
 
-@CommandLine.Command(name = "test", showEndOfOptionsDelimiterInUsageHelp = true, header = "Run the current project in continuous testing mode.")
+@CommandLine.Command(name = "test", showEndOfOptionsDelimiterInUsageHelp = true,
+        header = "Run the current project in continuous testing mode.")
 public class Test extends BaseBuildCommand implements Callable<Integer> {
 
     @CommandLine.ArgGroup(order = 1, exclusive = false, heading = "%nContinuous Test Mode options:%n")

--- a/devtools/cli/src/main/java/io/quarkus/cli/Update.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Update.java
@@ -8,7 +8,10 @@ import io.quarkus.cli.common.update.RewriteGroup;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "update", aliases = { "up",
-        "upgrade" }, sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Suggest project updates and create a recipe with the possibility to apply it.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "%nOptions:%n")
+        "upgrade" }, sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false,
+        header = "Suggest project updates and create a recipe with the possibility to apply it.", headerHeading = "%n",
+        commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n",
+        optionListHeading = "%nOptions:%n")
 public class Update extends BaseBuildCommand implements Callable<Integer> {
 
     @CommandLine.ArgGroup(order = 0, heading = "%nTarget Quarkus version:%n", multiplicity = "0..1")

--- a/devtools/cli/src/main/java/io/quarkus/cli/config/Decrypt.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/config/Decrypt.java
@@ -17,7 +17,8 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-@Command(name = "decrypt", aliases = "dec", header = "Decrypt Secrets", description = "Decrypt a Secret value using the AES/GCM/NoPadding algorithm as a default.")
+@Command(name = "decrypt", aliases = "dec", header = "Decrypt Secrets",
+        description = "Decrypt a Secret value using the AES/GCM/NoPadding algorithm as a default.")
 public class Decrypt extends BaseConfigCommand implements Callable<Integer> {
     @Parameters(index = "0", paramLabel = "SECRET", description = "The secret value to decrypt")
     String secret;

--- a/devtools/cli/src/main/java/io/quarkus/cli/config/Encrypt.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/config/Encrypt.java
@@ -19,7 +19,8 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-@Command(name = "encrypt", aliases = "enc", header = "Encrypt Secrets", description = "Encrypt a Secret value using the AES/GCM/NoPadding algorithm as a default. The encryption key is generated unless a specific key is set with the --key option.")
+@Command(name = "encrypt", aliases = "enc", header = "Encrypt Secrets",
+        description = "Encrypt a Secret value using the AES/GCM/NoPadding algorithm as a default. The encryption key is generated unless a specific key is set with the --key option.")
 public class Encrypt extends BaseConfigCommand implements Callable<Integer> {
     @Parameters(index = "0", paramLabel = "SECRET", description = "The secret value to encrypt")
     String secret;

--- a/devtools/cli/src/main/java/io/quarkus/cli/create/CodeGenerationGroup.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/create/CodeGenerationGroup.java
@@ -26,7 +26,8 @@ public class CodeGenerationGroup {
     public boolean includeWrapper = true;
 
     @CommandLine.Option(names = {
-            "--no-code" }, description = "Include starter code provided by extensions or generate an empty project", negatable = true)
+            "--no-code" }, description = "Include starter code provided by extensions or generate an empty project",
+            negatable = true)
     public boolean includeCode = true;
 
     @CommandLine.Option(names = {
@@ -34,7 +35,8 @@ public class CodeGenerationGroup {
     public boolean includeDockerfiles = true;
 
     @CommandLine.Option(names = { "-c",
-            "--app-config" }, description = "Configuration attributes to be set in the application.properties/yml file. Specify as 'key1=value1,key2=value2'")
+            "--app-config" },
+            description = "Configuration attributes to be set in the application.properties/yml file. Specify as 'key1=value1,key2=value2'")
     void setAppConfig(String config) {
         if (config.trim().length() > 0) {
             appConfig = ToolsUtils.stringToMap(config, ",", "=");

--- a/devtools/cli/src/main/java/io/quarkus/cli/create/ExtensionGAVMixin.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/create/ExtensionGAVMixin.java
@@ -15,12 +15,13 @@ public class ExtensionGAVMixin {
     String extensionId = null;
     String version = null;
 
-    @CommandLine.Parameters(arity = "0..1", paramLabel = "[GROUP-ID:]EXTENSION-ID[:VERSION]", description = "Quarkus extension project identifiers%n"
-            + "  " + EXAMPLE_GAV + "%n"
-            + "  Examples:%n"
-            + "     my-extension%n"
-            + "     my.group:my-extension%n"
-            + "     my.group:my-extension:0.1%n")
+    @CommandLine.Parameters(arity = "0..1", paramLabel = "[GROUP-ID:]EXTENSION-ID[:VERSION]",
+            description = "Quarkus extension project identifiers%n"
+                    + "  " + EXAMPLE_GAV + "%n"
+                    + "  Examples:%n"
+                    + "     my-extension%n"
+                    + "     my.group:my-extension%n"
+                    + "     my.group:my-extension:0.1%n")
     String gav = null;
 
     void projectGav() {

--- a/devtools/cli/src/main/java/io/quarkus/cli/create/TargetGAVGroup.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/create/TargetGAVGroup.java
@@ -18,12 +18,13 @@ public class TargetGAVGroup {
     String artifactId = CreateProjectHelper.DEFAULT_ARTIFACT_ID;
     String version = CreateProjectHelper.DEFAULT_VERSION;
 
-    @CommandLine.Parameters(arity = "0..1", paramLabel = "[GROUP-ID:]ARTIFACT-ID[:VERSION]", description = "Java project identifiers%n"
-            + "  default: " + DEFAULT_GAV + "%n"
-            + "  Examples:%n"
-            + "     my-project%n"
-            + "     my.group:my-project%n"
-            + "     my.group:my-project:0.1%n")
+    @CommandLine.Parameters(arity = "0..1", paramLabel = "[GROUP-ID:]ARTIFACT-ID[:VERSION]",
+            description = "Java project identifiers%n"
+                    + "  default: " + DEFAULT_GAV + "%n"
+                    + "  Examples:%n"
+                    + "     my-project%n"
+                    + "     my.group:my-project%n"
+                    + "     my.group:my-project:0.1%n")
     String gav = null;
 
     boolean initialized = false;

--- a/devtools/cli/src/main/java/io/quarkus/cli/create/TargetLanguageGroup.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/create/TargetLanguageGroup.java
@@ -21,7 +21,8 @@ public class TargetLanguageGroup {
     }
 
     @CommandLine.Option(names = {
-            "--java" }, description = "Target Java version.\n  Valid values: ${COMPLETION-CANDIDATES}", completionCandidates = VersionCandidates.class, defaultValue = JavaVersion.DETECT_JAVA_RUNTIME_VERSION)
+            "--java" }, description = "Target Java version.\n  Valid values: ${COMPLETION-CANDIDATES}",
+            completionCandidates = VersionCandidates.class, defaultValue = JavaVersion.DETECT_JAVA_RUNTIME_VERSION)
     String javaVersion = JavaVersion.DETECT_JAVA_RUNTIME_VERSION;
 
     @CommandLine.Option(names = { "--kotlin" }, description = "Use Kotlin")

--- a/devtools/cli/src/main/java/io/quarkus/cli/deploy/Kind.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/deploy/Kind.java
@@ -5,9 +5,13 @@ import java.util.Optional;
 import io.quarkus.cli.common.BuildToolContext;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "kind", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Perform the deploy action on Kind.", description = "%n"
-        + "The command will deploy the application on Kind.", footer = "%n"
-                + "For example (using default values), it will create a Deployment named '<project.artifactId>' using the image with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>' and will deploy it to the target cluster.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+@CommandLine.Command(name = "kind", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false,
+        header = "Perform the deploy action on Kind.", description = "%n"
+                + "The command will deploy the application on Kind.",
+        footer = "%n"
+                + "For example (using default values), it will create a Deployment named '<project.artifactId>' using the image with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>' and will deploy it to the target cluster.",
+        headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n",
+        optionListHeading = "Options:%n")
 public class Kind extends BaseKubernetesDeployCommand {
 
     private static final String KIND = "kind";

--- a/devtools/cli/src/main/java/io/quarkus/cli/deploy/Knative.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/deploy/Knative.java
@@ -3,9 +3,13 @@ package io.quarkus.cli.deploy;
 import io.quarkus.cli.common.BuildToolContext;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "knative", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Perform the deploy action on Knative.", description = "%n"
-        + "The command will deploy the application on Knative.", footer = "%n"
-                + "For example (using default values), it will create a Deployment named '<project.artifactId>' using the image with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>' and will deploy it to the target cluster.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+@CommandLine.Command(name = "knative", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false,
+        header = "Perform the deploy action on Knative.", description = "%n"
+                + "The command will deploy the application on Knative.",
+        footer = "%n"
+                + "For example (using default values), it will create a Deployment named '<project.artifactId>' using the image with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>' and will deploy it to the target cluster.",
+        headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n",
+        optionListHeading = "Options:%n")
 public class Knative extends BaseKubernetesDeployCommand {
 
     private static final String KNATIVE = "knative";

--- a/devtools/cli/src/main/java/io/quarkus/cli/deploy/Kubernetes.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/deploy/Kubernetes.java
@@ -5,9 +5,13 @@ import java.util.Optional;
 import io.quarkus.cli.common.BuildToolContext;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "kubernetes", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Perform the deploy action on Kubernetes.", description = "%n"
-        + "The command will deploy the application on Kubernetes.", footer = "%n"
-                + "For example (using default values), it will create a Deployment named '<project.artifactId>' using the image with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>' and will deploy it to the target cluster.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+@CommandLine.Command(name = "kubernetes", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false,
+        header = "Perform the deploy action on Kubernetes.", description = "%n"
+                + "The command will deploy the application on Kubernetes.",
+        footer = "%n"
+                + "For example (using default values), it will create a Deployment named '<project.artifactId>' using the image with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>' and will deploy it to the target cluster.",
+        headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n",
+        optionListHeading = "Options:%n")
 public class Kubernetes extends BaseKubernetesDeployCommand {
 
     private static final String KUBERNETES = "kubernetes";

--- a/devtools/cli/src/main/java/io/quarkus/cli/deploy/Minikube.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/deploy/Minikube.java
@@ -5,9 +5,13 @@ import java.util.Optional;
 import io.quarkus.cli.common.BuildToolContext;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "minikube", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Perform the deploy action on minikube.", description = "%n"
-        + "The command will deploy the application on minikube.", footer = "%n"
-                + "For example (using default values), it will create a Deployment named '<project.artifactId>' using the image with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>' and will deploy it to the target cluster.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+@CommandLine.Command(name = "minikube", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false,
+        header = "Perform the deploy action on minikube.", description = "%n"
+                + "The command will deploy the application on minikube.",
+        footer = "%n"
+                + "For example (using default values), it will create a Deployment named '<project.artifactId>' using the image with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>' and will deploy it to the target cluster.",
+        headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n",
+        optionListHeading = "Options:%n")
 public class Minikube extends BaseKubernetesDeployCommand {
 
     private static final String MINIKUBE = "minikube";

--- a/devtools/cli/src/main/java/io/quarkus/cli/deploy/Openshift.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/deploy/Openshift.java
@@ -5,9 +5,13 @@ import java.util.Optional;
 import io.quarkus.cli.common.BuildToolContext;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "openshift", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Perform the deploy action on OpenShift.", description = "%n"
-        + "The command will deploy the application on OpenShift.", footer = "%n"
-                + "For example (using default values), it will create a Deployment named '<project.artifactId>' using the image with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>' and will deploy it to the target cluster.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+@CommandLine.Command(name = "openshift", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false,
+        header = "Perform the deploy action on OpenShift.", description = "%n"
+                + "The command will deploy the application on OpenShift.",
+        footer = "%n"
+                + "For example (using default values), it will create a Deployment named '<project.artifactId>' using the image with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>' and will deploy it to the target cluster.",
+        headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n",
+        optionListHeading = "Options:%n")
 public class Openshift extends BaseKubernetesDeployCommand {
 
     private static final String OPENSHIFT = "openshift";

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Build.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Build.java
@@ -7,14 +7,19 @@ import io.quarkus.cli.common.BuildToolContext;
 import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "build", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image.", description = "%n"
-        + "This command will build a container image for the project.", subcommands = { Docker.class,
+@CommandLine.Command(name = "build", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false,
+        header = "Build a container image.", description = "%n"
+                + "This command will build a container image for the project.",
+        subcommands = { Docker.class,
                 Podman.class,
                 Buildpack.class,
                 Jib.class,
-                Openshift.class }, footer = { "%n"
-                        + "For example (using default values), it will create a container image using docker with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'."
-                        + "%n" }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+                Openshift.class },
+        footer = { "%n"
+                + "For example (using default values), it will create a container image using docker with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'."
+                + "%n" },
+        headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n",
+        optionListHeading = "Options:%n")
 public class Build extends BaseImageCommand {
 
     private static final String FALLBACK_BUILDER = "docker";

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Buildpack.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Buildpack.java
@@ -7,9 +7,13 @@ import java.util.Optional;
 import io.quarkus.cli.common.BuildToolContext;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "buildpack", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image using Buildpack.", description = "%n"
-        + "This command will build or push a container image for the project, using Buildpack.", footer = "%n"
-                + "For example (using default values), it will create a container image using with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+@CommandLine.Command(name = "buildpack", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false,
+        header = "Build a container image using Buildpack.", description = "%n"
+                + "This command will build or push a container image for the project, using Buildpack.",
+        footer = "%n"
+                + "For example (using default values), it will create a container image using with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.",
+        headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n",
+        optionListHeading = "Options:%n")
 public class Buildpack extends BaseImageSubCommand {
 
     private static final String BUILDPACK = "buildpack";

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Docker.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Docker.java
@@ -6,9 +6,13 @@ import java.util.Optional;
 import io.quarkus.cli.common.BuildToolContext;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "docker", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image using Docker.", description = "%n"
-        + "This command will build or push a container image for the project, using Docker.", footer = "%n"
-                + "For example (using default values), it will create a container image using with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+@CommandLine.Command(name = "docker", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false,
+        header = "Build a container image using Docker.", description = "%n"
+                + "This command will build or push a container image for the project, using Docker.",
+        footer = "%n"
+                + "For example (using default values), it will create a container image using with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.",
+        headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n",
+        optionListHeading = "Options:%n")
 public class Docker extends BaseImageSubCommand {
 
     private static final String DOCKER = "docker";

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Jib.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Jib.java
@@ -12,9 +12,13 @@ import java.util.stream.Collectors;
 import io.quarkus.cli.common.BuildToolContext;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "jib", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image using Jib.", description = "%n"
-        + "This command will build or push a container image for the project, using Jib.", footer = "%n"
-                + "For example (using default values), it will create a container image using with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+@CommandLine.Command(name = "jib", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false,
+        header = "Build a container image using Jib.", description = "%n"
+                + "This command will build or push a container image for the project, using Jib.",
+        footer = "%n"
+                + "For example (using default values), it will create a container image using with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.",
+        headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n",
+        optionListHeading = "Options:%n")
 public class Jib extends BaseImageSubCommand {
 
     private static final String JIB = "jib";
@@ -58,19 +62,23 @@ public class Jib extends BaseImageSubCommand {
     public String user;
 
     @CommandLine.Option(order = 14, names = {
-            "--always-cache-base-image" }, description = "Controls the optimization which skips downloading base image layers that exist in a target registry.")
+            "--always-cache-base-image" },
+            description = "Controls the optimization which skips downloading base image layers that exist in a target registry.")
     public boolean alwaysCacheBaseImage;
 
     @CommandLine.Option(order = 15, names = {
-            "--platform" }, description = "The target platforms defined using the pattern <os>[/arch][/variant]|<os>/<arch>[/variant]")
+            "--platform" },
+            description = "The target platforms defined using the pattern <os>[/arch][/variant]|<os>/<arch>[/variant]")
     public Set<String> platforms = new HashSet<>();
 
     @CommandLine.Option(order = 16, names = {
-            "--image-digest-file" }, description = "The path of a file that will be written containing the digest of the generated image.")
+            "--image-digest-file" },
+            description = "The path of a file that will be written containing the digest of the generated image.")
     public String imageDigestFile;
 
     @CommandLine.Option(order = 17, names = {
-            "--image-id-file" }, description = "The path of a file that will be written containing the id of the generated image.")
+            "--image-id-file" },
+            description = "The path of a file that will be written containing the id of the generated image.")
     public String imageIdFile;
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Openshift.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Openshift.java
@@ -10,9 +10,13 @@ import java.util.stream.Collectors;
 import io.quarkus.cli.common.BuildToolContext;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "openshift", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image using OpenShift.", description = "%n"
-        + "This command will build or push a container image for the project, using Openshift.", footer = "%n"
-                + "For example (using default values), it will create a container image in OpenShift using the docker build strategy with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+@CommandLine.Command(name = "openshift", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false,
+        header = "Build a container image using OpenShift.", description = "%n"
+                + "This command will build or push a container image for the project, using Openshift.",
+        footer = "%n"
+                + "For example (using default values), it will create a container image in OpenShift using the docker build strategy with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.",
+        headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n",
+        optionListHeading = "Options:%n")
 public class Openshift extends BaseImageSubCommand implements Callable<Integer> {
 
     private static final String OPENSHIFT = "openshift";
@@ -46,7 +50,8 @@ public class Openshift extends BaseImageSubCommand implements Callable<Integer> 
     public String dockerfile;
 
     @CommandLine.Option(order = 11, names = {
-            "--artifact-directory" }, description = "The directory where the jar/native binary is added during the assemble phase.")
+            "--artifact-directory" },
+            description = "The directory where the jar/native binary is added during the assemble phase.")
     public String artifactDirectory;
 
     @CommandLine.Option(order = 12, names = { "--artifact-filename" }, description = "The filename of the jar/native binary.")

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Podman.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Podman.java
@@ -5,9 +5,13 @@ import java.util.Optional;
 import io.quarkus.cli.common.BuildToolContext;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "podman", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image using Podman.", description = "%n"
-        + "This command will build or push a container image for the project, using Podman.", footer = "%n"
-                + "For example (using default values), it will create a container image using with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+@CommandLine.Command(name = "podman", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false,
+        header = "Build a container image using Podman.", description = "%n"
+                + "This command will build or push a container image for the project, using Podman.",
+        footer = "%n"
+                + "For example (using default values), it will create a container image using with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.",
+        headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n",
+        optionListHeading = "Options:%n")
 public class Podman extends BaseImageSubCommand {
 
     private static final String PODMAN = "podman";

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Push.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Push.java
@@ -7,8 +7,11 @@ import io.quarkus.cli.common.BuildToolContext;
 import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "push", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Push a container image.", description = "%n"
-        + "This command will build and push a container image for the project.", footer = "%n", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+@CommandLine.Command(name = "push", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false,
+        header = "Push a container image.", description = "%n"
+                + "This command will build and push a container image for the project.",
+        footer = "%n", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ",
+        parameterListHeading = "%n", optionListHeading = "Options:%n")
 public class Push extends BaseImageCommand {
 
     protected static final String QUARKUS_CONTAINER_IMAGE_EXTENSION = "io.quarkus:quarkus-container-image";

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsAdd.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsAdd.java
@@ -20,7 +20,8 @@ public class CliPluginsAdd extends CliPluginsBase implements Callable<Integer> {
             "--description" }, paramLabel = "Plugin description", order = 5, description = "The plugin description")
     Optional<String> description;
 
-    @CommandLine.Parameters(arity = "1", paramLabel = "PLUGIN_NAME", description = " The plugin name or location (e.g. url, path or maven coordinates in GACTV form)")
+    @CommandLine.Parameters(arity = "1", paramLabel = "PLUGIN_NAME",
+            description = " The plugin name or location (e.g. url, path or maven coordinates in GACTV form)")
     String nameOrLocation;
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsList.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsList.java
@@ -27,11 +27,13 @@ public class CliPluginsList extends CliPluginsBase implements Callable<Integer> 
     boolean installable = false;
 
     @CommandLine.Option(names = { "-s",
-            "--search" }, defaultValue = "*", order = 5, paramLabel = "PATTERN", description = "Search for matching plugins (simple glob using '*' and '?').")
+            "--search" }, defaultValue = "*", order = 5, paramLabel = "PATTERN",
+            description = "Search for matching plugins (simple glob using '*' and '?').")
     String searchPattern;
 
     @CommandLine.Option(names = { "-c",
-            "--show-command" }, defaultValue = "false", order = 6, description = "Show the command that corresponds to the plugin")
+            "--show-command" }, defaultValue = "false", order = 6,
+            description = "Show the command that corresponds to the plugin")
     boolean showCommand = false;
 
     Map<String, Plugin> installedPlugins = new HashMap<>();

--- a/devtools/cli/src/test/java/io/quarkus/cli/config/DecryptTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/config/DecryptTest.java
@@ -12,7 +12,8 @@ import org.junit.jupiter.api.io.TempDir;
 
 import io.quarkus.cli.CliDriver;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Parsing the stdout is not working on Github Windows, maybe because of the console formatting. I did try it in a Windows box and it works fine.")
+@DisabledOnOs(value = OS.WINDOWS,
+        disabledReason = "Parsing the stdout is not working on Github Windows, maybe because of the console formatting. I did try it in a Windows box and it works fine.")
 public class DecryptTest {
     @TempDir
     Path tempDir;

--- a/devtools/cli/src/test/java/io/quarkus/cli/config/EncryptTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/config/EncryptTest.java
@@ -14,10 +14,11 @@ import io.quarkus.cli.CliDriver;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Parsing the stdout is not working on Github Windows, maybe because of the console formatting. "
-        +
-        "I did try it in a Windows box and it works fine. Regardless, this commands is tested indirectly" +
-        " in SetConfigTest, which is still enabled in Windows ")
+@DisabledOnOs(value = OS.WINDOWS,
+        disabledReason = "Parsing the stdout is not working on Github Windows, maybe because of the console formatting. "
+                +
+                "I did try it in a Windows box and it works fine. Regardless, this commands is tested indirectly" +
+                " in SetConfigTest, which is still enabled in Windows ")
 class EncryptTest {
     @TempDir
     Path tempDir;

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -294,7 +294,8 @@ public abstract class QuarkusDev extends QuarkusTask {
     }
 
     @SuppressWarnings("unused")
-    @Option(description = "Additional parameters to pass to javac when recompiling changed source files", option = "compiler-args")
+    @Option(description = "Additional parameters to pass to javac when recompiling changed source files",
+            option = "compiler-args")
     public void setCompilerArgs(List<String> compilerArgs) {
         getCompilerArguments().set(compilerArgs);
     }
@@ -329,7 +330,8 @@ public abstract class QuarkusDev extends QuarkusTask {
     }
 
     @SuppressWarnings("unused")
-    @Option(description = "Sets test class or method name to be included (for continuous testing), '*' is supported.", option = "tests")
+    @Option(description = "Sets test class or method name to be included (for continuous testing), '*' is supported.",
+            option = "tests")
     public void setTests(List<String> tests) {
         getTests().set(tests);
     }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusListCategories.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusListCategories.java
@@ -34,7 +34,8 @@ public abstract class QuarkusListCategories extends QuarkusPlatformTask {
         return format;
     }
 
-    @Option(description = "Select the output format among 'id' (display the categoryId only), 'concise' (display name and categoryId) and 'full' (name, categoryId and description columns).", option = "format")
+    @Option(description = "Select the output format among 'id' (display the categoryId only), 'concise' (display name and categoryId) and 'full' (name, categoryId and description columns).",
+            option = "format")
     public void setFormat(String format) {
         this.format = format;
     }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusListExtensions.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusListExtensions.java
@@ -60,7 +60,8 @@ public abstract class QuarkusListExtensions extends QuarkusPlatformTask {
         return format;
     }
 
-    @Option(description = "Select the output format among 'id' (display the artifactId only), 'concise' (display name and artifactId), 'origins' (display extension catalog IDs providing extension information), 'support-scope' (support scope associated with each extension, if any) and 'full' (concise format and version related columns).", option = "format")
+    @Option(description = "Select the output format among 'id' (display the artifactId only), 'concise' (display name and artifactId), 'origins' (display extension catalog IDs providing extension information), 'support-scope' (support scope associated with each extension, if any) and 'full' (concise format and version related columns).",
+            option = "format")
     public void setFormat(String format) {
         this.format = format;
     }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
@@ -97,7 +97,8 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
         return rewriteQuarkusUpdateRecipes;
     }
 
-    @Option(description = "Use a custom io.quarkus:quarkus-update-recipes:LATEST artifact (GAV) or just provide the version. This artifact should contain the base Quarkus update recipes to update a project.", option = "quarkusUpdateRecipes")
+    @Option(description = "Use a custom io.quarkus:quarkus-update-recipes:LATEST artifact (GAV) or just provide the version. This artifact should contain the base Quarkus update recipes to update a project.",
+            option = "quarkusUpdateRecipes")
     public QuarkusUpdate setRewriteQuarkusUpdateRecipes(String rewriteQuarkusUpdateRecipes) {
         this.rewriteQuarkusUpdateRecipes = rewriteQuarkusUpdateRecipes;
         return this;
@@ -109,7 +110,8 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
         return rewriteAdditionalUpdateRecipes;
     }
 
-    @Option(description = "Specify a list of additional artifacts (GAV) containing rewrite recipes.", option = "additionalUpdateRecipes")
+    @Option(description = "Specify a list of additional artifacts (GAV) containing rewrite recipes.",
+            option = "additionalUpdateRecipes")
     public QuarkusUpdate setRewriteAdditionalUpdateRecipes(String rewriteAdditionalUpdateRecipes) {
         this.rewriteAdditionalUpdateRecipes = rewriteAdditionalUpdateRecipes;
         return this;

--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildEnhancedArtifactMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildEnhancedArtifactMojo.java
@@ -32,7 +32,8 @@ import io.quarkus.deployment.pkg.builditem.BuildPgoOptimizedNativeResultBuildIte
  * <li>PGO-optimized native images (from GraalVM PGO profiling)</li>
  * </ul>
  */
-@Mojo(name = "build-enhanced-artifact", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+@Mojo(name = "build-enhanced-artifact", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class BuildEnhancedArtifactMojo extends QuarkusBootstrapMojo {
 
     private static final String PGO_PROFILE_NAME = "default.iprof";

--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -32,7 +32,8 @@ import io.quarkus.maven.dependency.ArtifactCoords;
 /**
  * Builds the Quarkus application.
  */
-@Mojo(name = "build", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+@Mojo(name = "build", defaultPhase = LifecyclePhase.PACKAGE,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class BuildMojo extends QuarkusBootstrapMojo {
 
     @Component

--- a/devtools/maven/src/main/java/io/quarkus/maven/DependencyListMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DependencyListMojo.java
@@ -37,7 +37,8 @@ import io.quarkus.maven.dependency.ResolvedDependency;
 /**
  * Lists dependencies of a Quarkus application as resolved by the Quarkus bootstrap dependency resolver.
  */
-@Mojo(name = "dependency-list", defaultPhase = LifecyclePhase.NONE, requiresDependencyResolution = ResolutionScope.NONE, threadSafe = true)
+@Mojo(name = "dependency-list", defaultPhase = LifecyclePhase.NONE, requiresDependencyResolution = ResolutionScope.NONE,
+        threadSafe = true)
 public class DependencyListMojo extends AbstractMojo {
 
     @Inject

--- a/devtools/maven/src/main/java/io/quarkus/maven/DependencySbomMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DependencySbomMojo.java
@@ -30,7 +30,8 @@ import io.quarkus.sbom.SbomContribution;
 /**
  * Quarkus application SBOM generator
  */
-@Mojo(name = "dependency-sbom", defaultPhase = LifecyclePhase.NONE, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
+@Mojo(name = "dependency-sbom", defaultPhase = LifecyclePhase.NONE, requiresDependencyResolution = ResolutionScope.TEST,
+        threadSafe = true)
 public class DependencySbomMojo extends AbstractMojo {
 
     @Component

--- a/devtools/maven/src/main/java/io/quarkus/maven/DependencyTreeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DependencyTreeMojo.java
@@ -31,7 +31,8 @@ import io.quarkus.maven.dependency.ArtifactCoords;
 /**
  * Displays Quarkus application build dependency tree including the deployment ones.
  */
-@Mojo(name = "dependency-tree", defaultPhase = LifecyclePhase.NONE, requiresDependencyResolution = ResolutionScope.NONE, threadSafe = true)
+@Mojo(name = "dependency-tree", defaultPhase = LifecyclePhase.NONE, requiresDependencyResolution = ResolutionScope.NONE,
+        threadSafe = true)
 public class DependencyTreeMojo extends AbstractMojo {
 
     @Component

--- a/devtools/maven/src/main/java/io/quarkus/maven/DeployMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DeployMojo.java
@@ -18,7 +18,8 @@ import io.quarkus.deployment.cmd.DeployCommandDeclarationHandler;
 import io.quarkus.deployment.cmd.DeployCommandDeclarationResultBuildItem;
 import io.quarkus.deployment.cmd.DeployCommandHandler;
 
-@Mojo(name = "deploy", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+@Mojo(name = "deploy", defaultPhase = LifecyclePhase.PACKAGE,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class DeployMojo extends AbstractDeploymentMojo {
 
     @Override

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -126,7 +126,8 @@ import io.smallrye.common.expression.Expression;
  * <p>
  * You can use this dev mode in a remote container environment with {@code remote-dev}.
  */
-@Mojo(name = "dev", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
+@Mojo(name = "dev", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, requiresDependencyResolution = ResolutionScope.TEST,
+        threadSafe = true)
 public class DevMojo extends AbstractMojo {
 
     private static final Set<String> IGNORED_PHASES = Set.of(

--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
@@ -32,7 +32,8 @@ import io.quarkus.runtime.LaunchMode;
 // in the PROCESS_RESOURCES phase because we want the config to be available
 // by the time code gen providers are triggered (the resources plugin copies the config files
 // to the destination location at the beginning of this phase)
-@Mojo(name = "generate-code", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+@Mojo(name = "generate-code", defaultPhase = LifecyclePhase.PROCESS_RESOURCES,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class GenerateCodeMojo extends QuarkusBootstrapMojo {
 
     /**

--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeTestsMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeTestsMojo.java
@@ -22,7 +22,8 @@ import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.runtime.LaunchMode;
 
-@Mojo(name = "generate-code-tests", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+@Mojo(name = "generate-code-tests", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class GenerateCodeTestsMojo extends GenerateCodeMojo {
 
     /**

--- a/devtools/maven/src/main/java/io/quarkus/maven/ImageBuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/ImageBuildMojo.java
@@ -10,7 +10,8 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 /**
  * Builds a container image.
  */
-@Mojo(name = "image-build", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+@Mojo(name = "image-build", defaultPhase = LifecyclePhase.PACKAGE,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class ImageBuildMojo extends AbstractImageMojo {
 
     @Override

--- a/devtools/maven/src/main/java/io/quarkus/maven/ImagePushMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/ImagePushMojo.java
@@ -10,7 +10,8 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 /**
  * Pushes a container image.
  */
-@Mojo(name = "image-push", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+@Mojo(name = "image-push", defaultPhase = LifecyclePhase.PACKAGE,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class ImagePushMojo extends AbstractImageMojo {
 
     @Override

--- a/devtools/maven/src/main/java/io/quarkus/maven/NativeImageAgentMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/NativeImageAgentMojo.java
@@ -28,7 +28,8 @@ import io.quarkus.bootstrap.json.JsonValue;
 /**
  * Post-processes native image agent generated configuration to trim any unnecessary configuration.
  */
-@Mojo(name = "native-image-agent", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+@Mojo(name = "native-image-agent", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class NativeImageAgentMojo extends QuarkusBootstrapMojo {
 
     private final Pattern resourceSkipPattern;

--- a/devtools/maven/src/main/java/io/quarkus/maven/PrepareMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/PrepareMojo.java
@@ -7,7 +7,8 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 @Deprecated
-@Mojo(name = "prepare", defaultPhase = LifecyclePhase.GENERATE_SOURCES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+@Mojo(name = "prepare", defaultPhase = LifecyclePhase.GENERATE_SOURCES,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class PrepareMojo extends GenerateCodeMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {

--- a/devtools/maven/src/main/java/io/quarkus/maven/PrepareTestsMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/PrepareTestsMojo.java
@@ -7,7 +7,8 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 @Deprecated
-@Mojo(name = "prepare-tests", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+@Mojo(name = "prepare-tests", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class PrepareTestsMojo extends GenerateCodeTestsMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {

--- a/devtools/maven/src/main/java/io/quarkus/maven/TestMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/TestMojo.java
@@ -13,7 +13,8 @@ import io.quarkus.runtime.LaunchMode;
 /**
  * The test mojo, that starts continuous testing outside of dev mode
  */
-@Mojo(name = "test", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
+@Mojo(name = "test", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, requiresDependencyResolution = ResolutionScope.TEST,
+        threadSafe = true)
 public class TestMojo extends DevMojo {
 
     @Override

--- a/devtools/maven/src/main/java/io/quarkus/maven/TrackConfigChangesMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/TrackConfigChangesMojo.java
@@ -35,7 +35,8 @@ import io.quarkus.runtime.LaunchMode;
  * both configuration files could be compared by tools caching build goal outcomes to check whether the previous
  * outcome of the {@link BuildMojo} needs to be rebuilt.
  */
-@Mojo(name = "track-config-changes", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+@Mojo(name = "track-config-changes", defaultPhase = LifecyclePhase.PROCESS_RESOURCES,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class TrackConfigChangesMojo extends QuarkusBootstrapMojo {
 
     /**

--- a/docs/src/test/java/io/quarkus/docs/vale/LocalValeLintTest.java
+++ b/docs/src/test/java/io/quarkus/docs/vale/LocalValeLintTest.java
@@ -16,7 +16,8 @@ import io.quarkus.docs.vale.ValeAsciidocLint.ChecksBySeverity;
 
 public class LocalValeLintTest {
     @Test
-    @EnabledIfSystemProperty(named = "vale", matches = ".*", disabledReason = "Requires a container runtime. Specifiy -Dvale to enable.")
+    @EnabledIfSystemProperty(named = "vale", matches = ".*",
+            disabledReason = "Requires a container runtime. Specifiy -Dvale to enable.")
     public void testAsciidocFiles() throws Exception {
         Path srcDir = Path.of("").resolve("src/main/asciidoc");
         Path targetDir = Path.of("").resolve("target");

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/config/ConfigPropertyMapInjectionTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/config/ConfigPropertyMapInjectionTest.java
@@ -43,7 +43,8 @@ public class ConfigPropertyMapInjectionTest {
     @ConfigProperty(name = "versions")
     Map<String, Version> versions;
 
-    @ConfigProperty(name = "default.versions", defaultValue = "v0.1=0.The version 0;v1\\=1\\;2\\;3=1.The version 1\\;2\\;3;v2\\=2\\;1\\;0=2.The version 2\\;1\\;0")
+    @ConfigProperty(name = "default.versions",
+            defaultValue = "v0.1=0.The version 0;v1\\=1\\;2\\;3=1.The version 1\\;2\\;3;v2\\=2\\;1\\;0=2.The version 2\\;1\\;0")
     Map<String, Version> versionsDefault;
 
     @Test

--- a/extensions/azure-functions-http/runtime/src/main/java/io/quarkus/azure/functions/resteasy/runtime/Function.java
+++ b/extensions/azure-functions-http/runtime/src/main/java/io/quarkus/azure/functions/resteasy/runtime/Function.java
@@ -17,9 +17,10 @@ public class Function extends BaseFunction {
 
     @FunctionName(QUARKUS_HTTP)
     public HttpResponseMessage run(
-            @HttpTrigger(name = "req", dataType = "binary", route = "{*path}", authLevel = AuthorizationLevel.ANONYMOUS, methods = {
-                    GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE,
-                    PATCH }) HttpRequestMessage<Optional<String>> request,
+            @HttpTrigger(name = "req", dataType = "binary", route = "{*path}", authLevel = AuthorizationLevel.ANONYMOUS,
+                    methods = {
+                            GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE,
+                            PATCH }) HttpRequestMessage<Optional<String>> request,
             ExecutionContext context) {
 
         return dispatch(request);

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/exception/ExceptionProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/exception/ExceptionProcessor.java
@@ -21,9 +21,12 @@ import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
 /**
  * Exposes the last exception (compilation, deployment, or runtime) as a Dev MCP tool.
  */
-@DevMcpBuildTimeTool(name = "getLastException", description = "Get the last exception that occurred in this Quarkus application. Returns compilation errors, deployment failures, hot-reload problems, or runtime exceptions with full stack traces and source locations.", params = {
-        @DevMcpParam(name = "maxCauseDepth", description = "Maximum depth for the cause chain (default 5)", required = false)
-})
+@DevMcpBuildTimeTool(name = "getLastException",
+        description = "Get the last exception that occurred in this Quarkus application. Returns compilation errors, deployment failures, hot-reload problems, or runtime exceptions with full stack traces and source locations.",
+        params = {
+                @DevMcpParam(name = "maxCauseDepth", description = "Maximum depth for the cause chain (default 5)",
+                        required = false)
+        })
 @DevMcpBuildTimeTool(name = "clearLastException", description = "Clear the last recorded runtime exception.")
 public class ExceptionProcessor {
 

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/DevServicesProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/DevServicesProcessor.java
@@ -23,7 +23,8 @@ import io.quarkus.devui.spi.page.Page;
 /**
  * This creates DevServices Page
  */
-@DevMcpBuildTimeTool(name = "getDevServices", description = "Get all the DevServices started by this Quarkus app, including information on container and the config that is being set automatically")
+@DevMcpBuildTimeTool(name = "getDevServices",
+        description = "Get all the DevServices started by this Quarkus app, including information on container and the config that is being set automatically")
 public class DevServicesProcessor {
 
     @BuildStep(onlyIf = IsLocalDevelopment.class)

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ExtensionsProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ExtensionsProcessor.java
@@ -35,12 +35,15 @@ import io.quarkus.devui.spi.page.Page;
 /**
  * This creates Extensions Page
  */
-@DevMcpBuildTimeTool(name = "listInstallableExtensions", description = "Get all extensions that can be added to the current project")
+@DevMcpBuildTimeTool(name = "listInstallableExtensions",
+        description = "Get all extensions that can be added to the current project")
 @DevMcpBuildTimeTool(name = "removeExtension", description = "Remove a certain extension from the current project", params = {
-        @DevMcpParam(name = "extensionArtifactId", description = "The gav string of the extension to remove in format groupId:artifactId:version")
+        @DevMcpParam(name = "extensionArtifactId",
+                description = "The gav string of the extension to remove in format groupId:artifactId:version")
 })
 @DevMcpBuildTimeTool(name = "addExtension", description = "Add a certain extension to the current project", params = {
-        @DevMcpParam(name = "extensionArtifactId", description = "The gav string of the extension to add in format groupId:artifactId:version")
+        @DevMcpParam(name = "extensionArtifactId",
+                description = "The gav string of the extension to add in format groupId:artifactId:version")
 })
 public class ExtensionsProcessor {
 

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/OneShotTestingProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/OneShotTestingProcessor.java
@@ -25,11 +25,15 @@ import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
  * without requiring continuous testing to be started.
  */
 @DevMcpBuildTimeTool(name = OneShotTestingProcessor.RUN_TESTS_NAME, description = OneShotTestingProcessor.RUN_TESTS_DESC)
-@DevMcpBuildTimeTool(name = OneShotTestingProcessor.RUN_AFFECTED_TESTS_NAME, description = OneShotTestingProcessor.RUN_AFFECTED_TESTS_DESC)
-@DevMcpBuildTimeTool(name = OneShotTestingProcessor.RUN_TEST_NAME, description = OneShotTestingProcessor.RUN_TEST_DESC, params = {
-        @DevMcpParam(name = "className", description = "The fully qualified test class name, e.g. com.example.MyTest"),
-        @DevMcpParam(name = "methodName", description = "The test method name to run. If not provided, all tests in the class are run.", required = false)
-})
+@DevMcpBuildTimeTool(name = OneShotTestingProcessor.RUN_AFFECTED_TESTS_NAME,
+        description = OneShotTestingProcessor.RUN_AFFECTED_TESTS_DESC)
+@DevMcpBuildTimeTool(name = OneShotTestingProcessor.RUN_TEST_NAME, description = OneShotTestingProcessor.RUN_TEST_DESC,
+        params = {
+                @DevMcpParam(name = "className", description = "The fully qualified test class name, e.g. com.example.MyTest"),
+                @DevMcpParam(name = "methodName",
+                        description = "The test method name to run. If not provided, all tests in the class are run.",
+                        required = false)
+        })
 @DevMcpBuildTimeTool(name = OneShotTestingProcessor.CANCEL_TESTS_NAME, description = OneShotTestingProcessor.CANCEL_TESTS_DESC)
 @DevMcpBuildTimeTool(name = OneShotTestingProcessor.RESET_TESTS_NAME, description = OneShotTestingProcessor.RESET_TESTS_DESC)
 public class OneShotTestingProcessor {

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/WorkspaceProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/WorkspaceProcessor.java
@@ -51,10 +51,13 @@ import io.quarkus.devui.spi.workspace.WorkspaceBuildItem;
 /**
  * This creates the workspace Page
  */
-@DevMcpBuildTimeTool(name = "getWorkspaceItems", description = "Gets all the items in the current workspace of the Quarkus project. Returns a list of workspace items with name and path.")
-@DevMcpBuildTimeTool(name = "getWorkspaceItemContent", description = "Get the content of a certain workspace item. Returns a WorkspaceContent with type, content, and isBinary fields.", params = {
-        @DevMcpParam(name = "path", description = "The path, as a URI in String format, to the workspace item")
-})
+@DevMcpBuildTimeTool(name = "getWorkspaceItems",
+        description = "Gets all the items in the current workspace of the Quarkus project. Returns a list of workspace items with name and path.")
+@DevMcpBuildTimeTool(name = "getWorkspaceItemContent",
+        description = "Get the content of a certain workspace item. Returns a WorkspaceContent with type, content, and isBinary fields.",
+        params = {
+                @DevMcpParam(name = "path", description = "The path, as a URI in String format, to the workspace item")
+        })
 @DevMcpBuildTimeTool(name = "saveWorkspaceItemContent", description = "Add or update an item in the workspace", params = {
         @DevMcpParam(name = "content", description = "The new or updated content in String format"),
         @DevMcpParam(name = "path", description = "The path, as a URI in String format, to the workspace item")

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/reportissues/ReportIssuesJsonRPCService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/reportissues/ReportIssuesJsonRPCService.java
@@ -28,7 +28,8 @@ public class ReportIssuesJsonRPCService {
     private static final Logger LOG = Logger.getLogger(ReportIssuesJsonRPCService.class);
 
     @Inject
-    @ConfigProperty(name = "quarkus.devui.report-issues.url", defaultValue = "https://github.com/quarkusio/quarkus/issues/new?labels=kind%2Fbug&template=bug_report.yml")
+    @ConfigProperty(name = "quarkus.devui.report-issues.url",
+            defaultValue = "https://github.com/quarkusio/quarkus/issues/new?labels=kind%2Fbug&template=bug_report.yml")
     String reportURL;
 
     @JsonRpcDescription("Creates a url that if opened, will go to issue report for the Quarkus project with some of the value pre-filled")

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/client/tls/MtlsWithJKSTrustStoreWithHttpServerWithAliasTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/client/tls/MtlsWithJKSTrustStoreWithHttpServerWithAliasTest.java
@@ -20,7 +20,8 @@ import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
         @Certificate(name = "grpc-alias", password = "password", formats = { Format.JKS, Format.PEM,
-                Format.PKCS12 }, client = true, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost"))
+                Format.PKCS12 }, client = true,
+                aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost"))
 })
 class MtlsWithJKSTrustStoreWithHttpServerWithAliasTest {
 

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/client/tls/MtlsWithP12TrustStoreWithHttpServerWithAliasTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/client/tls/MtlsWithP12TrustStoreWithHttpServerWithAliasTest.java
@@ -20,7 +20,8 @@ import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
         @Certificate(name = "grpc-alias", password = "password", formats = { Format.JKS, Format.PEM,
-                Format.PKCS12 }, client = true, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost"))
+                Format.PKCS12 }, client = true,
+                aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost"))
 })
 class MtlsWithP12TrustStoreWithHttpServerWithAliasTest {
 

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/tls/TlsWithHttpServerUsingJKSWithAliasTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/tls/TlsWithHttpServerUsingJKSWithAliasTest.java
@@ -28,7 +28,8 @@ import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
         @Certificate(name = "grpc-alias", password = "password", formats = { Format.JKS, Format.PEM,
-                Format.PKCS12 }, client = true, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost"))
+                Format.PKCS12 }, client = true,
+                aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost"))
 })
 public class TlsWithHttpServerUsingJKSWithAliasTest {
 

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/tls/TlsWithHttpServerUsingP12WithAliasTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/tls/TlsWithHttpServerUsingP12WithAliasTest.java
@@ -28,7 +28,8 @@ import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
         @Certificate(name = "grpc-alias", password = "password", formats = { Format.JKS, Format.PEM,
-                Format.PKCS12 }, client = true, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost"))
+                Format.PKCS12 }, client = true,
+                aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost"))
 })
 public class TlsWithHttpServerUsingP12WithAliasTest {
 

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/tls/TlsWithJksKeyStoreAndAliasTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/tls/TlsWithJksKeyStoreAndAliasTest.java
@@ -28,7 +28,8 @@ import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
         @Certificate(name = "grpc-alias", password = "password", formats = { Format.JKS, Format.PEM,
-                Format.PKCS12 }, client = true, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost"))
+                Format.PKCS12 }, client = true,
+                aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost"))
 })
 public class TlsWithJksKeyStoreAndAliasTest {
 

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/tls/TlsWithP12KeyStoreAndAliasTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/tls/TlsWithP12KeyStoreAndAliasTest.java
@@ -28,7 +28,8 @@ import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
         @Certificate(name = "grpc-alias", password = "password", formats = { Format.JKS, Format.PEM,
-                Format.PKCS12 }, client = true, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost"))
+                Format.PKCS12 }, client = true,
+                aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost"))
 })
 public class TlsWithP12KeyStoreAndAliasTest {
 

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/databaseormcompatibility/DatabaseOrmCompatibilityVersionTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/databaseormcompatibility/DatabaseOrmCompatibilityVersionTest.java
@@ -97,7 +97,8 @@ public class DatabaseOrmCompatibilityVersionTest {
     public static class SpyingIdentifierGeneratorEntity {
         @Id
         @GeneratedValue(generator = "spying-generator")
-        @GenericGenerator(name = "spying-generator", strategy = "io.quarkus.hibernate.orm.config.SettingsSpyingIdentifierGenerator")
+        @GenericGenerator(name = "spying-generator",
+                strategy = "io.quarkus.hibernate.orm.config.SettingsSpyingIdentifierGenerator")
         private Long id;
 
         public SpyingIdentifierGeneratorEntity() {

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/unsupportedproperties/UnsupportedPropertiesTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/unsupportedproperties/UnsupportedPropertiesTest.java
@@ -221,7 +221,8 @@ public class UnsupportedPropertiesTest {
     public static class SpyingIdentifierGeneratorEntity {
         @Id
         @GeneratedValue(generator = "spying-generator")
-        @GenericGenerator(name = "spying-generator", strategy = "io.quarkus.hibernate.orm.config.SettingsSpyingIdentifierGenerator")
+        @GenericGenerator(name = "spying-generator",
+                strategy = "io.quarkus.hibernate.orm.config.SettingsSpyingIdentifierGenerator")
         private Long id;
 
         public SpyingIdentifierGeneratorEntity() {

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/dev/MyEntityWithSuccessfulDDLGeneration.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/dev/MyEntityWithSuccessfulDDLGeneration.java
@@ -11,7 +11,8 @@ import jakarta.persistence.Table;
 
 @Entity(name = MyEntityWithSuccessfulDDLGeneration.NAME)
 @Table(name = MyEntityWithSuccessfulDDLGeneration.TABLE_NAME)
-@NamedQuery(name = "MyEntity.findAll", query = "SELECT e FROM MyEntity e ORDER BY e.name", hints = @QueryHint(name = "org.hibernate.cacheable", value = "true"))
+@NamedQuery(name = "MyEntity.findAll", query = "SELECT e FROM MyEntity e ORDER BY e.name",
+        hints = @QueryHint(name = "org.hibernate.cacheable", value = "true"))
 @NamedNativeQuery(name = "MyEntity.nativeFindAll", query = "SELECT e FROM MyEntityTable e ORDER BY e.name")
 public class MyEntityWithSuccessfulDDLGeneration {
     public static final String NAME = "MyEntity";

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/mapping/id/optimizer/EntityWithGenericGeneratorAndPooledLoOptimizer.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/mapping/id/optimizer/EntityWithGenericGeneratorAndPooledLoOptimizer.java
@@ -14,7 +14,8 @@ public class EntityWithGenericGeneratorAndPooledLoOptimizer {
 
     @Id
     @GeneratedValue(generator = "gen_gen_pooled_lo")
-    @GenericGenerator(name = "gen_gen_pooled_lo", type = SequenceStyleGenerator.class, parameters = @Parameter(name = OptimizableGenerator.OPT_PARAM, value = "pooled-lo"))
+    @GenericGenerator(name = "gen_gen_pooled_lo", type = SequenceStyleGenerator.class,
+            parameters = @Parameter(name = OptimizableGenerator.OPT_PARAM, value = "pooled-lo"))
     Long id;
 
     public EntityWithGenericGeneratorAndPooledLoOptimizer() {

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/mapping/id/optimizer/EntityWithGenericGeneratorAndPooledOptimizer.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/mapping/id/optimizer/EntityWithGenericGeneratorAndPooledOptimizer.java
@@ -14,7 +14,8 @@ public class EntityWithGenericGeneratorAndPooledOptimizer {
 
     @Id
     @GeneratedValue(generator = "gen_gen_pooled_lo")
-    @GenericGenerator(name = "gen_gen_pooled_lo", type = SequenceStyleGenerator.class, parameters = @Parameter(name = OptimizableGenerator.OPT_PARAM, value = "pooled"))
+    @GenericGenerator(name = "gen_gen_pooled_lo", type = SequenceStyleGenerator.class,
+            parameters = @Parameter(name = OptimizableGenerator.OPT_PARAM, value = "pooled"))
     Long id;
 
     public EntityWithGenericGeneratorAndPooledOptimizer() {

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/narayana/quarkus/Fruit.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/narayana/quarkus/Fruit.java
@@ -13,7 +13,8 @@ import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "known_fruits")
-@NamedQuery(name = "Fruits.findAll", query = "SELECT f FROM Fruit f ORDER BY f.name", hints = @QueryHint(name = "org.hibernate.cacheable", value = "true"))
+@NamedQuery(name = "Fruits.findAll", query = "SELECT f FROM Fruit f ORDER BY f.name",
+        hints = @QueryHint(name = "org.hibernate.cacheable", value = "true"))
 @Cacheable
 public class Fruit {
     @Id

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/graal/Substitute_JacksonIntegration.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/graal/Substitute_JacksonIntegration.java
@@ -13,7 +13,8 @@ import com.oracle.svm.core.annotate.TargetClass;
 /**
  * Substitution for {@code JacksonIntegration} when Jackson is not on the classpath.
  */
-@TargetClass(className = "org.hibernate.type.format.jackson.JacksonIntegration", onlyWith = Substitute_JacksonIntegration.IsJacksonAbsent.class)
+@TargetClass(className = "org.hibernate.type.format.jackson.JacksonIntegration",
+        onlyWith = Substitute_JacksonIntegration.IsJacksonAbsent.class)
 final class Substitute_JacksonIntegration {
 
     static final class IsJacksonAbsent implements BooleanSupplier {

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/unsupportedproperties/UnsupportedPropertiesTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/unsupportedproperties/UnsupportedPropertiesTest.java
@@ -122,7 +122,8 @@ public class UnsupportedPropertiesTest {
     public static class SpyingIdentifierGeneratorEntity {
         @Id
         @GeneratedValue(generator = "spying-generator")
-        @GenericGenerator(name = "spying-generator", strategy = "io.quarkus.hibernate.reactive.config.SettingsSpyingIdentifierGenerator")
+        @GenericGenerator(name = "spying-generator",
+                strategy = "io.quarkus.hibernate.reactive.config.SettingsSpyingIdentifierGenerator")
         private Long id;
 
         public SpyingIdentifierGeneratorEntity() {

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/mapping/id/optimizer/optimizer/EntityWithGenericGeneratorAndPooledLoOptimizer.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/mapping/id/optimizer/optimizer/EntityWithGenericGeneratorAndPooledLoOptimizer.java
@@ -14,7 +14,8 @@ public class EntityWithGenericGeneratorAndPooledLoOptimizer {
 
     @Id
     @GeneratedValue(generator = "gen_gen_pooled_lo")
-    @GenericGenerator(name = "gen_gen_pooled_lo", type = SequenceStyleGenerator.class, parameters = @Parameter(name = OptimizableGenerator.OPT_PARAM, value = "pooled-lo"))
+    @GenericGenerator(name = "gen_gen_pooled_lo", type = SequenceStyleGenerator.class,
+            parameters = @Parameter(name = OptimizableGenerator.OPT_PARAM, value = "pooled-lo"))
     Long id;
 
     public EntityWithGenericGeneratorAndPooledLoOptimizer() {

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/mapping/id/optimizer/optimizer/EntityWithGenericGeneratorAndPooledOptimizer.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/mapping/id/optimizer/optimizer/EntityWithGenericGeneratorAndPooledOptimizer.java
@@ -14,7 +14,8 @@ public class EntityWithGenericGeneratorAndPooledOptimizer {
 
     @Id
     @GeneratedValue(generator = "gen_gen_pooled_lo")
-    @GenericGenerator(name = "gen_gen_pooled_lo", type = SequenceStyleGenerator.class, parameters = @Parameter(name = OptimizableGenerator.OPT_PARAM, value = "pooled"))
+    @GenericGenerator(name = "gen_gen_pooled_lo", type = SequenceStyleGenerator.class,
+            parameters = @Parameter(name = OptimizableGenerator.OPT_PARAM, value = "pooled"))
     Long id;
 
     public EntityWithGenericGeneratorAndPooledOptimizer() {

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/graal/Substitute_FastBootHibernateReactivePersistenceProvider.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/graal/Substitute_FastBootHibernateReactivePersistenceProvider.java
@@ -12,7 +12,8 @@ import com.oracle.svm.core.annotate.TargetClass;
 import io.quarkus.hibernate.orm.runtime.FastBootHibernatePersistenceProvider;
 import io.quarkus.hibernate.reactive.runtime.graal.Substitute_FastBootHibernateReactivePersistenceProvider.IsAgroalAbsent;
 
-@TargetClass(className = "io.quarkus.hibernate.reactive.runtime.FastBootHibernateReactivePersistenceProvider", onlyWith = IsAgroalAbsent.class)
+@TargetClass(className = "io.quarkus.hibernate.reactive.runtime.FastBootHibernateReactivePersistenceProvider",
+        onlyWith = IsAgroalAbsent.class)
 public final class Substitute_FastBootHibernateReactivePersistenceProvider {
 
     @Substitute

--- a/extensions/http3/deployment/src/test/java/io/quarkus/http3/deployment/Http3ExplicitTlsTest.java
+++ b/extensions/http3/deployment/src/test/java/io/quarkus/http3/deployment/Http3ExplicitTlsTest.java
@@ -18,8 +18,9 @@ import io.smallrye.certs.junit5.Certificates;
 /**
  * Verifies that auto-TLS is skipped when TLS is explicitly configured.
  */
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "http3-explicit-test", password = "secret", formats = {
-        Format.JKS }))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "http3-explicit-test", password = "secret", formats = {
+                Format.JKS }))
 class Http3ExplicitTlsTest {
 
     @RegisterExtension

--- a/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoProcessor.java
+++ b/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoProcessor.java
@@ -53,7 +53,8 @@ import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.spi.RouteBuildItem;
 
-@DevMcpBuildTimeTool(name = "getApplicationAndEnvironmentInfo", description = "Information about the environment where this Quarkus application is running. Things like Operating System, Java version, Git information and application details.")
+@DevMcpBuildTimeTool(name = "getApplicationAndEnvironmentInfo",
+        description = "Information about the environment where this Quarkus application is running. Things like Operating System, Java version, Git information and application details.")
 public class InfoProcessor {
 
     private static final Logger log = Logger.getLogger(InfoProcessor.class);

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/Db2DbTokenStateManagerTest.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/Db2DbTokenStateManagerTest.java
@@ -10,7 +10,8 @@ import io.quarkus.test.QuarkusExtensionTest;
 //   hang detection timeout set by 'quarkus.test.hang-detection-timeout=60', we need to discuss and try
 //   to find a way to run it (like allow QuarkusExtensionTests to override system property etc.)
 //   but it will require separate PR and make changes unrelated to DB Token State Manager
-@EnabledIfSystemProperty(named = "run-db2-db-token-state-manager-test", disabledReason = "Db2 is slow to start", matches = "true")
+@EnabledIfSystemProperty(named = "run-db2-db-token-state-manager-test", disabledReason = "Db2 is slow to start",
+        matches = "true")
 public class Db2DbTokenStateManagerTest extends AbstractDbTokenStateManagerTest {
 
     @RegisterExtension

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/MsSqlDbTokenStateManagerTest.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/MsSqlDbTokenStateManagerTest.java
@@ -7,7 +7,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusExtensionTest;
 
 // Becomes flaky in Github CI due to limited resources
-@EnabledIfSystemProperty(named = "run-mssql-db-token-state-manager-test", disabledReason = "Insufficient GH CI resources", matches = "true")
+@EnabledIfSystemProperty(named = "run-mssql-db-token-state-manager-test", disabledReason = "Insufficient GH CI resources",
+        matches = "true")
 public class MsSqlDbTokenStateManagerTest extends AbstractDbTokenStateManagerTest {
 
     @RegisterExtension

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/MySqlDbTokenStateManagerTest.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/MySqlDbTokenStateManagerTest.java
@@ -6,7 +6,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusExtensionTest;
 
 // Becomes flaky in Github CI due to limited resources
-@EnabledIfSystemProperty(named = "run-mysql-db-token-state-manager-test", disabledReason = "Insufficient GH CI resources", matches = "true")
+@EnabledIfSystemProperty(named = "run-mysql-db-token-state-manager-test", disabledReason = "Insufficient GH CI resources",
+        matches = "true")
 public class MySqlDbTokenStateManagerTest extends AbstractDbTokenStateManagerTest {
 
     @RegisterExtension

--- a/extensions/openshift-client/runtime/src/main/java/io/quarkus/it/openshift/client/runtime/graal/MiscellaneousSubstitutions.java
+++ b/extensions/openshift-client/runtime/src/main/java/io/quarkus/it/openshift/client/runtime/graal/MiscellaneousSubstitutions.java
@@ -29,7 +29,8 @@ import io.fabric8.openshift.api.model.miscellaneous.metal3.v1beta1.Metal3Remedia
 /**
  * Allows the exclusion of the openshift-model-miscellaneous model without breaking the --link-at-build-time check.
  */
-@TargetClass(className = "io.fabric8.openshift.client.impl.OpenShiftClientImpl", onlyWith = MiscellaneousSubstitutions.NoOpenShiftMiscellaneousModel.class)
+@TargetClass(className = "io.fabric8.openshift.client.impl.OpenShiftClientImpl",
+        onlyWith = MiscellaneousSubstitutions.NoOpenShiftMiscellaneousModel.class)
 public final class MiscellaneousSubstitutions {
 
     @Substitute

--- a/extensions/openshift-client/runtime/src/main/java/io/quarkus/it/openshift/client/runtime/graal/OperatorSubstitutions.java
+++ b/extensions/openshift-client/runtime/src/main/java/io/quarkus/it/openshift/client/runtime/graal/OperatorSubstitutions.java
@@ -20,7 +20,8 @@ import io.fabric8.openshift.client.dsl.OpenShiftOperatorAPIGroupDSL;
 /**
  * Allows the exclusion of the openshift-model-operator model without breaking the --link-at-build-time check.
  */
-@TargetClass(className = "io.fabric8.openshift.client.impl.OpenShiftClientImpl", onlyWith = OperatorSubstitutions.NoOpenShiftOperatorModel.class)
+@TargetClass(className = "io.fabric8.openshift.client.impl.OpenShiftClientImpl",
+        onlyWith = OperatorSubstitutions.NoOpenShiftOperatorModel.class)
 public final class OperatorSubstitutions {
 
     @Substitute

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/headers/AdvancedClientHeaderParamExpressionTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/headers/AdvancedClientHeaderParamExpressionTest.java
@@ -60,7 +60,8 @@ public class AdvancedClientHeaderParamExpressionTest {
     public interface Client {
 
         @GET
-        @ClientHeaderParam(name = "method-header", value = "${my.property-value}-{calculate}-{io.quarkus.rest.client.reactive.headers.DummyHeaderCalculator.calculate2}")
+        @ClientHeaderParam(name = "method-header",
+                value = "${my.property-value}-{calculate}-{io.quarkus.rest.client.reactive.headers.DummyHeaderCalculator.calculate2}")
         String call();
 
         @GET

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/proxy/HttpProxyDevServicesDeclarativeClientTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/proxy/HttpProxyDevServicesDeclarativeClientTest.java
@@ -42,7 +42,8 @@ public class HttpProxyDevServicesDeclarativeClientTest {
     @RestClient
     Client client;
 
-    @ConfigProperty(name = "quarkus.rest-client.\"io.quarkus.rest.client.reactive.proxy.HttpProxyDevServicesDeclarativeClientTest$Client\".override-uri")
+    @ConfigProperty(
+            name = "quarkus.rest-client.\"io.quarkus.rest.client.reactive.proxy.HttpProxyDevServicesDeclarativeClientTest$Client\".override-uri")
     String proxyUrl;
 
     @Test

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/proxy/HttpProxyDevServicesMultipleCustomProvidersTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/proxy/HttpProxyDevServicesMultipleCustomProvidersTest.java
@@ -68,7 +68,8 @@ public class HttpProxyDevServicesMultipleCustomProvidersTest {
                 }
             });
 
-    @ConfigProperty(name = "quarkus.rest-client.\"io.quarkus.rest.client.reactive.proxy.HttpProxyDevServicesMultipleCustomProvidersTest$Client\".override-uri")
+    @ConfigProperty(
+            name = "quarkus.rest-client.\"io.quarkus.rest.client.reactive.proxy.HttpProxyDevServicesMultipleCustomProvidersTest$Client\".override-uri")
     String proxyUrl;
 
     @Test

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/proxy/HttpProxyDevServicesProgrammaticClientTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/proxy/HttpProxyDevServicesProgrammaticClientTest.java
@@ -43,7 +43,8 @@ public class HttpProxyDevServicesProgrammaticClientTest {
                 }
             });
 
-    @ConfigProperty(name = "quarkus.rest-client.\"io.quarkus.rest.client.reactive.proxy.HttpProxyDevServicesProgrammaticClientTest$Client\".override-uri")
+    @ConfigProperty(
+            name = "quarkus.rest-client.\"io.quarkus.rest.client.reactive.proxy.HttpProxyDevServicesProgrammaticClientTest$Client\".override-uri")
     String proxyUrl;
 
     @Test

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/proxy/HttpProxyDevServicesSingleCustomProviderTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/proxy/HttpProxyDevServicesSingleCustomProviderTest.java
@@ -61,7 +61,8 @@ public class HttpProxyDevServicesSingleCustomProviderTest {
                 }
             });
 
-    @ConfigProperty(name = "quarkus.rest-client.\"io.quarkus.rest.client.reactive.proxy.HttpProxyDevServicesSingleCustomProviderTest$Client\".override-uri")
+    @ConfigProperty(
+            name = "quarkus.rest-client.\"io.quarkus.rest.client.reactive.proxy.HttpProxyDevServicesSingleCustomProviderTest$Client\".override-uri")
     String proxyUrl;
 
     @Test

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/registerclientheaders/MultipleHeadersBindingClient.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/registerclientheaders/MultipleHeadersBindingClient.java
@@ -16,8 +16,10 @@ import io.quarkus.rest.client.reactive.TestJacksonBasicMessageBodyReader;
 @RegisterRestClient
 @RegisterClientHeaders(MyHeadersFactory.class)
 @ClientHeaderParam(name = "my-header", value = "constant-header-value")
-@ClientHeaderParam(name = "computed-header", value = "{io.quarkus.rest.client.reactive.registerclientheaders.ComputedHeader.get}")
-@ClientHeaderParam(name = "Content-Type", value = "{io.quarkus.rest.client.reactive.registerclientheaders.ComputedHeader.contentType}")
+@ClientHeaderParam(name = "computed-header",
+        value = "{io.quarkus.rest.client.reactive.registerclientheaders.ComputedHeader.get}")
+@ClientHeaderParam(name = "Content-Type",
+        value = "{io.quarkus.rest.client.reactive.registerclientheaders.ComputedHeader.contentType}")
 @RegisterProvider(TestJacksonBasicMessageBodyReader.class)
 public interface MultipleHeadersBindingClient {
     @GET

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/CustomDeserialization.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/CustomDeserialization.java
@@ -16,7 +16,8 @@ import io.smallrye.common.annotation.Experimental;
  * Annotation that can be used on RESTEasy Reactive Resource method to allow users to configure Jackson deserialization
  * for that method only, without affecting the global Jackson configuration.
  */
-@Experimental(value = "Remains to be determined if this is the best possible API for users to configure per Resource Method Deserialization")
+@Experimental(
+        value = "Remains to be determined if this is the best possible API for users to configure per Resource Method Deserialization")
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
 public @interface CustomDeserialization {

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/CustomSerialization.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/CustomSerialization.java
@@ -16,7 +16,8 @@ import io.smallrye.common.annotation.Experimental;
  * Annotation that can be used on RESTEasy Reactive Resource method to allow users to configure Jackson serialization
  * for that method only, without affecting the global Jackson configuration.
  */
-@Experimental(value = "Remains to be determined if this is the best possible API for users to configure per Resource Method Serialization")
+@Experimental(
+        value = "Remains to be determined if this is the best possible API for users to configure per Resource Method Serialization")
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
 public @interface CustomSerialization {

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/DisableSecureSerialization.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/DisableSecureSerialization.java
@@ -13,7 +13,8 @@ import io.smallrye.common.annotation.Experimental;
  * will proceed as if the annotation did not exist.
  * Placing it on a class, is equivalent of placing it on all JAX-RS methods of the class.
  */
-@Experimental(value = "Remains to be determined if this is the best possible API for users to configure security of serialized fields")
+@Experimental(
+        value = "Remains to be determined if this is the best possible API for users to configure security of serialized fields")
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
 public @interface DisableSecureSerialization {

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/EnableSecureSerialization.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/EnableSecureSerialization.java
@@ -11,7 +11,8 @@ import io.smallrye.common.annotation.Experimental;
  * If placed on a method, then all {@link SecureField} annotations of the response type will be taken into account,
  * even if the class is annotated with {@link DisableSecureSerialization}.
  */
-@Experimental(value = "Remains to be determined if this is the best possible API for users to configure security of serialized fields")
+@Experimental(
+        value = "Remains to be determined if this is the best possible API for users to configure security of serialized fields")
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
 public @interface EnableSecureSerialization {

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/SecureField.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/SecureField.java
@@ -16,7 +16,8 @@ import io.smallrye.common.annotation.Experimental;
  * Users that wish to use the feature and have the ability to configure the response of the JAX-RS method are advised to
  * use {@link org.jboss.resteasy.reactive.RestResponse}.
  */
-@Experimental(value = "Remains to be determined if this is the best possible API for users to configure security of serialized fields")
+@Experimental(
+        value = "Remains to be determined if this is the best possible API for users to configure security of serialized fields")
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.FIELD })
 public @interface SecureField {

--- a/extensions/resteasy-reactive/rest-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/TestResource.java
+++ b/extensions/resteasy-reactive/rest-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/TestResource.java
@@ -175,7 +175,8 @@ public class TestResource {
     @GET
     @Path("/with-rest-link-id/{id}")
     @Produces({ MediaType.APPLICATION_JSON, RestMediaType.APPLICATION_HAL_JSON })
-    @RestLink(entityType = TestRecordWithRestLinkId.class, title = "The with rest link title", type = MediaType.APPLICATION_JSON)
+    @RestLink(entityType = TestRecordWithRestLinkId.class, title = "The with rest link title",
+            type = MediaType.APPLICATION_JSON)
     @InjectRestLinks
     public TestRecordWithRestLinkId getWithRestLinkId(@PathParam("id") int id) {
         return REST_LINK_ID_RECORDS.stream()

--- a/extensions/security-jpa-reactive/deployment/src/test/java/io/quarkus/security/jpa/reactive/ExternalRolesUserEntity.java
+++ b/extensions/security-jpa-reactive/deployment/src/test/java/io/quarkus/security/jpa/reactive/ExternalRolesUserEntity.java
@@ -34,7 +34,8 @@ public class ExternalRolesUserEntity {
     @Password(PasswordType.CLEAR)
     public String pass;
 
-    @JoinTable(name = "test_user_role", joinColumns = @JoinColumn(name = "user_id"), inverseJoinColumns = @JoinColumn(name = "role_id"))
+    @JoinTable(name = "test_user_role", joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id"))
     @ManyToMany
     @Roles
     public List<RoleEntity> roles = new ArrayList<>();

--- a/extensions/security-jpa-reactive/deployment/src/test/java/io/quarkus/security/jpa/reactive/PanacheUserEntity.java
+++ b/extensions/security-jpa-reactive/deployment/src/test/java/io/quarkus/security/jpa/reactive/PanacheUserEntity.java
@@ -29,7 +29,8 @@ public class PanacheUserEntity extends PanacheEntity {
     @Password(PasswordType.CLEAR)
     public String pass;
 
-    @JoinTable(name = "test_user_role", joinColumns = @JoinColumn(name = "user_id"), inverseJoinColumns = @JoinColumn(name = "role_id"))
+    @JoinTable(name = "test_user_role", joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id"))
     @ManyToMany
     @Roles
     public List<PanacheRoleEntity> roles = new ArrayList<>();

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/ExternalRolesUserEntity.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/ExternalRolesUserEntity.java
@@ -28,7 +28,8 @@ public class ExternalRolesUserEntity {
     @Password(PasswordType.CLEAR)
     public String pass;
 
-    @JoinTable(name = "test_user_role", joinColumns = @JoinColumn(name = "user_id"), inverseJoinColumns = @JoinColumn(name = "role_id"))
+    @JoinTable(name = "test_user_role", joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id"))
     @ManyToMany
     @Roles
     public List<RoleEntity> roles = new ArrayList<>();

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/PanacheUserEntity.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/PanacheUserEntity.java
@@ -24,7 +24,8 @@ public class PanacheUserEntity extends PanacheEntity {
     @Password(PasswordType.CLEAR)
     public String pass;
 
-    @JoinTable(name = "test_user_role", joinColumns = @JoinColumn(name = "user_id"), inverseJoinColumns = @JoinColumn(name = "role_id"))
+    @JoinTable(name = "test_user_role", joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id"))
     @ManyToMany
     @Roles
     public List<PanacheRoleEntity> roles = new ArrayList<>();

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/SecuredBean.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/SecuredBean.java
@@ -12,7 +12,8 @@ public class SecuredBean {
         return record.propertyOne();
     }
 
-    @PermissionsAllowed(value = "ignored", permission = CustomPermissionWithStringArg.class, params = "record.secondTier.thirdTier.propertyOne")
+    @PermissionsAllowed(value = "ignored", permission = CustomPermissionWithStringArg.class,
+            params = "record.secondTier.thirdTier.propertyOne")
     public String nestedRecordParam_ThreeTiers(TopTierRecord record) {
         return record.secondTier().thirdTier().propertyOne();
     }
@@ -22,17 +23,20 @@ public class SecuredBean {
         return simpleParam.propertyOne;
     }
 
-    @PermissionsAllowed(value = "ignored", permission = CustomPermissionWithStringArg.class, params = "complexParam.nestedFieldParam.simpleFieldParam.propertyOne")
+    @PermissionsAllowed(value = "ignored", permission = CustomPermissionWithStringArg.class,
+            params = "complexParam.nestedFieldParam.simpleFieldParam.propertyOne")
     public String nestedFieldParam_ThreeTiers(ComplexFieldParam complexParam) {
         return complexParam.nestedFieldParam.simpleFieldParam.propertyOne;
     }
 
-    @PermissionsAllowed(value = "ignored", permission = CustomPermissionWithStringArg.class, params = "obj.second.third.fourth.propertyOne")
+    @PermissionsAllowed(value = "ignored", permission = CustomPermissionWithStringArg.class,
+            params = "obj.second.third.fourth.propertyOne")
     public String multipleNestedMethods(NestedMethodsObject obj) {
         return obj.second().third().fourth().getPropertyOne();
     }
 
-    @PermissionsAllowed(value = "ignored", permission = CustomPermissionWithStringArg.class, params = "obj.paramField.myVal.propertyOne")
+    @PermissionsAllowed(value = "ignored", permission = CustomPermissionWithStringArg.class,
+            params = "obj.paramField.myVal.propertyOne")
     public String combinedParam(CombinedAccessParam obj) {
         return obj.paramField.myVal().propertyOne;
     }

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/graal/BouncyCastleSubstitutions.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/graal/BouncyCastleSubstitutions.java
@@ -18,7 +18,8 @@ final class BouncyCastlePackages {
             .map(p -> p.getName()).filter(p -> p.startsWith(ORG_BOUNCYCASTLE_CRYPTO_PACKAGE)).collect(Collectors.toSet());
 }
 
-@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.general.DSA$1", onlyWith = BouncyCastleCryptoGeneral.class)
+@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.general.DSA$1",
+        onlyWith = BouncyCastleCryptoGeneral.class)
 final class Target_org_bouncycastle_crypto_general_DSA$1 {
     @com.oracle.svm.core.annotate.Substitute
     public boolean hasTestPassed(Target_org_bouncycastle_crypto_internal_AsymmetricCipherKeyPair kp) {
@@ -26,7 +27,8 @@ final class Target_org_bouncycastle_crypto_general_DSA$1 {
     }
 }
 
-@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.general.DSTU4145$2", onlyWith = BouncyCastleCryptoGeneral.class)
+@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.general.DSTU4145$2",
+        onlyWith = BouncyCastleCryptoGeneral.class)
 final class Target_org_bouncycastle_crypto_general_DSTU4145$2 {
     @com.oracle.svm.core.annotate.Substitute
     public boolean hasTestPassed(Target_org_bouncycastle_crypto_internal_AsymmetricCipherKeyPair kp) {
@@ -34,7 +36,8 @@ final class Target_org_bouncycastle_crypto_general_DSTU4145$2 {
     }
 }
 
-@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.general.ECGOST3410$2", onlyWith = BouncyCastleCryptoGeneral.class)
+@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.general.ECGOST3410$2",
+        onlyWith = BouncyCastleCryptoGeneral.class)
 final class Target_org_bouncycastle_crypto_general_ECGOST3410$2 {
     @com.oracle.svm.core.annotate.Substitute
     public boolean hasTestPassed(Target_org_bouncycastle_crypto_internal_AsymmetricCipherKeyPair kp) {
@@ -42,7 +45,8 @@ final class Target_org_bouncycastle_crypto_general_ECGOST3410$2 {
     }
 }
 
-@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.general.GOST3410$1", onlyWith = BouncyCastleCryptoGeneral.class)
+@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.general.GOST3410$1",
+        onlyWith = BouncyCastleCryptoGeneral.class)
 final class Target_org_bouncycastle_crypto_general_GOST3410$1 {
     @com.oracle.svm.core.annotate.Substitute
     public boolean hasTestPassed(Target_org_bouncycastle_crypto_internal_AsymmetricCipherKeyPair kp) {
@@ -50,7 +54,8 @@ final class Target_org_bouncycastle_crypto_general_GOST3410$1 {
     }
 }
 
-@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.fips.FipsDSA$2", onlyWith = BouncyCastleCryptoFips.class)
+@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.fips.FipsDSA$2",
+        onlyWith = BouncyCastleCryptoFips.class)
 final class Target_org_bouncycastle_crypto_fips_FipsDSA$2 {
     @com.oracle.svm.core.annotate.Substitute
     public boolean hasTestPassed(Target_org_bouncycastle_crypto_internal_AsymmetricCipherKeyPair kp) {
@@ -58,7 +63,8 @@ final class Target_org_bouncycastle_crypto_fips_FipsDSA$2 {
     }
 }
 
-@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.fips.FipsEC$1", onlyWith = BouncyCastleCryptoFips.class)
+@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.fips.FipsEC$1",
+        onlyWith = BouncyCastleCryptoFips.class)
 final class Target_org_bouncycastle_crypto_fips_FipsEC$1 {
     @com.oracle.svm.core.annotate.Substitute
     public boolean hasTestPassed(Target_org_bouncycastle_crypto_internal_AsymmetricCipherKeyPair kp) {
@@ -66,7 +72,8 @@ final class Target_org_bouncycastle_crypto_fips_FipsEC$1 {
     }
 }
 
-@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.fips.FipsRSA$3", onlyWith = BouncyCastleCryptoFips.class)
+@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.fips.FipsRSA$3",
+        onlyWith = BouncyCastleCryptoFips.class)
 final class Target_org_bouncycastle_crypto_fips_FipsRSA$3 {
     @com.oracle.svm.core.annotate.Substitute
     public boolean hasTestPassed(Target_org_bouncycastle_crypto_internal_AsymmetricCipherKeyPair kp) {
@@ -74,7 +81,8 @@ final class Target_org_bouncycastle_crypto_fips_FipsRSA$3 {
     }
 }
 
-@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.fips.FipsRSA$EngineProvider$1", onlyWith = BouncyCastleCryptoFips.class)
+@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.fips.FipsRSA$EngineProvider$1",
+        onlyWith = BouncyCastleCryptoFips.class)
 final class Target_org_bouncycastle_crypto_fips_FipsRSA$EngineProvider$1 {
     @com.oracle.svm.core.annotate.Substitute
     public void evaluate(Target_org_bouncycastle_crypto_fips_RsaBlindedEngine rsaEngine) {
@@ -82,15 +90,18 @@ final class Target_org_bouncycastle_crypto_fips_FipsRSA$EngineProvider$1 {
     }
 }
 
-@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.internal.AsymmetricCipherKeyPair", onlyWith = BouncyCastleCryptoInternal.class)
+@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.internal.AsymmetricCipherKeyPair",
+        onlyWith = BouncyCastleCryptoInternal.class)
 final class Target_org_bouncycastle_crypto_internal_AsymmetricCipherKeyPair {
 }
 
-@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.fips.RsaBlindedEngine", onlyWith = BouncyCastleCryptoFips.class)
+@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.fips.RsaBlindedEngine",
+        onlyWith = BouncyCastleCryptoFips.class)
 final class Target_org_bouncycastle_crypto_fips_RsaBlindedEngine {
 }
 
-@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider", onlyWith = BouncyCastleCryptoFips.class)
+@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider",
+        onlyWith = BouncyCastleCryptoFips.class)
 final class Target_org_bouncycastle_jcajce_provider_BouncyCastleFipsProvider {
     @Alias
     @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/RetryConfigBean.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/RetryConfigBean.java
@@ -41,7 +41,8 @@ public class RetryConfigBean {
 
     private long lastStartTime = 0;
 
-    @Retry(abortOn = TestConfigExceptionA.class, delay = 0, jitter = 0, maxRetries = 1000, maxDuration = 10, durationUnit = ChronoUnit.SECONDS)
+    @Retry(abortOn = TestConfigExceptionA.class, delay = 0, jitter = 0, maxRetries = 1000, maxDuration = 10,
+            durationUnit = ChronoUnit.SECONDS)
     public void jitter() {
         long startTime = System.nanoTime();
         if (lastStartTime != 0) {

--- a/extensions/smallrye-reactive-messaging-kafka/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/graal/ShareGroupSubstitutions.java
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/graal/ShareGroupSubstitutions.java
@@ -29,7 +29,8 @@ final class ShareGroupSubstitutions {
     }
 }
 
-@TargetClass(className = "io.smallrye.reactive.messaging.kafka.commit.KafkaShareGroupCommit", onlyWith = ShareGroupSubstitutions.IsAcquisitionLockTimeoutMsMissing.class)
+@TargetClass(className = "io.smallrye.reactive.messaging.kafka.commit.KafkaShareGroupCommit",
+        onlyWith = ShareGroupSubstitutions.IsAcquisitionLockTimeoutMsMissing.class)
 final class Target_io_smallrye_reactive_messaging_kafka_commit_KafkaShareGroupCommit {
 
     @Alias

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/ChannelEmitterWithOverflowAndBroadcast.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/ChannelEmitterWithOverflowAndBroadcast.java
@@ -27,7 +27,8 @@ public class ChannelEmitterWithOverflowAndBroadcast {
 
     @Inject
     public void setEmitter(@Channel("sink-1") @Broadcast Emitter<String> sink1,
-            @Channel("sink-2") @Broadcast @OnOverflow(value = OnOverflow.Strategy.BUFFER, bufferSize = 4) Emitter<String> sink2) {
+            @Channel("sink-2") @Broadcast @OnOverflow(value = OnOverflow.Strategy.BUFFER,
+                    bufferSize = 4) Emitter<String> sink2) {
         this.emitterForSink1 = sink1;
         this.emitterForSink2 = sink2;
     }

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusWorkerPoolRegistry.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusWorkerPoolRegistry.java
@@ -62,7 +62,8 @@ public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
     }
 
     public void terminate(
-            @Observes(notifyObserver = Reception.IF_EXISTS) @Priority(Interceptor.Priority.PLATFORM_BEFORE) @BeforeDestroyed(ApplicationScoped.class) Object event) {
+            @Observes(
+                    notifyObserver = Reception.IF_EXISTS) @Priority(Interceptor.Priority.PLATFORM_BEFORE) @BeforeDestroyed(ApplicationScoped.class) Object event) {
         log.debug("Terminating messaging worker pools");
         if (!workerExecutors.isEmpty()) {
             closed = true;

--- a/extensions/spiffe-client/deployment/src/test/java/io/quarkus/spiffe/client/deployment/test/SpiffeClientUdsTest.java
+++ b/extensions/spiffe-client/deployment/src/test/java/io/quarkus/spiffe/client/deployment/test/SpiffeClientUdsTest.java
@@ -6,7 +6,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusExtensionTest;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "SPIRE agent uses named pipes on Windows, but currently Vert.x does not support them")
+@DisabledOnOs(value = OS.WINDOWS,
+        disabledReason = "SPIRE agent uses named pipes on Windows, but currently Vert.x does not support them")
 class SpiffeClientUdsTest extends AbstractSpiffeClientTest {
 
     @RegisterExtension

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/User.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/User.java
@@ -15,7 +15,8 @@ import jakarta.persistence.Table;
 @Entity
 @Table(name = "User_")
 @NamedQuery(name = "User.getUserByFullNameUsingNamedQuery", query = "select u from User u where u.fullName=:name")
-@NamedQueries(@NamedQuery(name = "User.getUserByFullNameUsingNamedQueries", query = "select u from User u where u.fullName=:name"))
+@NamedQueries(@NamedQuery(name = "User.getUserByFullNameUsingNamedQueries",
+        query = "select u from User u where u.fullName=:name"))
 public class User {
 
     @Id

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/second/SecondEntityRepository.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/second/SecondEntityRepository.java
@@ -25,10 +25,12 @@ public interface SecondEntityRepository extends org.springframework.data.reposit
 
     Page<SecondEntity> findByName(String name, Pageable pageable);
 
-    @Query(value = "SELECT se FROM SecondEntity se WHERE name=?1", countQuery = "SELECT COUNT(*) FROM SecondEntity se WHERE name=?1")
+    @Query(value = "SELECT se FROM SecondEntity se WHERE name=?1",
+            countQuery = "SELECT COUNT(*) FROM SecondEntity se WHERE name=?1")
     Page<SecondEntity> findByNameQueryIndexed(String name, Pageable pageable);
 
-    @Query(value = "SELECT se FROM SecondEntity se WHERE name=:name", countQuery = "SELECT COUNT(*) FROM SecondEntity se WHERE name=:name")
+    @Query(value = "SELECT se FROM SecondEntity se WHERE name=:name",
+            countQuery = "SELECT COUNT(*) FROM SecondEntity se WHERE name=:name")
     Page<SecondEntity> findByNameQueryNamed(@Param("name") String name, Pageable pageable);
 
 }

--- a/extensions/spring-scheduled/deployment/src/test/java/io/quarkus/spring/scheduled/deployment/SpringDelayedTest.java
+++ b/extensions/spring-scheduled/deployment/src/test/java/io/quarkus/spring/scheduled/deployment/SpringDelayedTest.java
@@ -36,7 +36,8 @@ public class SpringDelayedTest {
         static final CountDownLatch LATCH = new CountDownLatch(4);
 
         @Scheduled(fixedRate = 1000, initialDelay = 1000)
-        @Scheduled(fixedRateString = "${springScheduledSimpleJobs.fixedRate}", initialDelayString = "${springScheduledSimpleJobs.initialDelay}")
+        @Scheduled(fixedRateString = "${springScheduledSimpleJobs.fixedRate}",
+                initialDelayString = "${springScheduledSimpleJobs.initialDelay}")
         void ping() {
             LATCH.countDown();
         }

--- a/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/resteasy/reactive/test/TestController.java
+++ b/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/resteasy/reactive/test/TestController.java
@@ -93,7 +93,8 @@ public class TestController {
         return someClass.getMessage();
     }
 
-    @RequestMapping(path = "/json2", method = RequestMethod.POST, produces = MediaType.TEXT_PLAIN, consumes = MediaType.APPLICATION_JSON)
+    @RequestMapping(path = "/json2", method = RequestMethod.POST, produces = MediaType.TEXT_PLAIN,
+            consumes = MediaType.APPLICATION_JSON)
     public String postWithJsonBodyFromRequestMapping(@RequestBody SomeClass someClass) {
         return someClass.getMessage();
     }

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/GenerateCACommand.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/GenerateCACommand.java
@@ -20,7 +20,8 @@ import org.jboss.logging.Logger;
 import io.smallrye.certs.ca.CaGenerator;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "generate-quarkus-ca", mixinStandardHelpOptions = true, description = "Generate Quarkus Dev CA certificate and private key.")
+@CommandLine.Command(name = "generate-quarkus-ca", mixinStandardHelpOptions = true,
+        description = "Generate Quarkus Dev CA certificate and private key.")
 public class GenerateCACommand implements Callable<Integer> {
 
     @CommandLine.Option(names = { "-i",
@@ -28,7 +29,8 @@ public class GenerateCACommand implements Callable<Integer> {
     boolean install;
 
     @CommandLine.Option(names = { "-t",
-            "--truststore" }, description = "Generate a PKCS12 (`.p12`) truststore containing the generated CA.", defaultValue = "false")
+            "--truststore" }, description = "Generate a PKCS12 (`.p12`) truststore containing the generated CA.",
+            defaultValue = "false")
     boolean truststore;
 
     @CommandLine.Option(names = { "-r",

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/GenerateCertificateCommand.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/GenerateCertificateCommand.java
@@ -34,23 +34,28 @@ import io.smallrye.certs.Format;
 import io.smallrye.common.os.OS;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "generate-certificate", mixinStandardHelpOptions = true, description = "Generate a TLS certificate with the Quarkus Dev CA if available.")
+@CommandLine.Command(name = "generate-certificate", mixinStandardHelpOptions = true,
+        description = "Generate a TLS certificate with the Quarkus Dev CA if available.")
 public class GenerateCertificateCommand implements Callable<Integer> {
 
     @CommandLine.Option(names = { "-n",
-            "--name" }, description = "Name of the certificate. It will be used as file name and alias in the keystore", required = true)
+            "--name" }, description = "Name of the certificate. It will be used as file name and alias in the keystore",
+            required = true)
     String name;
 
     @CommandLine.Option(names = { "-p",
-            "--password" }, description = "The password of the keystore. Default is 'password'", defaultValue = "password", required = false)
+            "--password" }, description = "The password of the keystore. Default is 'password'", defaultValue = "password",
+            required = false)
     String password;
 
     @CommandLine.Option(names = { "-c",
-            "--cn" }, description = "The common name of the certificate. Default is 'localhost'", defaultValue = "localhost", required = false)
+            "--cn" }, description = "The common name of the certificate. Default is 'localhost'", defaultValue = "localhost",
+            required = false)
     String cn;
 
     @CommandLine.Option(names = { "-d",
-            "--directory" }, description = "The directory in which the certificates will be created. Default is `.certs`", defaultValue = ".certs")
+            "--directory" }, description = "The directory in which the certificates will be created. Default is `.certs`",
+            defaultValue = ".certs")
     Path directory;
 
     @CommandLine.Option(names = { "-r",

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/LetsEncryptCommand.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/LetsEncryptCommand.java
@@ -5,11 +5,12 @@ import io.quarkus.tls.cli.letsencrypt.LetsEncryptPrepareCommand;
 import io.quarkus.tls.cli.letsencrypt.LetsEncryptRenewCommand;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "lets-encrypt", mixinStandardHelpOptions = true, sortOptions = false, header = "Prepare, generate and renew Let's Encrypt Certificates", subcommands = {
-        LetsEncryptPrepareCommand.class,
-        LetsEncryptIssueCommand.class,
-        LetsEncryptRenewCommand.class,
-})
+@CommandLine.Command(name = "lets-encrypt", mixinStandardHelpOptions = true, sortOptions = false,
+        header = "Prepare, generate and renew Let's Encrypt Certificates", subcommands = {
+                LetsEncryptPrepareCommand.class,
+                LetsEncryptIssueCommand.class,
+                LetsEncryptRenewCommand.class,
+        })
 public class LetsEncryptCommand {
 
 }

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/TlsCommand.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/TlsCommand.java
@@ -4,11 +4,12 @@ import java.util.concurrent.Callable;
 
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "tls", mixinStandardHelpOptions = true, sortOptions = false, header = "Install and Manage TLS development certificates", subcommands = {
-        GenerateCACommand.class,
-        GenerateCertificateCommand.class,
-        LetsEncryptCommand.class
-})
+@CommandLine.Command(name = "tls", mixinStandardHelpOptions = true, sortOptions = false,
+        header = "Install and Manage TLS development certificates", subcommands = {
+                GenerateCACommand.class,
+                GenerateCertificateCommand.class,
+                LetsEncryptCommand.class
+        })
 public class TlsCommand implements Callable<Integer> {
 
     @CommandLine.Spec

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptIssueCommand.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptIssueCommand.java
@@ -14,9 +14,10 @@ import org.jboss.logging.Logger;
 
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "issue-certificate", mixinStandardHelpOptions = true, description = "Issue a certificate from let's encrypt. This command runs the HTTP 01 challenge of let's encrypt. "
-        +
-        "Make sure the application is running before running this command.")
+@CommandLine.Command(name = "issue-certificate", mixinStandardHelpOptions = true,
+        description = "Issue a certificate from let's encrypt. This command runs the HTTP 01 challenge of let's encrypt. "
+                +
+                "Make sure the application is running before running this command.")
 public class LetsEncryptIssueCommand implements Callable<Integer> {
 
     static Logger LOGGER = Logger.getLogger(LetsEncryptIssueCommand.class);
@@ -26,12 +27,14 @@ public class LetsEncryptIssueCommand implements Callable<Integer> {
     String domain;
 
     @CommandLine.Option(names = { "-n",
-            "--tls-configuration-name" }, description = "The name of the TLS configuration to be used, if not set, the default configuration is used")
+            "--tls-configuration-name" },
+            description = "The name of the TLS configuration to be used, if not set, the default configuration is used")
     String tlsConfigurationName;
 
     // TODO Check if /lets-encrypt is appended
     @CommandLine.Option(names = {
-            "--management-url" }, description = "The URL of the management endpoint to use for the ACME challenge", required = true)
+            "--management-url" }, description = "The URL of the management endpoint to use for the ACME challenge",
+            required = true)
     String managementUrl;
 
     @CommandLine.Option(names = {
@@ -51,7 +54,9 @@ public class LetsEncryptIssueCommand implements Callable<Integer> {
     boolean staging;
 
     @CommandLine.Option(names = {
-            "--insecure" }, description = "Disable SSL certificate validation for the management endpoint (INSECURE - development/testing only)", defaultValue = "false")
+            "--insecure" },
+            description = "Disable SSL certificate validation for the management endpoint (INSECURE - development/testing only)",
+            defaultValue = "false")
     boolean insecure;
 
     @CommandLine.Option(names = {

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptPrepareCommand.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptPrepareCommand.java
@@ -22,8 +22,9 @@ import io.smallrye.certs.CertificateRequest;
 import io.smallrye.certs.Format;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "prepare", mixinStandardHelpOptions = true, description = "Prepare the environment to receive Let's Encrypt certificates."
-        + " Make sure to restart the application after having run this command.")
+@CommandLine.Command(name = "prepare", mixinStandardHelpOptions = true,
+        description = "Prepare the environment to receive Let's Encrypt certificates."
+                + " Make sure to restart the application after having run this command.")
 public class LetsEncryptPrepareCommand implements Callable<Integer> {
 
     static Logger LOGGER = Logger.getLogger(LetsEncryptPrepareCommand.class);
@@ -33,7 +34,8 @@ public class LetsEncryptPrepareCommand implements Callable<Integer> {
     String domain;
 
     @CommandLine.Option(names = { "-n",
-            "--tls-configuration-name" }, description = "The name of the TLS configuration to be used, if not set, the default configuration is used")
+            "--tls-configuration-name" },
+            description = "The name of the TLS configuration to be used, if not set, the default configuration is used")
     String tlsConfigurationName;
 
     @Override

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptRenewCommand.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptRenewCommand.java
@@ -12,8 +12,9 @@ import org.jboss.logging.Logger;
 
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "renew-certificate", mixinStandardHelpOptions = true, description = "Renew a Let's Encrypt. This command re-runs the HTTP 01 challenge of let's encrypt to retrieve a new certificate. "
-        + "Make sure the application is running before running this command.")
+@CommandLine.Command(name = "renew-certificate", mixinStandardHelpOptions = true,
+        description = "Renew a Let's Encrypt. This command re-runs the HTTP 01 challenge of let's encrypt to retrieve a new certificate. "
+                + "Make sure the application is running before running this command.")
 public class LetsEncryptRenewCommand implements Callable<Integer> {
 
     static Logger LOGGER = Logger.getLogger(LetsEncryptRenewCommand.class);
@@ -23,11 +24,13 @@ public class LetsEncryptRenewCommand implements Callable<Integer> {
     String domain;
 
     @CommandLine.Option(names = { "-n",
-            "--tls-configuration-name" }, description = "The name of the TLS configuration to be used, if not set, the default configuration is used")
+            "--tls-configuration-name" },
+            description = "The name of the TLS configuration to be used, if not set, the default configuration is used")
     String tlsConfigurationName;
 
     @CommandLine.Option(names = {
-            "--management-url" }, description = "The URL of the management endpoint to use for the ACME challenge", required = true)
+            "--management-url" }, description = "The URL of the management endpoint to use for the ACME challenge",
+            required = true)
     String managementUrl;
 
     @CommandLine.Option(names = {
@@ -43,7 +46,9 @@ public class LetsEncryptRenewCommand implements Callable<Integer> {
     boolean staging;
 
     @CommandLine.Option(names = {
-            "--insecure" }, description = "Disable SSL certificate validation for the management endpoint (INSECURE - development/testing only)", defaultValue = "false")
+            "--insecure" },
+            description = "Disable SSL certificate validation for the management endpoint (INSECURE - development/testing only)",
+            defaultValue = "false")
     boolean insecure;
 
     @CommandLine.Option(names = {

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/CertificateUpdatedEventWithPeriodicReloadTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/CertificateUpdatedEventWithPeriodicReloadTest.java
@@ -27,8 +27,10 @@ import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
-        @Certificate(name = "test-periodic-event-A", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:localhost"),
-        @Certificate(name = "test-periodic-event-B", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:acme.org")
+        @Certificate(name = "test-periodic-event-A", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:localhost"),
+        @Certificate(name = "test-periodic-event-B", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:acme.org")
 })
 public class CertificateUpdatedEventWithPeriodicReloadTest {
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/DefaultJKSTrustStoreWithCredentialsProviderWithAliasTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/DefaultJKSTrustStoreWithCredentialsProviderWithAliasTest.java
@@ -25,7 +25,8 @@ import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
         @Certificate(name = "test-credentials-provider-alias", password = "secret123!", formats = { Format.JKS,
-                Format.PKCS12 }, aliases = @Alias(name = "my-alias", password = "alias-secret123!", subjectAlternativeNames = "dns:acme.org"))
+                Format.PKCS12 },
+                aliases = @Alias(name = "my-alias", password = "alias-secret123!", subjectAlternativeNames = "dns:acme.org"))
 })
 public class DefaultJKSTrustStoreWithCredentialsProviderWithAliasTest {
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/DefaultP12TrustStoreWithCredentialsProviderWithAliasTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/DefaultP12TrustStoreWithCredentialsProviderWithAliasTest.java
@@ -25,7 +25,8 @@ import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
         @Certificate(name = "test-credentials-provider-alias", password = "secret123!", formats = { Format.JKS,
-                Format.PKCS12 }, aliases = @Alias(name = "my-alias", password = "alias-secret123!", subjectAlternativeNames = "dns:acme.org"))
+                Format.PKCS12 },
+                aliases = @Alias(name = "my-alias", password = "alias-secret123!", subjectAlternativeNames = "dns:acme.org"))
 })
 public class DefaultP12TrustStoreWithCredentialsProviderWithAliasTest {
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/JKSKeyStoreWithAliasCredentialsProviderTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/JKSKeyStoreWithAliasCredentialsProviderTest.java
@@ -25,7 +25,8 @@ import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
         @Certificate(name = "test-credentials-provider-alias", password = "secret123!", formats = { Format.JKS,
-                Format.PKCS12 }, aliases = @Alias(name = "my-alias", password = "alias-secret123!", subjectAlternativeNames = "dns:acme.org"))
+                Format.PKCS12 },
+                aliases = @Alias(name = "my-alias", password = "alias-secret123!", subjectAlternativeNames = "dns:acme.org"))
 })
 public class JKSKeyStoreWithAliasCredentialsProviderTest {
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ManualReloadDoesNotFireEventTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ManualReloadDoesNotFireEventTest.java
@@ -25,8 +25,10 @@ import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
-        @Certificate(name = "test-reload-event-A", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:localhost"),
-        @Certificate(name = "test-reload-event-B", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:acme.org")
+        @Certificate(name = "test-reload-event-A", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:localhost"),
+        @Certificate(name = "test-reload-event-B", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:acme.org")
 })
 public class ManualReloadDoesNotFireEventTest {
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/NamedJKSKeyStoreWithAliasCredentialsProviderTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/NamedJKSKeyStoreWithAliasCredentialsProviderTest.java
@@ -25,7 +25,8 @@ import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
         @Certificate(name = "test-credentials-provider-alias", password = "secret123!", formats = { Format.JKS,
-                Format.PKCS12 }, aliases = @Alias(name = "my-alias", password = "alias-secret123!", subjectAlternativeNames = "dns:acme.org"))
+                Format.PKCS12 },
+                aliases = @Alias(name = "my-alias", password = "alias-secret123!", subjectAlternativeNames = "dns:acme.org"))
 })
 public class NamedJKSKeyStoreWithAliasCredentialsProviderTest {
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/NamedJKSTrustStoreWithCredentialsProviderWithAliasTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/NamedJKSTrustStoreWithCredentialsProviderWithAliasTest.java
@@ -25,7 +25,8 @@ import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
         @Certificate(name = "test-credentials-provider-alias", password = "secret123!", formats = { Format.JKS,
-                Format.PKCS12 }, aliases = @Alias(name = "my-alias", password = "alias-secret123!", subjectAlternativeNames = "dns:acme.org"))
+                Format.PKCS12 },
+                aliases = @Alias(name = "my-alias", password = "alias-secret123!", subjectAlternativeNames = "dns:acme.org"))
 })
 public class NamedJKSTrustStoreWithCredentialsProviderWithAliasTest {
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/NamedP12KeyStoreWithAliasCredentialsProviderTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/NamedP12KeyStoreWithAliasCredentialsProviderTest.java
@@ -25,7 +25,8 @@ import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
         @Certificate(name = "test-credentials-provider-alias", password = "secret123!", formats = { Format.JKS,
-                Format.PKCS12 }, aliases = @Alias(name = "my-alias", password = "alias-secret123!", subjectAlternativeNames = "dns:acme.org"))
+                Format.PKCS12 },
+                aliases = @Alias(name = "my-alias", password = "alias-secret123!", subjectAlternativeNames = "dns:acme.org"))
 })
 public class NamedP12KeyStoreWithAliasCredentialsProviderTest {
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/NamedP12TrustStoreWithCredentialsProviderWithAliasTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/NamedP12TrustStoreWithCredentialsProviderWithAliasTest.java
@@ -25,7 +25,8 @@ import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
         @Certificate(name = "test-credentials-provider-alias", password = "secret123!", formats = { Format.JKS,
-                Format.PKCS12 }, aliases = @Alias(name = "my-alias", password = "alias-secret123!", subjectAlternativeNames = "dns:acme.org"))
+                Format.PKCS12 },
+                aliases = @Alias(name = "my-alias", password = "alias-secret123!", subjectAlternativeNames = "dns:acme.org"))
 })
 public class NamedP12TrustStoreWithCredentialsProviderWithAliasTest {
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/P12KeyStoreWithAliasCredentialsProviderTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/P12KeyStoreWithAliasCredentialsProviderTest.java
@@ -25,7 +25,8 @@ import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
         @Certificate(name = "test-credentials-provider-alias", password = "secret123!", formats = { Format.JKS,
-                Format.PKCS12 }, aliases = @Alias(name = "my-alias", password = "alias-secret123!", subjectAlternativeNames = "dns:acme.org"))
+                Format.PKCS12 },
+                aliases = @Alias(name = "my-alias", password = "alias-secret123!", subjectAlternativeNames = "dns:acme.org"))
 })
 public class P12KeyStoreWithAliasCredentialsProviderTest {
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/PeriodicReloadTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/PeriodicReloadTest.java
@@ -30,8 +30,10 @@ import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
-        @Certificate(name = "test-periodic-A", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:localhost"),
-        @Certificate(name = "test-periodic-B", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:acme.org")
+        @Certificate(name = "test-periodic-A", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:localhost"),
+        @Certificate(name = "test-periodic-B", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:acme.org")
 })
 public class PeriodicReloadTest {
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ReloadFailureTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ReloadFailureTest.java
@@ -25,7 +25,8 @@ import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
-        @Certificate(name = "test-reload-fail-A", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:localhost"),
+        @Certificate(name = "test-reload-fail-A", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:localhost"),
 })
 public class ReloadFailureTest {
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ReloadKeyStoreTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ReloadKeyStoreTest.java
@@ -25,8 +25,10 @@ import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
-        @Certificate(name = "test-reload-A", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:localhost"),
-        @Certificate(name = "test-reload-B", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:acme.org")
+        @Certificate(name = "test-reload-A", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:localhost"),
+        @Certificate(name = "test-reload-B", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:acme.org")
 })
 public class ReloadKeyStoreTest {
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ReloadOtherKeyStoreTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ReloadOtherKeyStoreTest.java
@@ -25,8 +25,10 @@ import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
-        @Certificate(name = "test-reload-A", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:localhost"),
-        @Certificate(name = "test-reload-B", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:acme.org")
+        @Certificate(name = "test-reload-A", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:localhost"),
+        @Certificate(name = "test-reload-B", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:acme.org")
 })
 public class ReloadOtherKeyStoreTest {
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ReloadOtherKeyStoreWithFactoryTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ReloadOtherKeyStoreWithFactoryTest.java
@@ -28,8 +28,10 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.net.JksOptions;
 
 @Certificates(baseDir = "target/certs", certificates = {
-        @Certificate(name = "test-reload-A", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:localhost"),
-        @Certificate(name = "test-reload-B", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:acme.org")
+        @Certificate(name = "test-reload-A", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:localhost"),
+        @Certificate(name = "test-reload-B", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:acme.org")
 })
 public class ReloadOtherKeyStoreWithFactoryTest {
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ReloadOtherTrustStoreTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ReloadOtherTrustStoreTest.java
@@ -25,8 +25,10 @@ import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
-        @Certificate(name = "test-reload-A", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:localhost"),
-        @Certificate(name = "test-reload-B", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:acme.org")
+        @Certificate(name = "test-reload-A", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:localhost"),
+        @Certificate(name = "test-reload-B", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:acme.org")
 })
 public class ReloadOtherTrustStoreTest {
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ReloadOtherTrustStoreWithFactoryTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ReloadOtherTrustStoreWithFactoryTest.java
@@ -28,8 +28,10 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.net.JksOptions;
 
 @Certificates(baseDir = "target/certs", certificates = {
-        @Certificate(name = "test-reload-A", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:localhost"),
-        @Certificate(name = "test-reload-B", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:acme.org")
+        @Certificate(name = "test-reload-A", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:localhost"),
+        @Certificate(name = "test-reload-B", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:acme.org")
 })
 public class ReloadOtherTrustStoreWithFactoryTest {
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ReloadTrustStoreTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ReloadTrustStoreTest.java
@@ -25,8 +25,10 @@ import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
-        @Certificate(name = "test-reload-A", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:localhost"),
-        @Certificate(name = "test-reload-B", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:acme.org")
+        @Certificate(name = "test-reload-A", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:localhost"),
+        @Certificate(name = "test-reload-B", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:acme.org")
 })
 public class ReloadTrustStoreTest {
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ReloadWithCRLUpdateTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ReloadWithCRLUpdateTest.java
@@ -24,8 +24,10 @@ import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 
 @Certificates(baseDir = "target/certs", certificates = {
-        @Certificate(name = "test-reload-crl-A", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:localhost"),
-        @Certificate(name = "test-reload-crl-B", password = "password", formats = Format.PKCS12, subjectAlternativeNames = "dns:acme.org")
+        @Certificate(name = "test-reload-crl-A", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:localhost"),
+        @Certificate(name = "test-reload-crl-B", password = "password", formats = Format.PKCS12,
+                subjectAlternativeNames = "dns:acme.org")
 })
 @DisabledOnOs(OS.WINDOWS)
 public class ReloadWithCRLUpdateTest {

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/AnnotatedFilterInitParam.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/AnnotatedFilterInitParam.java
@@ -13,7 +13,8 @@ import jakarta.servlet.annotation.WebInitParam;
 import jakarta.servlet.http.HttpFilter;
 
 @WebFilter(urlPatterns = SERVLET_ENDPOINT, description = "Haha Filter", initParams = {
-        @WebInitParam(name = "AnnotatedInitFilterParamName", value = "AnnotatedInitFilterParamValue", description = "Described filter init param")
+        @WebInitParam(name = "AnnotatedInitFilterParamName", value = "AnnotatedInitFilterParamValue",
+                description = "Described filter init param")
 })
 public class AnnotatedFilterInitParam extends HttpFilter {
 

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementAndPrimaryUsingSameTlsConfigurationTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementAndPrimaryUsingSameTlsConfigurationTest.java
@@ -29,8 +29,9 @@ import io.vertx.core.Handler;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-management-interface-test", password = "secret", formats = {
-        Format.JKS, Format.PKCS12, Format.PEM }))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "ssl-management-interface-test", password = "secret", formats = {
+                Format.JKS, Format.PKCS12, Format.PEM }))
 public class ManagementAndPrimaryUsingSameTlsConfigurationTest {
     private static final String APP_PROPS = """
             quarkus.management.enabled=true

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithJksAndTlsRegistryTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithJksAndTlsRegistryTest.java
@@ -25,8 +25,9 @@ import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-management-interface-test", password = "secret", formats = {
-        Format.JKS, Format.PKCS12, Format.PEM }))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "ssl-management-interface-test", password = "secret", formats = {
+                Format.JKS, Format.PKCS12, Format.PEM }))
 public class ManagementWithJksAndTlsRegistryTest {
     private static final String configuration = """
             quarkus.management.enabled=true

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithJksTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithJksTest.java
@@ -25,8 +25,9 @@ import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-management-interface-test", password = "secret", formats = {
-        Format.JKS, Format.PKCS12, Format.PEM }))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "ssl-management-interface-test", password = "secret", formats = {
+                Format.JKS, Format.PKCS12, Format.PEM }))
 public class ManagementWithJksTest {
     private static final String configuration = """
             quarkus.management.enabled=true

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithJksWithAliasAndTlsRegistryTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithJksWithAliasAndTlsRegistryTest.java
@@ -26,9 +26,11 @@ import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-management-interface-alias-test", password = "secret", formats = {
-        Format.JKS, Format.PKCS12,
-        Format.PEM }, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost")))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "ssl-management-interface-alias-test", password = "secret", formats = {
+                Format.JKS, Format.PKCS12,
+                Format.PEM },
+                aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost")))
 public class ManagementWithJksWithAliasAndTlsRegistryTest {
     private static final String configuration = """
             quarkus.management.enabled=true

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithJksWithAliasTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithJksWithAliasTest.java
@@ -26,9 +26,11 @@ import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-management-interface-alias-test", password = "secret", formats = {
-        Format.JKS, Format.PKCS12,
-        Format.PEM }, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost")))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "ssl-management-interface-alias-test", password = "secret", formats = {
+                Format.JKS, Format.PKCS12,
+                Format.PEM },
+                aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost")))
 public class ManagementWithJksWithAliasTest {
     private static final String configuration = """
             quarkus.management.enabled=true

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithP12AndTlsRegistryTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithP12AndTlsRegistryTest.java
@@ -25,8 +25,9 @@ import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-management-interface-test", password = "secret", formats = {
-        Format.JKS, Format.PKCS12, Format.PEM }))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "ssl-management-interface-test", password = "secret", formats = {
+                Format.JKS, Format.PKCS12, Format.PEM }))
 public class ManagementWithP12AndTlsRegistryTest {
     private static final String configuration = """
             quarkus.management.enabled=true

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithP12Test.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithP12Test.java
@@ -25,8 +25,9 @@ import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-management-interface-test", password = "secret", formats = {
-        Format.JKS, Format.PKCS12, Format.PEM }))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "ssl-management-interface-test", password = "secret", formats = {
+                Format.JKS, Format.PKCS12, Format.PEM }))
 public class ManagementWithP12Test {
     private static final String configuration = """
             quarkus.management.enabled=true

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithP12WithAliasAndTlsRegistryTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithP12WithAliasAndTlsRegistryTest.java
@@ -26,9 +26,11 @@ import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-management-interface-alias-test", password = "secret", formats = {
-        Format.JKS, Format.PKCS12,
-        Format.PEM }, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost")))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "ssl-management-interface-alias-test", password = "secret", formats = {
+                Format.JKS, Format.PKCS12,
+                Format.PEM },
+                aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost")))
 public class ManagementWithP12WithAliasAndTlsRegistryTest {
     private static final String configuration = """
             quarkus.management.enabled=true

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithP12WithAliasTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithP12WithAliasTest.java
@@ -26,9 +26,11 @@ import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-management-interface-alias-test", password = "secret", formats = {
-        Format.JKS, Format.PKCS12,
-        Format.PEM }, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost")))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "ssl-management-interface-alias-test", password = "secret", formats = {
+                Format.JKS, Format.PKCS12,
+                Format.PEM },
+                aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost")))
 public class ManagementWithP12WithAliasTest {
     private static final String configuration = """
             quarkus.management.enabled=true

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithPemAndNamedTlsRegistryTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithPemAndNamedTlsRegistryTest.java
@@ -25,8 +25,9 @@ import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-management-interface-test", password = "secret", formats = {
-        Format.JKS, Format.PKCS12, Format.PEM }))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "ssl-management-interface-test", password = "secret", formats = {
+                Format.JKS, Format.PKCS12, Format.PEM }))
 public class ManagementWithPemAndNamedTlsRegistryTest {
 
     private static final String configuration = """

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithPemAndTlsRegistryTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithPemAndTlsRegistryTest.java
@@ -25,8 +25,9 @@ import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-management-interface-test", password = "secret", formats = {
-        Format.JKS, Format.PKCS12, Format.PEM }))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "ssl-management-interface-test", password = "secret", formats = {
+                Format.JKS, Format.PKCS12, Format.PEM }))
 public class ManagementWithPemAndTlsRegistryTest {
 
     private static final String configuration = """

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithPemTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithPemTest.java
@@ -25,8 +25,9 @@ import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-management-interface-test", password = "secret", formats = {
-        Format.JKS, Format.PKCS12, Format.PEM }))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "ssl-management-interface-test", password = "secret", formats = {
+                Format.JKS, Format.PKCS12, Format.PEM }))
 public class ManagementWithPemTest {
 
     private static final String configuration = """

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/ForwardedProtoHttpsOnHttpConnectionTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/ForwardedProtoHttpsOnHttpConnectionTest.java
@@ -27,8 +27,9 @@ import io.vertx.core.http.HttpServerRequest;
  * @see ForwardedServerRequestWrapper#isSSL() for reasons why it can indicate SSL/TLS communicate
  *      while {@link ForwardedServerRequestWrapper#sslSession()} is null
  */
-@Certificates(baseDir = "target/certs", replaceIfExists = true, certificates = @Certificate(name = ForwardedProtoHttpsOnHttpConnectionTest.CERT_NAME, password = PASSWORD, formats = {
-        Format.PKCS12 }, client = true))
+@Certificates(baseDir = "target/certs", replaceIfExists = true,
+        certificates = @Certificate(name = ForwardedProtoHttpsOnHttpConnectionTest.CERT_NAME, password = PASSWORD, formats = {
+                Format.PKCS12 }, client = true))
 class ForwardedProtoHttpsOnHttpConnectionTest {
 
     static final String CERT_NAME = "forwarded-proto-https-on-http";

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyPerEntryCheckTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyPerEntryCheckTest.java
@@ -28,10 +28,11 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.net.PfxOptions;
 
 @Certificates(certificates = {
-        @Certificate(name = TrustedProxyPerEntryCheckTest.CERT_NAME, password = PASSWORD, formats = Format.PKCS12, subjectAlternativeNames = "DNS:localhost", client = true, aliases = {
-                @Alias(name = "proxy-a", cn = "proxy-a", client = true, password = PASSWORD),
-                @Alias(name = "proxy-b", cn = "proxy-b", client = true, password = PASSWORD)
-        })
+        @Certificate(name = TrustedProxyPerEntryCheckTest.CERT_NAME, password = PASSWORD, formats = Format.PKCS12,
+                subjectAlternativeNames = "DNS:localhost", client = true, aliases = {
+                        @Alias(name = "proxy-a", cn = "proxy-a", client = true, password = PASSWORD),
+                        @Alias(name = "proxy-b", cn = "proxy-b", client = true, password = PASSWORD)
+                })
 }, replaceIfExists = true, baseDir = "target/certs")
 class TrustedProxyPerEntryCheckTest {
 

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiAuthenticationMechanismSelectionTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiAuthenticationMechanismSelectionTest.java
@@ -44,7 +44,8 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.ClientAuth;
 import io.vertx.ext.web.RoutingContext;
 
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "mtls-test", password = "secret", formats = Format.PKCS12, client = true))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "mtls-test", password = "secret", formats = Format.PKCS12, client = true))
 public class FluentApiAuthenticationMechanismSelectionTest {
 
     @RegisterExtension

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiInclusiveAuthenticationMechanismSelectionTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiInclusiveAuthenticationMechanismSelectionTest.java
@@ -43,7 +43,8 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.ClientAuth;
 import io.vertx.ext.web.RoutingContext;
 
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "mtls-test", password = "secret", formats = Format.PKCS12, client = true))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "mtls-test", password = "secret", formats = Format.PKCS12, client = true))
 class FluentApiInclusiveAuthenticationMechanismSelectionTest {
 
     @RegisterExtension

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiMTLSAuthenticationOnRequestTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiMTLSAuthenticationOnRequestTest.java
@@ -21,7 +21,8 @@ import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.http.ClientAuth;
 
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "mtls-test", password = "secret", formats = Format.PKCS12, client = true))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "mtls-test", password = "secret", formats = Format.PKCS12, client = true))
 public class FluentApiMTLSAuthenticationOnRequestTest {
 
     @RegisterExtension

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiMTLSAuthenticationRequiredDevModeTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiMTLSAuthenticationRequiredDevModeTest.java
@@ -25,7 +25,8 @@ import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "mtls-test", password = "secret", formats = Format.PKCS12, client = true))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "mtls-test", password = "secret", formats = Format.PKCS12, client = true))
 public class FluentApiMTLSAuthenticationRequiredDevModeTest {
 
     private static final String HOT_RELOAD_FILTER = "HotReloadFilter.java";

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiMTLSAuthenticationRequiredTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiMTLSAuthenticationRequiredTest.java
@@ -29,7 +29,8 @@ import io.vertx.core.net.KeyStoreOptions;
 import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.core.net.TrustOptions;
 
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "mtls-test", password = "secret", formats = Format.PKCS12, client = true))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "mtls-test", password = "secret", formats = Format.PKCS12, client = true))
 public class FluentApiMTLSAuthenticationRequiredTest {
 
     @RegisterExtension

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiMechanismPrioritizationTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiMechanismPrioritizationTest.java
@@ -24,7 +24,8 @@ import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.http.ClientAuth;
 
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "mtls-test", password = "secret", formats = Format.PKCS12, client = true))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "mtls-test", password = "secret", formats = Format.PKCS12, client = true))
 class FluentApiMechanismPrioritizationTest {
 
     @RegisterExtension

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/SslServerWithJKSWithSniMatchingSanDNSTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/SslServerWithJKSWithSniMatchingSanDNSTest.java
@@ -26,7 +26,8 @@ import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 
 @Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-test-sni", password = "secret", formats = {
-        Format.JKS, Format.PKCS12, Format.PEM }, cn = "acme.org", subjectAlternativeNames = "DNS:example.com", aliases = {
+        Format.JKS, Format.PKCS12, Format.PEM }, cn = "acme.org", subjectAlternativeNames = "DNS:example.com",
+        aliases = {
                 @Alias(name = "alias", cn = "foo.com", subjectAlternativeNames = "DNS:acme.org", password = "secret"),
                 @Alias(name = "alias-2", cn = "bar.biz", subjectAlternativeNames = "DNS:localhost", password = "secret")
         }))

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/SslServerWithP12WithSniMatchingSanDNSTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/SslServerWithP12WithSniMatchingSanDNSTest.java
@@ -26,7 +26,8 @@ import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 
 @Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-test-sni", password = "secret", formats = {
-        Format.JKS, Format.PKCS12, Format.PEM }, cn = "acme.org", subjectAlternativeNames = "DNS:example.com", aliases = {
+        Format.JKS, Format.PKCS12, Format.PEM }, cn = "acme.org", subjectAlternativeNames = "DNS:example.com",
+        aliases = {
                 @Alias(name = "alias", cn = "foo.com", subjectAlternativeNames = "DNS:acme.org", password = "secret"),
                 @Alias(name = "alias-2", cn = "bar.biz", subjectAlternativeNames = "DNS:localhost", password = "secret")
         }))

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/SslServerWithPemWithSniMatchingSanDNSTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/SslServerWithPemWithSniMatchingSanDNSTest.java
@@ -27,7 +27,8 @@ import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 
 @Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-test-sni", password = "secret", formats = {
-        Format.JKS, Format.PKCS12, Format.PEM }, cn = "acme.org", subjectAlternativeNames = "DNS:example.com", aliases = {
+        Format.JKS, Format.PKCS12, Format.PEM }, cn = "acme.org", subjectAlternativeNames = "DNS:example.com",
+        aliases = {
                 @Alias(name = "alias", cn = "foo.com", subjectAlternativeNames = "DNS:acme.org", password = "secret"),
                 @Alias(name = "alias-2", cn = "bar.biz", subjectAlternativeNames = "DNS:localhost", password = "secret")
         }))

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/TlsServerWithJKSWithSniMatchingSanDNSTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/TlsServerWithJKSWithSniMatchingSanDNSTest.java
@@ -26,7 +26,8 @@ import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 
 @Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-test-sni", password = "secret", formats = {
-        Format.JKS, Format.PKCS12, Format.PEM }, cn = "acme.org", subjectAlternativeNames = "DNS:example.com", aliases = {
+        Format.JKS, Format.PKCS12, Format.PEM }, cn = "acme.org", subjectAlternativeNames = "DNS:example.com",
+        aliases = {
                 @Alias(name = "alias", cn = "foo.com", subjectAlternativeNames = "DNS:acme.org", password = "secret"),
                 @Alias(name = "alias-2", cn = "bar.biz", subjectAlternativeNames = "DNS:localhost", password = "secret")
         }))

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/TlsServerWithP12WithSniMatchingSanDNSTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/TlsServerWithP12WithSniMatchingSanDNSTest.java
@@ -26,7 +26,8 @@ import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 
 @Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-test-sni", password = "secret", formats = {
-        Format.JKS, Format.PKCS12, Format.PEM }, cn = "acme.org", subjectAlternativeNames = "DNS:example.com", aliases = {
+        Format.JKS, Format.PKCS12, Format.PEM }, cn = "acme.org", subjectAlternativeNames = "DNS:example.com",
+        aliases = {
                 @Alias(name = "alias", cn = "foo.com", subjectAlternativeNames = "DNS:acme.org", password = "secret"),
                 @Alias(name = "alias-2", cn = "bar.biz", subjectAlternativeNames = "DNS:localhost", password = "secret")
         }))

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/TlsServerWithPemWithSniMatchingSanDNSTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/TlsServerWithPemWithSniMatchingSanDNSTest.java
@@ -27,7 +27,8 @@ import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 
 @Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-test-sni", password = "secret", formats = {
-        Format.JKS, Format.PKCS12, Format.PEM }, cn = "acme.org", subjectAlternativeNames = "DNS:example.com", aliases = {
+        Format.JKS, Format.PKCS12, Format.PEM }, cn = "acme.org", subjectAlternativeNames = "DNS:example.com",
+        aliases = {
                 @Alias(name = "alias", cn = "foo.com", subjectAlternativeNames = "DNS:acme.org", password = "secret"),
                 @Alias(name = "alias-2", cn = "bar.biz", subjectAlternativeNames = "DNS:localhost", password = "secret")
         }))

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/jackson/graal/JacksonSubstitutions.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/jackson/graal/JacksonSubstitutions.java
@@ -14,7 +14,8 @@ import io.vertx.core.spi.json.JsonCodec;
  * and {@code DatabindCodec}). GraalVM's static analysis resolves all referenced types at build time,
  * so the try/catch fallback in the original method is not sufficient.
  */
-@TargetClass(className = "io.quarkus.vertx.runtime.jackson.QuarkusJacksonFactory", onlyWith = JacksonDatabindMissingSelector.class)
+@TargetClass(className = "io.quarkus.vertx.runtime.jackson.QuarkusJacksonFactory",
+        onlyWith = JacksonDatabindMissingSelector.class)
 final class Target_QuarkusJacksonFactory {
 
     @Substitute

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/HttpUpgradeSelectAuthMechWithAnnotationTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/HttpUpgradeSelectAuthMechWithAnnotationTest.java
@@ -62,7 +62,8 @@ import io.vertx.core.http.WebSocketConnectOptions;
 import io.vertx.ext.auth.authentication.UsernamePasswordCredentials;
 import io.vertx.ext.web.RoutingContext;
 
-@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "mtls-test", password = "secret", formats = Format.PKCS12, client = true))
+@Certificates(baseDir = "target/certs",
+        certificates = @Certificate(name = "mtls-test", password = "secret", formats = Format.PKCS12, client = true))
 public class HttpUpgradeSelectAuthMechWithAnnotationTest extends SecurityTestBase {
 
     @RegisterExtension

--- a/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -89,7 +89,8 @@ import io.quarkus.platform.tools.ExtensionMetadataValidator;
  *
  * @author Alexey Loubyansky
  */
-@Mojo(name = "extension-descriptor", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+@Mojo(name = "extension-descriptor", defaultPhase = LifecyclePhase.PROCESS_RESOURCES,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class ExtensionDescriptorMojo extends AbstractMojo {
 
     public static class RemovedResources {

--- a/independent-projects/ide-config/src/main/resources/eclipse-format.xml
+++ b/independent-projects/ide-config/src/main/resources/eclipse-format.xml
@@ -4,7 +4,7 @@
 <setting id="org.eclipse.jdt.core.formatter.align_assignment_statements_on_columns" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>

--- a/independent-projects/junit-virtual-threads/src/test/java/io/quarkus/test/junit/virtual/internal/Java25FieldsTest.java
+++ b/independent-projects/junit-virtual-threads/src/test/java/io/quarkus/test/junit/virtual/internal/Java25FieldsTest.java
@@ -13,7 +13,8 @@ import io.quarkus.test.junit.virtual.VirtualThreadUnit;
  */
 @VirtualThreadUnit
 @EnabledForJreRange(min = JRE.JAVA_21)
-@DisabledIfSystemProperty(named = "java.runtime.name", matches = ".*Semeru.*", disabledReason = "Semeru doesn't support JFR yet")
+@DisabledIfSystemProperty(named = "java.runtime.name", matches = ".*Semeru.*",
+        disabledReason = "Semeru doesn't support JFR yet")
 public class Java25FieldsTest {
 
     @Test

--- a/independent-projects/junit-virtual-threads/src/test/java/io/quarkus/test/junit/virtual/internal/ShouldNotPinTest.java
+++ b/independent-projects/junit-virtual-threads/src/test/java/io/quarkus/test/junit/virtual/internal/ShouldNotPinTest.java
@@ -19,7 +19,8 @@ import io.quarkus.test.junit.virtual.internal.ignore.LoomUnitExampleShouldNotPin
 import io.quarkus.test.junit.virtual.internal.ignore.LoomUnitExampleShouldNotPinOnSuperClassTest;
 import io.quarkus.test.junit.virtual.internal.ignore.LoomUnitExampleShouldPinOnSuperClassTest;
 
-@DisabledIfSystemProperty(named = "java.runtime.name", matches = ".*Semeru.*", disabledReason = "Semeru doesn't support JFR yet")
+@DisabledIfSystemProperty(named = "java.runtime.name", matches = ".*Semeru.*",
+        disabledReason = "Semeru doesn't support JFR yet")
 public class ShouldNotPinTest {
 
     @ParameterizedTest

--- a/independent-projects/junit-virtual-threads/src/test/java/io/quarkus/test/junit/virtual/internal/ShouldPinTest.java
+++ b/independent-projects/junit-virtual-threads/src/test/java/io/quarkus/test/junit/virtual/internal/ShouldPinTest.java
@@ -17,7 +17,8 @@ import io.quarkus.test.junit.virtual.internal.ignore.LoomUnitExampleShouldNotPin
 import io.quarkus.test.junit.virtual.internal.ignore.LoomUnitExampleShouldNotPinOnSuperClassTest;
 import io.quarkus.test.junit.virtual.internal.ignore.LoomUnitExampleShouldPinOnSuperClassTest;
 
-@DisabledIfSystemProperty(named = "java.runtime.name", matches = ".*Semeru.*", disabledReason = "Semeru doesn't support JFR yet")
+@DisabledIfSystemProperty(named = "java.runtime.name", matches = ".*Semeru.*",
+        disabledReason = "Semeru doesn't support JFR yet")
 public class ShouldPinTest {
 
     @ParameterizedTest

--- a/independent-projects/junit-virtual-threads/src/test/java/io/quarkus/test/junit/virtual/internal/VirtualThreadExtensionTest.java
+++ b/independent-projects/junit-virtual-threads/src/test/java/io/quarkus/test/junit/virtual/internal/VirtualThreadExtensionTest.java
@@ -89,7 +89,8 @@ class VirtualThreadExtensionTest {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "java.runtime.name", matches = ".*Semeru.*", disabledReason = "Semeru doesn't support JFR yet")
+    @DisabledIfSystemProperty(named = "java.runtime.name", matches = ".*Semeru.*",
+            disabledReason = "Semeru doesn't support JFR yet")
     void afterEachShouldPinButNoEvents() throws NoSuchMethodException {
         extensionContext.setMethod(TestClass.class.getDeclaredMethod("methodShouldPinButDoesnt"));
         assertThatThrownBy(() -> extension.afterEach(extensionContext))

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/simple/LocalDateParamTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/simple/LocalDateParamTest.java
@@ -100,13 +100,15 @@ public class LocalDateParamTest {
 
         @POST
         public String helloForm(
-                @FormParam("date") @DateFormat(dateTimeFormatterProvider = CustomDateTimeFormatterProvider.class) LocalDate date) {
+                @FormParam("date") @DateFormat(
+                        dateTimeFormatterProvider = CustomDateTimeFormatterProvider.class) LocalDate date) {
             return "hello:" + date;
         }
 
         @POST
         public String helloFormSet(
-                @FormParam("date") @DateFormat(dateTimeFormatterProvider = CustomDateTimeFormatterProvider.class) Set<LocalDate> dates) {
+                @FormParam("date") @DateFormat(
+                        dateTimeFormatterProvider = CustomDateTimeFormatterProvider.class) Set<LocalDate> dates) {
             String formattedDates = dates.stream()
                     .map(date -> date.format(CustomDateTimeFormatterProvider.FORMATTER))
                     .collect(Collectors.joining(","));

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/simple/LocalDateTimeParamTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/simple/LocalDateTimeParamTest.java
@@ -151,7 +151,8 @@ public class LocalDateTimeParamTest {
 
         @POST
         public String helloForm(
-                @FormParam("date") @DateFormat(dateTimeFormatterProvider = CustomDateTimeFormatterProvider.class) LocalDateTime date) {
+                @FormParam("date") @DateFormat(
+                        dateTimeFormatterProvider = CustomDateTimeFormatterProvider.class) LocalDateTime date) {
             if (date == null) {
                 return "hello:null";
             }
@@ -161,7 +162,8 @@ public class LocalDateTimeParamTest {
         @POST
         @Path("list")
         public String helloFormSet(
-                @FormParam("date") @DateFormat(dateTimeFormatterProvider = CustomDateTimeFormatterProvider.class) Set<LocalDateTime> dates) {
+                @FormParam("date") @DateFormat(
+                        dateTimeFormatterProvider = CustomDateTimeFormatterProvider.class) Set<LocalDateTime> dates) {
             String joinedDays = dates.stream()
                     .map(LocalDateTime::getDayOfMonth)
                     .sorted()

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/simple/YearMonthParamTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/simple/YearMonthParamTest.java
@@ -75,7 +75,8 @@ public class YearMonthParamTest {
 
         @POST
         public String helloForm(
-                @FormParam("date") @DateFormat(dateTimeFormatterProvider = CustomDateTimeFormatterProvider.class) YearMonth date) {
+                @FormParam("date") @DateFormat(
+                        dateTimeFormatterProvider = CustomDateTimeFormatterProvider.class) YearMonth date) {
             return "hello:" + date;
         }
 

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/CustomManifestArgumentsTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/CustomManifestArgumentsTest.java
@@ -17,7 +17,8 @@ import org.junit.jupiter.api.condition.OS;
 public class CustomManifestArgumentsTest extends QuarkusGradleWrapperTestBase {
 
     @Test
-    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "for whatever reason, this is not working anymore on Widndows, the customSection is null...")
+    @DisabledOnOs(value = OS.WINDOWS,
+            disabledReason = "for whatever reason, this is not working anymore on Widndows, the customSection is null...")
     public void shouldContainsSpecificManifestProperty() throws Exception {
         File projectDir = getProjectDir("custom-config-java-module");
 

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/ImageTasksWithConfigurationCacheTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/ImageTasksWithConfigurationCacheTest.java
@@ -12,7 +12,8 @@ import org.junit.jupiter.api.condition.OS;
 public class ImageTasksWithConfigurationCacheTest extends QuarkusGradleWrapperTestBase {
 
     @Test
-    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "cannot access the file because another process has locked a portion of the file")
+    @DisabledOnOs(value = OS.WINDOWS,
+            disabledReason = "cannot access the file because another process has locked a portion of the file")
     public void shouldReuseConfigurationCacheImageBuildIfTheExtensionIsAdded() throws Exception {
         File projectDir = getProjectDir("it-test-basic-project");
 
@@ -28,7 +29,8 @@ public class ImageTasksWithConfigurationCacheTest extends QuarkusGradleWrapperTe
     }
 
     @Test
-    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "cannot access the file because another process has locked a portion of the file")
+    @DisabledOnOs(value = OS.WINDOWS,
+            disabledReason = "cannot access the file because another process has locked a portion of the file")
     public void shouldReuseConfigurationCacheWithProjectIsolationImageBuildIfTheExtensionIsAdded() throws Exception {
         File projectDir = getProjectDir("it-test-basic-project");
 

--- a/integration-tests/grpc-stork-recovery/src/main/java/io/quarkus/grpc/examples/stork/DelayedServiceDiscoveryProvider.java
+++ b/integration-tests/grpc-stork-recovery/src/main/java/io/quarkus/grpc/examples/stork/DelayedServiceDiscoveryProvider.java
@@ -27,7 +27,8 @@ import io.smallrye.stork.utils.StorkAddressUtils;
  */
 @ServiceDiscoveryType("delayed")
 @ServiceDiscoveryAttribute(name = "address-list", description = "comma-separated host:port list served once the delay elapses")
-@ServiceDiscoveryAttribute(name = "available-after-ms", description = "milliseconds after the first lookup before instances become available")
+@ServiceDiscoveryAttribute(name = "available-after-ms",
+        description = "milliseconds after the first lookup before instances become available")
 public class DelayedServiceDiscoveryProvider implements ServiceDiscoveryProvider<DelayedConfiguration> {
 
     @Override

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/defaultpu/Person.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/defaultpu/Person.java
@@ -43,7 +43,8 @@ import io.quarkus.hibernate.orm.panache.runtime.JpaOperations;
         @NamedQuery(name = "Person.deleteById", query = "delete from Person2 p where p.id = :id"),
         @NamedQuery(name = "Person.deleteById.ordinal", query = "delete from Person2 p where p.id = ?1"),
 })
-@FilterDef(name = "Person.hasName", defaultCondition = "name = :name", parameters = @ParamDef(name = "name", type = String.class))
+@FilterDef(name = "Person.hasName", defaultCondition = "name = :name",
+        parameters = @ParamDef(name = "name", type = String.class))
 @FilterDef(name = "Person.isAlive", defaultCondition = "status = 'LIVING'")
 @FilterDef(name = "Person.name.in", defaultCondition = "name in (:names)", parameters = {
         @ParamDef(name = "names", type = String.class) })

--- a/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/Person.java
+++ b/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/Person.java
@@ -45,7 +45,8 @@ import io.smallrye.mutiny.Uni;
         @NamedQuery(name = "Person.deleteById", query = "delete from Person2 p where p.id = :id"),
         @NamedQuery(name = "Person.deleteById.ordinal", query = "delete from Person2 p where p.id = ?1"),
 })
-@FilterDef(name = "Person.hasName", defaultCondition = "name = :name", parameters = @ParamDef(name = "name", type = String.class))
+@FilterDef(name = "Person.hasName", defaultCondition = "name = :name",
+        parameters = @ParamDef(name = "name", type = String.class))
 @FilterDef(name = "Person.isAlive", defaultCondition = "status = 'LIVING'")
 @Filter(name = "Person.isAlive")
 @Filter(name = "Person.hasName")

--- a/integration-tests/infinispan-client/src/main/java/io/quarkus/it/infinispan/client/Book.java
+++ b/integration-tests/infinispan-client/src/main/java/io/quarkus/it/infinispan/client/Book.java
@@ -11,6 +11,7 @@ import org.infinispan.protostream.annotations.Proto;
 @Proto
 @Indexed
 public record Book(@Text String title,
-        @Keyword(projectable = true, sortable = true, normalizer = "lowercase", indexNullAs = "unnamed", norms = false) String description,
+        @Keyword(projectable = true, sortable = true, normalizer = "lowercase", indexNullAs = "unnamed",
+                norms = false) String description,
         int publicationYear, Set<Author> authors, Type bookType, BigDecimal price) {
 }

--- a/integration-tests/jpa-h2/src/test/java/io/quarkus/it/jpa/h2/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-h2/src/test/java/io/quarkus/it/jpa/h2/HibernateOrmNoWarningsTest.java
@@ -23,7 +23,8 @@ import io.quarkus.test.junit.QuarkusTest;
         @ResourceArg(name = LogCollectingTestResource.LEVEL, value = "WARNING"),
         @ResourceArg(name = LogCollectingTestResource.INCLUDE, value = "org\\.hibernate\\..*"),
         //We actually have a single warning, caused by the intentional peculiarities of io.quarkus.it.jpa.h2.CompanyCustomer:
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.metamodel\\.internal\\.EntityRepresentationStrategyPojoStandard"),
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE,
+                value = "org\\.hibernate\\.metamodel\\.internal\\.EntityRepresentationStrategyPojoStandard"),
 })
 public class HibernateOrmNoWarningsTest {
     @Test

--- a/integration-tests/jpa/src/main/java/io/quarkus/it/jpa/generatedvalue/EntityWithCustomGenericGeneratorReferencedAsClassName.java
+++ b/integration-tests/jpa/src/main/java/io/quarkus/it/jpa/generatedvalue/EntityWithCustomGenericGeneratorReferencedAsClassName.java
@@ -10,6 +10,7 @@ import org.hibernate.annotations.GenericGenerator;
 public class EntityWithCustomGenericGeneratorReferencedAsClassName {
     @Id
     @GeneratedValue(generator = "referenced-as-class-name")
-    @GenericGenerator(name = "referenced-as-class-name", strategy = "io.quarkus.it.jpa.generatedvalue.MyCustomGenericGeneratorReferencedAsClassName")
+    @GenericGenerator(name = "referenced-as-class-name",
+            strategy = "io.quarkus.it.jpa.generatedvalue.MyCustomGenericGeneratorReferencedAsClassName")
     public String id;
 }

--- a/integration-tests/kubernetes-service-binding-jdbc/src/main/java/io/quarkus/it/k8ssb/jdbc/Fruit.java
+++ b/integration-tests/kubernetes-service-binding-jdbc/src/main/java/io/quarkus/it/k8ssb/jdbc/Fruit.java
@@ -11,7 +11,8 @@ import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "known_fruits")
-@NamedQuery(name = "Fruits.findAll", query = "SELECT f FROM Fruit f ORDER BY f.name", hints = @QueryHint(name = "org.hibernate.cacheable", value = "true"))
+@NamedQuery(name = "Fruits.findAll", query = "SELECT f FROM Fruit f ORDER BY f.name",
+        hints = @QueryHint(name = "org.hibernate.cacheable", value = "true"))
 public class Fruit {
 
     @Id

--- a/integration-tests/kubernetes-service-binding-reactive/src/main/java/io/quarkus/it/k8ssb/jdbc/Fruit.java
+++ b/integration-tests/kubernetes-service-binding-reactive/src/main/java/io/quarkus/it/k8ssb/jdbc/Fruit.java
@@ -11,7 +11,8 @@ import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "known_fruits")
-@NamedQuery(name = "Fruits.findAll", query = "SELECT f FROM Fruit f ORDER BY f.name", hints = @QueryHint(name = "org.hibernate.cacheable", value = "true"))
+@NamedQuery(name = "Fruits.findAll", query = "SELECT f FROM Fruit f ORDER BY f.name",
+        hints = @QueryHint(name = "org.hibernate.cacheable", value = "true"))
 public class Fruit {
 
     @Id

--- a/integration-tests/main/src/main/java/io/quarkus/it/jaxb/mapper/codegen/feed/package-info.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/jaxb/mapper/codegen/feed/package-info.java
@@ -5,5 +5,6 @@
 // Generated on: 2014.09.12 at 03:00:35 PM CEST
 //
 
-@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://www.w3.org/2005/Atom", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://www.w3.org/2005/Atom",
+        elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package io.quarkus.it.jaxb.mapper.codegen.feed;

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/TestResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/TestResource.java
@@ -265,7 +265,8 @@ public class TestResource {
     @GET
     @Path("/openapi/responses")
     @Produces("application/json")
-    @APIResponse(content = @Content(mediaType = "application/json", schema = @Schema(type = SchemaType.OBJECT, implementation = MyOpenApiEntityV1.class)))
+    @APIResponse(content = @Content(mediaType = "application/json",
+            schema = @Schema(type = SchemaType.OBJECT, implementation = MyOpenApiEntityV1.class)))
     public Response openApiResponse() {
         MyOpenApiEntityV1 entity = new MyOpenApiEntityV1();
         entity.setName("my openapi entity name");

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/RegisterForReflectionTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/RegisterForReflectionTestCase.java
@@ -54,7 +54,8 @@ public class RegisterForReflectionTestCase {
     }
 
     @Test
-    @DisabledOnSemeru(reason = "The lambda name will be empty on Semeru. As there's little chance we will use Semeru to build a native executable, we can skip this test.")
+    @DisabledOnSemeru(
+            reason = "The lambda name will be empty on Semeru. As there's little chance we will use Semeru to build a native executable, we can skip this test.")
     public void testLambdaCapturing() {
         final String resourceLambda = BASE_PKG + ".ResourceLambda";
 

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -1634,7 +1634,8 @@ public class DevMojoIT extends LaunchMojoTestBase {
     }
 
     @Test
-    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Installing the library again is failing on Windows, probably because the jar is accessed by the dev mode process")
+    @DisabledOnOs(value = OS.WINDOWS,
+            disabledReason = "Installing the library again is failing on Windows, probably because the jar is accessed by the dev mode process")
     public void testExternalReloadableArtifacts() throws Exception {
         final String rootProjectPath = "projects/external-reloadable-artifacts";
 
@@ -1695,7 +1696,8 @@ public class DevMojoIT extends LaunchMojoTestBase {
      * Same test as @{link testExternalReloadableArtifacts} but the external JAR is outside the project directory.
      */
     @Test
-    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Installing the library again is failing on Windows, probably because the jar is accessed by the dev mode process")
+    @DisabledOnOs(value = OS.WINDOWS,
+            disabledReason = "Installing the library again is failing on Windows, probably because the jar is accessed by the dev mode process")
     public void testReloadableArtifactsOutsideProjectDirectory() throws Exception {
         final String rootProjectPath = "projects/external-reloadable-artifacts-with-external-lib";
         final String externalJarPath = "projects/external-lib";

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/JarRunnerIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/JarRunnerIT.java
@@ -65,7 +65,8 @@ public class JarRunnerIT extends MojoTestBase {
      * @see <a href="https://github.com/quarkusio/quarkus/issues/11511"/>
      */
     @Test
-    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "With maven-compiler-plugin 2.11.0, this test is not working anymore on Windows: Error while storing the mojo status: Input length = 1")
+    @DisabledOnOs(value = OS.WINDOWS,
+            disabledReason = "With maven-compiler-plugin 2.11.0, this test is not working anymore on Windows: Error while storing the mojo status: Input length = 1")
     public void testNonAsciiDir() throws Exception {
         final File testDir = initProject("projects/classic", "projects/ěščřžýáíéůú");
         final RunningInvoker running = new RunningInvoker(testDir, false);

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcNoTLSWithCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcNoTLSWithCompressionTest.java
@@ -7,7 +7,8 @@ import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "enableCompression", value = "true"), restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class,
+        initArgs = @ResourceArg(name = "enableCompression", value = "true"), restrictToAnnotatedClass = true)
 public class GrpcNoTLSWithCompressionTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcWithTLSNoCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcWithTLSNoCompressionTest.java
@@ -7,7 +7,8 @@ import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "enableTLS", value = "true"), restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "enableTLS", value = "true"),
+        restrictToAnnotatedClass = true)
 public class GrpcWithTLSNoCompressionTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/SimpleGrpcNoTLSWithCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/SimpleGrpcNoTLSWithCompressionTest.java
@@ -9,7 +9,8 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "enableCompression", value = "true"), restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class,
+        initArgs = @ResourceArg(name = "enableCompression", value = "true"), restrictToAnnotatedClass = true)
 @TestProfile(SimpleProfile.class)
 public class SimpleGrpcNoTLSWithCompressionTest extends AbstractExporterTest {
 

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/SimpleGrpcWithTLSNoCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/SimpleGrpcWithTLSNoCompressionTest.java
@@ -9,7 +9,8 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "enableTLS", value = "true"), restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "enableTLS", value = "true"),
+        restrictToAnnotatedClass = true)
 @TestProfile(SimpleProfile.class)
 public class SimpleGrpcWithTLSNoCompressionTest extends AbstractExporterTest {
 

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpNoTLSNoCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpNoTLSNoCompressionTest.java
@@ -7,7 +7,8 @@ import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "protocol", value = "http/protobuf"), restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class,
+        initArgs = @ResourceArg(name = "protocol", value = "http/protobuf"), restrictToAnnotatedClass = true)
 public class HttpNoTLSNoCompressionTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpNoTLSReusableDataTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpNoTLSReusableDataTest.java
@@ -10,7 +10,8 @@ import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(ReusableDataProfile.class)
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "protocol", value = "http/protobuf"), restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class,
+        initArgs = @ResourceArg(name = "protocol", value = "http/protobuf"), restrictToAnnotatedClass = true)
 public class HttpNoTLSReusableDataTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/SimpleHttpNoTLSNoCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/SimpleHttpNoTLSNoCompressionTest.java
@@ -9,7 +9,8 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "protocol", value = "http/protobuf"), restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class,
+        initArgs = @ResourceArg(name = "protocol", value = "http/protobuf"), restrictToAnnotatedClass = true)
 @TestProfile(SimpleProfile.class)
 public class SimpleHttpNoTLSNoCompressionTest extends AbstractExporterTest {
 

--- a/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/DefaultValueProviderCommand.java
+++ b/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/DefaultValueProviderCommand.java
@@ -2,7 +2,8 @@ package io.quarkus.it.picocli;
 
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "default-value-provider", mixinStandardHelpOptions = false, defaultValueProvider = CustomDefaultValueProvider.class)
+@CommandLine.Command(name = "default-value-provider", mixinStandardHelpOptions = false,
+        defaultValueProvider = CustomDefaultValueProvider.class)
 public class DefaultValueProviderCommand implements Runnable {
 
     @CommandLine.Option(names = "--defaulted")

--- a/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/LocalizedCommandOne.java
+++ b/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/LocalizedCommandOne.java
@@ -2,7 +2,8 @@ package io.quarkus.it.picocli;
 
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "localized-command-one", mixinStandardHelpOptions = true, resourceBundle = "i18s.LocalizedCommandOne")
+@CommandLine.Command(name = "localized-command-one", mixinStandardHelpOptions = true,
+        resourceBundle = "i18s.LocalizedCommandOne")
 public class LocalizedCommandOne {
     @CommandLine.Option(names = "--first")
     String firstOption;

--- a/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/LocalizedCommandTwo.java
+++ b/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/LocalizedCommandTwo.java
@@ -2,7 +2,8 @@ package io.quarkus.it.picocli;
 
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "localized-command-two", mixinStandardHelpOptions = true, resourceBundle = "i18s.LocalizedCommandTwo")
+@CommandLine.Command(name = "localized-command-two", mixinStandardHelpOptions = true,
+        resourceBundle = "i18s.LocalizedCommandTwo")
 public class LocalizedCommandTwo {
     @CommandLine.Option(names = "--first")
     String firstOption;

--- a/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/TopTestCommand.java
+++ b/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/TopTestCommand.java
@@ -4,20 +4,21 @@ import io.quarkus.picocli.runtime.annotations.TopCommand;
 import picocli.CommandLine;
 
 @TopCommand
-@CommandLine.Command(name = "test", mixinStandardHelpOptions = true, commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "%nOptions:%n", subcommands = {
-        ExitCodeCommand.class,
-        CommandUsedAsParent.class,
-        CompletionReflectionCommand.class,
-        DefaultValueProviderCommand.class,
-        DynamicVersionProviderCommand.class,
-        LocalizedCommandOne.class,
-        LocalizedCommandTwo.class,
-        MutuallyExclusiveOptionsCommand.class,
-        TestCommand.class,
-        UnmatchedCommand.class,
-        DynamicProxyInvokerCommand.class,
-        WithMethodSubCommand.class,
-        SystemPropertyCommand.class })
+@CommandLine.Command(name = "test", mixinStandardHelpOptions = true, commandListHeading = "%nCommands:%n",
+        synopsisHeading = "%nUsage: ", optionListHeading = "%nOptions:%n", subcommands = {
+                ExitCodeCommand.class,
+                CommandUsedAsParent.class,
+                CompletionReflectionCommand.class,
+                DefaultValueProviderCommand.class,
+                DynamicVersionProviderCommand.class,
+                LocalizedCommandOne.class,
+                LocalizedCommandTwo.class,
+                MutuallyExclusiveOptionsCommand.class,
+                TestCommand.class,
+                UnmatchedCommand.class,
+                DynamicProxyInvokerCommand.class,
+                WithMethodSubCommand.class,
+                SystemPropertyCommand.class })
 public class TopTestCommand {
 
 }

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisTest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisTest.java
@@ -41,7 +41,8 @@ public class DevServicesRedisTest {
 
     // For some reason, the quarkus.test.native isn't being set in the failsafe path with -Pnative
     // We'll just use a different property that is being set instead
-    @DisabledIfSystemProperty(named = "native.image.path", matches = ".*", disabledReason = "Not working; tracked by https://github.com/quarkusio/quarkus/issues/50085")
+    @DisabledIfSystemProperty(named = "native.image.path", matches = ".*",
+            disabledReason = "Not working; tracked by https://github.com/quarkusio/quarkus/issues/50085")
     @Test
     @DisplayName("given redis container must have been preloaded with contents of import.redis")
     public void shouldReturnPreloadKeys() {

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Person.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Person.java
@@ -44,7 +44,8 @@ public class Person {
     private Address someAddress;
 
     @ManyToMany
-    @JoinTable(name = "liked_songs", joinColumns = @JoinColumn(name = "person_id"), inverseJoinColumns = @JoinColumn(name = "song_id"))
+    @JoinTable(name = "liked_songs", joinColumns = @JoinColumn(name = "person_id"),
+            inverseJoinColumns = @JoinColumn(name = "song_id"))
     private Set<Song> likedSongs;
 
     public Person(String name) {


### PR DESCRIPTION
The formatter had alignment_for_arguments_in_annotation set to 0 ("do not
wrap"). That takes precedence over join_wrapped_lines=false, so annotations
wrapped by hand were collapsed onto one line regardless of length:

E.g. 
`@GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/todo-demo-app.git", artifact = "todo-backend-1.0-SNAPSHOT-runner.jar", mavenArgs = ARGS)`

Setting it to 16 ("wrap where necessary") preserves the wrapping as written

E.g.
```

    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/todo-demo-app.git",
            artifact = "todo-backend-1.0-SNAPSHOT-runner.jar",
            mavenArgs = ARGS)

```
16 is already what method invocations, allocation expressions, enum constants
and constructor parameters use, so annotations were the only outlier.

- Fixes: #55505