### PR TITLE
Set Unix permissions when copying entries into function.zip

### DIFF
--- a/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/FunctionZipProcessor.java
+++ b/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/FunctionZipProcessor.java
@@ -166,6 +166,13 @@ public class FunctionZipProcessor {
 
     private void copyZipEntry(ZipArchiveOutputStream zip, InputStream zinput, ZipArchiveEntry from) throws Exception {
         ZipArchiveEntry entry = new ZipArchiveEntry(from);
+        // Runner jars often lack Unix modes (especially when built on Windows). SAM CLI and the
+        // Lambda runtime expect permission bits in the zip external attributes; without them
+        // local SAM on Windows logs "does not have permission information" for every entry.
+        // See https://github.com/quarkusio/quarkus/issues/46633
+        if (entry.getUnixMode() == 0) {
+            entry.setUnixMode(entry.isDirectory() ? 0755 : 0644);
+        }
         zip.putArchiveEntry(entry);
         zinput.transferTo(zip);
         zip.closeArchiveEntry();


### PR DESCRIPTION
## Fix

JVM `function.zip` packaging copies runner-jar entries without Unix permission bits. On Windows those entries typically have no modes at all, so SAM CLI logs `File … in zipfile does not have permission information` for every class/`META-INF` entry when running .

`lib/` entries were already given modes via `addZipEntry`; this change defaults missing modes to `0644` for files and `0755` for directories when copying jar entries, while preserving any existing non-zero mode.

- Closes: #46633
