### PR TITLE
[3.33] Bump Jackson BOM to 2.21.5

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -88,7 +88,7 @@
         <graal-sdk.version>23.1.2</graal-sdk.version>
         <gizmo.version>1.10.1</gizmo.version>
         <gizmo2.version>2.1.1</gizmo2.version>
-        <jackson-bom.version>2.21.4</jackson-bom.version>
+        <jackson-bom.version>2.21.5</jackson-bom.version>
         <commons-logging-jboss-logging.version>2.0.0.Final</commons-logging-jboss-logging.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <commons-codec.version>1.21.0</commons-codec.version>


### PR DESCRIPTION
CVE-2026-59889 is only fixed in 2.21.5, we should bump Jackson version. I do not imply that Quarkus is affected (although someone in platform consuming your BOM could be?), but ideally we would silence scanners used by Keycloak users, e.g. https://github.com/keycloak/keycloak/issues/50955.
