### PR TITLE
Prevent unboxing of null Character in reflecton-free Jackson serializers

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -61,6 +61,8 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.gizmo.AssignableResultHandle;
+import io.quarkus.gizmo.BranchResult;
 import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
@@ -771,7 +773,7 @@ public abstract class JacksonCodeGenerator {
 
         ResultHandle toValueWriterHandle(BytecodeCreator bytecode, ResultHandle valueHandle) {
             return switch (fieldType.name().toString()) {
-                case "char", "java.lang.Character" -> bytecode.invokeVirtualMethod(
+                case "char" -> bytecode.invokeVirtualMethod(
                         MethodDescriptor.ofMethod(String.class, "charAt", char.class, int.class), valueHandle,
                         bytecode.load(0));
                 default -> valueHandle;
@@ -782,8 +784,16 @@ public abstract class JacksonCodeGenerator {
             ResultHandle handle = accessorHandle(bytecode, valueHandle);
 
             return switch (fieldType.name().toString()) {
-                case "char", "java.lang.Character" -> bytecode.invokeStaticMethod(
+                case "char" -> bytecode.invokeStaticMethod(
                         MethodDescriptor.ofMethod(Character.class, "toString", String.class, char.class), handle);
+                case "java.lang.Character" -> {
+                    AssignableResultHandle result = bytecode.createVariable(String.class);
+                    BranchResult nullCheck = bytecode.ifNull(handle);
+                    nullCheck.trueBranch().assign(result, nullCheck.trueBranch().loadNull());
+                    nullCheck.falseBranch().assign(result, nullCheck.falseBranch().invokeStaticMethod(
+                            MethodDescriptor.ofMethod(Character.class, "toString", String.class, char.class), handle));
+                    yield result;
+                }
                 default -> handle;
             };
         }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
@@ -1239,6 +1239,38 @@ public abstract class AbstractSimpleJsonTest {
     }
 
     @Test
+    public void testNullCharacterFieldInBean() {
+        // Reproducer for https://github.com/quarkusio/quarkus/issues/55519
+        // Null boxed Character field must be serialized as null without NPE
+        RestAssured
+                .with()
+                .body("{}")
+                .contentType("application/json; charset=utf-8")
+                .post("/simple/primitive-types-bean")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("$", hasKey("characterPrimitive"))
+                .body("characterPrimitive", Matchers.nullValue());
+    }
+
+    @Test
+    public void testNullCharacterFieldInRecord() {
+        // Reproducer for https://github.com/quarkusio/quarkus/issues/55519
+        // Null boxed Character field must be serialized as null without NPE
+        RestAssured
+                .with()
+                .body("{}")
+                .contentType("application/json; charset=utf-8")
+                .post("/simple/primitive-types-record")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("$", hasKey("characterPrimitive"))
+                .body("characterPrimitive", Matchers.nullValue());
+    }
+
+    @Test
     void testShouldDeserializePolymorphicItems() {
         RestAssured
                 .with()


### PR DESCRIPTION
Note that `Character` is the only boxed primitive with this problem, because in `toValueReaderHandle()`, only `char`/`java.lang.Character` has special-case handling the `String` conversion. All other boxed types (`Integer`, `Short`, `Long`, `Float`, `Double`, `Boolean)` go through the default branch, which returns the value as-is, with no conversion and no unboxing.

- Fixes: #55519