### PR TITLE
Add shared APIs for external dev-mode build producers

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/BuildOutputChangesPolicy.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/BuildOutputChangesPolicy.java
@@ -1,0 +1,248 @@
+package io.quarkus.deployment.dev;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Build-tool-agnostic coalescing policy for externally produced Quarkus dev
+ * build-output changes. Its public surface stays free of Gradle and Quarkus
+ * Gradle plugin types so external build tools can share the same delivery
+ * semantics.
+ */
+public final class BuildOutputChangesPolicy {
+
+    private long lastAcceptedSequence = Long.MIN_VALUE;
+    private PendingChanges pending;
+
+    public Result acceptStartupBaseline(BuildOutputChanges candidate) {
+        requireNonNull(candidate, "candidate");
+        if (isStale(candidate.sequence())) {
+            return Result.stale(candidate.sequence());
+        }
+        lastAcceptedSequence = candidate.sequence();
+        return Result.baselineDropped(candidate.sequence());
+    }
+
+    public Result acceptRestartRequired(long sequence) {
+        if (isStale(sequence)) {
+            return Result.stale(sequence);
+        }
+        lastAcceptedSequence = sequence;
+        return Result.restartRequired(sequence);
+    }
+
+    public Result accept(BuildOutputChanges candidate) {
+        requireNonNull(candidate, "candidate");
+        if (isStale(candidate.sequence())) {
+            return Result.stale(candidate.sequence());
+        }
+        lastAcceptedSequence = candidate.sequence();
+        if (candidate.status() != BuildOutputChangeStatus.BUILD_SUCCEEDED) {
+            return Result.nonReloadableStatus(candidate);
+        }
+        if (candidate.mainClassChanges().isEmpty() && candidate.mainResourceChanges().isEmpty()) {
+            return Result.noReloadableChanges(candidate.sequence());
+        }
+        PendingChanges next = pending == null ? new PendingChanges(candidate) : pending.withSequence(candidate);
+        coalesce(next.mainClassChanges, OutputCategory.MAIN_CLASSES, candidate.mainClassChanges());
+        coalesce(next.mainResourceChanges, OutputCategory.MAIN_RESOURCES, candidate.mainResourceChanges());
+        if (next.isEmpty()) {
+            pending = null;
+            return Result.noReloadableChanges(candidate.sequence());
+        }
+        pending = next;
+        return Result.pending(candidate.sequence());
+    }
+
+    public Result deliver(Sender sender) {
+        requireNonNull(sender, "sender");
+        if (pending == null || pending.isEmpty()) {
+            return Result.nothingToSend(lastAcceptedSequence);
+        }
+        BuildOutputChanges emitted = pending.toBuildOutputChanges();
+        try {
+            BuildOutputChangesApplyStatus status = requireNonNull(sender.send(emitted), "sender result");
+            if (status == BuildOutputChangesApplyStatus.APPLIED) {
+                pending = null;
+                return Result.sentApplied(emitted);
+            }
+            return Result.sentNotApplied(emitted);
+        } catch (IOException e) {
+            return Result.sendFailed(emitted, e);
+        }
+    }
+
+    public Result discardPending(String reason) {
+        requireNonNull(reason, "reason");
+        if (pending == null || pending.isEmpty()) {
+            return Result.nothingToSend(lastAcceptedSequence);
+        }
+        BuildOutputChanges discarded = pending.toBuildOutputChanges();
+        pending = null;
+        return Result.discarded(discarded, reason);
+    }
+
+    public boolean hasPendingChanges() {
+        return pending != null && !pending.isEmpty();
+    }
+
+    private boolean isStale(long sequence) {
+        return sequence <= lastAcceptedSequence;
+    }
+
+    private static void coalesce(Map<ChangeKey, BuildOutputChangeKind> target, OutputCategory category,
+            List<BuildOutputPathChange> changes) {
+        for (BuildOutputPathChange change : changes) {
+            var key = new ChangeKey(category, change.outputRoot(), change.changedPath());
+            BuildOutputChangeKind merged = merge(target.get(key), change.kind());
+            if (merged == null) {
+                target.remove(key);
+            } else {
+                target.put(key, merged);
+            }
+        }
+    }
+
+    private static BuildOutputChangeKind merge(BuildOutputChangeKind previous, BuildOutputChangeKind next) {
+        if (previous == null) {
+            return next;
+        }
+        return switch (previous) {
+            case ADDED -> switch (next) {
+                case ADDED, MODIFIED -> BuildOutputChangeKind.ADDED;
+                case DELETED -> null;
+            };
+            case MODIFIED -> switch (next) {
+                case ADDED -> BuildOutputChangeKind.ADDED;
+                case MODIFIED -> BuildOutputChangeKind.MODIFIED;
+                case DELETED -> BuildOutputChangeKind.DELETED;
+            };
+            case DELETED -> switch (next) {
+                case ADDED, MODIFIED -> BuildOutputChangeKind.MODIFIED;
+                case DELETED -> BuildOutputChangeKind.DELETED;
+            };
+        };
+    }
+
+    @FunctionalInterface
+    public interface Sender {
+        BuildOutputChangesApplyStatus send(BuildOutputChanges changes) throws IOException;
+    }
+
+    public enum Outcome {
+        BASELINE_DROPPED,
+        STALE_REJECTED,
+        NON_RELOADABLE_STATUS,
+        NO_RELOADABLE_CHANGES,
+        RESTART_REQUIRED,
+        PENDING,
+        NOTHING_TO_SEND,
+        SENT_APPLIED,
+        SENT_NOT_APPLIED,
+        SEND_FAILED,
+        DISCARDED
+    }
+
+    public record Result(
+            Outcome outcome,
+            long sequence,
+            BuildOutputChanges changes,
+            IOException failure,
+            String message) {
+
+        private static Result baselineDropped(long sequence) {
+            return new Result(Outcome.BASELINE_DROPPED, sequence, null, null, null);
+        }
+
+        private static Result stale(long sequence) {
+            return new Result(Outcome.STALE_REJECTED, sequence, null, null, null);
+        }
+
+        private static Result nonReloadableStatus(BuildOutputChanges changes) {
+            return new Result(Outcome.NON_RELOADABLE_STATUS, changes.sequence(), changes, null, null);
+        }
+
+        private static Result noReloadableChanges(long sequence) {
+            return new Result(Outcome.NO_RELOADABLE_CHANGES, sequence, null, null, null);
+        }
+
+        private static Result restartRequired(long sequence) {
+            return new Result(Outcome.RESTART_REQUIRED, sequence, null, null, null);
+        }
+
+        private static Result pending(long sequence) {
+            return new Result(Outcome.PENDING, sequence, null, null, null);
+        }
+
+        private static Result nothingToSend(long sequence) {
+            return new Result(Outcome.NOTHING_TO_SEND, sequence, null, null, null);
+        }
+
+        private static Result sentApplied(BuildOutputChanges changes) {
+            return new Result(Outcome.SENT_APPLIED, changes.sequence(), changes, null, null);
+        }
+
+        private static Result sentNotApplied(BuildOutputChanges changes) {
+            return new Result(Outcome.SENT_NOT_APPLIED, changes.sequence(), changes, null, null);
+        }
+
+        private static Result sendFailed(BuildOutputChanges changes, IOException failure) {
+            return new Result(Outcome.SEND_FAILED, changes.sequence(), changes, failure, null);
+        }
+
+        private static Result discarded(BuildOutputChanges changes, String reason) {
+            return new Result(Outcome.DISCARDED, changes.sequence(), changes, null, reason);
+        }
+    }
+
+    private enum OutputCategory {
+        MAIN_CLASSES,
+        MAIN_RESOURCES
+    }
+
+    private record ChangeKey(OutputCategory category, Path outputRoot, Path changedPath) {
+    }
+
+    private record PendingChanges(
+            long sequence,
+            boolean userInitiated,
+            boolean forceRestart,
+            Map<ChangeKey, BuildOutputChangeKind> mainClassChanges,
+            Map<ChangeKey, BuildOutputChangeKind> mainResourceChanges) {
+
+        private PendingChanges(BuildOutputChanges candidate) {
+            this(candidate.sequence(), candidate.userInitiated(), candidate.forceRestart(), new LinkedHashMap<>(),
+                    new LinkedHashMap<>());
+        }
+
+        private PendingChanges withSequence(BuildOutputChanges candidate) {
+            return new PendingChanges(candidate.sequence(), userInitiated || candidate.userInitiated(),
+                    forceRestart || candidate.forceRestart(), mainClassChanges, mainResourceChanges);
+        }
+
+        private boolean isEmpty() {
+            return mainClassChanges.isEmpty() && mainResourceChanges.isEmpty();
+        }
+
+        private BuildOutputChanges toBuildOutputChanges() {
+            return new BuildOutputChanges(sequence, BuildOutputChangeStatus.BUILD_SUCCEEDED,
+                    toPathChanges(mainClassChanges), toPathChanges(mainResourceChanges),
+                    null, null, null, null, userInitiated, forceRestart);
+        }
+
+        private static List<BuildOutputPathChange> toPathChanges(Map<ChangeKey, BuildOutputChangeKind> changes) {
+            var pathChanges = new ArrayList<BuildOutputPathChange>(changes.size());
+            for (Map.Entry<ChangeKey, BuildOutputChangeKind> entry : changes.entrySet()) {
+                ChangeKey key = entry.getKey();
+                pathChanges.add(new BuildOutputPathChange(key.outputRoot(), key.changedPath(), entry.getValue()));
+            }
+            return pathChanges;
+        }
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/remotedev/HttpRemoteDevPackageClient.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/remotedev/HttpRemoteDevPackageClient.java
@@ -1,0 +1,238 @@
+package io.quarkus.deployment.dev.remotedev;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.dev.spi.RemoteDevState;
+import io.quarkus.runtime.util.HashUtil;
+
+public final class HttpRemoteDevPackageClient implements RemoteDevPackageClient {
+
+    private static final Logger LOG = Logger.getLogger(HttpRemoteDevPackageClient.class);
+
+    private static final String CONTENT_TYPE = "application/quarkus-live-reload";
+    private static final String PASSWORD = "X-Quarkus-Password";
+    private static final String SESSION = "X-Quarkus-Session";
+    private static final String COUNT = "X-Quarkus-Count";
+
+    private final RemoteDevPackageClientConfig config;
+    private final HttpClient client;
+    private String session;
+    private int count;
+    private volatile boolean closed;
+    private Thread changePollingThread;
+
+    public HttpRemoteDevPackageClient(RemoteDevPackageClientConfig config) {
+        this.config = config;
+        this.client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+    }
+
+    @Override
+    public RemoteDevPackageClientResult connect(Map<String, String> localHashes) throws IOException {
+        byte[] body = remoteState(localHashes);
+        HttpRequest.Builder request = request(resolve("/connect"))
+                .header("Content-Type", CONTENT_TYPE)
+                .header(PASSWORD, HashUtil.sha256(HashUtil.sha256(body) + password()))
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body));
+        HttpResponse<String> response = send(request.build(), HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() / 100 != 2) {
+            throw new IOException("Remote dev connect to " + config.redactedRemoteUrl()
+                    + " failed with status " + response.statusCode());
+        }
+        synchronized (this) {
+            session = response.headers().firstValue(SESSION).orElse(session);
+            count = 0;
+        }
+        Set<String> requested = response.body() == null || response.body().isBlank()
+                ? Set.of()
+                : Arrays.stream(response.body().split(";"))
+                        .filter(path -> !path.isBlank())
+                        .collect(Collectors.toUnmodifiableSet());
+        return RemoteDevPackageClientResult.connected(requested);
+    }
+
+    @Override
+    public RemoteDevPackageClientResult send(RemoteDevPackageDiff diff) throws IOException {
+        int changed = 0;
+        for (RemoteDevPackageChange change : diff.changed()) {
+            byte[] bytes = Files.readAllBytes(change.file());
+            int requestCount = nextCount();
+            HttpRequest request = request(resolve("/" + change.relativePath()))
+                    .header("Content-Type", CONTENT_TYPE)
+                    .header(SESSION, session())
+                    .header(COUNT, Integer.toString(requestCount))
+                    .header(PASSWORD, HashUtil.sha256(HashUtil.sha256(bytes) + session() + requestCount + password()))
+                    .PUT(HttpRequest.BodyPublishers.ofByteArray(bytes))
+                    .build();
+            sendSuccessful(request, "upload " + change.relativePath());
+            changed++;
+        }
+        int deleted = 0;
+        for (String path : diff.deleted()) {
+            int requestCount = nextCount();
+            String requestPath = "/" + path;
+            HttpRequest request = request(resolve("/" + path))
+                    .header("Content-Type", CONTENT_TYPE)
+                    .header(SESSION, session())
+                    .header(COUNT, Integer.toString(requestCount))
+                    .header(PASSWORD,
+                            HashUtil.sha256(HashUtil.sha256(requestPath.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+                                    + session() + requestCount + password()))
+                    .DELETE()
+                    .build();
+            sendSuccessful(request, "delete " + path);
+            deleted++;
+        }
+        return RemoteDevPackageClientResult.sent(changed, deleted);
+    }
+
+    @Override
+    public synchronized void startChangePolling() throws IOException {
+        session();
+        if (changePollingThread != null && changePollingThread.isAlive()) {
+            return;
+        }
+        closed = false;
+        changePollingThread = new Thread(this::pollChanges, "Quarkus remote dev change poller");
+        changePollingThread.setDaemon(true);
+        changePollingThread.start();
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+        Thread thread;
+        synchronized (this) {
+            thread = changePollingThread;
+            changePollingThread = null;
+        }
+        if (thread != null) {
+            thread.interrupt();
+        }
+    }
+
+    private void pollChanges() {
+        while (!closed) {
+            try {
+                byte[] body = remoteProblem(null);
+                int requestCount = nextCount();
+                HttpRequest request = request(resolve("/dev"))
+                        .header("Content-Type", CONTENT_TYPE)
+                        .header(SESSION, session())
+                        .header(COUNT, Integer.toString(requestCount))
+                        .header(PASSWORD, HashUtil.sha256(HashUtil.sha256(body) + session() + requestCount + password()))
+                        .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                        .build();
+                HttpResponse<Void> response = send(request, HttpResponse.BodyHandlers.discarding());
+                if (response.statusCode() == 203) {
+                    LOG.debugf("Remote dev session for %s is no longer current", config.redactedRemoteUrl());
+                    return;
+                }
+                if (response.statusCode() / 100 != 2) {
+                    LOG.debugf("Remote dev change poll against %s failed with status %d", config.redactedRemoteUrl(),
+                            response.statusCode());
+                    sleepAfterPollFailure();
+                }
+            } catch (IOException e) {
+                if (!closed) {
+                    LOG.debugf(e, "Remote dev change poll against %s failed", config.redactedRemoteUrl());
+                    sleepAfterPollFailure();
+                }
+            }
+        }
+    }
+
+    private static byte[] remoteProblem(Throwable problem) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(problem);
+        }
+        return bytes.toByteArray();
+    }
+
+    private void sleepAfterPollFailure() {
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            closed = true;
+        }
+    }
+
+    private void sendSuccessful(HttpRequest request, String operation) throws IOException {
+        HttpResponse<Void> response = send(request, HttpResponse.BodyHandlers.discarding());
+        if (response.statusCode() / 100 != 2) {
+            throw new IOException("Remote dev " + operation + " against " + config.redactedRemoteUrl()
+                    + " failed with status " + response.statusCode());
+        }
+    }
+
+    private <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> handler) throws IOException {
+        try {
+            return client.send(request, handler);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while communicating with remote dev endpoint " + config.redactedRemoteUrl(), e);
+        }
+    }
+
+    private HttpRequest.Builder request(URI uri) {
+        return HttpRequest.newBuilder(uri)
+                .version(HttpClient.Version.HTTP_1_1)
+                .timeout(Duration.ofSeconds(30));
+    }
+
+    private URI resolve(String path) {
+        String base = config.remoteUrl().toString();
+        if (base.endsWith("/") && path.startsWith("/")) {
+            return URI.create(base.substring(0, base.length() - 1) + path);
+        }
+        if (!base.endsWith("/") && !path.startsWith("/")) {
+            return URI.create(base + "/" + path);
+        }
+        return URI.create(base + path);
+    }
+
+    private String session() throws IOException {
+        String currentSession;
+        synchronized (this) {
+            currentSession = session;
+        }
+        if (currentSession == null) {
+            throw new IOException("Remote dev session has not been established for " + config.redactedRemoteUrl());
+        }
+        return currentSession;
+    }
+
+    private synchronized int nextCount() {
+        return ++count;
+    }
+
+    private String password() throws IOException {
+        return config.password()
+                .orElseThrow(() -> new IOException("Remote dev password is required for " + config.redactedRemoteUrl()));
+    }
+
+    private static byte[] remoteState(Map<String, String> localHashes) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(new RemoteDevState(localHashes, null));
+        }
+        return bytes.toByteArray();
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageChange.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageChange.java
@@ -1,0 +1,25 @@
+package io.quarkus.deployment.dev.remotedev;
+
+import static java.util.Objects.requireNonNull;
+
+import java.nio.file.Path;
+
+public record RemoteDevPackageChange(
+        String relativePath,
+        Path file,
+        String sha1,
+        long size) {
+
+    public RemoteDevPackageChange {
+        if (relativePath == null || relativePath.isBlank()) {
+            throw new IllegalArgumentException("Remote-dev package change path must not be empty");
+        }
+        requireNonNull(file, "file");
+        if (sha1 == null || sha1.isBlank()) {
+            throw new IllegalArgumentException("Remote-dev package change hash must not be empty");
+        }
+        if (size < 0) {
+            throw new IllegalArgumentException("Remote-dev package change size must not be negative");
+        }
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageClient.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageClient.java
@@ -1,0 +1,16 @@
+package io.quarkus.deployment.dev.remotedev;
+
+import java.io.IOException;
+import java.util.Map;
+
+public interface RemoteDevPackageClient extends AutoCloseable {
+
+    RemoteDevPackageClientResult connect(Map<String, String> localHashes) throws IOException;
+
+    RemoteDevPackageClientResult send(RemoteDevPackageDiff diff) throws IOException;
+
+    void startChangePolling() throws IOException;
+
+    @Override
+    void close() throws IOException;
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageClientConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageClientConfig.java
@@ -1,0 +1,26 @@
+package io.quarkus.deployment.dev.remotedev;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.URI;
+import java.util.Optional;
+
+public record RemoteDevPackageClientConfig(
+        URI remoteUrl,
+        Optional<String> password) {
+
+    public RemoteDevPackageClientConfig {
+        requireNonNull(remoteUrl, "remoteUrl");
+        requireNonNull(password, "password");
+    }
+
+    public String redactedRemoteUrl() {
+        String value = remoteUrl.toString();
+        int scheme = value.indexOf("://");
+        int at = value.indexOf('@', scheme + 3);
+        if (scheme >= 0 && at > scheme) {
+            return value.substring(0, scheme + 3) + "<redacted>@" + value.substring(at + 1);
+        }
+        return value;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageClientFactory.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageClientFactory.java
@@ -1,0 +1,8 @@
+package io.quarkus.deployment.dev.remotedev;
+
+import java.io.IOException;
+
+public interface RemoteDevPackageClientFactory {
+
+    RemoteDevPackageClient create(RemoteDevPackageClientConfig config) throws IOException;
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageClientResult.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageClientResult.java
@@ -1,0 +1,23 @@
+package io.quarkus.deployment.dev.remotedev;
+
+import java.util.Set;
+
+public record RemoteDevPackageClientResult(
+        String outcome,
+        int requested,
+        int changed,
+        int deleted,
+        Set<String> requestedPaths) {
+
+    public RemoteDevPackageClientResult {
+        requestedPaths = Set.copyOf(requestedPaths);
+    }
+
+    public static RemoteDevPackageClientResult connected(Set<String> requestedPaths) {
+        return new RemoteDevPackageClientResult("CONNECTED", requestedPaths.size(), 0, 0, requestedPaths);
+    }
+
+    public static RemoteDevPackageClientResult sent(int changed, int deleted) {
+        return new RemoteDevPackageClientResult("SENT", 0, changed, deleted, Set.of());
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageDeletePolicy.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageDeletePolicy.java
@@ -1,0 +1,18 @@
+package io.quarkus.deployment.dev.remotedev;
+
+public final class RemoteDevPackageDeletePolicy {
+
+    private RemoteDevPackageDeletePolicy() {
+    }
+
+    public static boolean canDelete(String relativePath) {
+        String normalized = normalize(relativePath);
+        return normalized.contains("/")
+                && !normalized.endsWith("META-INF/MANIFEST.MF")
+                && !normalized.contains("META-INF/maven");
+    }
+
+    static String normalize(String relativePath) {
+        return relativePath.replace('\\', '/');
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageDiff.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageDiff.java
@@ -1,0 +1,34 @@
+package io.quarkus.deployment.dev.remotedev;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Comparator;
+import java.util.List;
+
+public record RemoteDevPackageDiff(
+        List<RemoteDevPackageChange> changed,
+        List<String> deleted) {
+
+    static final String APPMODEL = "lib/deployment/appmodel.dat";
+
+    public RemoteDevPackageDiff {
+        changed = requireNonNull(changed, "changed").stream()
+                .sorted(changeOrder())
+                .toList();
+        deleted = requireNonNull(deleted, "deleted").stream()
+                .map(RemoteDevPackageDeletePolicy::normalize)
+                .filter(RemoteDevPackageDeletePolicy::canDelete)
+                .sorted()
+                .toList();
+    }
+
+    public boolean isEmpty() {
+        return changed.isEmpty() && deleted.isEmpty();
+    }
+
+    private static Comparator<RemoteDevPackageChange> changeOrder() {
+        return Comparator
+                .comparing((RemoteDevPackageChange change) -> APPMODEL.equals(change.relativePath()))
+                .thenComparing(RemoteDevPackageChange::relativePath);
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageSnapshot.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageSnapshot.java
@@ -1,0 +1,177 @@
+package io.quarkus.deployment.dev.remotedev;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+public final class RemoteDevPackageSnapshot {
+
+    private final Map<String, FileState> files;
+
+    private RemoteDevPackageSnapshot(Map<String, FileState> files) {
+        this.files = Map.copyOf(files);
+    }
+
+    public static RemoteDevPackageSnapshot empty() {
+        return new RemoteDevPackageSnapshot(Map.of());
+    }
+
+    public static RemoteDevPackageSnapshot capture(Path packageRoot) throws IOException {
+        Path normalizedRoot = packageRoot.toAbsolutePath().normalize();
+        Map<String, FileState> files = new TreeMap<>();
+        if (!Files.exists(normalizedRoot)) {
+            return empty();
+        }
+        try (var paths = Files.walk(normalizedRoot)) {
+            for (Path file : paths.filter(Files::isRegularFile).toList()) {
+                Path normalizedFile = file.toAbsolutePath().normalize();
+                String relativePath = relativePath(normalizedRoot, normalizedFile);
+                if (relativePath.equals("quarkus") || relativePath.startsWith("quarkus/")) {
+                    continue;
+                }
+                files.put(relativePath, new FileState(sha1(normalizedFile), Files.size(normalizedFile)));
+            }
+        }
+        return new RemoteDevPackageSnapshot(files);
+    }
+
+    public static RemoteDevPackageSnapshot read(Path file) throws IOException {
+        if (!Files.exists(file)) {
+            return empty();
+        }
+        Map<String, FileState> files = new LinkedHashMap<>();
+        for (String line : Files.readAllLines(file, StandardCharsets.UTF_8)) {
+            if (line.isBlank()) {
+                continue;
+            }
+            String[] parts = line.split("\t", -1);
+            if (parts.length != 3) {
+                throw new IOException("Malformed remote-dev package snapshot line in " + file + ": " + line);
+            }
+            files.put(parts[0], new FileState(parts[1], Long.parseLong(parts[2])));
+        }
+        return new RemoteDevPackageSnapshot(files);
+    }
+
+    public void write(Path file) throws IOException {
+        if (file.getParent() != null) {
+            Files.createDirectories(file.getParent());
+        }
+        StringBuilder content = new StringBuilder();
+        files.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> content.append(entry.getKey())
+                        .append('\t')
+                        .append(entry.getValue().sha1())
+                        .append('\t')
+                        .append(entry.getValue().size())
+                        .append('\n'));
+        Files.writeString(file, content.toString(), StandardCharsets.UTF_8);
+    }
+
+    public RemoteDevPackageDiff diffSince(RemoteDevPackageSnapshot previous, Path packageRoot) {
+        requireNonNull(previous, "previous");
+        Path normalizedRoot = packageRoot.toAbsolutePath().normalize();
+        List<RemoteDevPackageChange> changed = files.entrySet().stream()
+                .filter(entry -> !entry.getValue().equals(previous.files.get(entry.getKey())))
+                .map(entry -> new RemoteDevPackageChange(
+                        entry.getKey(),
+                        normalizedRoot.resolve(entry.getKey()).normalize(),
+                        entry.getValue().sha1(),
+                        entry.getValue().size()))
+                .toList();
+        List<String> deleted = previous.files.keySet().stream()
+                .filter(path -> !files.containsKey(path))
+                .toList();
+        return new RemoteDevPackageDiff(changed, deleted);
+    }
+
+    public RemoteDevPackageDiff requestedFiles(Set<String> requestedPaths, Path packageRoot) {
+        requireNonNull(requestedPaths, "requestedPaths");
+        Path normalizedRoot = packageRoot.toAbsolutePath().normalize();
+        List<RemoteDevPackageChange> changed = requestedPaths.stream()
+                .map(RemoteDevPackageDeletePolicy::normalize)
+                .sorted()
+                .filter(files::containsKey)
+                .map(path -> {
+                    FileState state = files.get(path);
+                    return new RemoteDevPackageChange(
+                            path,
+                            normalizedRoot.resolve(path).normalize(),
+                            state.sha1(),
+                            state.size());
+                })
+                .toList();
+        return new RemoteDevPackageDiff(changed, List.of());
+    }
+
+    public Map<String, String> hashes() {
+        Map<String, String> hashes = new TreeMap<>();
+        files.forEach((path, state) -> hashes.put(path, state.sha1()));
+        return hashes;
+    }
+
+    public boolean isEmpty() {
+        return files.isEmpty();
+    }
+
+    private static String relativePath(Path root, Path file) {
+        if (!file.startsWith(root)) {
+            throw new IllegalArgumentException("Path " + file + " is not under package root " + root);
+        }
+        return root.relativize(file).toString().replace('\\', '/');
+    }
+
+    private static String sha1(Path file) {
+        MessageDigest digest = sha1();
+        try (var input = Files.newInputStream(file)) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                digest.update(buffer, 0, read);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to hash remote-dev package file " + file, e);
+        }
+        return hex(digest.digest());
+    }
+
+    private static MessageDigest sha1() {
+        try {
+            return MessageDigest.getInstance("SHA-1");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-1 is not available", e);
+        }
+    }
+
+    private static String hex(byte[] bytes) {
+        StringBuilder builder = new StringBuilder(bytes.length * 2);
+        for (byte value : bytes) {
+            builder.append(Character.forDigit((value >> 4) & 0xf, 16));
+            builder.append(Character.forDigit(value & 0xf, 16));
+        }
+        return builder.toString();
+    }
+
+    record FileState(String sha1, long size) {
+        FileState {
+            if (sha1 == null || sha1.isBlank()) {
+                throw new IllegalArgumentException("Remote-dev package file hash must not be empty");
+            }
+            if (size < 0) {
+                throw new IllegalArgumentException("Remote-dev package file size must not be negative");
+            }
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/dev/BuildOutputChangesPolicyTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/dev/BuildOutputChangesPolicyTest.java
@@ -1,0 +1,321 @@
+package io.quarkus.deployment.dev;
+
+import static io.quarkus.deployment.dev.BuildOutputChangeKind.ADDED;
+import static io.quarkus.deployment.dev.BuildOutputChangeKind.DELETED;
+import static io.quarkus.deployment.dev.BuildOutputChangeKind.MODIFIED;
+import static io.quarkus.deployment.dev.BuildOutputChangeStatus.BUILD_CANCELLED;
+import static io.quarkus.deployment.dev.BuildOutputChangeStatus.BUILD_FAILED;
+import static io.quarkus.deployment.dev.BuildOutputChangeStatus.BUILD_SUCCEEDED;
+import static io.quarkus.deployment.dev.BuildOutputChangeStatus.BUILD_SUPERSEDED;
+import static io.quarkus.deployment.dev.BuildOutputChangesApplyStatus.APPLIED;
+import static io.quarkus.deployment.dev.BuildOutputChangesApplyStatus.NOT_APPLIED;
+import static io.quarkus.deployment.dev.BuildOutputChangesPolicy.Outcome.BASELINE_DROPPED;
+import static io.quarkus.deployment.dev.BuildOutputChangesPolicy.Outcome.DISCARDED;
+import static io.quarkus.deployment.dev.BuildOutputChangesPolicy.Outcome.NON_RELOADABLE_STATUS;
+import static io.quarkus.deployment.dev.BuildOutputChangesPolicy.Outcome.NOTHING_TO_SEND;
+import static io.quarkus.deployment.dev.BuildOutputChangesPolicy.Outcome.NO_RELOADABLE_CHANGES;
+import static io.quarkus.deployment.dev.BuildOutputChangesPolicy.Outcome.PENDING;
+import static io.quarkus.deployment.dev.BuildOutputChangesPolicy.Outcome.RESTART_REQUIRED;
+import static io.quarkus.deployment.dev.BuildOutputChangesPolicy.Outcome.SEND_FAILED;
+import static io.quarkus.deployment.dev.BuildOutputChangesPolicy.Outcome.SENT_APPLIED;
+import static io.quarkus.deployment.dev.BuildOutputChangesPolicy.Outcome.SENT_NOT_APPLIED;
+import static io.quarkus.deployment.dev.BuildOutputChangesPolicy.Outcome.STALE_REJECTED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class BuildOutputChangesPolicyTest {
+
+    private final Path classes = Path.of("build/classes/java/main");
+    private final Path resources = Path.of("build/resources/main");
+    private final Path otherClasses = Path.of("other/classes");
+
+    @Test
+    void coalescesRepeatedModifiedChanges() {
+        var policy = new BuildOutputChangesPolicy();
+        policy.accept(success(1, classChange("com/acme/Foo.class", MODIFIED)));
+        policy.accept(success(2, classChange("com/acme/Foo.class", MODIFIED)));
+
+        var delivered = deliver(policy, APPLIED);
+
+        assertThat(delivered.mainClassChanges()).extracting(BuildOutputPathChange::kind)
+                .containsExactly(MODIFIED);
+    }
+
+    @Test
+    void coalescesAddedModifiedAndAddedDeletedChanges() {
+        var policy = new BuildOutputChangesPolicy();
+        policy.accept(success(1, classChange("com/acme/Added.class", ADDED)));
+        policy.accept(success(2, classChange("com/acme/Added.class", MODIFIED)));
+        policy.accept(success(3, resourceChange("temporary.txt", ADDED)));
+        policy.accept(success(4, resourceChange("temporary.txt", DELETED)));
+
+        var delivered = deliver(policy, APPLIED);
+
+        assertThat(delivered.mainClassChanges()).extracting(BuildOutputPathChange::kind)
+                .containsExactly(ADDED);
+        assertThat(delivered.mainResourceChanges()).isEmpty();
+    }
+
+    @Test
+    void coalescesDeleteAddModifyAsModified() {
+        var policy = new BuildOutputChangesPolicy();
+        policy.accept(success(1, classChange("com/acme/Foo.class", DELETED)));
+        policy.accept(success(2, classChange("com/acme/Foo.class", ADDED)));
+        policy.accept(success(3, classChange("com/acme/Foo.class", MODIFIED)));
+
+        var delivered = deliver(policy, APPLIED);
+
+        assertThat(delivered.mainClassChanges()).extracting(BuildOutputPathChange::kind)
+                .containsExactly(MODIFIED);
+    }
+
+    @Test
+    void coalescesModifiedDeletedAndDeletedAddedChanges() {
+        var policy = new BuildOutputChangesPolicy();
+        policy.accept(success(1, classChange("com/acme/Removed.class", MODIFIED)));
+        policy.accept(success(2, classChange("com/acme/Removed.class", DELETED)));
+        policy.accept(success(3, resourceChange("recreated.txt", DELETED)));
+        policy.accept(success(4, resourceChange("recreated.txt", ADDED)));
+
+        var delivered = deliver(policy, APPLIED);
+
+        assertThat(delivered.mainClassChanges()).extracting(BuildOutputPathChange::kind)
+                .containsExactly(DELETED);
+        assertThat(delivered.mainResourceChanges()).extracting(BuildOutputPathChange::kind)
+                .containsExactly(MODIFIED);
+    }
+
+    @Test
+    void coalescingKeysIncludeCategoryRootAndPath() {
+        var policy = new BuildOutputChangesPolicy();
+        policy.accept(success(1,
+                classChange(classes, "same/path.txt", MODIFIED),
+                resourceChange(resources, "same/path.txt", MODIFIED),
+                classChange(otherClasses, "same/path.txt", MODIFIED)));
+
+        var delivered = deliver(policy, APPLIED);
+
+        assertThat(delivered.mainClassChanges())
+                .extracting(BuildOutputPathChange::outputRoot)
+                .containsExactly(classes, otherClasses);
+        assertThat(delivered.mainResourceChanges())
+                .extracting(BuildOutputPathChange::outputRoot)
+                .containsExactly(resources);
+    }
+
+    @Test
+    void rejectsStaleSequences() {
+        var policy = new BuildOutputChangesPolicy();
+
+        assertThat(policy.accept(success(2, classChange("com/acme/Foo.class", MODIFIED))).outcome()).isEqualTo(PENDING);
+        assertThat(policy.accept(success(2, classChange("com/acme/Bar.class", MODIFIED))).outcome()).isEqualTo(STALE_REJECTED);
+        assertThat(policy.accept(success(1, classChange("com/acme/Baz.class", MODIFIED))).outcome()).isEqualTo(STALE_REJECTED);
+    }
+
+    @Test
+    void failedBuildsDoNotBecomeReloadsAndDoNotErasePendingSuccessfulChanges() {
+        var policy = new BuildOutputChangesPolicy();
+        policy.accept(success(1, classChange("com/acme/Foo.class", MODIFIED)));
+
+        var failed = policy.accept(changes(2, BUILD_FAILED, List.of(classChange("com/acme/Bad.class", MODIFIED)), List.of()));
+        assertThat(failed.outcome()).isEqualTo(NON_RELOADABLE_STATUS);
+        assertThat(failed.changes().status()).isEqualTo(BUILD_FAILED);
+        assertThat(policy.accept(changes(3, BUILD_CANCELLED, List.of(classChange("com/acme/Other.class", MODIFIED)),
+                List.of())).outcome())
+                .isEqualTo(NON_RELOADABLE_STATUS);
+        assertThat(policy.accept(changes(4, BUILD_SUPERSEDED, List.of(classChange("com/acme/Superseded.class", MODIFIED)),
+                List.of())).outcome())
+                .isEqualTo(NON_RELOADABLE_STATUS);
+
+        var delivered = deliver(policy, APPLIED);
+
+        assertThat(delivered.sequence()).isEqualTo(1);
+        assertThat(delivered.mainClassChanges()).extracting(BuildOutputPathChange::changedPath)
+                .containsExactly(classes.resolve("com/acme/Foo.class"));
+    }
+
+    @Test
+    void appliedDeliveryClearsPendingChanges() {
+        var policy = new BuildOutputChangesPolicy();
+        policy.accept(success(1, classChange("com/acme/Foo.class", MODIFIED)));
+
+        assertThat(policy.deliver(ignored -> APPLIED).outcome()).isEqualTo(SENT_APPLIED);
+
+        assertThat(policy.hasPendingChanges()).isFalse();
+        assertThat(policy.deliver(ignored -> APPLIED).outcome()).isEqualTo(NOTHING_TO_SEND);
+    }
+
+    @Test
+    void notAppliedDeliveryKeepsPendingChangesAndCoalescesLaterEvents() {
+        var policy = new BuildOutputChangesPolicy();
+        policy.accept(success(1, classChange("com/acme/Foo.class", MODIFIED)));
+
+        assertThat(policy.deliver(ignored -> NOT_APPLIED).outcome()).isEqualTo(SENT_NOT_APPLIED);
+        assertThat(policy.hasPendingChanges()).isTrue();
+
+        policy.accept(success(2, classChange("com/acme/Foo.class", DELETED)));
+        var delivered = deliver(policy, APPLIED);
+
+        assertThat(delivered.sequence()).isEqualTo(2);
+        assertThat(delivered.mainClassChanges()).extracting(BuildOutputPathChange::kind)
+                .containsExactly(DELETED);
+    }
+
+    @Test
+    void sendFailuresKeepPendingChangesAndCoalesceLaterEvents() {
+        var policy = new BuildOutputChangesPolicy();
+        var failure = new IOException("timed out");
+        policy.accept(success(1, classChange("com/acme/Foo.class", ADDED)));
+
+        var failed = policy.deliver(ignored -> {
+            throw failure;
+        });
+
+        assertThat(failed.outcome()).isEqualTo(SEND_FAILED);
+        assertThat(failed.failure()).isSameAs(failure);
+        assertThat(policy.hasPendingChanges()).isTrue();
+
+        policy.accept(success(2, classChange("com/acme/Foo.class", MODIFIED)));
+        var delivered = deliver(policy, APPLIED);
+
+        assertThat(delivered.mainClassChanges()).extracting(BuildOutputPathChange::kind)
+                .containsExactly(ADDED);
+    }
+
+    @Test
+    void startupBaselineEventsProduceNoReloadableBatch() {
+        var policy = new BuildOutputChangesPolicy();
+
+        assertThat(policy.acceptStartupBaseline(success(1, classChange("com/acme/Foo.class", MODIFIED))).outcome())
+                .isEqualTo(BASELINE_DROPPED);
+        assertThat(policy.deliver(ignored -> APPLIED).outcome()).isEqualTo(NOTHING_TO_SEND);
+        assertThat(policy.accept(success(1, classChange("com/acme/Foo.class", MODIFIED))).outcome())
+                .isEqualTo(STALE_REJECTED);
+        assertThat(policy.accept(success(2, classChange("com/acme/Foo.class", MODIFIED))).outcome()).isEqualTo(PENDING);
+    }
+
+    @Test
+    void restartRequiredSnapshotsDoNotProduceNormalReloadBatchesOrErasePendingChanges() {
+        var policy = new BuildOutputChangesPolicy();
+        policy.accept(success(1, classChange("com/acme/Foo.class", MODIFIED)));
+
+        assertThat(policy.acceptRestartRequired(2).outcome()).isEqualTo(RESTART_REQUIRED);
+
+        var delivered = deliver(policy, APPLIED);
+
+        assertThat(delivered.sequence()).isEqualTo(1);
+        assertThat(delivered.mainClassChanges()).extracting(BuildOutputPathChange::changedPath)
+                .containsExactly(classes.resolve("com/acme/Foo.class"));
+    }
+
+    @Test
+    void busyDeliveryKeepsCoalescingUntilDeliveryIsAllowed() {
+        var policy = new BuildOutputChangesPolicy();
+
+        policy.accept(success(1, classChange("com/acme/Foo.class", MODIFIED)));
+        policy.accept(success(2, resourceChange("application.properties", MODIFIED)));
+        policy.accept(success(3, classChange("com/acme/Bar.class", MODIFIED)));
+
+        var delivered = deliver(policy, APPLIED);
+
+        assertThat(delivered.sequence()).isEqualTo(3);
+        assertThat(delivered.mainClassChanges()).extracting(BuildOutputPathChange::changedPath)
+                .containsExactly(classes.resolve("com/acme/Foo.class"), classes.resolve("com/acme/Bar.class"));
+        assertThat(delivered.mainResourceChanges()).extracting(BuildOutputPathChange::changedPath)
+                .containsExactly(resources.resolve("application.properties"));
+    }
+
+    @Test
+    void discardPendingChangesIsDeterministic() {
+        var policy = new BuildOutputChangesPolicy();
+        policy.accept(success(1, classChange("com/acme/Foo.class", MODIFIED)));
+
+        var discarded = policy.discardPending("session closed");
+
+        assertThat(discarded.outcome()).isEqualTo(DISCARDED);
+        assertThat(discarded.message()).isEqualTo("session closed");
+        assertThat(discarded.changes().sequence()).isEqualTo(1);
+        assertThat(policy.hasPendingChanges()).isFalse();
+        assertThat(policy.discardPending("again").outcome()).isEqualTo(NOTHING_TO_SEND);
+    }
+
+    @Test
+    void testOutputOnlySuccessfulBuildsAreNotReloadableInTheFirstSlice() {
+        var policy = new BuildOutputChangesPolicy();
+
+        var result = policy.accept(new BuildOutputChanges(1, BUILD_SUCCEEDED, null, null,
+                List.of(classChange("org/acme/FooTest.class", MODIFIED)), null, null, null, false, false));
+
+        assertThat(result.outcome()).isEqualTo(NO_RELOADABLE_CHANGES);
+        assertThat(policy.hasPendingChanges()).isFalse();
+    }
+
+    @Test
+    void policySurfaceDoesNotExposeGradleTypes() {
+        assertNoGradleType(BuildOutputChangesPolicy.class);
+        assertNoGradleType(BuildOutputChangesPolicy.Result.class);
+        assertNoGradleType(BuildOutputChangesPolicy.Sender.class);
+    }
+
+    private BuildOutputChanges deliver(BuildOutputChangesPolicy policy, BuildOutputChangesApplyStatus status) {
+        var delivered = new ArrayList<BuildOutputChanges>();
+        var result = policy.deliver(changes -> {
+            delivered.add(changes);
+            return status;
+        });
+        assertThat(result.outcome()).isEqualTo(status == APPLIED ? SENT_APPLIED : SENT_NOT_APPLIED);
+        assertThat(delivered).hasSize(1);
+        assertThat(result.changes()).isSameAs(delivered.get(0));
+        return delivered.get(0);
+    }
+
+    private BuildOutputChanges success(long sequence, BuildOutputPathChange... classChanges) {
+        var mainClassChanges = new ArrayList<BuildOutputPathChange>();
+        var mainResourceChanges = new ArrayList<BuildOutputPathChange>();
+        for (BuildOutputPathChange change : classChanges) {
+            if (change.outputRoot().equals(resources)) {
+                mainResourceChanges.add(change);
+            } else {
+                mainClassChanges.add(change);
+            }
+        }
+        return changes(sequence, BUILD_SUCCEEDED, mainClassChanges, mainResourceChanges);
+    }
+
+    private BuildOutputChanges changes(long sequence, BuildOutputChangeStatus status,
+            List<BuildOutputPathChange> classChanges, List<BuildOutputPathChange> resourceChanges) {
+        return new BuildOutputChanges(sequence, status, classChanges, resourceChanges, null, null, null, null, false, false);
+    }
+
+    private BuildOutputPathChange classChange(String path, BuildOutputChangeKind kind) {
+        return classChange(classes, path, kind);
+    }
+
+    private BuildOutputPathChange classChange(Path root, String path, BuildOutputChangeKind kind) {
+        return new BuildOutputPathChange(root, root.resolve(path), kind);
+    }
+
+    private BuildOutputPathChange resourceChange(String path, BuildOutputChangeKind kind) {
+        return resourceChange(resources, path, kind);
+    }
+
+    private BuildOutputPathChange resourceChange(Path root, String path, BuildOutputChangeKind kind) {
+        return new BuildOutputPathChange(root, root.resolve(path), kind);
+    }
+
+    private static void assertNoGradleType(Class<?> type) {
+        for (Method method : type.getDeclaredMethods()) {
+            assertThat(method.getReturnType().getName()).doesNotContain("org.gradle");
+            for (Class<?> parameterType : method.getParameterTypes()) {
+                assertThat(parameterType.getName()).doesNotContain("org.gradle");
+            }
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageClientTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageClientTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.deployment.dev.remotedev;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+class RemoteDevPackageClientTest {
+
+    @Test
+    void clientSurfaceDoesNotExposeGradleTypes() {
+        assertNoGradleType(RemoteDevPackageClient.class);
+        assertNoGradleType(RemoteDevPackageClientConfig.class);
+        assertNoGradleType(RemoteDevPackageClientFactory.class);
+        assertNoGradleType(RemoteDevPackageClientResult.class);
+        assertNoGradleType(RemoteDevPackageChange.class);
+        assertNoGradleType(RemoteDevPackageDiff.class);
+    }
+
+    @Test
+    void redactsUrlUserInfo() {
+        var config = new RemoteDevPackageClientConfig(
+                java.net.URI.create("https://user:secret@example.com/app"),
+                java.util.Optional.of("password"));
+
+        assertThat(config.redactedRemoteUrl()).isEqualTo("https://<redacted>@example.com/app");
+    }
+
+    private static void assertNoGradleType(Class<?> type) {
+        for (Method method : type.getDeclaredMethods()) {
+            assertThat(method.getReturnType().getName()).doesNotContain("org.gradle");
+            for (Class<?> parameterType : method.getParameterTypes()) {
+                assertThat(parameterType.getName()).doesNotContain("org.gradle");
+            }
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageSnapshotTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/dev/remotedev/RemoteDevPackageSnapshotTest.java
@@ -1,0 +1,75 @@
+package io.quarkus.deployment.dev.remotedev;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RemoteDevPackageSnapshotTest {
+
+    @TempDir
+    Path directory;
+
+    @Test
+    void detectsAddedModifiedAndDeletedPackageFiles() throws Exception {
+        Path root = Files.createDirectory(directory.resolve("quarkus-app"));
+        write(root.resolve("app/app.jar"), "one");
+        write(root.resolve("lib/main/lib.jar"), "lib");
+        RemoteDevPackageSnapshot previous = RemoteDevPackageSnapshot.capture(root);
+
+        write(root.resolve("app/app.jar"), "two");
+        Files.delete(root.resolve("lib/main/lib.jar"));
+        write(root.resolve("lib/deployment/appmodel.dat"), "model");
+        RemoteDevPackageSnapshot current = RemoteDevPackageSnapshot.capture(root);
+
+        RemoteDevPackageDiff diff = current.diffSince(previous, root);
+
+        assertThat(diff.changed()).extracting(RemoteDevPackageChange::relativePath)
+                .containsExactly("app/app.jar", "lib/deployment/appmodel.dat");
+        assertThat(diff.deleted()).containsExactly("lib/main/lib.jar");
+    }
+
+    @Test
+    void skipsQuarkusDirectoryAndProtectedDeletes() throws Exception {
+        Path root = Files.createDirectory(directory.resolve("quarkus-app"));
+        write(root.resolve("quarkus/quarkus-application.dat"), "ignored");
+        write(root.resolve("root-file.txt"), "root");
+        write(root.resolve("META-INF/MANIFEST.MF"), "manifest");
+        write(root.resolve("META-INF/maven/app/pom.properties"), "maven");
+        write(root.resolve("lib/main/removed.jar"), "remove");
+        RemoteDevPackageSnapshot previous = RemoteDevPackageSnapshot.capture(root);
+
+        Files.delete(root.resolve("quarkus/quarkus-application.dat"));
+        Files.delete(root.resolve("root-file.txt"));
+        Files.delete(root.resolve("META-INF/MANIFEST.MF"));
+        Files.delete(root.resolve("META-INF/maven/app/pom.properties"));
+        Files.delete(root.resolve("lib/main/removed.jar"));
+        RemoteDevPackageSnapshot current = RemoteDevPackageSnapshot.capture(root);
+
+        RemoteDevPackageDiff diff = current.diffSince(previous, root);
+
+        assertThat(diff.changed()).isEmpty();
+        assertThat(diff.deleted()).containsExactly("lib/main/removed.jar");
+    }
+
+    @Test
+    void writesAndReadsStableSnapshot() throws Exception {
+        Path root = Files.createDirectory(directory.resolve("quarkus-app"));
+        write(root.resolve("app/app.jar"), "one");
+        Path snapshotFile = directory.resolve("snapshot.tsv");
+
+        RemoteDevPackageSnapshot.capture(root).write(snapshotFile);
+        RemoteDevPackageSnapshot read = RemoteDevPackageSnapshot.read(snapshotFile);
+
+        assertThat(Files.readString(snapshotFile)).contains("app/app.jar\t");
+        assertThat(read.diffSince(RemoteDevPackageSnapshot.capture(root), root).isEmpty()).isTrue();
+    }
+
+    private static void write(Path file, String content) throws Exception {
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, content);
+    }
+}


### PR DESCRIPTION
External build tools need a way to let Quarkus keep owning dev-mode and remote-dev runtime behavior while the build tool owns source compilation, resource processing, and package production.

Add core/deployment helpers for that boundary:

- `BuildOutputChangesPolicy` coalesces externally produced class/resource changes and only drops them once Quarkus accepts the update
- remote-dev package snapshot/diff types compare mutable-jar package roots using package-relative paths
- `RemoteDevPackageClient` sends changed and deleted package files through the existing remote-dev protocol

This gives the Gradle application plugin a Quarkus-owned implementation for its continuous dev and remote-dev handoff logic, and provides the same reusable building blocks for other external build integrations such as Bazel.