### PR TITLE
HTTP/3 - Fix altSvc for HTTP/1 and HTTP/1.1

### DIFF
--- a/extensions/http3/deployment/src/main/java/io/quarkus/http3/deployment/Http3Processor.java
+++ b/extensions/http3/deployment/src/main/java/io/quarkus/http3/deployment/Http3Processor.java
@@ -95,7 +95,7 @@ class Http3Processor {
 
     @BuildStep
     FilterBuildItem altSvcFilter(Http3BuildTimeConfig config, Http3EnabledBuildItem http3Enabled) {
-        if (!config.altSvc()) {
+        if (!config.enabled() || !config.altSvc()) {
             return null;
         }
         return new FilterBuildItem(new Http3AltSvcHandler(), 10);

--- a/extensions/http3/runtime/src/main/java/io/quarkus/http3/runtime/Http3AltSvcHandler.java
+++ b/extensions/http3/runtime/src/main/java/io/quarkus/http3/runtime/Http3AltSvcHandler.java
@@ -27,11 +27,28 @@ public class Http3AltSvcHandler implements Handler<RoutingContext> {
     @Override
     public void handle(RoutingContext rc) {
         if (rc.request().isSSL() && rc.request().version() != HttpVersion.HTTP_3) {
-            int port = rc.request().localAddress().port();
-            String advertisement = "h3=\":" + port + "\"; ma=" + maxAgeSeconds;
-            rc.response().writeAltSvc(advertisement)
-                    .onFailure(t -> LOG.warn("Failed to write Alt-Svc advertisement", t))
-                    .onComplete(x -> rc.next());
+            // We cannot add a header as the head has already be written
+            // For HTTP/1 and HTTP/1.1, the advertisement is done using a header, so we need to check
+            // if we can write it. For HTTP/2 it's a custom frame.
+            if (rc.request().version() != HttpVersion.HTTP_2 && !rc.response().headWritten()) {
+                int port = rc.request().localAddress().port();
+                String advertisement = "h3=\":" + port + "\"; ma=" + maxAgeSeconds;
+                try {
+                    rc.response().writeAltSvc(advertisement)
+                            .onFailure(t -> LOG.debug("Failed to write Alt-Svc advertisement", t))
+                            .onComplete(x -> rc.next());
+                } catch (Exception e) {
+                    // When using HTTP/1, writeAltSvc is synchronous.
+                    // This catch block is just in case we pass the previous "head not written" condition, but it got
+                    // written in the meantime (because writes are async)
+                    LOG.debugf(e, "Failed to write Alt-Svc advertisement");
+                    rc.next();
+                }
+            } else {
+                // Too late to add the header
+                LOG.debug("Failed to write Alt-Svc advertisement, head already written");
+                rc.next();
+            }
         } else {
             rc.next();
         }


### PR DESCRIPTION
Because it uses a header to pass the advertisement when using HTTP < 2, we need to be more defensive and only write the header if the head has not been written yet.

