### PR TITLE
Update OpenTelemetry instrumentation to 1.63

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -29,7 +29,7 @@
         <resteasy-microprofile.version>3.0.1.Final</resteasy-microprofile.version>
         <resteasy-spring-web.version>3.2.0.Final</resteasy-spring-web.version>
         <resteasy.version>6.2.16.Final</resteasy.version>
-        <opentelemetry-instrumentation.version>2.28.1-alpha</opentelemetry-instrumentation.version> <!-- OTel SDk 1.62.0-->
+        <opentelemetry-instrumentation.version>2.29.0-alpha</opentelemetry-instrumentation.version> <!-- OTel SDK 1.63.0-->
         <opentelemetry-semconv.version>1.40.0-alpha</opentelemetry-semconv.version>
         <quarkus-http.version>6.0.0.Alpha4</quarkus-http.version>
         <micrometer.version>1.17.0</micrometer.version><!-- keep in sync with hdrhistogram: https://central.sonatype.com/artifact/io.micrometer/micrometer-core -->

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -29,7 +29,7 @@
         <resteasy-microprofile.version>3.0.1.Final</resteasy-microprofile.version>
         <resteasy-spring-web.version>3.2.0.Final</resteasy-spring-web.version>
         <resteasy.version>7.0.2.Final</resteasy.version>
-        <opentelemetry-instrumentation.version>2.28.1-alpha</opentelemetry-instrumentation.version> <!-- OTel SDk 1.62.0-->
+        <opentelemetry-instrumentation.version>2.29.0-alpha</opentelemetry-instrumentation.version> <!-- OTel SDK 1.63.0-->
         <opentelemetry-semconv.version>1.40.0-alpha</opentelemetry-semconv.version>
         <quarkus-http.version>6.0.0.Alpha4</quarkus-http.version>
         <micrometer.version>1.17.0</micrometer.version><!-- keep in sync with hdrhistogram: https://central.sonatype.com/artifact/io.micrometer/micrometer-core -->

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterProcessor.java
@@ -112,8 +112,8 @@ public class OtlpExporterProcessor {
     @BuildStep
     void logging(BuildProducer<LogCategoryBuildItem> log) {
         // Reduce the log level of the exporters because it's too much, and we do log important things ourselves.
-        log.produce(new LogCategoryBuildItem("io.opentelemetry.exporter.internal.grpc.GrpcExporter", Level.OFF));
-        log.produce(new LogCategoryBuildItem("io.opentelemetry.exporter.internal.http.HttpExporter", Level.OFF));
+        log.produce(new LogCategoryBuildItem("io.opentelemetry.exporter.otlp.internal.GrpcExporter", Level.OFF));
+        log.produce(new LogCategoryBuildItem("io.opentelemetry.exporter.otlp.internal.HttpExporter", Level.OFF));
     }
 
     @BuildStep

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OTelExporterRecorder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OTelExporterRecorder.java
@@ -18,9 +18,9 @@ import java.util.function.Supplier;
 import org.jboss.logging.Logger;
 
 import io.opentelemetry.api.metrics.MeterProvider;
-import io.opentelemetry.exporter.internal.ExporterBuilderUtil;
-import io.opentelemetry.exporter.internal.grpc.GrpcExporter;
-import io.opentelemetry.exporter.internal.http.HttpExporter;
+import io.opentelemetry.exporter.internal.EndpointUtil;
+import io.opentelemetry.exporter.otlp.internal.GrpcExporter;
+import io.opentelemetry.exporter.otlp.internal.HttpExporter;
 import io.opentelemetry.exporter.otlp.internal.OtlpUserAgent;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.common.InternalTelemetryVersion;
@@ -400,7 +400,7 @@ public class OTelExporterRecorder {
         if (endpoint.isEmpty()) {
             return null;
         }
-        return ExporterBuilderUtil.validateEndpoint(endpoint);
+        return EndpointUtil.validateEndpoint(endpoint);
     }
 
     private URI getMetricsUri(OtlpExporterRuntimeConfig exporterRuntimeConfig) {
@@ -408,7 +408,7 @@ public class OTelExporterRecorder {
         if (endpoint.isEmpty()) {
             return null;
         }
-        return ExporterBuilderUtil.validateEndpoint(endpoint);
+        return EndpointUtil.validateEndpoint(endpoint);
     }
 
     private URI getLogsUri(OtlpExporterRuntimeConfig exporterRuntimeConfig) {
@@ -416,7 +416,7 @@ public class OTelExporterRecorder {
         if (endpoint.isEmpty()) {
             return null;
         }
-        return ExporterBuilderUtil.validateEndpoint(endpoint);
+        return EndpointUtil.validateEndpoint(endpoint);
     }
 
     static String resolveTraceEndpoint(final OtlpExporterRuntimeConfig runtimeConfig) {

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/logs/VertxGrpcLogRecordExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/logs/VertxGrpcLogRecordExporter.java
@@ -2,8 +2,8 @@ package io.quarkus.opentelemetry.runtime.exporter.otlp.logs;
 
 import java.util.Collection;
 
-import io.opentelemetry.exporter.internal.grpc.GrpcExporter;
 import io.opentelemetry.exporter.internal.otlp.logs.LogReusableDataMarshaler;
+import io.opentelemetry.exporter.otlp.internal.GrpcExporter;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.logs.data.LogRecordData;

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/logs/VertxHttpLogRecordExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/logs/VertxHttpLogRecordExporter.java
@@ -2,8 +2,8 @@ package io.quarkus.opentelemetry.runtime.exporter.otlp.logs;
 
 import java.util.Collection;
 
-import io.opentelemetry.exporter.internal.http.HttpExporter;
 import io.opentelemetry.exporter.internal.otlp.logs.LogReusableDataMarshaler;
+import io.opentelemetry.exporter.otlp.internal.HttpExporter;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.logs.data.LogRecordData;

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/metrics/VertxGrpcMetricExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/metrics/VertxGrpcMetricExporter.java
@@ -2,8 +2,8 @@ package io.quarkus.opentelemetry.runtime.exporter.otlp.metrics;
 
 import java.util.Collection;
 
-import io.opentelemetry.exporter.internal.grpc.GrpcExporter;
 import io.opentelemetry.exporter.internal.otlp.metrics.MetricReusableDataMarshaler;
+import io.opentelemetry.exporter.otlp.internal.GrpcExporter;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.metrics.Aggregation;

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/metrics/VertxHttpMetricsExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/metrics/VertxHttpMetricsExporter.java
@@ -2,8 +2,8 @@ package io.quarkus.opentelemetry.runtime.exporter.otlp.metrics;
 
 import java.util.Collection;
 
-import io.opentelemetry.exporter.internal.http.HttpExporter;
 import io.opentelemetry.exporter.internal.otlp.metrics.MetricReusableDataMarshaler;
+import io.opentelemetry.exporter.otlp.internal.HttpExporter;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.metrics.Aggregation;

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/tracing/VertxGrpcSpanExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/tracing/VertxGrpcSpanExporter.java
@@ -2,8 +2,8 @@ package io.quarkus.opentelemetry.runtime.exporter.otlp.tracing;
 
 import java.util.Collection;
 
-import io.opentelemetry.exporter.internal.grpc.GrpcExporter;
 import io.opentelemetry.exporter.internal.otlp.traces.SpanReusableDataMarshaler;
+import io.opentelemetry.exporter.otlp.internal.GrpcExporter;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.trace.data.SpanData;

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/tracing/VertxHttpSpanExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/tracing/VertxHttpSpanExporter.java
@@ -2,8 +2,8 @@ package io.quarkus.opentelemetry.runtime.exporter.otlp.tracing;
 
 import java.util.Collection;
 
-import io.opentelemetry.exporter.internal.http.HttpExporter;
 import io.opentelemetry.exporter.internal.otlp.traces.SpanReusableDataMarshaler;
+import io.opentelemetry.exporter.otlp.internal.HttpExporter;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.trace.data.SpanData;


### PR DESCRIPTION
OpenTelemetry 1.63 relocated OTLP exporter internals that Quarkus still calls at startup (`validateEndpoint` moved to `EndpointUtil`, and `GrpcExporter`/`HttpExporter` moved under `exporter.otlp.internal`). Without this adaptation, applications fail to start with a `NoSuchMethodError` when using the newer OpenTelemetry BOM.