### PR TITLE
Fix scalpel configuration

### DIFF
--- a/.github/filter-integration-tests-json.sh
+++ b/.github/filter-integration-tests-json.sh
@@ -60,7 +60,7 @@ do
   # - trailing "|" (after EXPR) avoids grep return code > 0 if nothing matches (which is a valid case)
   # - "paste" joins all matches to get a single line
   FILTERED=$(echo -n "${modules}" | grep -Po "${EXPR}|" | paste -sd " " -)
-  JSON=$(echo -n "${JSON}" | sed "s|${modules}|${FILTERED}|")
+  JSON=$(echo -n "${JSON}" | sed "s|\"test-modules\": \"${modules}\"|\"test-modules\": \"${FILTERED}\"|")
 done < <(echo -n "${JSON}" | jq -r '.include[] | ."test-modules"')
 
 # Step 3: delete entire elements from "include" array that now have an empty "test-modules" list


### PR DESCRIPTION
The filter script loops over every category's
`test-modules` value and uses `sed` to replace it in the JSON. One category is `"Main"` with `test-modules: "main"`. When scalpel says that module isn't impacted,
the script tries to replace `"main"` with `""` (empty) using: `sed "s|main||"`

But sed doesn't know it should only replace the "test-modules": "main" field. It replaces every occurrence of the string `main` in the entire JSON — including the `main` inside `grpc-domain-socket`, turning it into `grpc-do-socket`.