### PR TITLE
Skip building the OpenAPI document eagerly on startup

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiRunStageMultiStageFilterTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiRunStageMultiStageFilterTest.java
@@ -89,7 +89,7 @@ class OpenApiRunStageMultiStageFilterTest {
                 matchesRegex(patternFormat.formatted(BuildAndPerRequestFilter.EXTENSION_NAME, 1)));
         assertThat(buildTimeDocument, not(containsString(StartupAndPerRequestFilter.EXTENSION_NAME)));
 
-        // Verify which filters have run during runtime startup
+        // verify which filters where explicitly only run during RUNTIME_STARTUP stage
         assertThat(buildAndPerRequestFilter.currentCLInvocationCount, is(0));
         assertThat(startupAndPerRequestFilter.currentCLInvocationCount, is(1));
 

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiRunStageNoRequestFilterTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiRunStageNoRequestFilterTest.java
@@ -27,18 +27,16 @@ import io.quarkus.smallrye.openapi.OpenApiFilter.RunStage;
 import io.quarkus.smallrye.openapi.runtime.OpenApiConstants;
 import io.quarkus.test.QuarkusExtensionTest;
 
-class OpenApiRunStageFilterTest {
+class OpenApiRunStageNoRequestFilterTest {
 
-    private static final String STORE_SCHEMA_DIRECTORY = "target/generated/OpenApiRunStageFilterTest/";
+    private static final String STORE_SCHEMA_DIRECTORY = "target/generated/OpenApiRunStageNoRequestFilterTest/";
 
     @RegisterExtension
     static QuarkusExtensionTest runner = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar
                     .addClass(BuildFilter.class)
                     .addClass(RuntimeStartupFilter.class)
-                    .addClass(RuntimePerRequestFilter.class)
                     .addClass(RunFilter.class)
-                    .addClass(BothFilter.class)
                     .addAsResource(
                             new StringAsset(
                                     "quarkus.smallrye-openapi.store-schema-directory=" + STORE_SCHEMA_DIRECTORY),
@@ -88,16 +86,6 @@ class OpenApiRunStageFilterTest {
     }
 
     @Singleton
-    @OpenApiFilter(stages = RunStage.RUNTIME_PER_REQUEST)
-    public static class RuntimePerRequestFilter extends BaseFilter implements OASFilter {
-        public static final String EXTENSION_NAME = EXTENSION_NAME_PREFIX + "-runtime-per-request";
-
-        public String getExtensionName() {
-            return EXTENSION_NAME;
-        }
-    }
-
-    @Singleton
     @OpenApiFilter(stages = RunStage.RUN)
     public static class RunFilter extends BaseFilter implements OASFilter {
         public static final String EXTENSION_NAME = EXTENSION_NAME_PREFIX + "-run";
@@ -107,30 +95,14 @@ class OpenApiRunStageFilterTest {
         }
     }
 
-    @Singleton
-    @OpenApiFilter(stages = RunStage.BOTH)
-    public static class BothFilter extends BaseFilter implements OASFilter {
-        public static final String EXTENSION_NAME = EXTENSION_NAME_PREFIX + "-both";
-
-        public String getExtensionName() {
-            return EXTENSION_NAME;
-        }
-    }
+    @Inject
+    OpenApiRunStageNoRequestFilterTest.BuildFilter buildFilter;
 
     @Inject
-    OpenApiRunStageFilterTest.BuildFilter buildFilter;
+    OpenApiRunStageNoRequestFilterTest.RuntimeStartupFilter runtimeStartupFilter;
 
     @Inject
-    OpenApiRunStageFilterTest.RuntimeStartupFilter runtimeStartupFilter;
-
-    @Inject
-    OpenApiRunStageFilterTest.RuntimePerRequestFilter runtimePerRequestFilter;
-
-    @Inject
-    OpenApiRunStageFilterTest.RunFilter runFilter;
-
-    @Inject
-    OpenApiRunStageFilterTest.BothFilter bothFilter;
+    OpenApiRunStageNoRequestFilterTest.RunFilter runFilter;
 
     @Test
     public void testFiltersApplied() throws IOException {
@@ -145,25 +117,19 @@ class OpenApiRunStageFilterTest {
         // verify which filters where run during BUILD stage
         assertThat(buildTimeDocument, matchesRegex(patternFormat.formatted(buildFilter.getExtensionName(), 1)));
         assertThat(buildTimeDocument, not(containsString(runtimeStartupFilter.getExtensionName())));
-        assertThat(buildTimeDocument, not(containsString(runtimePerRequestFilter.getExtensionName())));
         assertThat(buildTimeDocument, not(containsString(runFilter.getExtensionName())));
-        assertThat(buildTimeDocument, matchesRegex(patternFormat.formatted(bothFilter.getExtensionName(), 1)));
 
         // Verify which filters run during SmallRyeOpenApiProcessor.applyRuntimeFilters
         // should just be the (already run) build stage + runtime startup stage
         String storedDocument = Files.readString(Paths.get(STORE_SCHEMA_DIRECTORY, "openapi.json"));
         assertThat(storedDocument, matchesRegex(patternFormat.formatted(buildFilter.getExtensionName(), 1)));
         assertThat(storedDocument, matchesRegex(patternFormat.formatted(runtimeStartupFilter.getExtensionName(), 1)));
-        assertThat(storedDocument, not(containsString(runtimePerRequestFilter.getExtensionName())));
         assertThat(storedDocument, matchesRegex(patternFormat.formatted(runFilter.getExtensionName(), 1)));
-        assertThat(storedDocument, matchesRegex(patternFormat.formatted(bothFilter.getExtensionName(), 2)));
 
         // verify which filters where explicitly only run during RUNTIME_STARTUP stage
         assertThat(buildFilter.currentCLInvocationCount, is(0));
         assertThat(runtimeStartupFilter.currentCLInvocationCount, is(1));
-        assertThat(runtimePerRequestFilter.currentCLInvocationCount, is(0));
         assertThat(runFilter.currentCLInvocationCount, is(1));
-        assertThat(bothFilter.currentCLInvocationCount, is(1));
 
         // now verify which filters are run at runtime request
         // results should be build stage + run stage + runtime request stage
@@ -173,14 +139,10 @@ class OpenApiRunStageFilterTest {
                 .statusCode(200)
                 .body(buildFilter.getExtensionName(), equalTo(1))
                 .body(runtimeStartupFilter.getExtensionName(), equalTo(1))
-                .body(runtimePerRequestFilter.getExtensionName(), equalTo(1))
-                .body(runFilter.getExtensionName(), equalTo(1))
-                .body(bothFilter.getExtensionName(), equalTo(2));
+                .body(runFilter.getExtensionName(), equalTo(1));
         assertThat(buildFilter.currentCLInvocationCount, is(0));
         assertThat(runtimeStartupFilter.currentCLInvocationCount, is(1));
-        assertThat(runtimePerRequestFilter.currentCLInvocationCount, is(1));
         assertThat(runFilter.currentCLInvocationCount, is(1));
-        assertThat(bothFilter.currentCLInvocationCount, is(1));
 
         // Verify that only the runtime request filters are run again on another request
         // however, changes from previous run runtime request filters are not persisted, i.e. invocation count is still 1 in the extension, but in the var will be 2
@@ -190,14 +152,10 @@ class OpenApiRunStageFilterTest {
                 .statusCode(200)
                 .body(buildFilter.getExtensionName(), equalTo(1))
                 .body(runtimeStartupFilter.getExtensionName(), equalTo(1))
-                .body(runtimePerRequestFilter.getExtensionName(), equalTo(1))
-                .body(runFilter.getExtensionName(), equalTo(1))
-                .body(bothFilter.getExtensionName(), equalTo(2));
+                .body(runFilter.getExtensionName(), equalTo(1));
         assertThat(buildFilter.currentCLInvocationCount, is(0));
         assertThat(runtimeStartupFilter.currentCLInvocationCount, is(1));
-        assertThat(runtimePerRequestFilter.currentCLInvocationCount, is(2));
         assertThat(runFilter.currentCLInvocationCount, is(1));
-        assertThat(bothFilter.currentCLInvocationCount, is(1));
     }
 
     private String readBuildTimeDocument() throws IOException {

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiDocumentService.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiDocumentService.java
@@ -1,5 +1,6 @@
 package io.quarkus.smallrye.openapi.runtime;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -10,14 +11,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.openapi.OASFilter;
-import org.eclipse.microprofile.openapi.models.OpenAPI;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.smallrye.openapi.OpenApiFilter;
@@ -27,8 +29,8 @@ import io.smallrye.openapi.api.SmallRyeOpenAPI;
 import io.smallrye.openapi.runtime.io.Format;
 
 /**
- * Loads the document and make it available
- */
+ * Loads the document and make it available.
+ **/
 @ApplicationScoped
 public class OpenApiDocumentService {
 
@@ -44,59 +46,86 @@ public class OpenApiDocumentService {
         ClassLoader loader = Optional.ofNullable(OpenApiConstants.classLoader)
                 .orElseGet(Thread.currentThread()::getContextClassLoader);
 
-        boolean isDefaultDocument = OpenApiConstants.DEFAULT_DOCUMENT_NAME.equals(documentName);
-        String name = OpenApiConstants.BASE_NAME + (isDefaultDocument ? "" : ("-" + documentName));
+        Config wrappedConfig = OpenApiConfigHelper.wrap(config, documentName);
+        boolean dynamic = wrappedConfig.getOptionalValue("quarkus.smallrye-openapi.always-run-filter", boolean.class)
+                .orElse(false);
 
-        try (InputStream source = loader.getResourceAsStream(name + ".JSON")) {
-            if (source != null) {
-                Config wrappedConfig = OpenApiConfigHelper.wrap(config, documentName);
-                boolean dynamic = wrappedConfig.getOptionalValue("quarkus.smallrye-openapi.always-run-filter", boolean.class)
-                        .orElse(false);
+        Set<String> startupFilters = new LinkedHashSet<>(filtersByStage.get(OpenApiFilter.RunStage.RUNTIME_STARTUP));
+        Set<String> requestFilters = new LinkedHashSet<>(
+                filtersByStage.get(OpenApiFilter.RunStage.RUNTIME_PER_REQUEST));
+        if (!dynamic) {
+            startupFilters.addAll(filtersByStage.get(OpenApiFilter.RunStage.RUN));
+        } else {
+            requestFilters.addAll(filtersByStage.get(OpenApiFilter.RunStage.RUN));
+        }
 
-                SmallRyeOpenAPI.Builder builder = new OpenAPIRuntimeBuilder()
-                        .withConfig(wrappedConfig)
-                        .withApplicationClassLoader(loader)
-                        .enableModelReader(false)
-                        .enableStandardStaticFiles(false)
-                        .enableAnnotationScan(false)
-                        .enableStandardFilter(false)
-                        .withCustomStaticFile(() -> source);
+        boolean hasStartup = !startupFilters.isEmpty();
+        boolean hasRequest = !requestFilters.isEmpty();
 
-                // Auth-security and disabled endpoint filters will only run once
-                Optional.ofNullable(autoSecurityFilter)
-                        .ifPresent(builder::addFilter);
-                DisabledRestEndpointsFilter.maybeGetInstance()
-                        .ifPresent(builder::addFilter);
-
-                Set<String> startupFilters = new LinkedHashSet<>(filtersByStage.get(OpenApiFilter.RunStage.RUNTIME_STARTUP));
-                Set<String> requestFilters = new LinkedHashSet<>(
-                        filtersByStage.get(OpenApiFilter.RunStage.RUNTIME_PER_REQUEST));
-                if (!dynamic) {
-                    startupFilters.addAll(filtersByStage.get(OpenApiFilter.RunStage.RUN));
-                } else {
-                    requestFilters.addAll(filtersByStage.get(OpenApiFilter.RunStage.RUN));
-                }
-
-                var startupFilterSetup = addFilters(startupFilters, loader);
-                startupFilterSetup.accept(builder);
-                if (requestFilters.isEmpty()) {
-                    this.documentHolders.put(documentName, new StaticDocument(builder.build()));
-                } else {
-                    // Mark the model as intermediate so that private extensions remain
-                    // available for filters running at each request.
-                    builder.withIntermediateModel(true);
-                    var perRequestFilterSetup = addFilters(requestFilters, loader);
-                    // Only regenerate the OpenAPI document when configured and there are filters to run
-                    this.documentHolders.put(documentName,
-                            new DynamicDocument(builder.build().model(), loader, wrappedConfig, perRequestFilterSetup));
-                }
-
-            } else {
-                this.documentHolders.put(documentName, new EmptyDocument());
+        var startupFilterSetup = addFilters(startupFilters, loader);
+        Consumer<SmallRyeOpenAPI.Builder> builderSetup = b -> {
+            if (hasRequest) {
+                // Mark the model as intermediate so that private extensions remain
+                // available for filters running at each request.
+                b.withIntermediateModel(true);
             }
+            startupFilterSetup.accept(b);
+        };
+
+        Supplier<SmallRyeOpenAPI.Builder> builderSupplier = baseBuilderSupplier(wrappedConfig, autoSecurityFilter,
+                documentName, loader, builderSetup);
+
+        if (builderSupplier == null) {
+            this.documentHolders.put(documentName, EMPTY_DOCUMENT);
+            return;
+        }
+
+        OpenApiDocumentHolder holder;
+        if (!hasRequest) {
+            holder = new StaticDocument(hasStartup, builderSupplier);
+        } else {
+            holder = new DynamicDocument(hasStartup, builderSupplier, loader, wrappedConfig,
+                    addFilters(requestFilters, loader));
+        }
+        this.documentHolders.put(documentName, holder);
+    }
+
+    private Supplier<SmallRyeOpenAPI.Builder> baseBuilderSupplier(Config wrappedConfig,
+            AutoSecurityFilter autoSecurityFilter,
+            String documentName, ClassLoader loader, Consumer<SmallRyeOpenAPI.Builder> builderSetup) {
+        boolean isDefaultDocument = OpenApiConstants.DEFAULT_DOCUMENT_NAME.equals(documentName);
+        String documentResourceName = OpenApiConstants.BASE_NAME + (isDefaultDocument ? "" : ("-" + documentName)) + ".JSON";
+
+        byte[] documentBytes;
+        try (InputStream source = loader.getResourceAsStream(documentResourceName)) {
+            if (source == null) {
+                return null;
+            }
+
+            documentBytes = source.readAllBytes();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+
+        return () -> {
+            SmallRyeOpenAPI.Builder builder = new OpenAPIRuntimeBuilder()
+                    .withConfig(wrappedConfig)
+                    .withApplicationClassLoader(loader)
+                    .enableModelReader(false)
+                    .enableStandardStaticFiles(false)
+                    .enableAnnotationScan(false)
+                    .enableStandardFilter(false)
+                    .withCustomStaticFile(() -> new ByteArrayInputStream(documentBytes));
+
+            builderSetup.accept(builder);
+
+            // Auth-security and disabled endpoint filters will only run once
+            Optional.ofNullable(autoSecurityFilter)
+                    .ifPresent(builder::addFilter);
+            DisabledRestEndpointsFilter.maybeGetInstance()
+                    .ifPresent(builder::addFilter);
+            return builder;
+        };
     }
 
     public byte[] getDocument(String documentName, Format format) {
@@ -141,6 +170,42 @@ public class OpenApiDocumentService {
         return Arc.container().instance(filterClass).get();
     }
 
+    /**
+     * Deferred allows to lazily execute the loader. The loader is discarded after the first call. <br/>
+     * In case the action happened before construction of the Deferred, an already materialized value can be provided, so that
+     * the same API can be used in deferred and non defered code paths.
+     */
+    static class Deferred<T> {
+        private final ReentrantLock lock = new ReentrantLock();
+        private volatile Supplier<T> loader;
+
+        private T materialized;
+
+        public Deferred(Supplier<T> loader) {
+            this.loader = loader;
+        }
+
+        public Deferred(T materialized) {
+            this.materialized = materialized;
+        }
+
+        public T get() {
+            if (this.loader != null) {
+                lock.lock();
+                try {
+                    if (this.loader != null) {
+                        materialized = loader.get();
+                        loader = null;
+                    }
+                } finally {
+                    lock.unlock();
+                }
+            }
+
+            return materialized;
+        }
+    }
+
     static class EmptyDocument implements OpenApiDocumentHolder {
         static final byte[] EMPTY = new byte[0];
 
@@ -154,24 +219,36 @@ public class OpenApiDocumentService {
     }
 
     /**
-     * Generate the document once on creation.
+     * Generate the document once when resolved by the deferred openapi.
      */
     static class StaticDocument implements OpenApiDocumentHolder {
 
-        private byte[] jsonDocument;
-        private byte[] yamlDocument;
+        private record Formats(byte[] json, byte[] yaml) {
+            public Formats(SmallRyeOpenAPI openAPI) {
+                this(openAPI.toJSON().getBytes(StandardCharsets.UTF_8), openAPI.toYAML().getBytes(StandardCharsets.UTF_8));
+            }
+        }
 
-        StaticDocument(SmallRyeOpenAPI openAPI) {
-            jsonDocument = openAPI.toJSON().getBytes(StandardCharsets.UTF_8);
-            yamlDocument = openAPI.toYAML().getBytes(StandardCharsets.UTF_8);
+        private final Deferred<Formats> formats;
+
+        StaticDocument(boolean hasStartup, Supplier<SmallRyeOpenAPI.Builder> openAPISupplier) {
+            if (hasStartup) {
+                SmallRyeOpenAPI openAPI = openAPISupplier.get().build();
+                this.formats = new Deferred<>(new Formats(openAPI));
+            } else {
+                this.formats = new Deferred<>(() -> {
+                    SmallRyeOpenAPI openAPI = openAPISupplier.get().build();
+                    return new Formats(openAPI);
+                });
+            }
         }
 
         public byte[] getJsonDocument() {
-            return this.jsonDocument;
+            return this.formats.get().json;
         }
 
         public byte[] getYamlDocument() {
-            return this.yamlDocument;
+            return this.formats.get().yaml;
         }
     }
 
@@ -180,14 +257,20 @@ public class OpenApiDocumentService {
      */
     static class DynamicDocument implements OpenApiDocumentHolder {
 
-        private final OpenAPI generatedOnBuild;
         private final ClassLoader loader;
         private final Config config;
-        private Consumer<SmallRyeOpenAPI.Builder> filterSetup;
+        private final Consumer<SmallRyeOpenAPI.Builder> filterSetup;
 
-        DynamicDocument(OpenAPI generatedOnBuild, ClassLoader loader, Config config,
+        private final Deferred<SmallRyeOpenAPI> baseOpenAPI;
+
+        DynamicDocument(boolean hasStartup, Supplier<SmallRyeOpenAPI.Builder> model, ClassLoader loader, Config config,
                 Consumer<SmallRyeOpenAPI.Builder> filterSetup) {
-            this.generatedOnBuild = generatedOnBuild;
+            if (hasStartup) {
+                this.baseOpenAPI = new Deferred<>(model.get().build());
+            } else {
+                this.baseOpenAPI = new Deferred<>(() -> model.get().build());
+            }
+
             this.loader = loader;
             this.config = config;
             this.filterSetup = filterSetup;
@@ -197,13 +280,14 @@ public class OpenApiDocumentService {
             SmallRyeOpenAPI.Builder builder = new OpenAPIRuntimeBuilder()
                     .withConfig(config)
                     .withApplicationClassLoader(loader)
-                    .withInitialModel(generatedOnBuild)
+                    .withInitialModel(baseOpenAPI.get().model())
                     .enableModelReader(false)
                     .enableStandardStaticFiles(false)
                     .enableAnnotationScan(false)
                     .enableStandardFilter(false);
 
             filterSetup.accept(builder);
+
             return builder.build();
         }
 


### PR DESCRIPTION
When no Open API Filter with stage RUNTIME_STARTUP exists.

The BUILD stage filters still get executed eagerly during the quarkus:build action. When RUNTIME_STARTUP is present, the OpenAPI document is built eagerly on startup, otherwise lazily on first request.

- Fixes: #54826

