### PR TITLE
Preserve RequestScoped data for synchronous @CacheResult calls

### DIFF
--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CacheResultClearedCdiContextTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CacheResultClearedCdiContextTest.java
@@ -1,0 +1,138 @@
+package io.quarkus.cache.test.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.context.control.RequestContextController;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.cache.CacheManager;
+import io.quarkus.cache.CacheResult;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.smallrye.context.api.ManagedExecutorConfig;
+import io.smallrye.context.api.NamedInstance;
+
+/**
+ * A ManagedExecutor with CDI cleared is used so the HTTP request scope can end while work
+ * continues. The worker then activates a RequestContext, sets request-scoped data, and calls
+ * a {@code @CacheResult} method. That data must still be visible inside the cached method —
+ * the synchronous {@code @CacheResult} path must not go through Mutiny {@code Uni.await()},
+ * which would let SmallRye Context Propagation re-clear CDI.
+ */
+public class CacheResultClearedCdiContextTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-smallrye-context-propagation-deployment",
+                            Version.getVersion())))
+            .withApplicationRoot(jar -> jar.addClasses(
+                    Dispatcher.class,
+                    CachedLookup.class,
+                    RequestData.class));
+
+    @Inject
+    Dispatcher dispatcher;
+
+    @Inject
+    CacheManager cacheManager;
+
+    @Test
+    void requestScopedDataVisibleInsideCacheResultWhenCdiClearedOnManagedExecutor() throws Exception {
+        cacheManager.getCache("issue-52119-cache").ifPresent(cache -> cache.invalidateAll().await().indefinitely());
+
+        String withoutCache = dispatcher.lookupWithoutCache().get(5, TimeUnit.SECONDS);
+        assertEquals("expected", withoutCache,
+                "baseline: manual RequestContext + cleared CDI without @CacheResult");
+
+        String withCache = dispatcher.lookupWithCache().get(5, TimeUnit.SECONDS);
+        assertEquals("expected", withCache,
+                "@CacheResult must see RequestScoped data set on the worker after CDI was cleared");
+    }
+
+    @ApplicationScoped
+    static class Dispatcher {
+
+        @Inject
+        @ManagedExecutorConfig(propagated = ThreadContext.ALL_REMAINING, cleared = ThreadContext.CDI)
+        @NamedInstance("cleared-cdi")
+        ManagedExecutor clearedCdiExecutor;
+
+        @Inject
+        RequestContextController requestContextController;
+
+        @Inject
+        RequestData requestData;
+
+        @Inject
+        CachedLookup cachedLookup;
+
+        CompletableFuture<String> lookupWithoutCache() {
+            return clearedCdiExecutor.supplyAsync(() -> {
+                requestContextController.activate();
+                try {
+                    requestData.setValue("expected");
+                    return cachedLookup.lookup();
+                } finally {
+                    requestData.setValue(null);
+                    requestContextController.deactivate();
+                }
+            });
+        }
+
+        CompletableFuture<String> lookupWithCache() {
+            return clearedCdiExecutor.supplyAsync(() -> {
+                requestContextController.activate();
+                try {
+                    requestData.setValue("expected");
+                    return cachedLookup.lookupFromCache();
+                } finally {
+                    requestData.setValue(null);
+                    requestContextController.deactivate();
+                }
+            });
+        }
+    }
+
+    @ApplicationScoped
+    static class CachedLookup {
+
+        @Inject
+        RequestData requestData;
+
+        String lookup() {
+            return requestData.getValue();
+        }
+
+        @CacheResult(cacheName = "issue-52119-cache")
+        String lookupFromCache() {
+            return requestData.getValue();
+        }
+    }
+
+    @RequestScoped
+    static class RequestData {
+
+        private String value;
+
+        String getValue() {
+            return value;
+        }
+
+        void setValue(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/AbstractCache.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/AbstractCache.java
@@ -1,7 +1,11 @@
 package io.quarkus.cache.runtime;
 
+import java.time.Duration;
+import java.util.function.Function;
+
 import io.quarkus.cache.Cache;
 import io.quarkus.cache.DefaultCacheKey;
+import io.smallrye.mutiny.Uni;
 
 public abstract class AbstractCache implements Cache {
 
@@ -25,6 +29,29 @@ public abstract class AbstractCache implements Cache {
         } else {
             throw new IllegalStateException("This cache is not an instance of " + type.getName());
         }
+    }
+
+    /**
+     * Synchronous compute-if-absent used by {@code @CacheResult} on non-async methods.
+     * <p>
+     * Default implementation uses {@link #get(Object, Function)} + {@code Uni.await()}.
+     * Caffeine overrides this to join the underlying {@link java.util.concurrent.CompletableFuture}
+     * without Mutiny, which avoids SmallRye Context Propagation clearing an activated CDI request
+     * context when a {@code ManagedExecutor} has {@code cleared=CDI}.
+     */
+    public <K, V> V getSynchronous(K key, Function<K, V> valueLoader) {
+        return get(key, valueLoader).await().indefinitely();
+    }
+
+    /**
+     * Same as {@link #getSynchronous(Object, Function)} with a lock timeout in milliseconds.
+     * Throws {@link io.smallrye.mutiny.TimeoutException} if the wait times out.
+     */
+    public <K, V> V getSynchronous(K key, Function<K, V> valueLoader, long lockTimeoutMillis) {
+        if (lockTimeoutMillis <= 0) {
+            return getSynchronous(key, valueLoader);
+        }
+        return get(key, valueLoader).await().atMost(Duration.ofMillis(lockTimeoutMillis));
     }
 
 }

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheResultInterceptor.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheResultInterceptor.java
@@ -86,7 +86,12 @@ public class CacheResultInterceptor extends CacheInterceptor {
                         });
                 return createAsyncResult(cacheValue, returnType);
             } else {
-                Uni<Object> cacheValue = cache.get(key, new Function<Object, Object>() {
+                /*
+                 * Prefer the synchronous cache API over Uni.await(). With a ManagedExecutor that clears CDI,
+                 * Mutiny + SmallRye Context Propagation can re-apply that cleared ThreadContext and wipe a
+                 * RequestContext activated on this thread.
+                 */
+                Function<Object, Object> valueLoader = new Function<Object, Object>() {
                     @Override
                     public Object apply(Object k) {
                         try {
@@ -99,24 +104,21 @@ public class CacheResultInterceptor extends CacheInterceptor {
                             throw new CacheException(e);
                         }
                     }
-                });
-                Object value;
+                };
                 if (binding.lockTimeout() <= 0) {
-                    value = cacheValue.await().indefinitely();
-                } else {
-                    try {
-                        /*
-                         * If the current thread started the cache value computation, then the computation is already finished
-                         * since
-                         * it was done synchronously and the following call will never time out.
-                         */
-                        value = cacheValue.await().atMost(Duration.ofMillis(binding.lockTimeout()));
-                    } catch (TimeoutException e) {
-                        // TODO: Add statistics here to monitor the timeout.
-                        return invocationContext.proceed();
-                    }
+                    return cache.getSynchronous(key, valueLoader);
                 }
-                return value;
+                try {
+                    /*
+                     * If the current thread started the cache value computation, then the computation is already finished
+                     * since
+                     * it was done synchronously and the following call will never time out.
+                     */
+                    return cache.getSynchronous(key, valueLoader, binding.lockTimeout());
+                } catch (TimeoutException e) {
+                    // TODO: Add statistics here to monitor the timeout.
+                    return invocationContext.proceed();
+                }
             }
 
         } catch (CacheException e) {

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheImpl.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheImpl.java
@@ -6,7 +6,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -97,6 +100,42 @@ public class CaffeineCacheImpl extends AbstractCache implements CaffeineCache {
                         return cast(caffeineValue);
                     }
                 });
+    }
+
+    @Override
+    public <K, V> V getSynchronous(K key, Function<K, V> valueLoader) {
+        return getSynchronous(key, valueLoader, -1);
+    }
+
+    /**
+     * Sync compute-if-absent for {@code @CacheResult} on non-async methods.
+     * Joins {@link #getFromCaffeine} directly so Mutiny {@code Uni.await()} is not involved.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K, V> V getSynchronous(K key, Function<K, V> valueLoader, long lockTimeoutMillis) {
+        Objects.requireNonNull(key, NULL_KEYS_NOT_SUPPORTED_MSG);
+        try {
+            CompletableFuture<Object> future = getFromCaffeine(key, valueLoader);
+            if (lockTimeoutMillis <= 0) {
+                return (V) future.get();
+            }
+            return (V) future.get(lockTimeoutMillis, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            throw new io.smallrye.mutiny.TimeoutException();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CacheException(e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause() == null ? e : e.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            throw new CacheException(cause);
+        }
     }
 
     @Override

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/noop/NoOpCache.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/noop/NoOpCache.java
@@ -36,6 +36,16 @@ public class NoOpCache extends AbstractCache {
     }
 
     @Override
+    public <K, V> V getSynchronous(K key, Function<K, V> valueLoader) {
+        return valueLoader.apply(key);
+    }
+
+    @Override
+    public <K, V> V getSynchronous(K key, Function<K, V> valueLoader, long lockTimeoutMillis) {
+        return valueLoader.apply(key);
+    }
+
+    @Override
     public Uni<Void> invalidate(Object key) {
         return Uni.createFrom().voidItem();
     }


### PR DESCRIPTION
When a `ManagedExecutor` is configured with `cleared = ThreadContext.CDI`, callers often activate a `RequestContext` on the worker and then invoke a `@CacheResult` method. The synchronous interceptor path previously went through Mutiny `Uni.await()`, which let SmallRye Context Propagation re-apply the executor's cleared CDI `ThreadContext` and wipe that RequestContext — so RequestScoped data (including `SecurityIdentity` in production) became `null` and was cached.

The sync `@CacheResult` path now uses a direct Caffeine compute-if-absent API (`getSynchronous`) that does not enter Mutiny, so the manually activated RequestContext stays visible while the method body runs.


- Fixes: https://github.com/quarkusio/quarkus/issues/52119