### PR TITLE
Provide simple way to evaluate HTTP permissions for a given route

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/ManagementInterfaceBasicAuthTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/ManagementInterfaceBasicAuthTest.java
@@ -7,6 +7,7 @@ import java.util.function.Supplier;
 
 import jakarta.enterprise.event.Observes;
 
+import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -19,14 +20,19 @@ import io.quarkus.security.test.utils.TestIdentityProvider;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.vertx.http.ManagementInterface;
+import io.quarkus.vertx.http.runtime.security.ManagementInterfaceHttpAuthorizer;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
+import io.quarkus.vertx.http.runtime.security.SecurityHandlerPriorities;
 import io.restassured.RestAssured;
+import io.vertx.ext.web.RoutingContext;
 
 /**
  * Tests that basic authentication is enabled for the management interface when no other
  * mechanism is available.
  */
 public class ManagementInterfaceBasicAuthTest {
+
+    private static final String CHECK_RESULT_HEADER = "check-result-header-name";
 
     @RegisterExtension
     static QuarkusExtensionTest test = new QuarkusExtensionTest().setArchiveProducer(new Supplier<>() {
@@ -48,10 +54,14 @@ public class ManagementInterfaceBasicAuthTest {
     @TestHTTPResource(value = "/metrics", management = true)
     URL metrics;
 
+    @TestHTTPResource(value = "/traces", management = true)
+    URL traces;
+
     @BeforeAll
     public static void setup() {
         TestIdentityController.resetRoles()
-                .add("admin", "admin", "admin");
+                .add("admin", "admin", "admin")
+                .add("user", "user", "user");
     }
 
     @Test
@@ -65,7 +75,8 @@ public class ManagementInterfaceBasicAuthTest {
                 .then()
                 .assertThat()
                 .statusCode(200)
-                .body(equalTo("admin:" + metrics.getPath()));
+                .body(equalTo("admin:" + metrics.getPath()))
+                .header(CHECK_RESULT_HEADER, Matchers.is("true"));
 
     }
 
@@ -77,7 +88,22 @@ public class ManagementInterfaceBasicAuthTest {
                 .get(metrics)
                 .then()
                 .assertThat()
-                .statusCode(401);
+                .statusCode(401)
+                .header(CHECK_RESULT_HEADER, Matchers.is("false"));
+
+    }
+
+    @Test
+    public void testBasicAuthFailureInsufficientRoles() {
+        RestAssured
+                .given()
+                .auth().preemptive().basic("user", "user")
+                .redirects().follow(false)
+                .get(metrics)
+                .then()
+                .assertThat()
+                .statusCode(403)
+                .header(CHECK_RESULT_HEADER, Matchers.is("false"));
 
     }
 
@@ -107,6 +133,21 @@ public class ManagementInterfaceBasicAuthTest {
     }
 
     @Test
+    public void testPermissionEvaluationReturnsNullWhenNoAuthorization() {
+        RestAssured
+                .given()
+                .auth().preemptive().basic("admin", "admin")
+                .redirects().follow(false)
+                .when()
+                .get(traces)
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body(equalTo("admin:" + traces.getPath()))
+                .header(CHECK_RESULT_HEADER, Matchers.nullValue());
+    }
+
+    @Test
     public void testBasicAuthFailureWrongPasswordWithMatrix() {
         RestAssured
                 .given()
@@ -121,17 +162,31 @@ public class ManagementInterfaceBasicAuthTest {
 
     public static class ManagementPathHandler {
 
-        void setup(@Observes ManagementInterface mi) {
-            mi.router().get("/q/metrics").handler(event -> {
-                QuarkusHttpUser user = (QuarkusHttpUser) event.user();
-                StringBuilder ret = new StringBuilder();
-                if (user != null) {
-                    ret.append(user.getSecurityIdentity().getPrincipal().getName());
-                }
-                ret.append(":");
-                ret.append(event.normalizedPath());
-                event.response().end(ret.toString());
-            });
+        void setup(@Observes ManagementInterface mi, ManagementInterfaceHttpAuthorizer managementAuthorizer) {
+            mi.router().route().order(-1 * (SecurityHandlerPriorities.AUTHENTICATION - 10))
+                    .handler(event -> managementAuthorizer
+                            .evaluatePermission(event).subscribe().with(
+                                    checkResult -> {
+                                        if (checkResult != null) {
+                                            event.response().putHeader(CHECK_RESULT_HEADER,
+                                                    Boolean.toString(checkResult.isPermitted()));
+                                        }
+                                        event.next();
+                                    },
+                                    throwable -> event.fail(500, throwable)));
+            mi.router().get("/q/metrics").handler(ManagementInterfaceBasicAuthTest::respond);
+            mi.router().get("/q/traces").handler(ManagementInterfaceBasicAuthTest::respond);
         }
+    }
+
+    private static void respond(RoutingContext event) {
+        QuarkusHttpUser user = (QuarkusHttpUser) event.user();
+        StringBuilder ret = new StringBuilder();
+        if (user != null) {
+            ret.append(user.getSecurityIdentity().getPrincipal().getName());
+        }
+        ret.append(":");
+        ret.append(event.normalizedPath());
+        event.response().end(ret.toString());
     }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/PathMatchingHttpSecurityPolicyTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/PathMatchingHttpSecurityPolicyTest.java
@@ -2,9 +2,11 @@ package io.quarkus.vertx.http.security;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.net.URL;
 import java.time.Duration;
+import java.util.function.Function;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
@@ -27,9 +29,12 @@ import io.quarkus.security.test.utils.TestIdentityController;
 import io.quarkus.security.test.utils.TestIdentityProvider;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.runtime.security.HttpAuthorizer;
 import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
+import io.quarkus.vertx.http.runtime.security.SecurityHandlerPriorities;
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
@@ -351,12 +356,32 @@ public abstract class PathMatchingHttpSecurityPolicyTest {
         // here no HTTP Security policy that requires authentication is applied, and we want to check that identity
         // is still augmented
         assurePath("/api/public", 200, null, "public1", null);
-        assurePath("/api/public", 403, null, "root1", null);
+        // here 403 comes from a test route logic, not from the authorization itself, hence override expected result
+        Function<Integer, PermissionEvaluationResult> statusCodeToEvalResult = s -> PermissionEvaluationResult.PERMIT;
+        assurePath("/api/public", 403, null, "root1", null, statusCodeToEvalResult);
+    }
+
+    enum PermissionEvaluationResult {
+        PERMIT,
+        DENY,
+        PUBLIC_ROUTE
     }
 
     @ApplicationScoped
     public static class RouteHandler {
-        public void setup(@Observes Router router) {
+        public void setup(@Observes Router router, HttpAuthorizer httpAuthorizer) {
+            Handler<RoutingContext> permissionEvaluationHandler = rc -> httpAuthorizer
+                    .evaluatePermission(rc).subscribe().with(item -> {
+                        final PermissionEvaluationResult result;
+                        if (item == null) {
+                            result = PermissionEvaluationResult.PUBLIC_ROUTE;
+                        } else {
+                            result = item.isPermitted() ? PermissionEvaluationResult.PERMIT : PermissionEvaluationResult.DENY;
+                        }
+                        rc.response().putHeader(PermissionEvaluationResult.class.getSimpleName(), result.toString());
+                        rc.next();
+                    }, err -> rc.fail(500, err));
+            router.route().order(-1 * (SecurityHandlerPriorities.AUTHENTICATION - 10)).handler(permissionEvaluationHandler);
             router.route("/api/baz").order(-1).handler(rc -> rc.response().end("/api/baz response"));
             router.route("/api/public").order(-1).handler(rc -> {
                 if (rc.user() instanceof QuarkusHttpUser user && user.getSecurityIdentity() != null
@@ -378,6 +403,17 @@ public abstract class PathMatchingHttpSecurityPolicyTest {
     }
 
     private void assurePath(String path, int expectedStatusCode, String body, String auth, String header) {
+        Function<Integer, PermissionEvaluationResult> statusCodeToEvalResult = statusCode -> {
+            if (expectedStatusCode == 401 || expectedStatusCode == 403) {
+                return PermissionEvaluationResult.DENY;
+            }
+            return PermissionEvaluationResult.PERMIT;
+        };
+        assurePath(path, expectedStatusCode, body, auth, header, statusCodeToEvalResult);
+    }
+
+    private void assurePath(String path, int expectedStatusCode, String body, String auth, String header,
+            Function<Integer, PermissionEvaluationResult> statusCodeToEvalResult) {
         var req = getClient().get(url.getPort(), url.getHost(), path);
         if (auth != null) {
             req.basicAuthentication(auth, auth);
@@ -387,10 +423,16 @@ public abstract class PathMatchingHttpSecurityPolicyTest {
         }
         var result = req.send();
         await().atMost(REQUEST_TIMEOUT).until(result::isComplete);
-        assertEquals(expectedStatusCode, result.result().statusCode(), path);
+        int resultStatusCode = result.result().statusCode();
+        assertEquals(expectedStatusCode, resultStatusCode, path);
         if (body != null) {
             Assertions.assertTrue(result.result().bodyAsString().contains(body), path);
         }
+        String evaluationResult = result.result().getHeader(PermissionEvaluationResult.class.getSimpleName());
+        assertNotNull(evaluationResult);
+        PermissionEvaluationResult actualEvaluationResult = PermissionEvaluationResult.valueOf(evaluationResult);
+        PermissionEvaluationResult expectedEvaluationResult = statusCodeToEvalResult.apply(expectedStatusCode);
+        assertEquals(expectedEvaluationResult, actualEvaluationResult);
     }
 
     @Singleton

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AbstractHttpAuthorizer.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AbstractHttpAuthorizer.java
@@ -24,6 +24,7 @@ import io.quarkus.security.spi.runtime.AuthorizationFailureEvent;
 import io.quarkus.security.spi.runtime.AuthorizationSuccessEvent;
 import io.quarkus.security.spi.runtime.BlockingSecurityExecutor;
 import io.quarkus.security.spi.runtime.SecurityEventHelper;
+import io.quarkus.vertx.http.runtime.security.ManagementInterfaceHttpAuthorizer.ManagementPathMatchingHttpSecurityPolicyWrapper;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.UniSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscription;
@@ -48,10 +49,43 @@ abstract class AbstractHttpAuthorizer {
             Event<AuthorizationSuccessEvent> authZSuccessEvent, boolean securityEventsEnabled) {
         this.identityProviderManager = identityProviderManager;
         this.controller = controller;
-        this.policies = policies;
+        this.policies = List.copyOf(policies);
         this.context = new HttpSecurityPolicy.DefaultAuthorizationRequestContext(blockingExecutor);
         this.securityEventHelper = new SecurityEventHelper<>(authZSuccessEvent, authZFailureEvent, AUTHORIZATION_SUCCESS,
                 AUTHORIZATION_FAILURE, beanManager, securityEventsEnabled);
+    }
+
+    /**
+     * Applies {@link HttpSecurityPolicy} configured for this route and returns the permission check result.
+     *
+     * @param routingContext {@link RoutingContext}
+     * @return {@link HttpSecurityPolicy.CheckResult} if at least one {@link HttpSecurityPolicy} was applied;
+     *         the check returns null if no {@link HttpSecurityPolicy} was applied or authorization was disabled
+     */
+    public Uni<HttpSecurityPolicy.CheckResult> evaluatePermission(RoutingContext routingContext) {
+        if (!controller.isAuthorizationEnabled() || policies.isEmpty()) {
+            return Uni.createFrom().nullItem();
+        }
+        return doPermissionCheck(routingContext, false)
+                .map(checkResult -> {
+                    if (checkResult == null || !checkResult.isPermitted()) {
+                        // illegal state - this code should be unreachable
+                        return HttpSecurityPolicy.CheckResult.DENY;
+                    }
+
+                    boolean anyCheckRun = permissionCheckPerformed(routingContext, policies.size() - 1);
+                    if (anyCheckRun) {
+                        return checkResult;
+                    }
+                    return null;
+                })
+                .onFailure().recoverWithItem(t -> {
+                    SecurityIdentity augmentedIdentity = null;
+                    if (t instanceof DoDenyException doDenyException) {
+                        augmentedIdentity = doDenyException.augmentedIdentity;
+                    }
+                    return new HttpSecurityPolicy.CheckResult(false, augmentedIdentity);
+                });
     }
 
     /**
@@ -64,7 +98,7 @@ abstract class AbstractHttpAuthorizer {
             return;
         }
 
-        doPermissionCheck(routingContext, QuarkusHttpUser.getSecurityIdentity(routingContext, identityProviderManager), 0, null)
+        doPermissionCheck(routingContext, securityEventHelper.fireEventOnSuccess())
                 .subscribe().with(new Consumer<HttpSecurityPolicy.CheckResult>() {
                     @Override
                     public void accept(HttpSecurityPolicy.CheckResult checkResult) {
@@ -104,8 +138,13 @@ abstract class AbstractHttpAuthorizer {
                 });
     }
 
+    private Uni<HttpSecurityPolicy.CheckResult> doPermissionCheck(RoutingContext routingContext, boolean fireEventOnSuccess) {
+        return doPermissionCheck(routingContext, QuarkusHttpUser.getSecurityIdentity(routingContext, identityProviderManager),
+                0, null, fireEventOnSuccess);
+    }
+
     private Uni<HttpSecurityPolicy.CheckResult> doPermissionCheck(RoutingContext routingContext,
-            Uni<SecurityIdentity> identityUni, int index, SecurityIdentity identity) {
+            Uni<SecurityIdentity> identityUni, int index, SecurityIdentity identity, boolean fireEventOnSuccess) {
         return policies.get(index)
                 .checkPermission(routingContext, identityUni, context)
                 .onItem().transformToUni(checkResult -> {
@@ -135,12 +174,11 @@ abstract class AbstractHttpAuthorizer {
                                 // perform security identity augmentation
                                 setIdentity(augmentedIdentity, routingContext);
                             }
-                            if (securityEventHelper.fireEventOnSuccess()) {
+                            if (fireEventOnSuccess) {
                                 securityEventHelper.fireSuccessEvent(new AuthorizationSuccessEvent(augmentedIdentity,
                                         Map.of(RoutingContext.class.getName(), routingContext)));
                             }
-                        } else if (securityEventHelper.fireEventOnSuccess()
-                                && permissionCheckPerformed(policies, routingContext, index)) {
+                        } else if (fireEventOnSuccess && permissionCheckPerformed(routingContext, index)) {
                             securityEventHelper.fireSuccessEvent(
                                     new AuthorizationSuccessEvent(
                                             currentUser == null ? null : currentUser.getSecurityIdentity(),
@@ -149,7 +187,8 @@ abstract class AbstractHttpAuthorizer {
                         return Uni.createFrom().item(checkResult);
                     } else {
                         // perform the next check
-                        return doPermissionCheck(routingContext, augmentedIdentityUni, index + 1, augmentedIdentity);
+                        return doPermissionCheck(routingContext, augmentedIdentityUni, index + 1, augmentedIdentity,
+                                fireEventOnSuccess);
                     }
                 });
     }
@@ -226,11 +265,11 @@ abstract class AbstractHttpAuthorizer {
         }
     }
 
-    private static boolean permissionCheckPerformed(List<HttpSecurityPolicy> permissionCheckers,
-            RoutingContext routingContext, int index) {
+    private boolean permissionCheckPerformed(RoutingContext routingContext, int index) {
         // the path matching policy is not permission check itself, it selects policy based on
         // configured HTTP permissions, but if there are no path matching HTTP permissions, there is no check
-        if (index == 0 && permissionCheckers.get(0) instanceof AbstractPathMatchingHttpSecurityPolicy) {
+        if (index == 0 && (policies.get(0) instanceof AbstractPathMatchingHttpSecurityPolicy
+                || policies.get(0) instanceof ManagementPathMatchingHttpSecurityPolicyWrapper)) {
             return AbstractPathMatchingHttpSecurityPolicy.policyApplied(routingContext);
         }
         return index > 0;

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/ManagementInterfaceHttpAuthorizer.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/ManagementInterfaceHttpAuthorizer.java
@@ -29,14 +29,17 @@ public class ManagementInterfaceHttpAuthorizer extends AbstractHttpAuthorizer {
             Event<AuthorizationSuccessEvent> authZSuccessEvent, BeanManager beanManager,
             @ConfigProperty(name = "quarkus.security.events.enabled") boolean securityEventsEnabled) {
         super(identityProviderManager, controller,
-                List.of(new HttpSecurityPolicy() {
+                List.of(new ManagementPathMatchingHttpSecurityPolicyWrapper(installedPolicy)),
+                beanManager, blockingExecutor, authZFailureEvent, authZSuccessEvent, securityEventsEnabled);
+    }
 
-                    @Override
-                    public Uni<CheckResult> checkPermission(RoutingContext request, Uni<SecurityIdentity> identity,
-                            AuthorizationRequestContext requestContext) {
-                        return installedPolicy.checkPermission(request, identity, requestContext);
-                    }
+    record ManagementPathMatchingHttpSecurityPolicyWrapper(
+            ManagementPathMatchingHttpSecurityPolicy installedPolicy) implements HttpSecurityPolicy {
 
-                }), beanManager, blockingExecutor, authZFailureEvent, authZSuccessEvent, securityEventsEnabled);
+        @Override
+        public Uni<CheckResult> checkPermission(RoutingContext request, Uni<SecurityIdentity> identity,
+                AuthorizationRequestContext requestContext) {
+            return installedPolicy.checkPermission(request, identity, requestContext);
+        }
     }
 }


### PR DESCRIPTION
* closes: https://github.com/quarkusio/quarkus/issues/55458
* this PR provides a way to evaluate if any HTTP security policy is applied on the given route and if so, whether the given incoming request should be allowed to access
* it is as minimalist as I could think of, I think it is fairly edge case and we should not invest time into API or maintaining more code than strictly necessary until there is more demand for such evaluator