### PR TITLE
Fix typos and duplicated text in guide summaries

### DIFF
--- a/docs/src/main/asciidoc/amqp-reference.adoc
+++ b/docs/src/main/asciidoc/amqp-reference.adoc
@@ -9,7 +9,7 @@ include::_attributes.adoc[]
 :extensions: io.quarkus:quarkus-messaging-amqp
 :topics: messaging,amqp
 
-This guide is the companion from the xref:amqp.adoc[Getting Started with AMQP 1.0].
+This guide is the companion to the xref:amqp.adoc[Getting Started with AMQP 1.0].
 It explains in more details the configuration and usage of the AMQP connector for reactive messaging.
 
 TIP: This documentation does not cover all the details of the connector.

--- a/docs/src/main/asciidoc/conditional-extension-dependencies.adoc
+++ b/docs/src/main/asciidoc/conditional-extension-dependencies.adoc
@@ -6,7 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Conditional Extension Dependencies
 include::_attributes.adoc[]
 :categories: writing-extensions
-:summary: Trigger the inclusion on additional extensions based on certain conditions.
+:summary: Trigger the inclusion of additional extensions based on certain conditions.
 :topics: extensions
 
 Quarkus extension dependencies are usually configured in the same way as any other project dependencies in a project's build file, for example the Maven `pom.xml` or the Gradle build scripts. However, Quarkus also supports types of dependencies that aren't supported out-of-the-box by Maven and Gradle. Conditional Quarkus extension dependencies is one such example.

--- a/docs/src/main/asciidoc/credentials-provider.adoc
+++ b/docs/src/main/asciidoc/credentials-provider.adoc
@@ -6,7 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using a Credentials Provider
 include::_attributes.adoc[]
 :categories: security
-:summary: This guides explains how to use the Vault credentials provider or implement your own custom one.
+:summary: This guide explains how to use the Vault credentials provider or implement your own custom one.
 :extension-status: preview
 :topics: security,credentials
 

--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -6,7 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Simplified Hibernate ORM with Panache
 include::_attributes.adoc[]
 :categories: data
-:summary: Hibernate ORM is the de facto Jakarta Persistence implementation and offers you the full breadth of an Object Relational Mapper. It makes complex mappings possible, but it does not make simple and common mappings trivial. Panache focuses on making your entities trivial and fun to write.
+:summary: Panache focuses on making your Hibernate ORM entities trivial and fun to write.
 :config-file: application.properties
 :topics: data,hibernate-orm,panache,sql,jdbc
 :extensions: io.quarkus:quarkus-hibernate-orm-panache,io.quarkus:quarkus-hibernate-orm

--- a/docs/src/main/asciidoc/liquibase-mongodb.adoc
+++ b/docs/src/main/asciidoc/liquibase-mongodb.adoc
@@ -12,7 +12,7 @@ include::_attributes.adoc[]
 :extensions: io.quarkus:quarkus-liquibase-mongodb
 
 https://www.liquibase.org/[Liquibase] is an open source tool for database schema change management,
-it allows managing MongoDB databases via it's https://github.com/liquibase/liquibase-mongodb[MongoDB Extension].
+it allows managing MongoDB databases via its https://github.com/liquibase/liquibase-mongodb[MongoDB Extension].
 
 Quarkus provides first class support for using Liquibase MongoDB Extension as will be explained in this guide.
 

--- a/docs/src/main/asciidoc/lra.adoc
+++ b/docs/src/main/asciidoc/lra.adoc
@@ -6,7 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Narayana LRA Participant Support
 include::_attributes.adoc[]
 :categories: data
-:summary: This guides covers the usage of LRA to coordinate activities across services.
+:summary: This guide covers the usage of LRA to coordinate activities across services.
 :topics: data,lra,narayana
 :extensions: io.quarkus:quarkus-narayana-lra
 

--- a/docs/src/main/asciidoc/observability.adoc
+++ b/docs/src/main/asciidoc/observability.adoc
@@ -7,7 +7,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 include::_attributes.adoc[]
 :diataxis-type: reference
 :categories: observability
-:summary: This guide explains how your Quarkus application can utilize OpenTelemetry to provide observability for interactive web applications.
+:summary: An overview of the observability capabilities of Quarkus.
 :topics: observability,opentelemetry, micrometer, jfr, logging, metrics, tracing, monitoring, devservice
 :extensions: io.quarkus:quarkus-opentelemetry,io.quarkus:quarkus-micrometer,io.quarkus:quarkus-jfr
 

--- a/docs/src/main/asciidoc/rabbitmq-reference.adoc
+++ b/docs/src/main/asciidoc/rabbitmq-reference.adoc
@@ -10,7 +10,7 @@ include::_attributes.adoc[]
 :topics: messaging,reactive-messaging,rabbitmq,dev-services,testing,dev-mode
 :extensions: io.quarkus:quarkus-messaging-rabbitmq
 
-This guide is the companion from the xref:rabbitmq.adoc[Getting Started with RabbitMQ].
+This guide is the companion to the xref:rabbitmq.adoc[Getting Started with RabbitMQ].
 It explains in more details the configuration and usage of the RabbitMQ connector for reactive messaging.
 
 TIP: This documentation does not cover all the details of the connector.

--- a/docs/src/main/asciidoc/security-ldap.adoc
+++ b/docs/src/main/asciidoc/security-ldap.adoc
@@ -6,7 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using Security with an LDAP Realm
 include::_attributes.adoc[]
 :categories: security
-:summary: This guide demonstrates how your Quarkus application can use a LDAP directory to store your user identities.
+:summary: This guide demonstrates how your Quarkus application can use an LDAP directory to store your user identities.
 :topics: security,identity-providers,ldap
 :extensions: io.quarkus:quarkus-elytron-security-ldap
 

--- a/docs/src/main/asciidoc/software-transactional-memory.adoc
+++ b/docs/src/main/asciidoc/software-transactional-memory.adoc
@@ -6,7 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using Software Transactional Memory in Quarkus
 include::_attributes.adoc[]
 :categories: data
-:summary: This guides covers the usage of Software Transactional Memory (STM).
+:summary: This guide covers the usage of Software Transactional Memory (STM).
 :extension-status: preview
 :topics: narayana,stm,transactions
 :extensions: io.quarkus:quarkus-narayana-stm

--- a/docs/src/main/asciidoc/stork-reference.adoc
+++ b/docs/src/main/asciidoc/stork-reference.adoc
@@ -10,7 +10,7 @@ include::_attributes.adoc[]
 :topics: service-discovery,load-balancing,stork
 :extensions: io.quarkus:quarkus-smallrye-stork
 
-This guide is the companion from the xref:stork.adoc[Stork Getting Started Guide].
+This guide is the companion to the xref:stork.adoc[Stork Getting Started Guide].
 It explains the configuration and usage of SmallRye Stork integration in Quarkus.
 
 include::{includes}/extension-status.adoc[]

--- a/docs/src/main/asciidoc/transaction.adoc
+++ b/docs/src/main/asciidoc/transaction.adoc
@@ -10,7 +10,7 @@ include::_attributes.adoc[]
 :topics: data,jpa,jta,transactions,narayana
 :extensions: io.quarkus:quarkus-narayana-jta
 
-The `quarkus-narayana-jta` extension provides a Transaction Manager that coordinates and expose transactions to your applications as described in the link:https://jakarta.ee/specifications/transactions/[Jakarta Transactions] specification, formerly known as Java Transaction API (JTA).
+The `quarkus-narayana-jta` extension provides a Transaction Manager that coordinates and exposes transactions to your applications as described in the link:https://jakarta.ee/specifications/transactions/[Jakarta Transactions] specification, formerly known as Java Transaction API (JTA).
 
 When discussing Quarkus transactions, this guide refers to Jakarta Transactions transaction style and uses only the term _transaction_ to address them.
 

--- a/docs/src/main/asciidoc/websockets-next-tutorial.adoc
+++ b/docs/src/main/asciidoc/websockets-next-tutorial.adoc
@@ -7,7 +7,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 include::_attributes.adoc[]
 :categories: web
 :diataxis-type: tutorial
-:summary: This guide explains how your Quarkus application can utilize web sockets to create interactive web applications. This guide uses the WebSockets Next extension
+:summary: Get started with WebSockets Next to create interactive web applications.
 :topics: web,websockets
 :extensions: io.quarkus:quarkus-websockets-next
 


### PR DESCRIPTION
Small fixes to guide summaries and related text.

**Grammar and typos**

- "This guides covers/explains" → "This guide covers/explains" (lra, software-transactional-memory, credentials-provider)
- "the companion from the" → "the companion to the" (amqp-reference, rabbitmq-reference, stork-reference)
- "via it's" → "via its" (liquibase-mongodb)
- "coordinates and expose" → "coordinates and exposes" (transaction)
- "the inclusion on additional extensions" → "the inclusion of additional extensions" (conditional-extension-dependencies)
- "use a LDAP directory" → "use an LDAP directory" (security-ldap)

**Duplicated summaries**

Three pairs of guides currently show identical text on the quarkus.io guides index, because the site displays only the first sentence of a summary and these pairs shared it. This changes one guide in each pair so both tiles are distinct:

- websockets-next-tutorial (vs websockets)
- hibernate-orm-panache (vs hibernate-orm) — reuses the summary's own third sentence, which already named the difference
- observability (vs opentelemetry)

No preamble rewording beyond the typo fixes; no content changes.
