### PR TITLE
Allow colons in @PermissionsAllowed actions

### DIFF
--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/PermissionSecurityChecks.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/PermissionSecurityChecks.java
@@ -598,16 +598,16 @@ interface PermissionSecurityChecks {
                     }
                 } else if (permissionValExpression.contains(PERMISSION_TO_ACTION_SEPARATOR)) {
 
-                    // expected format: permission:action
-                    final String[] permissionToActionArr = permissionValExpression.split(PERMISSION_TO_ACTION_SEPARATOR);
-                    if (permissionToActionArr.length != 2) {
+                    // expected format: permission:action (only the first separator is used)
+                    final int separatorIdx = permissionValExpression.indexOf(PERMISSION_TO_ACTION_SEPARATOR);
+                    final String permissionName = permissionValExpression.substring(0, separatorIdx);
+                    final String action = permissionValExpression.substring(separatorIdx + 1);
+                    if (permissionName.isEmpty() || action.isEmpty()) {
                         throw new RuntimeException(String.format(
-                                "PermissionsAllowed value '%s' contains more than one separator '%2$s', expected format is 'permissionName%2$saction'",
+                                "PermissionsAllowed value '%s' has empty permission name or action, expected format is 'permissionName%2$saction'",
                                 permissionValExpression, PERMISSION_TO_ACTION_SEPARATOR));
                     }
-                    final PermissionNameAndChecker permissionNameKey = new PermissionNameAndChecker(permissionToActionArr[0],
-                            null);
-                    final String action = permissionToActionArr[1];
+                    final PermissionNameAndChecker permissionNameKey = new PermissionNameAndChecker(permissionName, null);
                     if (permissionToActions.containsKey(permissionNameKey)) {
                         permissionToActions.get(permissionNameKey).add(action);
                     } else {

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/PermissionsAllowedMultipleColonsTest.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/PermissionsAllowedMultipleColonsTest.java
@@ -1,0 +1,78 @@
+package io.quarkus.security.test.permissionsallowed;
+
+import static io.quarkus.security.test.utils.SecurityTestUtils.assertFailureFor;
+import static io.quarkus.security.test.utils.SecurityTestUtils.assertSuccess;
+
+import java.util.Collections;
+import java.util.Set;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.PermissionsAllowed;
+import io.quarkus.security.StringPermission;
+import io.quarkus.security.test.utils.AuthData;
+import io.quarkus.security.test.utils.IdentityMock;
+import io.quarkus.security.test.utils.SecurityTestUtils;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class PermissionsAllowedMultipleColonsTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(IdentityMock.class, AuthData.class, SecurityTestUtils.class));
+
+    @Inject
+    SecuredBean bean;
+
+    @Test
+    public void testPermissionWithActionContainingColons() {
+        // @PermissionsAllowed("system:role:query1") is parsed as permission "system" and action "role:query1"
+        var allowed = new AuthData(Collections.singleton("user"), false, "user",
+                Set.of(new StringPermission("system", "role:query1")));
+        assertSuccess(() -> bean.query(), "query", allowed);
+
+        var wrongAction = new AuthData(Collections.singleton("user"), false, "user",
+                Set.of(new StringPermission("system", "role:update")));
+        assertFailureFor(() -> bean.query(), ForbiddenException.class, wrongAction);
+
+        var wrongPermission = new AuthData(Collections.singleton("user"), false, "user",
+                Set.of(new StringPermission("system:role:query1")));
+        assertFailureFor(() -> bean.query(), ForbiddenException.class, wrongPermission);
+    }
+
+    @Test
+    public void testMultipleActionsWithColonsAreAggregated() {
+        // "system:role:query" and "system:role:update" aggregate into one StringPermission with both actions
+        var withQuery = new AuthData(Collections.singleton("user"), false, "user",
+                Set.of(new StringPermission("system", "role:query")));
+        assertSuccess(() -> bean.queryOrUpdate(), "queryOrUpdate", withQuery);
+
+        var withUpdate = new AuthData(Collections.singleton("user"), false, "user",
+                Set.of(new StringPermission("system", "role:update")));
+        assertSuccess(() -> bean.queryOrUpdate(), "queryOrUpdate", withUpdate);
+
+        var withNeither = new AuthData(Collections.singleton("user"), false, "user",
+                Set.of(new StringPermission("system", "role:delete")));
+        assertFailureFor(() -> bean.queryOrUpdate(), ForbiddenException.class, withNeither);
+    }
+
+    @Singleton
+    public static class SecuredBean {
+
+        @PermissionsAllowed("system:role:query1")
+        public String query() {
+            return "query";
+        }
+
+        @PermissionsAllowed({ "system:role:query", "system:role:update" })
+        public String queryOrUpdate() {
+            return "queryOrUpdate";
+        }
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AbstractPathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AbstractPathMatchingHttpSecurityPolicy.java
@@ -347,17 +347,17 @@ public class AbstractPathMatchingHttpSecurityPolicy {
     private static void addPermissionToAction(Map<String, PermissionToActions> cache, String role, String permissionToAction) {
         final String permissionName;
         final String action;
-        // incoming value is either in format perm1:action1 or perm1 (with or withot action)
+        // incoming value is either in format perm1:action1 or perm1 (only the first separator is used)
         if (permissionToAction.contains(PERMISSION_TO_ACTION_SEPARATOR)) {
             // perm1:action1
-            var permToActions = permissionToAction.split(PERMISSION_TO_ACTION_SEPARATOR);
-            if (permToActions.length != 2) {
+            final int separatorIdx = permissionToAction.indexOf(PERMISSION_TO_ACTION_SEPARATOR);
+            permissionName = permissionToAction.substring(0, separatorIdx).trim();
+            action = permissionToAction.substring(separatorIdx + 1).trim();
+            if (action.isEmpty()) {
                 throw new ConfigurationException(
-                        String.format("Invalid permission format '%s', please use exactly one permission to action separator",
-                                permissionToAction));
+                        String.format("Invalid permission format '%s', expected 'permissionName%2$saction' or 'permissionName'",
+                                permissionToAction, PERMISSION_TO_ACTION_SEPARATOR));
             }
-            permissionName = permToActions[0].trim();
-            action = permToActions[1].trim();
         } else {
             // perm1
             permissionName = permissionToAction.trim();


### PR DESCRIPTION
Fixes #55545

`@PermissionsAllowed` values with more than one `:` (for example
`system:role:query`) failed the build with:

```
PermissionsAllowed value '...' contains more than one separator ':',
expected format is 'permissionName:action'
```

Parsing now uses only the first separator, so the permission name is the
part before it and the action is everything after it. That matches how
`@TestSecurity` already works, and the same approach is applied to
role-to-permission mapping in HTTP configuration.