### PR TITLE
Module tree shaking for JLink

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/JarTreeShakeBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/JarTreeShakeBuildItem.java
@@ -18,12 +18,14 @@ public final class JarTreeShakeBuildItem extends SimpleBuildItem {
     private final boolean classesShaken;
     private final Set<String> reachableClassNames;
     private final Map<ArtifactKey, List<String>> removedClasses;
+    private final Set<String> referencedJdkPackages;
 
     public JarTreeShakeBuildItem(boolean classesShaken, Set<String> reachableClassNames,
-            Map<ArtifactKey, List<String>> removedClasses) {
+            Map<ArtifactKey, List<String>> removedClasses, Set<String> referencedJdkPackages) {
         this.classesShaken = classesShaken;
         this.reachableClassNames = reachableClassNames;
         this.removedClasses = removedClasses;
+        this.referencedJdkPackages = referencedJdkPackages;
     }
 
     public boolean isClassesShaken() {
@@ -42,6 +44,13 @@ public final class JarTreeShakeBuildItem extends SimpleBuildItem {
      */
     public Map<ArtifactKey, List<String>> getRemovedClasses() {
         return removedClasses;
+    }
+
+    /**
+     * @return dot-separated JDK package names (java.*, javax.*, jdk.*) referenced by reachable code
+     */
+    public Set<String> getReferencedJdkPackages() {
+        return referencedJdkPackages;
     }
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/JarTreeShakeBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/JarTreeShakeBuildItem.java
@@ -21,12 +21,14 @@ public final class JarTreeShakeBuildItem extends SimpleBuildItem {
     private final boolean classesShaken;
     private final Set<String> reachableClassNames;
     private final Map<ArtifactKey, List<String>> removedClasses;
+    private final Set<String> referencedJdkPackages;
 
     public JarTreeShakeBuildItem(boolean classesShaken, Set<String> reachableClassNames,
-            Map<ArtifactKey, List<String>> removedClasses) {
+            Map<ArtifactKey, List<String>> removedClasses, Set<String> referencedJdkPackages) {
         this.classesShaken = classesShaken;
         this.reachableClassNames = reachableClassNames;
         this.removedClasses = removedClasses;
+        this.referencedJdkPackages = referencedJdkPackages;
     }
 
     public boolean isClassesShaken() {
@@ -83,6 +85,13 @@ public final class JarTreeShakeBuildItem extends SimpleBuildItem {
                 }
             });
         }
+    }
+
+    /**
+     * @return dot-separated JDK package names (java.*, javax.*, jdk.*) referenced by reachable code
+     */
+    public Set<String> getReferencedJdkPackages() {
+        return referencedJdkPackages;
     }
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarTreeShakeProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarTreeShakeProcessor.java
@@ -49,6 +49,7 @@ import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.DependencyFlags;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.paths.OpenPathTree;
+import io.quarkus.runtime.LaunchMode;
 
 public class JarTreeShakeProcessor {
 
@@ -58,14 +59,17 @@ public class JarTreeShakeProcessor {
 
     static class TreeShakeEnabled implements BooleanSupplier {
         private final PackageConfig packageConfig;
+        private final LaunchMode launchMode;
 
-        TreeShakeEnabled(PackageConfig packageConfig) {
+        TreeShakeEnabled(PackageConfig packageConfig, LaunchMode launchMode) {
             this.packageConfig = packageConfig;
+            this.launchMode = launchMode;
         }
 
         @Override
         public boolean getAsBoolean() {
-            return packageConfig.jar().treeShake().mode() == TreeShakeConfig.TreeShakeMode.CLASSES
+            return launchMode == LaunchMode.NORMAL
+                    && packageConfig.jar().treeShake().mode() == TreeShakeConfig.TreeShakeMode.CLASSES
                     && packageConfig.jar().type() != PackageConfig.JarConfig.JarType.MUTABLE_JAR;
         }
     }
@@ -86,7 +90,7 @@ public class JarTreeShakeProcessor {
     void skipTreeShaking(BuildProducer<JarTreeShakeBuildItem> treeShakeProducer) {
         treeShakeProducer
                 .produce(new JarTreeShakeBuildItem(false, Set.of(),
-                        Map.of()));
+                        Map.of(), Set.of()));
     }
 
     @BuildStep(onlyIf = TreeShakeEnabled.class)

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarTreeShakeProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarTreeShakeProcessor.java
@@ -90,7 +90,7 @@ public class JarTreeShakeProcessor {
     void skipTreeShaking(BuildProducer<JarTreeShakeBuildItem> treeShakeProducer) {
         treeShakeProducer
                 .produce(new JarTreeShakeBuildItem(false, Set.of(),
-                        Map.of()));
+                        Map.of(), Set.of()));
     }
 
     @BuildStep(onlyIf = TreeShakeEnabled.class)

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarTreeShaker.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarTreeShaker.java
@@ -66,6 +66,8 @@ class JarTreeShaker {
      */
     private final Map<MethodKey, Set<MethodKey>> callerIndex = new HashMap<>();
 
+    private final Set<String> referencedJdkPackages = new HashSet<>();
+
     JarTreeShaker(JarTreeShakeInput input) {
         this.input = input;
     }
@@ -172,7 +174,7 @@ class JarTreeShaker {
         }
 
         return new JarTreeShakeBuildItem(input.treeShakeMode == TreeShakeConfig.TreeShakeMode.CLASSES, reachable,
-                removedClassesPerDep);
+                removedClassesPerDep, referencedJdkPackages);
     }
 
     /**
@@ -299,6 +301,9 @@ class JarTreeShaker {
             // ServiceLoader calls, sisu detection, and resource/OIS detection in one pass
             scan.clear();
             scanBytecode(name, bytecode, sisuActivated, scan);
+
+            // Aggregate JDK package references for module tree shaking
+            referencedJdkPackages.addAll(scan.jdkPackages);
 
             // Enqueue discovered class references — only those we have bytecode for.
             // Skips JDK/platform classes that we'll never find, avoiding thousands of
@@ -473,6 +478,8 @@ class JarTreeShaker {
     private static class BfsScanResult {
         /** All class references discovered from bytecode (superclass, interfaces, fields, methods, annotations, etc.) */
         final Set<String> refs = new HashSet<>();
+        /** JDK package names (java.*, javax.*, jdk.*) referenced from scanned bytecode */
+        final Set<String> jdkPackages = new HashSet<>();
         /** Service interfaces loaded via {@code ServiceLoader.load(SomeClass.class)} patterns */
         final Set<String> serviceLoaderServices = new HashSet<>();
         /** Whether both sisu named resource string and getResources() call were detected */
@@ -483,6 +490,7 @@ class JarTreeShaker {
         /** Resets all fields for reuse with the next class, avoiding per-class allocation. */
         void clear() {
             refs.clear();
+            jdkPackages.clear();
             serviceLoaderServices.clear();
             sisuDetected = false;
             deserializationFlags = 0;
@@ -498,7 +506,7 @@ class JarTreeShaker {
             boolean sisuAlreadyActivated, BfsScanResult result) {
         String internalOwner = className.replace('.', '/');
         ClassReader reader = new ClassReader(bytecode);
-        reader.accept(new RefCollectingClassVisitor(result.refs) {
+        reader.accept(new RefCollectingClassVisitor(result.refs, result.jdkPackages) {
 
             // Sisu detection state (class-level, across methods)
             boolean hasSisuString;
@@ -512,7 +520,7 @@ class JarTreeShaker {
                 // shadowed by the inner visitor's visitMethodInsn parameters
                 final String mName = name;
                 final String mDesc = descriptor;
-                return new RefCollectingMethodVisitor(refs) {
+                return new RefCollectingMethodVisitor(refs, jdkPkgs) {
                     // Lazily constructed MethodKey for this method, built only
                     // when a caller index entry is actually recorded
                     private MethodKey callerKeyObj;
@@ -786,7 +794,8 @@ class JarTreeShaker {
     private Set<String> extractReferencesFromBytecode(byte[] bytecode) {
         final Set<String> refs = new HashSet<>();
         ClassReader reader = new ClassReader(bytecode);
-        reader.accept(new RefCollectingClassVisitor(refs), ClassReader.SKIP_FRAMES | ClassReader.SKIP_DEBUG);
+        reader.accept(new RefCollectingClassVisitor(refs, referencedJdkPackages),
+                ClassReader.SKIP_FRAMES | ClassReader.SKIP_DEBUG);
         return refs;
     }
 
@@ -849,23 +858,24 @@ class JarTreeShaker {
      * Handles class literals (e.g. {@code @Command(subcommands = {Foo.class})}),
      * enum constants, nested annotations, and arrays of these.
      */
-    private static org.objectweb.asm.AnnotationVisitor createAnnotationRefVisitor(Set<String> refs) {
+    private static org.objectweb.asm.AnnotationVisitor createAnnotationRefVisitor(Set<String> refs,
+            Set<String> jdkPkgs) {
         return new org.objectweb.asm.AnnotationVisitor(Opcodes.ASM9) {
             @Override
             public void visit(String name, Object value) {
                 if (value instanceof org.objectweb.asm.Type) {
-                    addAsmType((org.objectweb.asm.Type) value, refs);
+                    addAsmType((org.objectweb.asm.Type) value, refs, jdkPkgs);
                 }
             }
 
             @Override
             public void visitEnum(String name, String descriptor, String value) {
-                addDescriptorType(descriptor, refs);
+                addDescriptorType(descriptor, refs, jdkPkgs);
             }
 
             @Override
             public org.objectweb.asm.AnnotationVisitor visitAnnotation(String name, String descriptor) {
-                addDescriptorType(descriptor, refs);
+                addDescriptorType(descriptor, refs, jdkPkgs);
                 return this;
             }
 
@@ -886,46 +896,48 @@ class JarTreeShaker {
      */
     private static class RefCollectingClassVisitor extends ClassVisitor {
         final Set<String> refs;
+        final Set<String> jdkPkgs;
 
-        RefCollectingClassVisitor(Set<String> refs) {
+        RefCollectingClassVisitor(Set<String> refs, Set<String> jdkPkgs) {
             super(Opcodes.ASM9);
             this.refs = refs;
+            this.jdkPkgs = jdkPkgs;
         }
 
         @Override
         public void visit(int version, int access, String name, String signature,
                 String superName, String[] interfaces) {
             if (superName != null) {
-                addClassRef(superName, refs);
+                addClassRef(superName, refs, jdkPkgs);
             }
             if (interfaces != null) {
                 for (String iface : interfaces) {
-                    addClassRef(iface, refs);
+                    addClassRef(iface, refs, jdkPkgs);
                 }
             }
-            addSignatureTypes(signature, refs);
+            addSignatureTypes(signature, refs, jdkPkgs);
             int dollar = name.lastIndexOf('$');
             if (dollar > 0) {
-                addClassRef(name.substring(0, dollar), refs);
+                addClassRef(name.substring(0, dollar), refs, jdkPkgs);
             }
         }
 
         @Override
         public org.objectweb.asm.AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
-            addDescriptorType(descriptor, refs);
-            return createAnnotationRefVisitor(refs);
+            addDescriptorType(descriptor, refs, jdkPkgs);
+            return createAnnotationRefVisitor(refs, jdkPkgs);
         }
 
         @Override
         public org.objectweb.asm.FieldVisitor visitField(int access, String name,
                 String descriptor, String signature, Object value) {
-            addDescriptorType(descriptor, refs);
-            addSignatureTypes(signature, refs);
+            addDescriptorType(descriptor, refs, jdkPkgs);
+            addSignatureTypes(signature, refs, jdkPkgs);
             return new org.objectweb.asm.FieldVisitor(Opcodes.ASM9) {
                 @Override
                 public org.objectweb.asm.AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
-                    addDescriptorType(descriptor, refs);
-                    return createAnnotationRefVisitor(refs);
+                    addDescriptorType(descriptor, refs, jdkPkgs);
+                    return createAnnotationRefVisitor(refs, jdkPkgs);
                 }
             };
         }
@@ -934,16 +946,16 @@ class JarTreeShaker {
         public MethodVisitor visitMethod(int access, String name, String descriptor,
                 String signature, String[] exceptions) {
             visitMethodSignature(descriptor, signature, exceptions);
-            return new RefCollectingMethodVisitor(refs);
+            return new RefCollectingMethodVisitor(refs, jdkPkgs);
         }
 
         /** Adds method descriptor types, generic signature types, and exception types to refs. */
         final void visitMethodSignature(String descriptor, String signature, String[] exceptions) {
-            addMethodDescriptorTypes(descriptor, refs);
-            addSignatureTypes(signature, refs);
+            addMethodDescriptorTypes(descriptor, refs, jdkPkgs);
+            addSignatureTypes(signature, refs, jdkPkgs);
             if (exceptions != null) {
                 for (String ex : exceptions) {
-                    addClassRef(ex, refs);
+                    addClassRef(ex, refs, jdkPkgs);
                 }
             }
         }
@@ -957,37 +969,39 @@ class JarTreeShaker {
      */
     private static class RefCollectingMethodVisitor extends MethodVisitor {
         final Set<String> refs;
+        final Set<String> jdkPkgs;
         String lastStringConstant;
 
-        RefCollectingMethodVisitor(Set<String> refs) {
+        RefCollectingMethodVisitor(Set<String> refs, Set<String> jdkPkgs) {
             super(Opcodes.ASM9);
             this.refs = refs;
+            this.jdkPkgs = jdkPkgs;
         }
 
         @Override
         public void visitTryCatchBlock(Label start, Label end, Label handler, String type) {
             lastStringConstant = null;
             if (type != null) {
-                addClassRef(type, refs);
+                addClassRef(type, refs, jdkPkgs);
             }
         }
 
         @Override
         public org.objectweb.asm.AnnotationVisitor visitAnnotationDefault() {
-            return createAnnotationRefVisitor(refs);
+            return createAnnotationRefVisitor(refs, jdkPkgs);
         }
 
         @Override
         public void visitTypeInsn(int opcode, String type) {
             lastStringConstant = null;
-            addClassRef(type, refs);
+            addClassRef(type, refs, jdkPkgs);
         }
 
         @Override
         public void visitFieldInsn(int opcode, String owner, String name, String descriptor) {
             lastStringConstant = null;
-            addClassRef(owner, refs);
-            addDescriptorType(descriptor, refs);
+            addClassRef(owner, refs, jdkPkgs);
+            addDescriptorType(descriptor, refs, jdkPkgs);
         }
 
         @Override
@@ -1000,8 +1014,8 @@ class JarTreeShaker {
                 }
             }
             lastStringConstant = null;
-            addClassRef(owner, refs);
-            addMethodDescriptorTypes(descriptor, refs);
+            addClassRef(owner, refs, jdkPkgs);
+            addMethodDescriptorTypes(descriptor, refs, jdkPkgs);
         }
 
         @Override
@@ -1013,11 +1027,11 @@ class JarTreeShaker {
             }
             if (value instanceof org.objectweb.asm.Type type) {
                 if (type.getSort() == org.objectweb.asm.Type.OBJECT) {
-                    addClassRef(type.getInternalName(), refs);
+                    addClassRef(type.getInternalName(), refs, jdkPkgs);
                 } else if (type.getSort() == org.objectweb.asm.Type.ARRAY) {
                     org.objectweb.asm.Type elem = type.getElementType();
                     if (elem.getSort() == org.objectweb.asm.Type.OBJECT) {
-                        addClassRef(elem.getInternalName(), refs);
+                        addClassRef(elem.getInternalName(), refs, jdkPkgs);
                     }
                 }
             }
@@ -1051,13 +1065,13 @@ class JarTreeShaker {
         public void visitInvokeDynamicInsn(String iname, String idescriptor,
                 Handle bootstrapMethodHandle, Object... bootstrapMethodArguments) {
             lastStringConstant = null;
-            addHandleType(bootstrapMethodHandle, refs);
+            addHandleType(bootstrapMethodHandle, refs, jdkPkgs);
             if (bootstrapMethodArguments != null) {
                 for (Object arg : bootstrapMethodArguments) {
                     if (arg instanceof org.objectweb.asm.Type type) {
-                        addAsmType(type, refs);
+                        addAsmType(type, refs, jdkPkgs);
                     } else if (arg instanceof Handle) {
-                        addHandleType((Handle) arg, refs);
+                        addHandleType((Handle) arg, refs, jdkPkgs);
                     }
                 }
             }
@@ -1066,22 +1080,22 @@ class JarTreeShaker {
         @Override
         public void visitMultiANewArrayInsn(String descriptor, int numDimensions) {
             lastStringConstant = null;
-            addDescriptorType(descriptor, refs);
+            addDescriptorType(descriptor, refs, jdkPkgs);
         }
 
         @Override
         public org.objectweb.asm.AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
             lastStringConstant = null;
-            addDescriptorType(descriptor, refs);
-            return createAnnotationRefVisitor(refs);
+            addDescriptorType(descriptor, refs, jdkPkgs);
+            return createAnnotationRefVisitor(refs, jdkPkgs);
         }
 
         @Override
         public org.objectweb.asm.AnnotationVisitor visitParameterAnnotation(int parameter,
                 String descriptor, boolean visible) {
             lastStringConstant = null;
-            addDescriptorType(descriptor, refs);
-            return createAnnotationRefVisitor(refs);
+            addDescriptorType(descriptor, refs, jdkPkgs);
+            return createAnnotationRefVisitor(refs, jdkPkgs);
         }
     }
 
@@ -1102,11 +1116,24 @@ class JarTreeShaker {
      * or generated bytecode maps, so they are always filtered out downstream by
      * {@link JarTreeShakeInput#hasBytecode} — skipping them here avoids the
      * {@link String#replace} allocation and the {@link Set#add} lookup.
+     * <p>
+     * When {@code jdkPkgs} is non-null, JDK package names ({@code java.*}, {@code javax.*},
+     * {@code jdk.*}) are captured for later use by module tree shaking to replace
+     * {@code requires java.se} with specific JDK module requirements.
      */
-    private static void addClassRef(String internalName, Set<String> refs) {
-        if (!internalName.startsWith("java/")) {
-            refs.add(internalName.replace('/', '.'));
+    private static void addClassRef(String internalName, Set<String> refs, Set<String> jdkPkgs) {
+        if (internalName.startsWith("java/") || internalName.startsWith("javax/") || internalName.startsWith("jdk/")) {
+            if (jdkPkgs != null) {
+                int lastSlash = internalName.lastIndexOf('/');
+                if (lastSlash > 0) {
+                    jdkPkgs.add(internalName.substring(0, lastSlash).replace('/', '.'));
+                }
+            }
+            if (internalName.startsWith("java/")) {
+                return;
+            }
         }
+        refs.add(internalName.replace('/', '.'));
     }
 
     /**
@@ -1126,12 +1153,12 @@ class JarTreeShaker {
      * and adds any object type reference to {@code refs}. Skips parsing when the
      * descriptor contains only primitive types, void, or arrays of primitives.
      */
-    private static void addDescriptorType(String descriptor, Set<String> refs) {
+    private static void addDescriptorType(String descriptor, Set<String> refs, Set<String> jdkPkgs) {
         if (!hasObjectType(descriptor)) {
             return;
         }
         org.objectweb.asm.Type type = org.objectweb.asm.Type.getType(descriptor);
-        addAsmType(type, refs);
+        addAsmType(type, refs, jdkPkgs);
     }
 
     /**
@@ -1139,28 +1166,28 @@ class JarTreeShaker {
      * all argument and return type object references to {@code refs}. Skips
      * parsing when the descriptor contains only primitive types and void.
      */
-    private static void addMethodDescriptorTypes(String descriptor, Set<String> refs) {
+    private static void addMethodDescriptorTypes(String descriptor, Set<String> refs, Set<String> jdkPkgs) {
         if (!hasObjectType(descriptor)) {
             return;
         }
         for (org.objectweb.asm.Type argType : org.objectweb.asm.Type.getArgumentTypes(descriptor)) {
-            addAsmType(argType, refs);
+            addAsmType(argType, refs, jdkPkgs);
         }
-        addAsmType(org.objectweb.asm.Type.getReturnType(descriptor), refs);
+        addAsmType(org.objectweb.asm.Type.getReturnType(descriptor), refs, jdkPkgs);
     }
 
     /**
      * Adds the owner class reference and descriptor type references from an
      * {@code invokedynamic} bootstrap method handle to {@code refs}.
      */
-    private static void addHandleType(Handle handle, Set<String> refs) {
-        addClassRef(handle.getOwner(), refs);
+    private static void addHandleType(Handle handle, Set<String> refs, Set<String> jdkPkgs) {
+        addClassRef(handle.getOwner(), refs, jdkPkgs);
         int tag = handle.getTag();
         if (tag == Opcodes.H_GETFIELD || tag == Opcodes.H_GETSTATIC
                 || tag == Opcodes.H_PUTFIELD || tag == Opcodes.H_PUTSTATIC) {
-            addDescriptorType(handle.getDesc(), refs);
+            addDescriptorType(handle.getDesc(), refs, jdkPkgs);
         } else {
-            addMethodDescriptorTypes(handle.getDesc(), refs);
+            addMethodDescriptorTypes(handle.getDesc(), refs, jdkPkgs);
         }
     }
 
@@ -1170,14 +1197,14 @@ class JarTreeShaker {
      * that are not present in raw descriptors but can be resolved at runtime
      * via reflection on generic type metadata.
      */
-    private static void addSignatureTypes(String signature, Set<String> refs) {
+    private static void addSignatureTypes(String signature, Set<String> refs, Set<String> jdkPkgs) {
         if (signature == null) {
             return;
         }
         new SignatureReader(signature).accept(new SignatureVisitor(Opcodes.ASM9) {
             @Override
             public void visitClassType(String name) {
-                addClassRef(name, refs);
+                addClassRef(name, refs, jdkPkgs);
             }
         });
     }
@@ -1187,11 +1214,11 @@ class JarTreeShaker {
      * recursing into the element type for array types. Delegates to {@link #addClassRef}
      * to skip {@code java/} package classes.
      */
-    private static void addAsmType(org.objectweb.asm.Type type, Set<String> refs) {
+    private static void addAsmType(org.objectweb.asm.Type type, Set<String> refs, Set<String> jdkPkgs) {
         if (type.getSort() == org.objectweb.asm.Type.OBJECT) {
-            addClassRef(type.getInternalName(), refs);
+            addClassRef(type.getInternalName(), refs, jdkPkgs);
         } else if (type.getSort() == org.objectweb.asm.Type.ARRAY) {
-            addAsmType(type.getElementType(), refs);
+            addAsmType(type.getElementType(), refs, jdkPkgs);
         }
     }
 

--- a/docs/src/main/asciidoc/jar-tree-shaking.adoc
+++ b/docs/src/main/asciidoc/jar-tree-shaking.adoc
@@ -108,6 +108,18 @@ The algorithm runs in several stages:
                                      ▼
                     ┌───────────────────────────────────┐
                     │  Compute removals, produce JAR    │
+                    └────────────────┬──────────────────┘
+                                     │
+                            jlink extension active?
+                           ╱                ╲
+                         yes                 no ──► done
+                          │
+                          ▼
+                    ┌───────────────────────────────────┐
+                    │  Module-level tree-shaking        │
+                    │  • Remove class-dead modules      │
+                    │  • Clean stale requires/provides  │
+                    │  • Recompute JDK module set       │
                     └───────────────────────────────────┘
 ----
 
@@ -157,6 +169,26 @@ The chain analysis runs in an incremental fixed-point loop: the reverse caller i
 For example, BouncyCastle's `BouncyCastleProvider` constructor calls `setup()` which calls `loadAlgorithms()` which calls `loadServiceClass()` which calls `ClassUtil.loadClass()`.
 The tree-shaker identifies `BouncyCastleProvider` as the entry point, instantiates it in the recording class loader, and captures all dynamically loaded algorithm classes.
 
+=== Module-level tree-shaking
+
+When the Quarkus jlink extension is present, tree-shaking also operates at the module level.
+After the class-level analysis determines which classes are reachable, the module tree-shaker evaluates each module in the application's module model:
+
+* A module is *class-dead* if it contains `.class` entries but none of them are in the reachable set. Class-dead modules are removed entirely from the jlink image.
+* A module with no `.class` entries at all (a resource-only JAR) is kept alive — it may provide configuration files, native libraries, or other resources needed at runtime.
+* A module with an empty content tree (no content to contribute) is treated as dead.
+
+After dead modules are removed, surviving modules are cleaned up:
+
+* `requires` directives pointing to removed modules are dropped.
+* Auto-dependency groups whose entries all point to removed modules are dropped.
+* Service provider entries (`provides ... with ...`) whose implementation classes are not in the reachable set are removed.
+* The set of JDK modules included in the jlink image is recomputed from surviving modules only, which can reduce the image size.
+
+The module tree-shaker also performs a graph reachability analysis — a BFS from root modules (the application module and boot modules) through the dependency graph.
+Modules that are not reachable from any root but still contain reachable classes are *not* removed, since they may be accessed via reflection, service loading, or from automatic modules without explicit `requires` directives.
+A warning is logged for such modules to help diagnose missing dependency declarations.
+
 == Excluding artifacts from tree-shaking
 
 Some libraries may not work correctly if classes are removed — for example, libraries that perform self-integrity checks (e.g., BouncyCastle FIPS) or that load classes through mechanisms the tree-shaker cannot detect.
@@ -177,6 +209,7 @@ Extensions can also exclude artifacts programmatically by producing a `JarTreeSh
 * Tree-shaking is not supported for the `mutable-jar` package type, since re-augmentation requires all classes to be present.
 * Only classes from runtime dependencies are candidates for removal. Application classes are never removed.
 * The `classes` level only removes class files. Other resources (such as configuration files, property files, and `META-INF` entries) are preserved. Dependencies from which all classes have been removed are still included in the final JAR, since they may contain resources required at runtime.
+* Module-level tree-shaking (removing entire modules) is only performed when the jlink extension is present. Without jlink, only class-level removal applies.
 
 == Troubleshooting
 

--- a/docs/src/main/asciidoc/jar-tree-shaking.adoc
+++ b/docs/src/main/asciidoc/jar-tree-shaking.adoc
@@ -107,6 +107,18 @@ The algorithm runs in several stages:
                                      ▼
                     ┌───────────────────────────────────┐
                     │  Compute removals, produce JAR    │
+                    └────────────────┬──────────────────┘
+                                     │
+                            jlink extension active?
+                           ╱                ╲
+                         yes                 no ──► done
+                          │
+                          ▼
+                    ┌───────────────────────────────────┐
+                    │  Module-level tree-shaking        │
+                    │  • Remove class-dead modules      │
+                    │  • Clean stale requires/provides  │
+                    │  • Recompute JDK module set       │
                     └───────────────────────────────────┘
 ----
 
@@ -156,6 +168,26 @@ The chain analysis runs in an incremental fixed-point loop: the reverse caller i
 For example, BouncyCastle's `BouncyCastleProvider` constructor calls `setup()` which calls `loadAlgorithms()` which calls `loadServiceClass()` which calls `ClassUtil.loadClass()`.
 The tree-shaker identifies `BouncyCastleProvider` as the entry point, instantiates it in the recording class loader, and captures all dynamically loaded algorithm classes.
 
+=== Module-level tree-shaking
+
+When a Quarkus modular packaging extension is present (for example, `quarkus-jlink`), tree-shaking also operates at the module level.
+After the class-level analysis determines which classes are reachable, the module tree-shaker evaluates each module in the application's module model:
+
+* A module is *class-dead* if it contains `.class` entries but none of them are in the reachable set. Class-dead modules are removed entirely from the jlink image.
+* A module with no `.class` entries at all (a resource-only JAR) is kept alive — it may provide configuration files, native libraries, or other resources needed at runtime.
+* A module with an empty content tree (no content to contribute) is treated as dead.
+
+After dead modules are removed, surviving modules are cleaned up:
+
+* `requires` directives pointing to removed modules are dropped.
+* Auto-dependency groups whose entries all point to removed modules are dropped.
+* Service provider entries (`provides ... with ...`) whose implementation classes are not in the reachable set are removed.
+* The set of JDK modules included in the jlink image is recomputed from surviving modules only, which can reduce the image size.
+
+The module tree-shaker also performs a graph reachability analysis — a BFS from root modules (the application module and boot modules) through the dependency graph.
+Modules that are not reachable from any root but still contain reachable classes are *not* removed, since they may be accessed via reflection, service loading, or from automatic modules without explicit `requires` directives.
+A warning is logged for such modules to help diagnose missing dependency declarations.
+
 == Excluding artifacts from tree-shaking
 
 Some libraries may not work correctly if classes are removed — for example, libraries that perform self-integrity checks (e.g., BouncyCastle FIPS) or that load classes through mechanisms the tree-shaker cannot detect.
@@ -176,6 +208,7 @@ Extensions can also exclude artifacts programmatically by producing a `JarTreeSh
 * Tree-shaking is not supported for the `mutable-jar` package type, since re-augmentation requires all classes to be present.
 * Only classes from runtime dependencies are candidates for removal. Application classes are never removed.
 * The `classes` level only removes class files. Other resources (such as configuration files, property files, and `META-INF` entries) are preserved. Dependencies from which all classes have been removed are still included in the final JAR, since they may contain resources required at runtime.
+* Module-level tree-shaking (removing entire modules) is only performed when the jlink extension is present. Without jlink, only class-level removal applies.
 
 == Troubleshooting
 

--- a/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/JLinkSteps.java
+++ b/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/JLinkSteps.java
@@ -21,9 +21,12 @@ import java.util.spi.ToolProvider;
 import org.jboss.logging.Logger;
 
 import io.quarkus.builder.BuildException;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.pkg.builditem.JarTreeShakeBuildItem;
 import io.quarkus.gizmo2.Const;
 import io.quarkus.gizmo2.Gizmo;
 import io.quarkus.gizmo2.ParamVar;
@@ -38,8 +41,6 @@ import io.quarkus.modular.spi.model.AppModuleModel;
 import io.quarkus.modular.spi.model.DependencyInfo;
 import io.quarkus.modular.spi.model.ModuleInfo;
 import io.smallrye.common.io.Files2;
-import io.smallrye.common.resource.MemoryResource;
-import io.smallrye.common.resource.Resource;
 import io.smallrye.modules.desc.Dependency;
 
 /**
@@ -65,21 +66,53 @@ public final class JLinkSteps {
     }
 
     /**
+     * Generate the jlink launcher main class early so it is visible to the tree-shaker
+     * as a {@link GeneratedClassBuildItem}. This ensures the launcher module has a reachable
+     * class and is not pruned by module tree-shaking.
+     *
+     * @param curateOutcome provides the application model (for the app module name)
+     * @param generatedClasses producer for generated class build items
+     */
+    @BuildStep
+    void generateLauncherMainClass(
+            CurateOutcomeBuildItem curateOutcome,
+            BuildProducer<GeneratedClassBuildItem> generatedClasses) {
+
+        String appModuleName = curateOutcome.getApplicationModel().getAppArtifact().getModuleName();
+        Gizmo gizmo = Gizmo.create((path, bytes) -> generatedClasses.produce(
+                new GeneratedClassBuildItem(false, APP_MAIN, bytes)));
+        gizmo.class_(APP_MAIN, cc -> {
+            cc.public_();
+            cc.staticMethod("main", mc -> {
+                mc.public_();
+                ParamVar args = mc.parameter("args", String[].class);
+                mc.body(b0 -> {
+                    b0.invokeStatic(
+                            MethodDesc.of(JLinkAppLauncher.class, "run", void.class, String.class, String[].class),
+                            Const.of(appModuleName),
+                            args);
+                    b0.return_();
+                });
+            });
+        });
+    }
+
+    /**
      * Steps to stage the jlink output into directories so it can be processed by the tool itself.
      *
-     * @param curateOutcome the curate outcome item (must not be {@code null})
      * @param moduleInfoItem the modular model item (must not be {@code null})
      * @return the staged jlink output (not {@code null})
      * @throws IOException if a file operation fails
      */
     @BuildStep
     public JLinkStagedOutputItem stageOutput(
-            CurateOutcomeBuildItem curateOutcome,
-            ApplicationModuleInfoBuildItem moduleInfoItem) throws IOException {
+            ApplicationModuleInfoBuildItem moduleInfoItem,
+            JarTreeShakeBuildItem treeShakeResult) throws IOException {
 
         // gather information we'll need
         AppModuleModel model = moduleInfoItem.model();
         Map<String, ModuleInfo> modulesByName = model.modulesByName();
+        Set<String> reachable = treeShakeResult.isClassesShaken() ? treeShakeResult.getReachableClassNames() : null;
 
         // create the staging directory
         final Path staging = config.outputDirectory().resolve(config.stagingDirectory());
@@ -93,29 +126,11 @@ public final class JLinkSteps {
             if (moduleInfo == null) {
                 throw new IllegalStateException("Boot module listed in model is missing from the module index");
             }
-            // our special launcher module
+            // the launcher module gets extra dependencies on all other boot modules
+            // and the main class set (the AppMain class itself was generated earlier
+            // by generateLauncherMainClass so it is visible to the tree-shaker)
             if (moduleName.equals("io.quarkus.jlink.launcher")) {
-                // the list of resources produced by generating the main class
-                List<Resource> dynModuleResources = new ArrayList<>();
-                // generate the simple main class which runs the launcher with the app module info
-                Gizmo gizmo = Gizmo.create((path, bytes) -> dynModuleResources.add(new MemoryResource(path, bytes)));
-                gizmo.class_(APP_MAIN, cc -> {
-                    cc.public_();
-                    cc.staticMethod("main", mc -> {
-                        mc.public_();
-                        ParamVar args = mc.parameter("args", String[].class);
-                        mc.body(b0 -> {
-                            b0.invokeStatic(
-                                    MethodDesc.of(JLinkAppLauncher.class, "run", void.class, String.class, String[].class),
-                                    Const.of(moduleInfoItem.model().appModuleInfo().name()),
-                                    args);
-                            b0.return_();
-                        });
-                    });
-                });
-                // create a derived launcher module which includes our generated class and a dep on the app module
                 moduleInfo = moduleInfo
-                        .withMoreResources(dynModuleResources)
                         .withMoreDependencies(model.bootModules().stream().filter(n -> !n.equals(moduleName))
                                 .map(n -> new DependencyInfo(n,
                                         Dependency.Modifier.Set.of(Dependency.Modifier.LINKED, Dependency.Modifier.READ,
@@ -139,8 +154,7 @@ public final class JLinkSteps {
                 }
                 return null;
             });
-            // write the JAR
-            bmp.put(moduleName, ModuleWriter.writeModule(moduleInfo, staging, manifest, true));
+            bmp.put(moduleName, ModuleWriter.writeModule(moduleInfo, staging, manifest, true, reachable));
         }
         return new JLinkStagedOutputItem(staging, bmp);
     }
@@ -162,7 +176,8 @@ public final class JLinkSteps {
     @BuildStep
     public JLinkImageBuildItem jlink(
             JLinkStagedOutputItem stagedOutput,
-            ApplicationModuleInfoBuildItem moduleInfoItem) throws BuildException, IOException {
+            ApplicationModuleInfoBuildItem moduleInfoItem,
+            JarTreeShakeBuildItem treeShakeResult) throws BuildException, IOException {
         Path imagePath = config.outputDirectory().resolve(config.imagePath());
 
         // the image must be deleted or jlink will complain
@@ -176,19 +191,17 @@ public final class JLinkSteps {
         List<String> jvmArgs = new ArrayList<>();
         List<String> jlinkArgs = new ArrayList<>();
 
-        // JVM args
+        List<String> jdkModules = moduleInfoItem.model().jdkModulesUsed();
+        log.debugf("JDK modules included in image (%d): %s", jdkModules.size(), jdkModules);
+        String addedModules = "ALL-MODULE-PATH,jdk.jdwp.agent," + String.join(",", jdkModules);
 
-        String addedModules = "ALL-MODULE-PATH,jdk.jdwp.agent," + String.join(",", moduleInfoItem.model().jdkModulesUsed());
-
-        // access to module internals
+        // JVM args to embed in the image launcher script.
+        // These are written directly into the launcher after jlink runs,
+        // because jlink's --add-options parser rejects values starting with "--".
         jvmArgs.add("--add-exports=java.base/jdk.internal.module=io.smallrye.modules");
-        // add modules to JVM path
-        // xxx replace with injected module dependencies on main module?
         jvmArgs.add("--add-modules=" + addedModules);
         // todo: patch for loom
-        //jvmArgs.add("--patch-module");
-        //jvmArgs.add("java.base=" + javaBasePatchPath);
-        // memory
+        //jvmArgs.add("--patch-module=java.base=" + javaBasePatchPath);
         config.minHeapSize().ifPresent(s -> jvmArgs.add("-Xms" + s.toLowerString()));
         config.maxHeapSize().ifPresent(s -> jvmArgs.add("-Xmx" + s.toLowerString()));
         jvmArgs.add("-Djava.util.logging.manager=org.jboss.logmanager.LogManager");
@@ -217,10 +230,6 @@ public final class JLinkSteps {
 
         // CDS arguments -- todo
         //jlinkArgs.add("--generate-cds-archive");
-        // add necessary JDK options
-        if (!jvmArgs.isEmpty()) {
-            jlinkArgs.add("--add-options=" + String.join(" ", jvmArgs));
-        }
         // just choose server VM
         jlinkArgs.add("--vm");
         jlinkArgs.add("server");
@@ -251,12 +260,22 @@ public final class JLinkSteps {
         if (result != 0) {
             throw new BuildException("Build failed during jlink (exit code " + result + ")");
         }
+        // patch the launcher scripts to include JVM args
+        if (!jvmArgs.isEmpty()) {
+            Path binDir = imagePath.resolve("bin");
+            patchLauncherScript(binDir.resolve(config.launcherName()), jvmArgs);
+            Path batFile = binDir.resolve(config.launcherName() + ".bat");
+            if (Files.exists(batFile)) {
+                patchWindowsLauncherScript(batFile, jvmArgs);
+            }
+        }
         // produce the dynamic lib files
         // bundle dynamic modules into the image
         Path lib = config.outputDirectory().resolve(config.imagePath()).resolve("lib").resolve("quarkus");
         Files.createDirectories(lib);
         final AppModuleModel model = moduleInfoItem.model();
         Map<String, ModuleInfo> modulesByName = model.modulesByName();
+        Set<String> reachable = treeShakeResult.isClassesShaken() ? treeShakeResult.getReachableClassNames() : null;
         for (ModuleInfo moduleInfo : modulesByName.values()) {
             String moduleName = moduleInfo.name();
             if (model.bootModules().contains(moduleName)) {
@@ -264,12 +283,52 @@ public final class JLinkSteps {
                 continue;
             }
             // TODO: create an actual manifest (if needed)
-            ModuleWriter.writeModule(moduleInfo, lib.resolve(moduleInfo.name()), new Manifest(), false);
+            ModuleWriter.writeModule(moduleInfo, lib.resolve(moduleInfo.name()), new Manifest(), false, reachable);
         }
 
         log.infof("JLink image produced in %s at %s; to run the image, execute %s in that directory",
                 format(duration), imagePath, Path.of("bin").resolve(config.launcherName()));
         return new JLinkImageBuildItem(imagePath, Set.of(config.launcherName()));
+    }
+
+    /**
+     * Patch a jlink-generated launcher shell script to inject JVM arguments.
+     * <p>
+     * jlink's {@code --add-options} plugin cannot handle values starting with {@code "--"}
+     * (e.g. {@code --add-exports}, {@code --add-modules}), so we inject them directly
+     * into the launcher script by replacing the empty {@code JLINK_VM_OPTIONS=} line.
+     *
+     * @param launcherPath the path to the launcher script
+     * @param jvmArgs the JVM arguments to inject
+     * @throws IOException if the script cannot be read or written
+     */
+    private static void patchLauncherScript(Path launcherPath, List<String> jvmArgs) throws IOException {
+        String content = Files.readString(launcherPath);
+        String opts = String.join(" ", jvmArgs);
+        String patched = content.replace("JLINK_VM_OPTIONS=\n",
+                "JLINK_VM_OPTIONS=\"" + opts + "\"\n");
+        Files.writeString(launcherPath, patched);
+    }
+
+    /**
+     * Patch a jlink-generated Windows {@code .bat} launcher to inject JVM arguments.
+     * The batch file uses {@code set JLINK_VM_OPTIONS=} syntax.
+     *
+     * @param launcherPath the path to the {@code .bat} launcher script
+     * @param jvmArgs the JVM arguments to inject
+     * @throws IOException if the script cannot be read or written
+     */
+    private static void patchWindowsLauncherScript(Path launcherPath, List<String> jvmArgs) throws IOException {
+        String content = Files.readString(launcherPath);
+        String opts = String.join(" ", jvmArgs);
+        // handle both \r\n (Windows) and \n (Unix) line endings
+        String patched = content.replace("set JLINK_VM_OPTIONS=\r\n",
+                "set JLINK_VM_OPTIONS=" + opts + "\r\n");
+        if (patched.equals(content)) {
+            patched = content.replace("set JLINK_VM_OPTIONS=\n",
+                    "set JLINK_VM_OPTIONS=" + opts + "\n");
+        }
+        Files.writeString(launcherPath, patched);
     }
 
     /**

--- a/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/JLinkSteps.java
+++ b/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/JLinkSteps.java
@@ -292,11 +292,16 @@ public final class JLinkSteps {
     }
 
     /**
-     * Patch a jlink-generated launcher shell script to inject JVM arguments.
+     * Patch a jlink-generated launcher shell script to inject JVM arguments
+     * and use {@code exec} so the JVM replaces the shell process.
      * <p>
      * jlink's {@code --add-options} plugin cannot handle values starting with {@code "--"}
      * (e.g. {@code --add-exports}, {@code --add-modules}), so we inject them directly
      * into the launcher script by replacing the empty {@code JLINK_VM_OPTIONS=} line.
+     * <p>
+     * The {@code exec} prefix ensures the JVM inherits the shell's PID, so
+     * signals (e.g. SIGTERM) reach the JVM directly instead of only hitting
+     * the wrapper shell.
      *
      * @param launcherPath the path to the launcher script
      * @param jvmArgs the JVM arguments to inject
@@ -307,6 +312,8 @@ public final class JLinkSteps {
         String opts = String.join(" ", jvmArgs);
         String patched = content.replace("JLINK_VM_OPTIONS=\n",
                 "JLINK_VM_OPTIONS=\"" + opts + "\"\n");
+        // exec so the JVM replaces the shell — Process.destroy() then targets the JVM directly
+        patched = patched.replace("$DIR/java $JLINK_VM_OPTIONS", "exec $DIR/java $JLINK_VM_OPTIONS");
         Files.writeString(launcherPath, patched);
     }
 

--- a/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/JLinkSteps.java
+++ b/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/JLinkSteps.java
@@ -21,9 +21,12 @@ import java.util.spi.ToolProvider;
 import org.jboss.logging.Logger;
 
 import io.quarkus.builder.BuildException;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.pkg.builditem.JarTreeShakeBuildItem;
 import io.quarkus.gizmo2.Const;
 import io.quarkus.gizmo2.Gizmo;
 import io.quarkus.gizmo2.ParamVar;
@@ -38,8 +41,6 @@ import io.quarkus.modular.spi.model.AppModuleModel;
 import io.quarkus.modular.spi.model.DependencyInfo;
 import io.quarkus.modular.spi.model.ModuleInfo;
 import io.smallrye.common.io.Files2;
-import io.smallrye.common.resource.MemoryResource;
-import io.smallrye.common.resource.Resource;
 import io.smallrye.modules.desc.Dependency;
 
 /**
@@ -65,21 +66,53 @@ public final class JLinkSteps {
     }
 
     /**
+     * Generate the jlink launcher main class early so it is visible to the tree-shaker
+     * as a {@link GeneratedClassBuildItem}. This ensures the launcher module has a reachable
+     * class and is not pruned by module tree-shaking.
+     *
+     * @param curateOutcome provides the application model (for the app module name)
+     * @param generatedClasses producer for generated class build items
+     */
+    @BuildStep
+    void generateLauncherMainClass(
+            CurateOutcomeBuildItem curateOutcome,
+            BuildProducer<GeneratedClassBuildItem> generatedClasses) {
+
+        String appModuleName = curateOutcome.getApplicationModel().getAppArtifact().getModuleName();
+        Gizmo gizmo = Gizmo.create((path, bytes) -> generatedClasses.produce(
+                new GeneratedClassBuildItem(false, APP_MAIN, bytes)));
+        gizmo.class_(APP_MAIN, cc -> {
+            cc.public_();
+            cc.staticMethod("main", mc -> {
+                mc.public_();
+                ParamVar args = mc.parameter("args", String[].class);
+                mc.body(b0 -> {
+                    b0.invokeStatic(
+                            MethodDesc.of(JLinkAppLauncher.class, "run", void.class, String.class, String[].class),
+                            Const.of(appModuleName),
+                            args);
+                    b0.return_();
+                });
+            });
+        });
+    }
+
+    /**
      * Steps to stage the jlink output into directories so it can be processed by the tool itself.
      *
-     * @param curateOutcome the curate outcome item (must not be {@code null})
      * @param moduleInfoItem the modular model item (must not be {@code null})
      * @return the staged jlink output (not {@code null})
      * @throws IOException if a file operation fails
      */
     @BuildStep
     public JLinkStagedOutputItem stageOutput(
-            CurateOutcomeBuildItem curateOutcome,
-            ApplicationModuleInfoBuildItem moduleInfoItem) throws IOException {
+            ApplicationModuleInfoBuildItem moduleInfoItem,
+            JarTreeShakeBuildItem treeShakeResult) throws IOException {
 
         // gather information we'll need
         AppModuleModel model = moduleInfoItem.model();
         Map<String, ModuleInfo> modulesByName = model.modulesByName();
+        Set<String> reachable = treeShakeResult.isClassesShaken() ? treeShakeResult.getReachableClassNames() : null;
 
         // create the staging directory
         final Path staging = config.outputDirectory().resolve(config.stagingDirectory());
@@ -93,29 +126,11 @@ public final class JLinkSteps {
             if (moduleInfo == null) {
                 throw new IllegalStateException("Boot module listed in model is missing from the module index");
             }
-            // our special launcher module
+            // the launcher module gets extra dependencies on all other boot modules
+            // and the main class set (the AppMain class itself was generated earlier
+            // by generateLauncherMainClass so it is visible to the tree-shaker)
             if (moduleName.equals("io.quarkus.jlink.launcher")) {
-                // the list of resources produced by generating the main class
-                List<Resource> dynModuleResources = new ArrayList<>();
-                // generate the simple main class which runs the launcher with the app module info
-                Gizmo gizmo = Gizmo.create((path, bytes) -> dynModuleResources.add(new MemoryResource(path, bytes)));
-                gizmo.class_(APP_MAIN, cc -> {
-                    cc.public_();
-                    cc.staticMethod("main", mc -> {
-                        mc.public_();
-                        ParamVar args = mc.parameter("args", String[].class);
-                        mc.body(b0 -> {
-                            b0.invokeStatic(
-                                    MethodDesc.of(JLinkAppLauncher.class, "run", void.class, String.class, String[].class),
-                                    Const.of(moduleInfoItem.model().appModuleInfo().name()),
-                                    args);
-                            b0.return_();
-                        });
-                    });
-                });
-                // create a derived launcher module which includes our generated class and a dep on the app module
                 moduleInfo = moduleInfo
-                        .withMoreResources(dynModuleResources)
                         .withMoreDependencies(model.bootModules().stream().filter(n -> !n.equals(moduleName))
                                 .map(n -> new DependencyInfo(n,
                                         Dependency.Modifier.Set.of(Dependency.Modifier.LINKED, Dependency.Modifier.READ,
@@ -139,8 +154,7 @@ public final class JLinkSteps {
                 }
                 return null;
             });
-            // write the JAR
-            bmp.put(moduleName, ModuleWriter.writeModule(moduleInfo, staging, manifest, true));
+            bmp.put(moduleName, ModuleWriter.writeModule(moduleInfo, staging, manifest, true, reachable));
         }
         return new JLinkStagedOutputItem(staging, bmp);
     }
@@ -162,7 +176,8 @@ public final class JLinkSteps {
     @BuildStep
     public JLinkImageBuildItem jlink(
             JLinkStagedOutputItem stagedOutput,
-            ApplicationModuleInfoBuildItem moduleInfoItem) throws BuildException, IOException {
+            ApplicationModuleInfoBuildItem moduleInfoItem,
+            JarTreeShakeBuildItem treeShakeResult) throws BuildException, IOException {
         Path imagePath = config.outputDirectory().resolve(config.imagePath());
 
         // the image must be deleted or jlink will complain
@@ -176,19 +191,17 @@ public final class JLinkSteps {
         List<String> jvmArgs = new ArrayList<>();
         List<String> jlinkArgs = new ArrayList<>();
 
-        // JVM args
+        List<String> jdkModules = moduleInfoItem.model().jdkModulesUsed();
+        log.debugf("JDK modules included in image (%d): %s", jdkModules.size(), jdkModules);
+        String addedModules = "ALL-MODULE-PATH,jdk.jdwp.agent," + String.join(",", jdkModules);
 
-        String addedModules = "ALL-MODULE-PATH,jdk.jdwp.agent," + String.join(",", moduleInfoItem.model().jdkModulesUsed());
-
-        // access to module internals
+        // JVM args to embed in the image launcher script.
+        // These are written directly into the launcher after jlink runs,
+        // because jlink's --add-options parser rejects values starting with "--".
         jvmArgs.add("--add-exports=java.base/jdk.internal.module=io.smallrye.modules");
-        // add modules to JVM path
-        // xxx replace with injected module dependencies on main module?
         jvmArgs.add("--add-modules=" + addedModules);
         // todo: patch for loom
-        //jvmArgs.add("--patch-module");
-        //jvmArgs.add("java.base=" + javaBasePatchPath);
-        // memory
+        //jvmArgs.add("--patch-module=java.base=" + javaBasePatchPath);
         config.minHeapSize().ifPresent(s -> jvmArgs.add("-Xms" + s.toLowerString()));
         config.maxHeapSize().ifPresent(s -> jvmArgs.add("-Xmx" + s.toLowerString()));
         jvmArgs.add("-Djava.util.logging.manager=org.jboss.logmanager.LogManager");
@@ -217,10 +230,6 @@ public final class JLinkSteps {
 
         // CDS arguments -- todo
         //jlinkArgs.add("--generate-cds-archive");
-        // add necessary JDK options
-        if (!jvmArgs.isEmpty()) {
-            jlinkArgs.add("--add-options=" + String.join(" ", jvmArgs));
-        }
         // just choose server VM
         jlinkArgs.add("--vm");
         jlinkArgs.add("server");
@@ -251,12 +260,22 @@ public final class JLinkSteps {
         if (result != 0) {
             throw new BuildException("Build failed during jlink (exit code " + result + ")");
         }
+        // patch the launcher scripts to include JVM args
+        if (!jvmArgs.isEmpty()) {
+            Path binDir = imagePath.resolve("bin");
+            patchLauncherScript(binDir.resolve(config.launcherName()), jvmArgs);
+            Path batFile = binDir.resolve(config.launcherName() + ".bat");
+            if (Files.exists(batFile)) {
+                patchWindowsLauncherScript(batFile, jvmArgs);
+            }
+        }
         // produce the dynamic lib files
         // bundle dynamic modules into the image
         Path lib = config.outputDirectory().resolve(config.imagePath()).resolve("lib").resolve("quarkus");
         Files.createDirectories(lib);
         final AppModuleModel model = moduleInfoItem.model();
         Map<String, ModuleInfo> modulesByName = model.modulesByName();
+        Set<String> reachable = treeShakeResult.isClassesShaken() ? treeShakeResult.getReachableClassNames() : null;
         for (ModuleInfo moduleInfo : modulesByName.values()) {
             String moduleName = moduleInfo.name();
             if (model.bootModules().contains(moduleName)) {
@@ -264,12 +283,59 @@ public final class JLinkSteps {
                 continue;
             }
             // TODO: create an actual manifest (if needed)
-            ModuleWriter.writeModule(moduleInfo, lib.resolve(moduleInfo.name()), new Manifest(), false);
+            ModuleWriter.writeModule(moduleInfo, lib.resolve(moduleInfo.name()), new Manifest(), false, reachable);
         }
 
         log.infof("JLink image produced in %s at %s; to run the image, execute %s in that directory",
                 format(duration), imagePath, Path.of("bin").resolve(config.launcherName()));
         return new JLinkImageBuildItem(imagePath, Set.of(config.launcherName()));
+    }
+
+    /**
+     * Patch a jlink-generated launcher shell script to inject JVM arguments
+     * and use {@code exec} so the JVM replaces the shell process.
+     * <p>
+     * jlink's {@code --add-options} plugin cannot handle values starting with {@code "--"}
+     * (e.g. {@code --add-exports}, {@code --add-modules}), so we inject them directly
+     * into the launcher script by replacing the empty {@code JLINK_VM_OPTIONS=} line.
+     * <p>
+     * The {@code exec} prefix ensures the JVM inherits the shell's PID, so
+     * signals (e.g. SIGTERM) reach the JVM directly instead of only hitting
+     * the wrapper shell.
+     *
+     * @param launcherPath the path to the launcher script
+     * @param jvmArgs the JVM arguments to inject
+     * @throws IOException if the script cannot be read or written
+     */
+    private static void patchLauncherScript(Path launcherPath, List<String> jvmArgs) throws IOException {
+        String content = Files.readString(launcherPath);
+        String opts = String.join(" ", jvmArgs);
+        String patched = content.replace("JLINK_VM_OPTIONS=\n",
+                "JLINK_VM_OPTIONS=\"" + opts + "\"\n");
+        // exec so the JVM replaces the shell — Process.destroy() then targets the JVM directly
+        patched = patched.replace("$DIR/java $JLINK_VM_OPTIONS", "exec $DIR/java $JLINK_VM_OPTIONS");
+        Files.writeString(launcherPath, patched);
+    }
+
+    /**
+     * Patch a jlink-generated Windows {@code .bat} launcher to inject JVM arguments.
+     * The batch file uses {@code set JLINK_VM_OPTIONS=} syntax.
+     *
+     * @param launcherPath the path to the {@code .bat} launcher script
+     * @param jvmArgs the JVM arguments to inject
+     * @throws IOException if the script cannot be read or written
+     */
+    private static void patchWindowsLauncherScript(Path launcherPath, List<String> jvmArgs) throws IOException {
+        String content = Files.readString(launcherPath);
+        String opts = String.join(" ", jvmArgs);
+        // handle both \r\n (Windows) and \n (Unix) line endings
+        String patched = content.replace("set JLINK_VM_OPTIONS=\r\n",
+                "set JLINK_VM_OPTIONS=" + opts + "\r\n");
+        if (patched.equals(content)) {
+            patched = content.replace("set JLINK_VM_OPTIONS=\n",
+                    "set JLINK_VM_OPTIONS=" + opts + "\n");
+        }
+        Files.writeString(launcherPath, patched);
     }
 
     /**

--- a/extensions/packaging/modular/deployment/src/main/java/io/quarkus/modular/deployment/ModularitySteps.java
+++ b/extensions/packaging/modular/deployment/src/main/java/io/quarkus/modular/deployment/ModularitySteps.java
@@ -38,6 +38,7 @@ import io.quarkus.deployment.builditem.ModuleEnableNativeAccessBuildItem;
 import io.quarkus.deployment.builditem.ModuleOpenBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.pkg.builditem.JarTreeShakeBuildItem;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.Dependency;
@@ -50,6 +51,7 @@ import io.quarkus.modular.spi.model.AppModuleModel;
 import io.quarkus.modular.spi.model.AutoDependencyGroup;
 import io.quarkus.modular.spi.model.DependencyInfo;
 import io.quarkus.modular.spi.model.ModuleInfo;
+import io.quarkus.modular.spi.model.ModuleTreeShaker;
 import io.quarkus.paths.ManifestAttributes;
 import io.quarkus.paths.PathTree;
 import io.smallrye.classfile.Annotation;
@@ -113,7 +115,8 @@ public final class ModularitySteps {
             // TODO: List<ModuleExportBuildItem> exports,
             List<ModuleEnableNativeAccessBuildItem> nativeAccesses,
             List<AddDependencyBuildItem> extraDeps,
-            List<BootModulePathBuildItem> bootPathItems) {
+            List<BootModulePathBuildItem> bootPathItems,
+            JarTreeShakeBuildItem treeShakeResult) {
 
         /* @formatter:off
          * Build the modular application model. This is done in a few stages.
@@ -322,6 +325,34 @@ public final class ModularitySteps {
         extraDepsMap.computeIfAbsent("io.vertx.core", ModularitySteps::newMap)
                 .put("io.quarkus.vertx", Modifier.Set.of(Modifier.READ, Modifier.LINKED, Modifier.SYNTHETIC));
 
+        // When tree-shaking is active, pre-scan dependencies to identify dead modules
+        // so we can skip the expensive getModuleInfo() call for them.
+        final boolean treeShakeActive = treeShakeResult.isClassesShaken();
+        final Set<String> deadModules;
+        final Set<String> reachableClassNames;
+        final Set<String> neededJdkModules;
+        if (treeShakeActive) {
+            reachableClassNames = treeShakeResult.getReachableClassNames();
+            neededJdkModules = ModuleTreeShaker.computeNeededJdkModules(treeShakeResult.getReferencedJdkPackages());
+            deadModules = new HashSet<>();
+            for (ResolvedDependency dep : knownNamedModules.values()) {
+                if (!dep.isRuntimeCp()) {
+                    continue;
+                }
+                String mn = dep.getModuleName();
+                if (mn.equals(appModuleName)) {
+                    continue;
+                }
+                if (!ModuleTreeShaker.isModuleAlive(dep.getContentTree(), mn, reachableClassNames)) {
+                    deadModules.add(mn);
+                }
+            }
+        } else {
+            deadModules = Set.of();
+            reachableClassNames = Set.of();
+            neededJdkModules = Set.of();
+        }
+
         // Now go through the process to build a (Quarkus) module descriptor for each artifact.
         for (ResolvedDependency dependency : knownNamedModules.values()) {
             if (!dependency.isRuntimeCp()) {
@@ -330,6 +361,9 @@ public final class ModularitySteps {
             String moduleName = dependency.getModuleName();
             if (moduleName.equals(appModuleName)) {
                 // we do app module at the end
+                continue;
+            }
+            if (deadModules.contains(moduleName)) {
                 continue;
             }
             // Get the module info.
@@ -401,24 +435,30 @@ public final class ModularitySteps {
                                                     Collectors.toMap(Function.identity(), ignored -> PackageAccess.OPEN))))
                                     .toList());
                         }
-                        // tabulate any used JDK modules.
-                        mi.dependencies().stream()
-                                .map(DependencyInfo::moduleName)
-                                .filter(n -> n.startsWith("java.") || n.startsWith("jdk.") || n.startsWith("ibm."))
-                                .forEach(usedJdkModuleNames::add);
+                        // tabulate any used JDK modules (skipped when tree-shaking recomputes them).
+                        if (!treeShakeActive) {
+                            mi.dependencies().stream()
+                                    .map(DependencyInfo::moduleName)
+                                    .filter(n -> n.startsWith("java.") || n.startsWith("jdk.") || n.startsWith("ibm."))
+                                    .forEach(usedJdkModuleNames::add);
+                        }
                         return mi;
                     });
+            // Apply tree-shaking cleanup to the surviving module.
+            ModuleInfo cleanedModule = treeShakeActive
+                    ? ModuleTreeShaker.cleanModule(depModule, deadModules, reachableClassNames, neededJdkModules)
+                    : depModule;
             // Add the module to the index.
             if (modulesByName.containsKey(moduleName)) {
                 ModuleInfo existing = modulesByName.get(moduleName);
-                if (existing.equals(depModule)) {
+                if (existing.equals(cleanedModule)) {
                     // no harm; it's just in there twice for some reason
                     continue;
                 }
                 throw new IllegalStateException("Module '" + moduleName + "' has been defined twice, in: " +
-                        depModule.resolvedArtifact() + " and " + existing.resolvedArtifact());
+                        cleanedModule.resolvedArtifact() + " and " + existing.resolvedArtifact());
             }
-            modulesByName.put(moduleName, depModule);
+            modulesByName.put(moduleName, cleanedModule);
             // Warn about any split packages (temporary until #44657; then we don't care as much about it).
             depModule.packages().keySet().forEach(pn -> {
                 String existing = modulesByPackageTemporary.putIfAbsent(pn, moduleName);
@@ -490,16 +530,23 @@ public final class ModularitySteps {
                             .stream()
                             .map((e) -> new DependencyInfo(e.getKey(), e.getValue(), Map.of()))
                             .toList());
-                    // tabulate any used JDK modules.
-                    mi.dependencies().stream()
-                            .map(DependencyInfo::moduleName)
-                            .filter(n -> n.startsWith("java.") || n.startsWith("jdk.") || n.startsWith("ibm."))
-                            .forEach(usedJdkModuleNames::add);
+                    // tabulate any used JDK modules (skipped when tree-shaking recomputes them).
+                    if (!treeShakeActive) {
+                        mi.dependencies().stream()
+                                .map(DependencyInfo::moduleName)
+                                .filter(n -> n.startsWith("java.") || n.startsWith("jdk.") || n.startsWith("ibm."))
+                                .forEach(usedJdkModuleNames::add);
+                    }
                     return mi;
                 });
 
+        // Apply tree-shaking cleanup to the app module.
+        ModuleInfo cleanedAppModule = treeShakeActive
+                ? ModuleTreeShaker.cleanModule(appModule, deadModules, reachableClassNames, neededJdkModules)
+                : appModule;
+
         // Register the app module with the others.
-        modulesByName.put(appModuleName, appModule);
+        modulesByName.put(appModuleName, cleanedAppModule);
 
         // -----------------------------------
         // at this point, appModule is frozen!
@@ -516,11 +563,34 @@ public final class ModularitySteps {
         }
         // Build and return the final modular model.
         AppModuleModel.Builder amb = AppModuleModel.builder();
-        amb.appModuleInfo(appModule);
-        usedJdkModuleNames.forEach(amb::jdkModuleUsed);
+        amb.appModuleInfo(cleanedAppModule);
+        if (treeShakeActive) {
+            // Recompute JDK modules from cleaned surviving modules only.
+            Set<String> cleanedJdkModules = new HashSet<>();
+            for (ModuleInfo mi : modulesByName.values()) {
+                ModuleTreeShaker.collectJdkModules(mi, cleanedJdkModules);
+            }
+            cleanedJdkModules.forEach(amb::jdkModuleUsed);
+        } else {
+            usedJdkModuleNames.forEach(amb::jdkModuleUsed);
+        }
         bootModuleSet.forEach(m -> amb.bootModule(m.name()));
         modulesByName.values().forEach(amb::moduleInfo);
-        return new ApplicationModuleInfoBuildItem(amb.build());
+        AppModuleModel appModuleModel = amb.build();
+
+        if (treeShakeActive) {
+            // Warn about modules that are graph-unreachable but contain reachable classes.
+            Set<String> graphDead = ModuleTreeShaker.findGraphUnreachableModules(appModuleModel, deadModules);
+            if (!graphDead.isEmpty()) {
+                ModuleTreeShaker.logGraphDeadWithReachableClasses(graphDead);
+            }
+            if (!deadModules.isEmpty()) {
+                log.infof("Module tree-shaking removed %d unreachable modules; image will contain %d app + %d JDK modules",
+                        deadModules.size(), modulesByName.size(), appModuleModel.jdkModulesUsed().size());
+            }
+        }
+
+        return new ApplicationModuleInfoBuildItem(appModuleModel);
     }
 
     private static final Set<String> bootLayerNames = ModuleLayer.boot().modules().stream().map(Module::getName)
@@ -742,6 +812,7 @@ public final class ModularitySteps {
             case "io.quarkus.resteasy.reactive.vertx" -> {
                 depAccesses.computeIfAbsent("io.vertx.core", ModularitySteps::newMap)
                         .putAll(Map.of("io.vertx.core.impl", PackageAccess.EXPORTED,
+                                "io.vertx.core.impl.buffer", PackageAccess.EXPORTED,
                                 "io.vertx.core.buffer.impl", PackageAccess.EXPORTED,
                                 "io.vertx.core.http.impl", PackageAccess.EXPORTED,
                                 "io.vertx.core.net.impl", PackageAccess.EXPORTED));
@@ -782,7 +853,6 @@ public final class ModularitySteps {
                 depAccesses.computeIfAbsent("io.vertx.core", ModularitySteps::newMap)
                         .putAll(Map.of(
                                 "io.vertx.core.impl", PackageAccess.EXPORTED,
-                                "io.vertx.core.impl.logging", PackageAccess.EXPORTED,
                                 "io.vertx.core.http.impl", PackageAccess.EXPORTED,
                                 "io.vertx.core.net.impl", PackageAccess.EXPORTED));
             }

--- a/extensions/packaging/modular/deployment/src/main/java/io/quarkus/modular/deployment/ModularitySteps.java
+++ b/extensions/packaging/modular/deployment/src/main/java/io/quarkus/modular/deployment/ModularitySteps.java
@@ -38,6 +38,7 @@ import io.quarkus.deployment.builditem.ModuleEnableNativeAccessBuildItem;
 import io.quarkus.deployment.builditem.ModuleOpenBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.pkg.builditem.JarTreeShakeBuildItem;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.Dependency;
@@ -50,6 +51,7 @@ import io.quarkus.modular.spi.model.AppModuleModel;
 import io.quarkus.modular.spi.model.AutoDependencyGroup;
 import io.quarkus.modular.spi.model.DependencyInfo;
 import io.quarkus.modular.spi.model.ModuleInfo;
+import io.quarkus.modular.spi.model.ModuleTreeShaker;
 import io.quarkus.paths.ManifestAttributes;
 import io.quarkus.paths.PathTree;
 import io.smallrye.classfile.Annotation;
@@ -113,7 +115,8 @@ public final class ModularitySteps {
             // TODO: List<ModuleExportBuildItem> exports,
             List<ModuleEnableNativeAccessBuildItem> nativeAccesses,
             List<AddDependencyBuildItem> extraDeps,
-            List<BootModulePathBuildItem> bootPathItems) {
+            List<BootModulePathBuildItem> bootPathItems,
+            JarTreeShakeBuildItem treeShakeResult) {
 
         /* @formatter:off
          * Build the modular application model. This is done in a few stages.
@@ -322,6 +325,34 @@ public final class ModularitySteps {
         extraDepsMap.computeIfAbsent("io.vertx.core", ModularitySteps::newMap)
                 .put("io.quarkus.vertx", Modifier.Set.of(Modifier.READ, Modifier.LINKED, Modifier.SYNTHETIC));
 
+        // When tree-shaking is active, pre-scan dependencies to identify dead modules
+        // so we can skip the expensive getModuleInfo() call for them.
+        final boolean treeShakeActive = treeShakeResult.isClassesShaken();
+        final Set<String> deadModules;
+        final Set<String> reachableClassNames;
+        final Set<String> neededJdkModules;
+        if (treeShakeActive) {
+            reachableClassNames = treeShakeResult.getReachableClassNames();
+            neededJdkModules = ModuleTreeShaker.computeNeededJdkModules(treeShakeResult.getReferencedJdkPackages());
+            deadModules = new HashSet<>();
+            for (ResolvedDependency dep : knownNamedModules.values()) {
+                if (!dep.isRuntimeCp()) {
+                    continue;
+                }
+                String mn = dep.getModuleName();
+                if (mn.equals(appModuleName)) {
+                    continue;
+                }
+                if (!ModuleTreeShaker.isModuleAlive(dep.getContentTree(), mn, reachableClassNames)) {
+                    deadModules.add(mn);
+                }
+            }
+        } else {
+            deadModules = Set.of();
+            reachableClassNames = Set.of();
+            neededJdkModules = Set.of();
+        }
+
         // Now go through the process to build a (Quarkus) module descriptor for each artifact.
         for (ResolvedDependency dependency : knownNamedModules.values()) {
             if (!dependency.isRuntimeCp()) {
@@ -330,6 +361,9 @@ public final class ModularitySteps {
             String moduleName = dependency.getModuleName();
             if (moduleName.equals(appModuleName)) {
                 // we do app module at the end
+                continue;
+            }
+            if (deadModules.contains(moduleName)) {
                 continue;
             }
             // Get the module info.
@@ -401,24 +435,30 @@ public final class ModularitySteps {
                                                     Collectors.toMap(Function.identity(), ignored -> PackageAccess.OPEN))))
                                     .toList());
                         }
-                        // tabulate any used JDK modules.
-                        mi.dependencies().stream()
-                                .map(DependencyInfo::moduleName)
-                                .filter(n -> n.startsWith("java.") || n.startsWith("jdk.") || n.startsWith("ibm."))
-                                .forEach(usedJdkModuleNames::add);
+                        // tabulate any used JDK modules (skipped when tree-shaking recomputes them).
+                        if (!treeShakeActive) {
+                            mi.dependencies().stream()
+                                    .map(DependencyInfo::moduleName)
+                                    .filter(n -> n.startsWith("java.") || n.startsWith("jdk.") || n.startsWith("ibm."))
+                                    .forEach(usedJdkModuleNames::add);
+                        }
                         return mi;
                     });
+            // Apply tree-shaking cleanup to the surviving module.
+            ModuleInfo cleanedModule = treeShakeActive
+                    ? ModuleTreeShaker.cleanModule(depModule, deadModules, reachableClassNames, neededJdkModules)
+                    : depModule;
             // Add the module to the index.
             if (modulesByName.containsKey(moduleName)) {
                 ModuleInfo existing = modulesByName.get(moduleName);
-                if (existing.equals(depModule)) {
+                if (existing.equals(cleanedModule)) {
                     // no harm; it's just in there twice for some reason
                     continue;
                 }
                 throw new IllegalStateException("Module '" + moduleName + "' has been defined twice, in: " +
-                        depModule.resolvedArtifact() + " and " + existing.resolvedArtifact());
+                        cleanedModule.resolvedArtifact() + " and " + existing.resolvedArtifact());
             }
-            modulesByName.put(moduleName, depModule);
+            modulesByName.put(moduleName, cleanedModule);
             // Warn about any split packages (temporary until #44657; then we don't care as much about it).
             depModule.packages().keySet().forEach(pn -> {
                 String existing = modulesByPackageTemporary.putIfAbsent(pn, moduleName);
@@ -490,16 +530,23 @@ public final class ModularitySteps {
                             .stream()
                             .map((e) -> new DependencyInfo(e.getKey(), e.getValue(), Map.of()))
                             .toList());
-                    // tabulate any used JDK modules.
-                    mi.dependencies().stream()
-                            .map(DependencyInfo::moduleName)
-                            .filter(n -> n.startsWith("java.") || n.startsWith("jdk.") || n.startsWith("ibm."))
-                            .forEach(usedJdkModuleNames::add);
+                    // tabulate any used JDK modules (skipped when tree-shaking recomputes them).
+                    if (!treeShakeActive) {
+                        mi.dependencies().stream()
+                                .map(DependencyInfo::moduleName)
+                                .filter(n -> n.startsWith("java.") || n.startsWith("jdk.") || n.startsWith("ibm."))
+                                .forEach(usedJdkModuleNames::add);
+                    }
                     return mi;
                 });
 
+        // Apply tree-shaking cleanup to the app module.
+        ModuleInfo cleanedAppModule = treeShakeActive
+                ? ModuleTreeShaker.cleanModule(appModule, deadModules, reachableClassNames, neededJdkModules)
+                : appModule;
+
         // Register the app module with the others.
-        modulesByName.put(appModuleName, appModule);
+        modulesByName.put(appModuleName, cleanedAppModule);
 
         // -----------------------------------
         // at this point, appModule is frozen!
@@ -516,11 +563,34 @@ public final class ModularitySteps {
         }
         // Build and return the final modular model.
         AppModuleModel.Builder amb = AppModuleModel.builder();
-        amb.appModuleInfo(appModule);
-        usedJdkModuleNames.forEach(amb::jdkModuleUsed);
+        amb.appModuleInfo(cleanedAppModule);
+        if (treeShakeActive) {
+            // Recompute JDK modules from cleaned surviving modules only.
+            Set<String> cleanedJdkModules = new HashSet<>();
+            for (ModuleInfo mi : modulesByName.values()) {
+                ModuleTreeShaker.collectJdkModules(mi, cleanedJdkModules);
+            }
+            cleanedJdkModules.forEach(amb::jdkModuleUsed);
+        } else {
+            usedJdkModuleNames.forEach(amb::jdkModuleUsed);
+        }
         bootModuleSet.forEach(m -> amb.bootModule(m.name()));
         modulesByName.values().forEach(amb::moduleInfo);
-        return new ApplicationModuleInfoBuildItem(amb.build());
+        AppModuleModel appModuleModel = amb.build();
+
+        if (treeShakeActive) {
+            // Warn about modules that are graph-unreachable but contain reachable classes.
+            Set<String> graphDead = ModuleTreeShaker.findGraphUnreachableModules(appModuleModel, deadModules);
+            if (!graphDead.isEmpty()) {
+                ModuleTreeShaker.logGraphDeadWithReachableClasses(graphDead);
+            }
+            if (!deadModules.isEmpty()) {
+                log.infof("Module tree-shaking removed %d unreachable modules; image will contain %d app + %d JDK modules",
+                        deadModules.size(), modulesByName.size(), appModuleModel.jdkModulesUsed().size());
+            }
+        }
+
+        return new ApplicationModuleInfoBuildItem(appModuleModel);
     }
 
     private static final Set<String> bootLayerNames = ModuleLayer.boot().modules().stream().map(Module::getName)
@@ -743,6 +813,7 @@ public final class ModularitySteps {
                 depAccesses.computeIfAbsent("io.vertx.core", ModularitySteps::newMap)
                         .putAll(Map.of("io.vertx.core.impl", PackageAccess.EXPORTED,
                                 "io.vertx.core.impl.buffer", PackageAccess.EXPORTED,
+                                "io.vertx.core.buffer.impl", PackageAccess.EXPORTED,
                                 "io.vertx.core.http.impl", PackageAccess.EXPORTED,
                                 "io.vertx.core.net.impl", PackageAccess.EXPORTED));
             }

--- a/extensions/packaging/modular/spi/pom.xml
+++ b/extensions/packaging/modular/spi/pom.xml
@@ -46,6 +46,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/ClassPathUtils.java
+++ b/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/ClassPathUtils.java
@@ -1,0 +1,47 @@
+package io.quarkus.modular.spi;
+
+/**
+ * Shared utility methods for inspecting classpath resource paths.
+ */
+public final class ClassPathUtils {
+
+    private static final String DOT_CLASS = ".class";
+    private static final String MODULE_INFO_CLASS = "module-info.class";
+
+    private ClassPathUtils() {
+    }
+
+    /**
+     * Check whether a resource path represents a regular {@code .class} file entry,
+     * excluding {@code module-info.class} descriptors.
+     *
+     * @param resourcePath the resource path within a JAR
+     * @return {@code true} if this is a regular class file entry
+     */
+    public static boolean isClassEntry(String resourcePath) {
+        return resourcePath.endsWith(DOT_CLASS) && !isModuleInfoEntry(resourcePath);
+    }
+
+    /**
+     * Check whether a resource path is a {@code module-info.class} descriptor.
+     *
+     * @param resourcePath the resource path within a JAR
+     * @return {@code true} if the path is a {@code module-info.class}
+     */
+    public static boolean isModuleInfoEntry(String resourcePath) {
+        return resourcePath.endsWith(MODULE_INFO_CLASS) &&
+                (resourcePath.length() == MODULE_INFO_CLASS.length() ||
+                        resourcePath.charAt(resourcePath.length() - MODULE_INFO_CLASS.length() - 1) == '/');
+    }
+
+    /**
+     * Convert a JAR resource path for a class file to a dot-separated class name.
+     * For example, {@code "com/example/Foo.class"} becomes {@code "com.example.Foo"}.
+     *
+     * @param resourcePath the resource path (must end with {@code .class})
+     * @return the dot-separated class name
+     */
+    public static String resourcePathToClassName(String resourcePath) {
+        return resourcePath.substring(0, resourcePath.length() - DOT_CLASS.length()).replace('/', '.');
+    }
+}

--- a/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/ModuleWriter.java
+++ b/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/ModuleWriter.java
@@ -14,6 +14,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileAttribute;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -76,6 +77,23 @@ public final class ModuleWriter {
      */
     public static Path writeModule(ModuleInfo moduleInfo, Path outputDirectory, Manifest manifest, final boolean bootModule)
             throws IOException {
+        return writeModule(moduleInfo, outputDirectory, manifest, bootModule, null);
+    }
+
+    /**
+     * Write a patched module to the given output directory, optionally filtering out unreachable classes.
+     *
+     * @param moduleInfo the module information (must not be {@code null})
+     * @param outputDirectory the output directory (must not be {@code null})
+     * @param manifest the JAR manifest (must not be {@code null})
+     * @param bootModule {@code true} if this module is a boot module (and thus requires a {@code module-info.class})
+     * @param reachableClassNames dot-separated names of reachable classes, or {@code null} to include all classes
+     * @return the path of the written module
+     * @throws IOException if writing fails for some reason
+     */
+    public static Path writeModule(ModuleInfo moduleInfo, Path outputDirectory, Manifest manifest, final boolean bootModule,
+            Set<String> reachableClassNames)
+            throws IOException {
         Assert.checkNotNullParam("moduleInfo", moduleInfo);
         Assert.checkNotNullParam("outputDirectory", outputDirectory);
         Assert.checkNotNullParam("manifest", manifest);
@@ -111,10 +129,18 @@ public final class ModuleWriter {
             try (OutputStream os = ab.addEntry("META-INF/MANIFEST.MF", Set.of(ZipOption.STORED), defaultAttrs)) {
                 manifest.write(os);
             }
+            // when class filtering is active, compute the set of packages with surviving
+            // classes and use it to adjust both the descriptor and the content walk
+            final Set<String> survivingPackages = reachableClassNames != null && !reachableClassNames.isEmpty()
+                    ? computeSurvivingPackages(moduleInfo, reachableClassNames)
+                    : Set.of();
+            ModuleInfo descriptorInfo = !survivingPackages.isEmpty()
+                    ? adjustDescriptorForFiltering(moduleInfo, survivingPackages)
+                    : moduleInfo;
             // next, write module descriptor
             if (bootModule) {
                 // descriptor for "normal" module
-                ab.addEntry("module-info.class", getModuleInfoClass(moduleInfo), Set.of(ZipOption.STORED), defaultAttrs);
+                ab.addEntry("module-info.class", getModuleInfoClass(descriptorInfo), Set.of(ZipOption.STORED), defaultAttrs);
             } else {
                 // write XML for automatic module
                 try (Writer w = ab.addEntry("module.xml", StandardCharsets.UTF_8)) {
@@ -122,7 +148,7 @@ public final class ModuleWriter {
                     xmlOutputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, Boolean.TRUE);
                     XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(w);
                     try (XmlCloser ignored = xml::close) {
-                        writeModuleXml(new FormattingXMLStreamWriter(xml), moduleInfo);
+                        writeModuleXml(new FormattingXMLStreamWriter(xml), descriptorInfo);
                     }
                 } catch (XMLStreamException e) {
                     throw new IOException(e);
@@ -170,10 +196,19 @@ public final class ModuleWriter {
                         }
                     }
                 } else {
-                    if (rp.equals("META-INF/MANIFEST.MF") || rp.equals("module-info.class")
-                            || rp.endsWith("/module-info.class")) {
+                    if (rp.equals("META-INF/MANIFEST.MF") || ClassPathUtils.isModuleInfoEntry(rp)) {
                         // skip
                         return;
+                    }
+                    if (reachableClassNames != null) {
+                        if (ClassPathUtils.isClassEntry(rp)) {
+                            String className = ClassPathUtils.resourcePathToClassName(rp);
+                            if (!reachableClassNames.contains(className)) {
+                                return;
+                            }
+                        } else if (isResourceInDeadPackage(rp, moduleInfo.packages(), survivingPackages)) {
+                            return;
+                        }
                     }
                     int idx = rp.lastIndexOf('/');
                     if (idx != -1) {
@@ -546,6 +581,130 @@ public final class ModuleWriter {
             }
             xml.writeEndElement(); // dependency
         }
+    }
+
+    /**
+     * Create a ModuleInfo whose packages map exactly matches the classes that
+     * will survive filtering. Packages with no surviving classes are removed,
+     * and packages with surviving classes that were not in the original
+     * descriptor are added as PRIVATE. This keeps the module descriptor
+     * consistent with the actual JAR content, preventing jlink validation
+     * errors in both directions.
+     *
+     * @param moduleInfo the original module information (must not be {@code null})
+     * @param survivingPackages the set of package names that have at least one surviving class
+     * @return a new {@link ModuleInfo} with adjusted packages, or the original if no change is needed
+     */
+    private static ModuleInfo adjustDescriptorForFiltering(ModuleInfo moduleInfo, Set<String> survivingPackages) {
+        Map<String, PackageInfo> original = moduleInfo.packages();
+        if (survivingPackages.equals(original.keySet())) {
+            return moduleInfo;
+        }
+        Map<String, PackageInfo> adjusted = new HashMap<>(survivingPackages.size());
+        for (String pkg : survivingPackages) {
+            PackageInfo info = original.get(pkg);
+            adjusted.put(pkg, info != null ? info : PackageInfo.PRIVATE);
+        }
+        logPackageAdjustments(moduleInfo, survivingPackages);
+        return moduleInfo.withPackages(adjusted);
+    }
+
+    /**
+     * Log which packages were dropped and which were added for debugging.
+     *
+     * @param moduleInfo the module being adjusted (must not be {@code null})
+     * @param surviving the set of package names that survived filtering
+     */
+    private static void logPackageAdjustments(ModuleInfo moduleInfo, Set<String> surviving) {
+        if (!log.isDebugEnabled()) {
+            return;
+        }
+        Map<String, PackageInfo> packages = moduleInfo.packages();
+        List<String> dropped = null;
+        for (String pkg : packages.keySet()) {
+            if (!surviving.contains(pkg)) {
+                if (dropped == null) {
+                    dropped = new ArrayList<>();
+                }
+                dropped.add(pkg);
+            }
+        }
+        List<String> added = null;
+        for (String pkg : surviving) {
+            if (!packages.containsKey(pkg)) {
+                if (added == null) {
+                    added = new ArrayList<>();
+                }
+                added.add(pkg);
+            }
+        }
+        String moduleName = moduleInfo.name();
+        if (dropped != null) {
+            log.debugf("Module %s: dropping packages with no surviving classes: %s", moduleName, dropped);
+        }
+        if (added != null) {
+            log.debugf("Module %s: adding undeclared packages with surviving classes: %s", moduleName, added);
+        }
+    }
+
+    /**
+     * Scan the module's content tree and generated resources to determine which
+     * Java packages have at least one reachable class after filtering.
+     *
+     * @param moduleInfo the module whose content to scan (must not be {@code null})
+     * @param reachableClassNames dot-separated names of reachable classes (must not be {@code null})
+     * @return the set of package names that contain at least one reachable class
+     */
+    private static Set<String> computeSurvivingPackages(ModuleInfo moduleInfo, Set<String> reachableClassNames) {
+        Set<String> packages = new HashSet<>();
+        for (Resource resource : moduleInfo.generated()) {
+            collectPackageIfReachable(resource.pathName(), reachableClassNames, packages);
+        }
+        moduleInfo.resolvedArtifact().getContentTree()
+                .walk(visited -> collectPackageIfReachable(visited.getResourceName(), reachableClassNames, packages));
+        return packages;
+    }
+
+    /**
+     * If the resource path is a reachable class file (excluding module-info.class),
+     * add its package to the set.
+     *
+     * @param resourcePath the resource path within the JAR
+     * @param reachableClassNames dot-separated names of reachable classes
+     * @param packages the set to add the package name to if the class is reachable
+     */
+    private static void collectPackageIfReachable(String resourcePath, Set<String> reachableClassNames,
+            Set<String> packages) {
+        if (!ClassPathUtils.isClassEntry(resourcePath)) {
+            return;
+        }
+        String className = ClassPathUtils.resourcePathToClassName(resourcePath);
+        if (reachableClassNames.contains(className)) {
+            int dot = className.lastIndexOf('.');
+            if (dot > 0) {
+                packages.add(className.substring(0, dot));
+            }
+        }
+    }
+
+    /**
+     * Check whether a non-class resource belongs to a declared package whose
+     * classes have all been filtered out. Resources in dead packages are filtered
+     * to keep the JAR content consistent with the module descriptor.
+     *
+     * @param resourcePath the resource path within the JAR
+     * @param declaredPackages the module's declared packages map
+     * @param survivingPackages the set of package names that survived class filtering
+     * @return {@code true} if the resource belongs to a declared package with no surviving classes
+     */
+    private static boolean isResourceInDeadPackage(String resourcePath, Map<String, PackageInfo> declaredPackages,
+            Set<String> survivingPackages) {
+        int slash = resourcePath.lastIndexOf('/');
+        if (slash <= 0) {
+            return false;
+        }
+        String pkg = resourcePath.substring(0, slash).replace('/', '.');
+        return declaredPackages.containsKey(pkg) && !survivingPackages.contains(pkg);
     }
 
     @SuppressWarnings("unchecked")

--- a/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/model/AppModuleModel.java
+++ b/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/model/AppModuleModel.java
@@ -10,6 +10,7 @@ import java.util.Set;
 
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.smallrye.common.constraint.Assert;
+import io.smallrye.modules.desc.PackageAccess;
 
 public final class AppModuleModel {
     private final ModuleInfo appModuleInfo;
@@ -117,7 +118,68 @@ public final class AppModuleModel {
         }
 
         public AppModuleModel build() {
+            cleanDependencyPackageAccesses();
             return new AppModuleModel(this);
+        }
+
+        /**
+         * Remove package access entries (add-exports/add-opens) from dependencies
+         * that reference packages not present in the target module. This prevents
+         * warnings from the module runtime about missing packages.
+         */
+        private void cleanDependencyPackageAccesses() {
+            Map<String, ModuleInfo> updated = null;
+            for (ModuleInfo moduleInfo : modulesByName.values()) {
+                ModuleInfo cleaned = cleanDependencyPackageAccesses(moduleInfo);
+                if (cleaned != moduleInfo) {
+                    if (updated == null) {
+                        updated = new HashMap<>(modulesByName);
+                    }
+                    updated.put(cleaned.name(), cleaned);
+                    if (appModuleInfo != null && moduleInfo.name().equals(appModuleInfo.name())) {
+                        appModuleInfo = cleaned;
+                    }
+                }
+            }
+            if (updated != null) {
+                modulesByName = updated;
+            }
+        }
+
+        private ModuleInfo cleanDependencyPackageAccesses(ModuleInfo moduleInfo) {
+            List<DependencyInfo> deps = moduleInfo.dependencies();
+            if (deps.isEmpty()) {
+                return moduleInfo;
+            }
+            List<DependencyInfo> filtered = new ArrayList<>(deps.size());
+            boolean changed = false;
+            for (DependencyInfo dep : deps) {
+                if (dep.packageAccesses().isEmpty()) {
+                    filtered.add(dep);
+                    continue;
+                }
+                ModuleInfo targetModule = modulesByName.get(dep.moduleName());
+                if (targetModule == null) {
+                    filtered.add(dep);
+                    continue;
+                }
+                Map<String, PackageAccess> cleanedAccesses = null;
+                for (String pkg : dep.packageAccesses().keySet()) {
+                    if (!targetModule.packages().containsKey(pkg)) {
+                        if (cleanedAccesses == null) {
+                            cleanedAccesses = new HashMap<>(dep.packageAccesses());
+                        }
+                        cleanedAccesses.remove(pkg);
+                    }
+                }
+                if (cleanedAccesses != null) {
+                    changed = true;
+                    filtered.add(new DependencyInfo(dep.moduleName(), dep.modifiers(), cleanedAccesses));
+                } else {
+                    filtered.add(dep);
+                }
+            }
+            return changed ? moduleInfo.withDependencies(filtered) : moduleInfo;
         }
     }
 }

--- a/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/model/ModuleInfo.java
+++ b/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/model/ModuleInfo.java
@@ -173,6 +173,110 @@ public record ModuleInfo(
                 generated);
     }
 
+    /**
+     * Replace the entire packages map with the given one.
+     * Unlike {@link #withMorePackages(Map)}, which merges additively, this method replaces
+     * the entire map — useful for removing packages after tree-shaking.
+     *
+     * @param packages the new packages map (must not be {@code null})
+     * @return a new {@link ModuleInfo} with the replaced packages, or {@code this} if equal
+     */
+    public ModuleInfo withPackages(final Map<String, PackageInfo> packages) {
+        if (packages.equals(this.packages)) {
+            return this;
+        }
+        return new ModuleInfo(
+                name,
+                version,
+                modifiers,
+                resolvedArtifact,
+                mainClassName,
+                packages,
+                dependencies,
+                autoDependencies,
+                uses,
+                provides,
+                generated);
+    }
+
+    /**
+     * Replace the entire dependencies list with the given one.
+     * Unlike {@link #withMoreDependencies(List)}, which merges additively, this method replaces
+     * the entire list — useful for removing stale requires after module pruning.
+     *
+     * @param dependencies the new dependencies list (must not be {@code null})
+     * @return a new {@link ModuleInfo} with the replaced dependencies, or {@code this} if equal
+     */
+    public ModuleInfo withDependencies(final List<DependencyInfo> dependencies) {
+        if (dependencies.equals(this.dependencies)) {
+            return this;
+        }
+        return new ModuleInfo(
+                name,
+                version,
+                modifiers,
+                resolvedArtifact,
+                mainClassName,
+                packages,
+                dependencies,
+                autoDependencies,
+                uses,
+                provides,
+                generated);
+    }
+
+    /**
+     * Replace the entire auto-dependencies list with the given one.
+     * Auto-dependencies are groups of transitive Maven dependencies computed for automatic modules.
+     * This method replaces the entire list — useful for removing groups whose host module was pruned.
+     *
+     * @param autoDependencies the new auto-dependencies list (must not be {@code null})
+     * @return a new {@link ModuleInfo} with the replaced auto-dependencies, or {@code this} if equal
+     */
+    public ModuleInfo withAutoDependencies(final List<AutoDependencyGroup> autoDependencies) {
+        if (autoDependencies.equals(this.autoDependencies)) {
+            return this;
+        }
+        return new ModuleInfo(
+                name,
+                version,
+                modifiers,
+                resolvedArtifact,
+                mainClassName,
+                packages,
+                dependencies,
+                autoDependencies,
+                uses,
+                provides,
+                generated);
+    }
+
+    /**
+     * Replace the entire service provider map ({@code provides ... with ...}) with the given one.
+     * Unlike {@link #withMoreServices(Map)}, which merges additively, this method replaces
+     * the entire map — useful for removing dead service implementations after tree-shaking.
+     *
+     * @param provides the new provides map (must not be {@code null})
+     * @return a new {@link ModuleInfo} with the replaced provides, or {@code this} if equal
+     */
+    public ModuleInfo withProvides(final Map<String, List<String>> provides) {
+        if (provides.equals(this.provides)) {
+            return this;
+        }
+        return new ModuleInfo(
+                name,
+                version,
+                modifiers,
+                resolvedArtifact,
+                mainClassName,
+                packages,
+                dependencies,
+                autoDependencies,
+                uses,
+                provides,
+                generated);
+    }
+
     public ModuleInfo withMoreResources(final List<Resource> moreResources) {
         if (moreResources.isEmpty()) {
             return this;

--- a/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/model/ModuleTreeShaker.java
+++ b/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/model/ModuleTreeShaker.java
@@ -1,0 +1,666 @@
+package io.quarkus.modular.spi.model;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.modular.spi.ClassPathUtils;
+import io.quarkus.paths.PathTree;
+import io.smallrye.modules.desc.Dependency;
+
+/**
+ * Prunes unreachable modules from an {@link AppModuleModel} using class-level reachability data
+ * produced by the tree-shaking analysis in {@code core/deployment}.
+ * <p>
+ * The pruning operates in four phases:
+ * <ol>
+ * <li><b>Class-level liveness</b> — each module is checked against the reachable class set.
+ * A module is <em>class-dead</em> if it contains {@code .class} entries but none of them are
+ * reachable. Modules with no class entries (resource-only JARs) are treated as alive.
+ * The application module is always protected from removal.</li>
+ * <li><b>Graph reachability</b> — a BFS from root modules (application module + alive boot
+ * modules) through the dependency graph. Modules not reachable from any root are
+ * <em>graph-unreachable</em>. However, graph-unreachable modules that contain reachable classes
+ * are <em>not</em> removed — they may be accessed via reflection, service loading, or from
+ * automatic modules without explicit {@code requires} directives. A warning is logged for
+ * such modules to help diagnose missing dependency declarations.</li>
+ * <li><b>Dead module removal</b> — only class-dead modules are dropped.</li>
+ * <li><b>Descriptor cleanup</b> — surviving modules have stale {@code requires} directives,
+ * dead auto-dependency entries, and dead service implementations removed. The JDK module set
+ * ({@code java.*}/{@code jdk.*}/{@code ibm.*}) is recomputed from surviving modules only,
+ * which can significantly reduce the jlink image size.</li>
+ * </ol>
+ * <p>
+ * This class is stateless beyond its constructor arguments and safe to use from a single thread.
+ */
+public final class ModuleTreeShaker {
+    private static final Logger log = Logger.getLogger("io.quarkus.modular.spi");
+    private static final String JAVA_SE = "java.se";
+
+    private final AppModuleModel model;
+    private final Set<String> reachableClassNames;
+    private final Set<String> neededJdkModules;
+
+    /**
+     * Create a new tree shaker.
+     *
+     * @param model the application module model to prune (must not be {@code null})
+     * @param reachableClassNames dot-separated names of all classes determined to be reachable
+     *        by the class-level tree-shaking analysis (must not be {@code null})
+     * @param referencedJdkPackages dot-separated JDK package names ({@code java.*}, {@code javax.*},
+     *        {@code jdk.*}) referenced by reachable code; used to replace {@code requires java.se}
+     *        with specific JDK module requirements (must not be {@code null})
+     */
+    public ModuleTreeShaker(AppModuleModel model, Set<String> reachableClassNames,
+            Set<String> referencedJdkPackages) {
+        this.model = model;
+        this.reachableClassNames = reachableClassNames;
+        this.neededJdkModules = computeNeededJdkModules(referencedJdkPackages);
+    }
+
+    /**
+     * Run the module-level tree-shaking analysis and return the pruned model.
+     * <p>
+     * If no modules are dead, the original model instance is returned unchanged.
+     *
+     * @return a pruned {@link AppModuleModel}, or the original if nothing was pruned
+     */
+    public AppModuleModel shake() {
+        Set<String> classDead = identifyDeadModules();
+        Set<String> graphDead = findGraphUnreachableModules(classDead);
+        if (!graphDead.isEmpty()) {
+            logGraphDeadWithReachableClasses(graphDead);
+        }
+        return shake(classDead);
+    }
+
+    /**
+     * Apply module-level tree-shaking with an explicitly provided set of dead module names.
+     * <p>
+     * This overload is package-private to allow unit tests to supply a known set of dead modules
+     * without requiring real JAR content trees on disk.
+     *
+     * @param deadModules the names of modules to remove (may be empty)
+     * @return a pruned {@link AppModuleModel}, or the original if {@code deadModules} is empty
+     */
+    AppModuleModel shake(Set<String> deadModules) {
+        if (deadModules.isEmpty() && neededJdkModules.isEmpty()) {
+            return model;
+        }
+        return rebuildModel(deadModules);
+    }
+
+    /**
+     * Log a warning for modules that are graph-unreachable but contain reachable classes.
+     * These modules are kept alive because their classes may be accessed via reflection,
+     * service loading, or from automatic modules without explicit {@code requires} directives.
+     *
+     * @param graphDead the set of graph-unreachable module names with reachable classes
+     */
+    public static void logGraphDeadWithReachableClasses(Set<String> graphDead) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Module tree-shaking: ").append(graphDead.size())
+                .append(" module(s) are graph-unreachable but contain reachable classes (keeping them):");
+        graphDead.stream().sorted().forEach(name -> sb.append(System.lineSeparator()).append("  - ").append(name));
+        log.warn(sb.toString());
+    }
+
+    /**
+     * Scan all modules and classify each as alive or dead.
+     * <p>
+     * The application module is always classified as alive. All other modules —
+     * including boot modules — are alive only if they have at least one reachable class.
+     * Boot modules are expected to have reachable classes because the jlink extension
+     * registers their entry points as tree-shake roots.
+     * <p>
+     * A module with no {@code .class} entries at all (a resource-only JAR) is treated
+     * as alive — it may provide configuration files or other resources needed at runtime.
+     *
+     * @return the set of dead module names (may be empty, never {@code null})
+     */
+    private Set<String> identifyDeadModules() {
+        Map<String, ModuleInfo> modulesByName = model.modulesByName();
+        String appModuleName = model.appModuleInfo().name();
+
+        Set<String> deadModules = new HashSet<>();
+        log.debugf("Analyzing %d modules for class-level liveness (app=%s)", modulesByName.size(), appModuleName);
+        for (ModuleInfo moduleInfo : modulesByName.values()) {
+            String name = moduleInfo.name();
+            if (name.equals(appModuleName)) {
+                continue;
+            }
+            if (!hasReachableClass(moduleInfo)) {
+                deadModules.add(name);
+            }
+        }
+        return deadModules;
+    }
+
+    /**
+     * Walk the module dependency graph from root modules and find modules that
+     * are not reachable from any root. Root modules are the application module
+     * and any boot modules that are not class-dead.
+     * <p>
+     * A module may have reachable classes yet still be graph-unreachable — for example
+     * because it is accessed via reflection, service loading, or from an automatic module
+     * without an explicit {@code requires} directive. Such modules are <em>not</em> treated
+     * as dead; they are only logged as warnings to help diagnose missing dependency declarations.
+     *
+     * @param classDead modules already identified as dead by class-level analysis
+     * @return the set of graph-unreachable module names that are not class-dead (may be empty)
+     */
+    Set<String> findGraphUnreachableModules(Set<String> classDead) {
+        return findGraphUnreachableModules(model, classDead);
+    }
+
+    /**
+     * Walk the module dependency graph from root modules and find modules that
+     * are not reachable from any root. Root modules are the application module
+     * and any boot modules that are not class-dead.
+     * <p>
+     * A module may have reachable classes yet still be graph-unreachable — for example
+     * because it is accessed via reflection, service loading, or from an automatic module
+     * without an explicit {@code requires} directive. Such modules are <em>not</em> treated
+     * as dead; they are only logged as warnings to help diagnose missing dependency declarations.
+     *
+     * @param model the application module model
+     * @param classDead modules already identified as dead by class-level analysis
+     * @return the set of graph-unreachable module names that are not class-dead (may be empty)
+     */
+    public static Set<String> findGraphUnreachableModules(AppModuleModel model, Set<String> classDead) {
+        Set<String> visited = new HashSet<>();
+        Queue<String> queue = new ArrayDeque<>();
+
+        queue.add(model.appModuleInfo().name());
+        for (String boot : model.bootModules()) {
+            if (!classDead.contains(boot)) {
+                queue.add(boot);
+            }
+        }
+
+        Map<String, ModuleInfo> modulesByName = model.modulesByName();
+        while (!queue.isEmpty()) {
+            String name = queue.poll();
+            if (!visited.add(name) || classDead.contains(name)) {
+                continue;
+            }
+            ModuleInfo mi = modulesByName.get(name);
+            if (mi == null) {
+                continue;
+            }
+            for (DependencyInfo dep : mi.dependencies()) {
+                enqueueIfAppProvided(dep.moduleName(), classDead, visited, queue);
+            }
+            for (AutoDependencyGroup g : mi.autoDependencies()) {
+                for (DependencyInfo dep : g.dependencies()) {
+                    enqueueIfAppProvided(dep.moduleName(), classDead, visited, queue);
+                }
+            }
+        }
+
+        Set<String> graphDead = new HashSet<>();
+        for (String name : modulesByName.keySet()) {
+            if (!visited.contains(name) && !classDead.contains(name)) {
+                graphDead.add(name);
+            }
+        }
+        return graphDead;
+    }
+
+    /**
+     * Add a module name to the BFS queue if it is an application-provided (non-JDK)
+     * module that has not already been visited or classified as dead.
+     *
+     * @param name the module name to consider
+     * @param dead the set of modules already classified as dead
+     * @param visited the set of modules already visited by the BFS
+     * @param queue the BFS queue to add to
+     */
+    private static void enqueueIfAppProvided(String name, Set<String> dead,
+            Set<String> visited, Queue<String> queue) {
+        if (!dead.contains(name) && !visited.contains(name) && !isJdkModule(name)) {
+            queue.add(name);
+        }
+    }
+
+    /**
+     * Determine whether a module contains at least one reachable class.
+     *
+     * @param moduleInfo the module to inspect
+     * @return {@code true} if the module should be kept alive
+     */
+    private boolean hasReachableClass(ModuleInfo moduleInfo) {
+        return isModuleAlive(moduleInfo.resolvedArtifact().getContentTree(), moduleInfo.name(), reachableClassNames);
+    }
+
+    /**
+     * Determine whether a module's content tree contains at least one reachable class.
+     * <p>
+     * Walks the content tree looking for {@code .class} entries (excluding
+     * {@code module-info.class}). Returns {@code true} on the first reachable class found
+     * (early exit). If the content tree is empty, returns {@code false} — the module has
+     * no content to contribute. If the module contains no class files at all (a resource-only
+     * JAR), returns {@code true} to keep it alive — it may provide configuration files,
+     * native libraries, or other resources needed at runtime.
+     *
+     * @param contentTree the module's content tree
+     * @param moduleName the module name (used for debug logging)
+     * @param reachableClassNames dot-separated names of reachable classes
+     * @return {@code true} if the module should be kept alive
+     */
+    public static boolean isModuleAlive(PathTree contentTree, String moduleName, Set<String> reachableClassNames) {
+        if (contentTree.isEmpty()) {
+            log.debugf("Module %s: content tree is empty, treating as dead", moduleName);
+            return false;
+        }
+        boolean[] hasClasses = { false };
+        boolean[] found = { false };
+        contentTree.walk(visited -> {
+            String rp = visited.getResourceName();
+            if (ClassPathUtils.isClassEntry(rp)) {
+                hasClasses[0] = true;
+                String className = ClassPathUtils.resourcePathToClassName(rp);
+                if (reachableClassNames.contains(className)) {
+                    found[0] = true;
+                    visited.stopWalking();
+                }
+            }
+        });
+        if (!hasClasses[0]) {
+            log.debugf("Module %s: no class entries found, treating as alive (resource-only)", moduleName);
+        } else if (!found[0]) {
+            log.debugf("Module %s: has classes but none reachable, treating as dead", moduleName);
+        }
+        return !hasClasses[0] || found[0];
+    }
+
+    /**
+     * Build a new {@link AppModuleModel} with dead modules removed and surviving modules cleaned.
+     *
+     * @param deadModules the set of module names to remove (must not be empty)
+     * @return the rebuilt model
+     */
+    private AppModuleModel rebuildModel(Set<String> deadModules) {
+        AppModuleModel.Builder amb = AppModuleModel.builder();
+        Set<String> newJdkModules = new HashSet<>();
+        String appModuleName = model.appModuleInfo().name();
+        ModuleInfo cleanedAppModule = null;
+
+        for (ModuleInfo moduleInfo : model.modulesByName().values()) {
+            if (deadModules.contains(moduleInfo.name()) && !moduleInfo.name().equals(appModuleName)) {
+                continue;
+            }
+            ModuleInfo cleaned = cleanModule(moduleInfo, deadModules);
+            amb.moduleInfo(cleaned);
+            collectJdkModules(cleaned, newJdkModules);
+            if (moduleInfo.name().equals(appModuleName)) {
+                cleanedAppModule = cleaned;
+            }
+        }
+
+        amb.appModuleInfo(cleanedAppModule);
+        newJdkModules.forEach(amb::jdkModuleUsed);
+        Set<String> bootModules = survivingBootModules(deadModules);
+        amb.bootModules(bootModules);
+
+        int survivingModules = model.modulesByName().size() - deadModules.size();
+        logSummary(deadModules, survivingModules - bootModules.size(), bootModules.size(), newJdkModules);
+        return amb.build();
+    }
+
+    /**
+     * Compute the set of boot modules that survived pruning.
+     *
+     * @param deadModules the set of dead module names
+     * @return the surviving boot module names
+     */
+    private Set<String> survivingBootModules(Set<String> deadModules) {
+        Set<String> surviving = new HashSet<>(model.bootModules());
+        surviving.removeAll(deadModules);
+        return surviving;
+    }
+
+    /**
+     * Log a summary of module tree-shaking results at INFO level, with removed and
+     * JDK module listings at DEBUG level.
+     *
+     * @param removedModules the set of removed module names
+     * @param appModules the number of surviving application modules (excluding boot modules)
+     * @param bootModules the number of surviving boot modules
+     * @param jdkModules the recomputed set of JDK module names
+     */
+    private void logSummary(Set<String> removedModules, int appModules, int bootModules, Set<String> jdkModules) {
+        log.infof("Module tree-shaking removed %d unreachable modules; image will contain %d app + %d JDK modules",
+                removedModules.size(), appModules + bootModules, jdkModules.size());
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder();
+            if (!removedModules.isEmpty()) {
+                sb.append("Removed modules:");
+                removedModules.stream().sorted()
+                        .forEach(name -> sb.append(System.lineSeparator()).append("  - ").append(name));
+            }
+            if (!jdkModules.isEmpty()) {
+                if (!sb.isEmpty()) {
+                    sb.append(System.lineSeparator());
+                }
+                sb.append("JDK modules:");
+                jdkModules.stream().sorted()
+                        .forEach(name -> sb.append(System.lineSeparator()).append("  - ").append(name));
+            }
+            if (!sb.isEmpty()) {
+                log.debug(sb.toString());
+            }
+        }
+    }
+
+    /**
+     * Apply descriptor cleanup operations to a surviving module.
+     * Removes stale dependencies pointing to dead modules, dead auto-dependency groups,
+     * unreachable service implementations, and expands {@code requires java.se} into
+     * specific JDK module requirements.
+     * <p>
+     * Package cleanup is not performed here because modules may contain non-class
+     * resources (e.g. {@code .properties} files) that keep packages alive from jlink's
+     * perspective. Correct package cleanup requires resource-aware analysis which is
+     * beyond the scope of class-level tree-shaking.
+     *
+     * @param moduleInfo the module to clean up
+     * @param deadModules the set of dead module names
+     * @return the cleaned module, or the same instance if no changes were needed
+     */
+    private ModuleInfo cleanModule(ModuleInfo moduleInfo, Set<String> deadModules) {
+        return cleanModule(moduleInfo, deadModules, reachableClassNames, neededJdkModules);
+    }
+
+    /**
+     * Apply descriptor cleanup operations to a module, removing references to dead modules,
+     * unreachable service implementations, and expanding {@code requires java.se}.
+     *
+     * @param moduleInfo the module to clean up
+     * @param deadModules the set of dead module names
+     * @param reachableClassNames dot-separated names of reachable classes
+     * @param neededJdkModules the set of JDK module names needed by reachable code
+     * @return the cleaned module, or the same instance if no changes were needed
+     */
+    public static ModuleInfo cleanModule(ModuleInfo moduleInfo, Set<String> deadModules,
+            Set<String> reachableClassNames, Set<String> neededJdkModules) {
+        moduleInfo = cleanDependencies(moduleInfo, deadModules);
+        moduleInfo = cleanAutoDependencies(moduleInfo, deadModules);
+        moduleInfo = cleanProvides(moduleInfo, reachableClassNames);
+        moduleInfo = expandJavaSe(moduleInfo, neededJdkModules);
+        return moduleInfo;
+    }
+
+    /**
+     * Replace {@code requires java.se} with specific JDK module requirements based on
+     * the JDK packages actually referenced by reachable code. This allows jlink to exclude
+     * JDK modules that are not needed, significantly reducing the image size.
+     * <p>
+     * If the module does not have {@code requires java.se}, no change is made.
+     *
+     * @param moduleInfo the module to process
+     * @return the module with {@code java.se} expanded, or the same instance if unchanged
+     */
+    private static ModuleInfo expandJavaSe(ModuleInfo moduleInfo, Set<String> neededJdkModules) {
+        if (neededJdkModules.isEmpty()) {
+            return moduleInfo;
+        }
+        List<DependencyInfo> deps = moduleInfo.dependencies();
+        int javaseIdx = indexOfJavase(deps);
+        if (javaseIdx < 0) {
+            return moduleInfo;
+        }
+
+        DependencyInfo javaSeDep = deps.get(javaseIdx);
+        Dependency.Modifier.Set mods = javaSeDep.modifiers().xor(Dependency.Modifier.SYNTHETIC);
+        Set<String> existingDeps = getModuleNames(deps);
+
+        List<DependencyInfo> expanded = new ArrayList<>(deps.size() + neededJdkModules.size());
+        for (int i = 0; i < deps.size(); i++) {
+            if (i == javaseIdx) {
+                for (String jdkModule : neededJdkModules) {
+                    if (!JAVA_SE.equals(jdkModule) && !existingDeps.contains(jdkModule)) {
+                        expanded.add(new DependencyInfo(jdkModule, mods, Map.of()));
+                    }
+                }
+            } else {
+                expanded.add(deps.get(i));
+            }
+        }
+        return moduleInfo.withDependencies(expanded);
+    }
+
+    private static Set<String> getModuleNames(List<DependencyInfo> deps) {
+        Set<String> existingDeps = new HashSet<>(deps.size());
+        for (DependencyInfo dep : deps) {
+            existingDeps.add(dep.moduleName());
+        }
+        return existingDeps;
+    }
+
+    private static int indexOfJavase(List<DependencyInfo> deps) {
+        int javaseIdx = -1;
+        for (int i = 0; i < deps.size(); i++) {
+            if (JAVA_SE.equals(deps.get(i).moduleName())) {
+                javaseIdx = i;
+                break;
+            }
+        }
+        return javaseIdx;
+    }
+
+    /**
+     * Remove {@code requires} directives that point to dead modules.
+     * JDK modules ({@code java.*}, {@code jdk.*}, {@code ibm.*}) are never removed
+     * since they are always available in the runtime.
+     *
+     * @param moduleInfo the module to clean
+     * @param deadModules the set of dead module names
+     * @return the module with stale requires removed, or the same instance if unchanged
+     */
+    private static ModuleInfo cleanDependencies(ModuleInfo moduleInfo, Set<String> deadModules) {
+        List<DependencyInfo> deps = moduleInfo.dependencies();
+        if (deps.isEmpty()) {
+            return moduleInfo;
+        }
+        List<DependencyInfo> filtered = null;
+        for (int i = 0; i < deps.size(); i++) {
+            DependencyInfo dep = deps.get(i);
+            if (deadModules.contains(dep.moduleName())) {
+                if (filtered == null) {
+                    filtered = new ArrayList<>(deps.size() - 1);
+                    for (int j = 0; j < i; j++) {
+                        filtered.add(deps.get(j));
+                    }
+                }
+            } else if (filtered != null) {
+                filtered.add(dep);
+            }
+        }
+        return filtered != null ? moduleInfo.withDependencies(filtered) : moduleInfo;
+    }
+
+    /**
+     * Remove auto-dependency groups whose host module is dead, and remove individual
+     * entries within surviving groups that point to dead modules. If all entries in a
+     * group are removed, the entire group is dropped.
+     *
+     * @param moduleInfo the module to clean
+     * @param deadModules the set of dead module names
+     * @return the module with stale auto-dependencies removed, or the same instance if unchanged
+     */
+    private static ModuleInfo cleanAutoDependencies(ModuleInfo moduleInfo, Set<String> deadModules) {
+        List<AutoDependencyGroup> groups = moduleInfo.autoDependencies();
+        if (groups.isEmpty()) {
+            return moduleInfo;
+        }
+        List<AutoDependencyGroup> filtered = null;
+        for (int i = 0; i < groups.size(); i++) {
+            AutoDependencyGroup group = groups.get(i);
+            AutoDependencyGroup cleanedGroup = cleanAutoGroup(group, deadModules);
+            if (cleanedGroup != group) {
+                if (filtered == null) {
+                    filtered = new ArrayList<>(groups.size());
+                    for (int j = 0; j < i; j++) {
+                        filtered.add(groups.get(j));
+                    }
+                }
+                if (cleanedGroup != null) {
+                    filtered.add(cleanedGroup);
+                }
+            } else if (filtered != null) {
+                filtered.add(group);
+            }
+        }
+        return filtered != null ? moduleInfo.withAutoDependencies(filtered) : moduleInfo;
+    }
+
+    /**
+     * Remove entries pointing to dead modules from a single auto-dependency group.
+     *
+     * @param group the group to filter
+     * @param deadModules the set of dead module names
+     * @return the filtered group, the same instance if unchanged, or {@code null} if all entries were removed
+     */
+    private static AutoDependencyGroup cleanAutoGroup(AutoDependencyGroup group, Set<String> deadModules) {
+        List<DependencyInfo> deps = group.dependencies();
+        List<DependencyInfo> filtered = null;
+        for (int i = 0; i < deps.size(); i++) {
+            DependencyInfo dep = deps.get(i);
+            if (deadModules.contains(dep.moduleName())) {
+                if (filtered == null) {
+                    filtered = new ArrayList<>(deps.size() - 1);
+                    for (int j = 0; j < i; j++) {
+                        filtered.add(deps.get(j));
+                    }
+                }
+            } else if (filtered != null) {
+                filtered.add(dep);
+            }
+        }
+        if (filtered == null) {
+            return group;
+        }
+        return filtered.isEmpty() ? null : new AutoDependencyGroup(group.hostModuleName(), filtered);
+    }
+
+    /**
+     * Remove service provider entries ({@code provides ... with ...}) whose implementation
+     * classes are not in the reachable set. If all implementations for a given service interface
+     * are removed, the entire {@code provides} entry is dropped.
+     *
+     * @param moduleInfo the module to clean
+     * @return the module with dead service impls removed, or the same instance if unchanged
+     */
+    private static ModuleInfo cleanProvides(ModuleInfo moduleInfo, Set<String> reachableClassNames) {
+        Map<String, List<String>> provides = moduleInfo.provides();
+        if (provides.isEmpty()) {
+            return moduleInfo;
+        }
+        Map<String, List<String>> filtered = null;
+        for (var entry : provides.entrySet()) {
+            List<String> aliveImpls = filterReachableImpls(entry.getValue(), reachableClassNames);
+            if (aliveImpls != entry.getValue()) {
+                if (filtered == null) {
+                    filtered = new HashMap<>(provides);
+                }
+                if (aliveImpls.isEmpty()) {
+                    filtered.remove(entry.getKey());
+                } else {
+                    filtered.put(entry.getKey(), aliveImpls);
+                }
+            }
+        }
+        return filtered != null ? moduleInfo.withProvides(filtered) : moduleInfo;
+    }
+
+    private static List<String> filterReachableImpls(List<String> impls, Set<String> reachableClassNames) {
+        List<String> alive = null;
+        for (int i = 0; i < impls.size(); i++) {
+            String impl = impls.get(i);
+            if (!reachableClassNames.contains(impl)) {
+                if (alive == null) {
+                    alive = new ArrayList<>(impls.size() - 1);
+                    for (int j = 0; j < i; j++) {
+                        alive.add(impls.get(j));
+                    }
+                }
+            } else if (alive != null) {
+                alive.add(impl);
+            }
+        }
+        return alive != null ? alive : impls;
+    }
+
+    /**
+     * Collect JDK module names ({@code java.*}, {@code jdk.*}, {@code ibm.*}) referenced
+     * by a module's dependencies and auto-dependencies.
+     *
+     * @param moduleInfo the module to scan
+     * @param jdkModules the set to add JDK module names to
+     */
+    public static void collectJdkModules(ModuleInfo moduleInfo, Set<String> jdkModules) {
+        for (DependencyInfo dep : moduleInfo.dependencies()) {
+            addIfJdk(dep.moduleName(), jdkModules);
+        }
+        for (AutoDependencyGroup group : moduleInfo.autoDependencies()) {
+            for (DependencyInfo dep : group.dependencies()) {
+                addIfJdk(dep.moduleName(), jdkModules);
+            }
+        }
+    }
+
+    /**
+     * Add a module name to the JDK module set if it is a JDK module.
+     *
+     * @param moduleName the module name to check
+     * @param jdkModules the set to add to
+     */
+    private static void addIfJdk(String moduleName, Set<String> jdkModules) {
+        if (isJdkModule(moduleName)) {
+            jdkModules.add(moduleName);
+        }
+    }
+
+    /**
+     * Compute the set of JDK module names actually needed by the application, based on
+     * the JDK packages referenced from reachable code.
+     * <p>
+     * Iterating boot layer modules is sufficient because it covers all JDK modules;
+     * application and library modules are not in the boot layer, so the lookup
+     * naturally filters to JDK-only results. {@code java.base} is always included.
+     * Packages that don't map to any system module (e.g. third-party {@code javax.*}
+     * packages) are silently ignored.
+     *
+     * @param referencedJdkPackages the JDK package names referenced by reachable code
+     * @return the set of JDK module names needed (never empty — always contains {@code java.base})
+     */
+    public static Set<String> computeNeededJdkModules(Set<String> referencedJdkPackages) {
+        if (referencedJdkPackages.isEmpty()) {
+            return Set.of();
+        }
+        Set<String> needed = new HashSet<>();
+        needed.add("java.base");
+        for (Module module : ModuleLayer.boot().modules()) {
+            for (String pkg : module.getPackages()) {
+                if (referencedJdkPackages.contains(pkg)) {
+                    needed.add(module.getName());
+                    break;
+                }
+            }
+        }
+        log.debugf("JDK modules needed by reachable code: %s", needed);
+        return needed;
+    }
+
+    private static boolean isJdkModule(String name) {
+        return name.startsWith("java.") || name.startsWith("jdk.") || name.startsWith("ibm.");
+    }
+}

--- a/extensions/packaging/modular/spi/src/test/java/io/quarkus/modular/spi/model/AppModuleModelBuilderTest.java
+++ b/extensions/packaging/modular/spi/src/test/java/io/quarkus/modular/spi/model/AppModuleModelBuilderTest.java
@@ -11,18 +11,29 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.ResolvedDependency;
+import io.smallrye.modules.desc.Dependency;
 import io.smallrye.modules.desc.ModuleDescriptor;
+import io.smallrye.modules.desc.PackageAccess;
+import io.smallrye.modules.desc.PackageInfo;
 
 /**
  * Tests for {@link AppModuleModel.Builder}.
  */
 class AppModuleModelBuilderTest {
 
-    private ModuleInfo moduleInfo(String groupId, String artifactId, String name) {
+    private static ModuleInfo moduleInfo(String groupId, String artifactId, String name) {
         ResolvedDependency rd = TestResolvedDependency.create(groupId, artifactId, "1.0");
         return new ModuleInfo(
                 name, "1.0", ModuleDescriptor.Modifier.Set.of(), rd, null,
                 Map.of(), List.of(), List.of(), Set.of(), Map.of(), List.of());
+    }
+
+    private static ModuleInfo moduleInfo(String groupId, String artifactId, String name,
+            Map<String, PackageInfo> packages, List<DependencyInfo> dependencies) {
+        ResolvedDependency rd = TestResolvedDependency.create(groupId, artifactId, "1.0");
+        return new ModuleInfo(
+                name, "1.0", ModuleDescriptor.Modifier.Set.of(), rd, null,
+                packages, dependencies, List.of(), Set.of(), Map.of(), List.of());
     }
 
     @Test
@@ -164,6 +175,88 @@ class AppModuleModelBuilderTest {
                 .bootModule("boot.d")
                 .build();
         assertThat(model.bootModules()).containsExactlyInAnyOrder("boot.a", "boot.b", "boot.c", "boot.d");
+    }
+
+    // -- stale package access cleanup --
+    //
+    // Package access entries (add-exports/add-opens) can reference packages that don't
+    // exist in the target module. This happens when:
+    //  - a hardcoded workaround in ModularitySteps references a package that was removed
+    //    or renamed in a newer version of the library
+    //  - tree-shaking removes all classes from a package, eliminating it from the
+    //    target module's package map
+    // Stale entries cause warnings from the module runtime at startup. The builder
+    // strips them so the written descriptors stay consistent with actual module content.
+
+    @Test
+    void stalePackageAccessRemovedOnBuild() {
+        // lib.module declares package "com.lib.api" but NOT "com.lib.internal"
+        ModuleInfo libModule = moduleInfo("org.lib", "lib", "lib.module",
+                Map.of("com.lib.api", PackageInfo.EXPORTED), List.of());
+
+        // app.module depends on lib.module and requests access to both packages
+        DependencyInfo depToLib = new DependencyInfo("lib.module",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED),
+                Map.of("com.lib.api", PackageAccess.EXPORTED,
+                        "com.lib.internal", PackageAccess.EXPORTED));
+        ModuleInfo appModule = moduleInfo("org.app", "app", "app.module",
+                Map.of(), List.of(depToLib));
+
+        AppModuleModel model = AppModuleModel.builder()
+                .appModuleInfo(appModule)
+                .moduleInfo(libModule)
+                .build();
+
+        ModuleInfo cleanedApp = model.modulesByName().get("app.module");
+        DependencyInfo cleanedDep = cleanedApp.dependencies().stream()
+                .filter(d -> d.moduleName().equals("lib.module"))
+                .findFirst().orElseThrow();
+        assertThat(cleanedDep.packageAccesses()).containsKey("com.lib.api");
+        assertThat(cleanedDep.packageAccesses()).doesNotContainKey("com.lib.internal");
+    }
+
+    @Test
+    void validPackageAccessesPreservedOnBuild() {
+        ModuleInfo libModule = moduleInfo("org.lib", "lib", "lib.module",
+                Map.of("com.lib.api", PackageInfo.EXPORTED,
+                        "com.lib.spi", PackageInfo.EXPORTED),
+                List.of());
+
+        DependencyInfo depToLib = new DependencyInfo("lib.module",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED),
+                Map.of("com.lib.api", PackageAccess.EXPORTED,
+                        "com.lib.spi", PackageAccess.OPEN));
+        ModuleInfo appModule = moduleInfo("org.app", "app", "app.module",
+                Map.of(), List.of(depToLib));
+
+        AppModuleModel model = AppModuleModel.builder()
+                .appModuleInfo(appModule)
+                .moduleInfo(libModule)
+                .build();
+
+        ModuleInfo cleanedApp = model.modulesByName().get("app.module");
+        DependencyInfo cleanedDep = cleanedApp.dependencies().stream()
+                .filter(d -> d.moduleName().equals("lib.module"))
+                .findFirst().orElseThrow();
+        assertThat(cleanedDep.packageAccesses()).containsOnlyKeys("com.lib.api", "com.lib.spi");
+    }
+
+    @Test
+    void packageAccessToExternalModuleNotCleaned() {
+        // dependency to a module not in the model (e.g. JDK) should be left alone
+        DependencyInfo depToJdk = new DependencyInfo("java.base",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED),
+                Map.of("java.lang", PackageAccess.EXPORTED));
+        ModuleInfo appModule = moduleInfo("org.app", "app", "app.module",
+                Map.of(), List.of(depToJdk));
+
+        AppModuleModel model = AppModuleModel.builder()
+                .appModuleInfo(appModule)
+                .build();
+
+        ModuleInfo cleanedApp = model.modulesByName().get("app.module");
+        DependencyInfo cleanedDep = cleanedApp.dependencies().get(0);
+        assertThat(cleanedDep.packageAccesses()).containsKey("java.lang");
     }
 
     // -- immutability --

--- a/extensions/packaging/modular/spi/src/test/java/io/quarkus/modular/spi/model/ModuleTreeShakerTest.java
+++ b/extensions/packaging/modular/spi/src/test/java/io/quarkus/modular/spi/model/ModuleTreeShakerTest.java
@@ -1,0 +1,506 @@
+package io.quarkus.modular.spi.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.smallrye.modules.desc.Dependency;
+import io.smallrye.modules.desc.ModuleDescriptor;
+import io.smallrye.modules.desc.PackageInfo;
+
+/**
+ * Tests for {@link ModuleTreeShaker}.
+ * <p>
+ * These tests use the package-private {@link ModuleTreeShaker#shake(Set)} overload
+ * to supply a known set of dead modules, bypassing content-tree walking which
+ * requires real JAR files on disk.
+ */
+class ModuleTreeShakerTest {
+
+    private static final ResolvedDependency APP_DEP = TestResolvedDependency.create("org.app", "app", "1.0");
+    private static final ResolvedDependency LIB_A_DEP = TestResolvedDependency.create("org.lib", "lib-a", "1.0");
+    private static final ResolvedDependency LIB_B_DEP = TestResolvedDependency.create("org.lib", "lib-b", "1.0");
+    private static final ResolvedDependency LIB_C_DEP = TestResolvedDependency.create("org.lib", "lib-c", "1.0");
+
+    /**
+     * Create a minimal {@link ModuleInfo} for testing.
+     */
+    private static ModuleInfo module(String name, ResolvedDependency dep) {
+        return new ModuleInfo(
+                name, "1.0", ModuleDescriptor.Modifier.Set.of(), dep, null,
+                Map.of(), List.of(), List.of(), Set.of(), Map.of(), List.of());
+    }
+
+    /**
+     * Create a {@link ModuleInfo} with explicit packages, dependencies, and provides.
+     */
+    private static ModuleInfo module(String name, ResolvedDependency dep,
+            Map<String, PackageInfo> packages,
+            List<DependencyInfo> dependencies,
+            List<AutoDependencyGroup> autoDependencies,
+            Map<String, List<String>> provides) {
+        return new ModuleInfo(
+                name, "1.0", ModuleDescriptor.Modifier.Set.of(), dep, null,
+                packages, dependencies, autoDependencies, Set.of(), provides, List.of());
+    }
+
+    /**
+     * Build a model with the given app module, additional modules, JDK modules, and boot modules.
+     */
+    private static AppModuleModel buildModel(ModuleInfo appModule, List<ModuleInfo> modules,
+            List<String> jdkModules, Set<String> bootModules) {
+        AppModuleModel.Builder amb = AppModuleModel.builder();
+        amb.appModuleInfo(appModule);
+        modules.forEach(amb::moduleInfo);
+        jdkModules.forEach(amb::jdkModuleUsed);
+        amb.bootModules(bootModules);
+        return amb.build();
+    }
+
+    // -- no-op cases --
+
+    @Test
+    void noDeadModulesReturnsOriginalModel() {
+        ModuleInfo appModule = module("app.module", APP_DEP);
+        ModuleInfo libA = module("lib.a", LIB_A_DEP);
+        AppModuleModel model = buildModel(appModule, List.of(libA), List.of(), Set.of());
+
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, Set.of(), Set.of());
+        AppModuleModel result = shaker.shake(Set.of());
+
+        assertThat(result).isSameAs(model);
+    }
+
+    // -- dead module removal --
+
+    @Test
+    void deadModuleIsRemovedFromModel() {
+        ModuleInfo appModule = module("app.module", APP_DEP);
+        ModuleInfo libA = module("lib.a", LIB_A_DEP);
+        ModuleInfo libB = module("lib.b", LIB_B_DEP);
+        AppModuleModel model = buildModel(appModule, List.of(libA, libB), List.of(), Set.of());
+
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, Set.of(), Set.of());
+        AppModuleModel result = shaker.shake(Set.of("lib.b"));
+
+        assertThat(result.modulesByName()).containsKey("app.module");
+        assertThat(result.modulesByName()).containsKey("lib.a");
+        assertThat(result.modulesByName()).doesNotContainKey("lib.b");
+        assertThat(result.modulesByKey()).doesNotContainKey(ArtifactKey.ga("org.lib", "lib-b"));
+    }
+
+    @Test
+    void multipleDeadModulesRemovedSimultaneously() {
+        ModuleInfo appModule = module("app.module", APP_DEP);
+        ModuleInfo libA = module("lib.a", LIB_A_DEP);
+        ModuleInfo libB = module("lib.b", LIB_B_DEP);
+        ModuleInfo libC = module("lib.c", LIB_C_DEP);
+        AppModuleModel model = buildModel(appModule, List.of(libA, libB, libC), List.of(), Set.of());
+
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, Set.of(), Set.of());
+        AppModuleModel result = shaker.shake(Set.of("lib.a", "lib.c"));
+
+        assertThat(result.modulesByName()).containsOnlyKeys("app.module", "lib.b");
+    }
+
+    // -- protected modules --
+
+    @Test
+    void appModuleIsNeverRemoved() {
+        ModuleInfo appModule = module("app.module", APP_DEP);
+        AppModuleModel model = buildModel(appModule, List.of(), List.of(), Set.of());
+
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, Set.of(), Set.of());
+        // even if the app module were listed as dead, it should remain
+        AppModuleModel result = shaker.shake(Set.of("app.module"));
+
+        assertThat(result.modulesByName()).containsKey("app.module");
+    }
+
+    @Test
+    void deadBootModuleIsRemovedFromBootSet() {
+        ModuleInfo appModule = module("app.module", APP_DEP);
+        ModuleInfo libA = module("lib.a", LIB_A_DEP);
+        AppModuleModel model = buildModel(appModule, List.of(libA), List.of(), Set.of("lib.a"));
+
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, Set.of(), Set.of());
+        AppModuleModel result = shaker.shake(Set.of("lib.a"));
+
+        assertThat(result.modulesByName()).doesNotContainKey("lib.a");
+        assertThat(result.bootModules()).isEmpty();
+    }
+
+    // -- JDK module recomputation --
+
+    @Test
+    void jdkModulesRecomputedAfterPruning() {
+        DependencyInfo javaSql = new DependencyInfo("java.sql",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+        DependencyInfo javaBase = new DependencyInfo("java.base",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+
+        ModuleInfo appModule = module("app.module", APP_DEP,
+                Map.of(), List.of(javaBase), List.of(), Map.of());
+        ModuleInfo libA = module("lib.a", LIB_A_DEP,
+                Map.of(), List.of(javaSql), List.of(), Map.of());
+        AppModuleModel model = buildModel(appModule, List.of(libA),
+                List.of("java.base", "java.sql"), Set.of());
+
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, Set.of(), Set.of());
+        AppModuleModel result = shaker.shake(Set.of("lib.a"));
+
+        assertThat(result.jdkModulesUsed()).containsExactly("java.base");
+        assertThat(result.jdkModulesUsed()).doesNotContain("java.sql");
+    }
+
+    // -- dependency cleanup --
+
+    @Test
+    void staleDependenciesRemovedFromSurvivingModule() {
+        DependencyInfo depToDeadModule = new DependencyInfo("lib.b",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+        DependencyInfo depToAliveModule = new DependencyInfo("java.base",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+
+        ModuleInfo appModule = module("app.module", APP_DEP);
+        ModuleInfo libA = module("lib.a", LIB_A_DEP,
+                Map.of(), List.of(depToDeadModule, depToAliveModule), List.of(), Map.of());
+        ModuleInfo libB = module("lib.b", LIB_B_DEP);
+        AppModuleModel model = buildModel(appModule, List.of(libA, libB), List.of(), Set.of());
+
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, Set.of(), Set.of());
+        AppModuleModel result = shaker.shake(Set.of("lib.b"));
+
+        ModuleInfo cleanedA = result.modulesByName().get("lib.a");
+        assertThat(cleanedA.dependencies()).hasSize(1);
+        assertThat(cleanedA.dependencies().get(0).moduleName()).isEqualTo("java.base");
+    }
+
+    // -- auto-dependency cleanup --
+
+    @Test
+    void autoDepGroupForDeadHostKeepsAliveEntries() {
+        DependencyInfo aliveEntry = new DependencyInfo("some.dep",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+        AutoDependencyGroup group = new AutoDependencyGroup("dead.host", List.of(aliveEntry));
+
+        ModuleInfo appModule = module("app.module", APP_DEP);
+        ModuleInfo libA = module("lib.a", LIB_A_DEP,
+                Map.of(), List.of(), List.of(group), Map.of());
+        AppModuleModel model = buildModel(appModule, List.of(libA), List.of(), Set.of());
+
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, Set.of(), Set.of());
+        AppModuleModel result = shaker.shake(Set.of("dead.host"));
+
+        ModuleInfo cleanedA = result.modulesByName().get("lib.a");
+        assertThat(cleanedA.autoDependencies()).hasSize(1);
+        assertThat(cleanedA.autoDependencies().get(0).dependencies()).hasSize(1);
+        assertThat(cleanedA.autoDependencies().get(0).dependencies().get(0).moduleName()).isEqualTo("some.dep");
+    }
+
+    @Test
+    void autoDepGroupDroppedWhenHostAndAllEntriesDead() {
+        DependencyInfo deadEntry = new DependencyInfo("dead.dep",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+        AutoDependencyGroup group = new AutoDependencyGroup("dead.host", List.of(deadEntry));
+
+        ModuleInfo appModule = module("app.module", APP_DEP);
+        ModuleInfo libA = module("lib.a", LIB_A_DEP,
+                Map.of(), List.of(), List.of(group), Map.of());
+        AppModuleModel model = buildModel(appModule, List.of(libA), List.of(), Set.of());
+
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, Set.of(), Set.of());
+        AppModuleModel result = shaker.shake(Set.of("dead.host", "dead.dep"));
+
+        ModuleInfo cleanedA = result.modulesByName().get("lib.a");
+        assertThat(cleanedA.autoDependencies()).isEmpty();
+    }
+
+    @Test
+    void autoDepEntriesPointingToDeadModulesAreFiltered() {
+        DependencyInfo alive = new DependencyInfo("alive.dep",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+        DependencyInfo dead = new DependencyInfo("dead.dep",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+        AutoDependencyGroup group = new AutoDependencyGroup("host.module", List.of(alive, dead));
+
+        ModuleInfo appModule = module("app.module", APP_DEP);
+        ModuleInfo libA = module("lib.a", LIB_A_DEP,
+                Map.of(), List.of(), List.of(group), Map.of());
+        AppModuleModel model = buildModel(appModule, List.of(libA), List.of(), Set.of());
+
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, Set.of(), Set.of());
+        AppModuleModel result = shaker.shake(Set.of("dead.dep"));
+
+        ModuleInfo cleanedA = result.modulesByName().get("lib.a");
+        assertThat(cleanedA.autoDependencies()).hasSize(1);
+        assertThat(cleanedA.autoDependencies().get(0).dependencies()).hasSize(1);
+        assertThat(cleanedA.autoDependencies().get(0).dependencies().get(0).moduleName()).isEqualTo("alive.dep");
+    }
+
+    // -- provides cleanup --
+
+    @Test
+    void deadServiceImplsRemovedFromProvides() {
+        Map<String, List<String>> provides = Map.of(
+                "com.svc.Service", List.of("com.impl.Alive", "com.impl.Dead"));
+
+        ModuleInfo appModule = module("app.module", APP_DEP);
+        ModuleInfo libA = module("lib.a", LIB_A_DEP,
+                Map.of(), List.of(), List.of(), provides);
+        ModuleInfo libB = module("lib.b", LIB_B_DEP);
+        AppModuleModel model = buildModel(appModule, List.of(libA, libB), List.of(), Set.of());
+
+        // only com.impl.Alive is reachable
+        Set<String> reachable = Set.of("com.impl.Alive");
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, reachable, Set.of());
+        AppModuleModel result = shaker.shake(Set.of("lib.b"));
+
+        ModuleInfo cleanedA = result.modulesByName().get("lib.a");
+        assertThat(cleanedA.provides()).containsKey("com.svc.Service");
+        assertThat(cleanedA.provides().get("com.svc.Service")).containsExactly("com.impl.Alive");
+    }
+
+    @Test
+    void provideEntryDroppedWhenAllImplsDead() {
+        Map<String, List<String>> provides = Map.of(
+                "com.svc.Service", List.of("com.impl.Dead1", "com.impl.Dead2"));
+
+        ModuleInfo appModule = module("app.module", APP_DEP);
+        ModuleInfo libA = module("lib.a", LIB_A_DEP,
+                Map.of(), List.of(), List.of(), provides);
+        ModuleInfo libB = module("lib.b", LIB_B_DEP);
+        AppModuleModel model = buildModel(appModule, List.of(libA, libB), List.of(), Set.of());
+
+        // no impls are reachable
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, Set.of(), Set.of());
+        AppModuleModel result = shaker.shake(Set.of("lib.b"));
+
+        ModuleInfo cleanedA = result.modulesByName().get("lib.a");
+        assertThat(cleanedA.provides()).isEmpty();
+    }
+
+    // -- provides unchanged when all impls alive --
+
+    @Test
+    void providesUnchangedWhenAllImplsAlive() {
+        Map<String, List<String>> provides = Map.of(
+                "com.svc.Service", List.of("com.impl.A", "com.impl.B"));
+
+        ModuleInfo appModule = module("app.module", APP_DEP);
+        ModuleInfo libA = module("lib.a", LIB_A_DEP,
+                Map.of(), List.of(), List.of(), provides);
+        ModuleInfo libB = module("lib.b", LIB_B_DEP);
+        AppModuleModel model = buildModel(appModule, List.of(libA, libB), List.of(), Set.of());
+
+        Set<String> reachable = Set.of("com.impl.A", "com.impl.B");
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, reachable, Set.of());
+        AppModuleModel result = shaker.shake(Set.of("lib.b"));
+
+        ModuleInfo cleanedA = result.modulesByName().get("lib.a");
+        assertThat(cleanedA.provides().get("com.svc.Service")).containsExactly("com.impl.A", "com.impl.B");
+    }
+
+    // -- combined cleanup --
+
+    @Test
+    void allCleanupOperationsAppliedTogether() {
+        DependencyInfo depToDead = new DependencyInfo("lib.b",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+        DependencyInfo depToJdk = new DependencyInfo("java.base",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+        Map<String, List<String>> provides = Map.of(
+                "com.svc.Svc", List.of("com.alive.Impl"));
+
+        ModuleInfo appModule = module("app.module", APP_DEP);
+        ModuleInfo libA = module("lib.a", LIB_A_DEP,
+                Map.of(), List.of(depToDead, depToJdk), List.of(), provides);
+        ModuleInfo libB = module("lib.b", LIB_B_DEP);
+        AppModuleModel model = buildModel(appModule, List.of(libA, libB),
+                List.of("java.base", "java.sql"), Set.of());
+
+        Set<String> reachable = Set.of("com.alive.Impl");
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, reachable, Set.of());
+        AppModuleModel result = shaker.shake(Set.of("lib.b"));
+
+        ModuleInfo cleanedA = result.modulesByName().get("lib.a");
+        // dependency to dead module removed
+        assertThat(cleanedA.dependencies()).hasSize(1);
+        assertThat(cleanedA.dependencies().get(0).moduleName()).isEqualTo("java.base");
+        // provides kept because impl is reachable
+        assertThat(cleanedA.provides()).containsKey("com.svc.Svc");
+        // java.sql no longer used (only lib.b needed it, and lib.b was dead)
+        assertThat(result.jdkModulesUsed()).containsExactly("java.base");
+    }
+
+    // -- graph reachability --
+
+    @Test
+    void graphUnreachableModuleIsPruned() {
+        // app.module has no dependency on lib.c; lib.c is only depended on by dead lib.b
+        DependencyInfo depToC = new DependencyInfo("lib.c",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+        DependencyInfo depToA = new DependencyInfo("lib.a",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+
+        ModuleInfo appModule = module("app.module", APP_DEP,
+                Map.of(), List.of(depToA), List.of(), Map.of());
+        ModuleInfo libA = module("lib.a", LIB_A_DEP);
+        ModuleInfo libB = module("lib.b", LIB_B_DEP,
+                Map.of(), List.of(depToC), List.of(), Map.of());
+        ModuleInfo libC = module("lib.c", LIB_C_DEP);
+        AppModuleModel model = buildModel(appModule, List.of(libA, libB, libC), List.of(), Set.of());
+
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, Set.of(), Set.of());
+        Set<String> graphDead = shaker.findGraphUnreachableModules(Set.of("lib.b"));
+
+        assertThat(graphDead).containsExactly("lib.c");
+    }
+
+    @Test
+    void graphReachableThroughAliveModuleSurvives() {
+        // lib.c is depended on by dead lib.b AND alive app.module
+        DependencyInfo depToC = new DependencyInfo("lib.c",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+
+        ModuleInfo appModule = module("app.module", APP_DEP,
+                Map.of(), List.of(depToC), List.of(), Map.of());
+        ModuleInfo libB = module("lib.b", LIB_B_DEP,
+                Map.of(), List.of(depToC), List.of(), Map.of());
+        ModuleInfo libC = module("lib.c", LIB_C_DEP);
+        AppModuleModel model = buildModel(appModule, List.of(libB, libC), List.of(), Set.of());
+
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, Set.of(), Set.of());
+        Set<String> graphDead = shaker.findGraphUnreachableModules(Set.of("lib.b"));
+
+        assertThat(graphDead).isEmpty();
+    }
+
+    @Test
+    void transitiveChainThroughDeadModulePruned() {
+        // app → lib.b (dead) → lib.c (alive) → lib.a (alive)
+        // lib.c and lib.a are only reachable through dead lib.b
+        DependencyInfo depToB = new DependencyInfo("lib.b",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+        DependencyInfo depToC = new DependencyInfo("lib.c",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+        DependencyInfo depToA = new DependencyInfo("lib.a",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+
+        ModuleInfo appModule = module("app.module", APP_DEP,
+                Map.of(), List.of(depToB), List.of(), Map.of());
+        ModuleInfo libA = module("lib.a", LIB_A_DEP);
+        ModuleInfo libB = module("lib.b", LIB_B_DEP,
+                Map.of(), List.of(depToC), List.of(), Map.of());
+        ModuleInfo libC = module("lib.c", LIB_C_DEP,
+                Map.of(), List.of(depToA), List.of(), Map.of());
+        AppModuleModel model = buildModel(appModule, List.of(libA, libB, libC), List.of(), Set.of());
+
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, Set.of(), Set.of());
+        Set<String> graphDead = shaker.findGraphUnreachableModules(Set.of("lib.b"));
+
+        assertThat(graphDead).containsExactlyInAnyOrder("lib.a", "lib.c");
+    }
+
+    @Test
+    void bootModuleIsGraphRoot() {
+        // lib.a is not reachable from app.module, but is reachable from boot module lib.b
+        DependencyInfo depToA = new DependencyInfo("lib.a",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+
+        ModuleInfo appModule = module("app.module", APP_DEP);
+        ModuleInfo libA = module("lib.a", LIB_A_DEP);
+        ModuleInfo libB = module("lib.b", LIB_B_DEP,
+                Map.of(), List.of(depToA), List.of(), Map.of());
+        AppModuleModel model = buildModel(appModule, List.of(libA, libB), List.of(), Set.of("lib.b"));
+
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, Set.of(), Set.of());
+        Set<String> graphDead = shaker.findGraphUnreachableModules(Set.of());
+
+        assertThat(graphDead).isEmpty();
+    }
+
+    // -- java.se expansion --
+
+    @Test
+    void javaseExpandedToSpecificModules() {
+        DependencyInfo javaSeDep = new DependencyInfo("java.se",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED, Dependency.Modifier.SYNTHETIC), Map.of());
+        DependencyInfo javaBaseDep = new DependencyInfo("java.base",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED, Dependency.Modifier.MANDATED), Map.of());
+
+        ModuleInfo appModule = module("app.module", APP_DEP,
+                Map.of(), List.of(javaBaseDep), List.of(), Map.of());
+        ModuleInfo libA = module("lib.a", LIB_A_DEP,
+                Map.of(), List.of(javaSeDep, javaBaseDep), List.of(), Map.of());
+        AppModuleModel model = buildModel(appModule, List.of(libA),
+                List.of("java.base", "java.se"), Set.of());
+
+        Set<String> jdkPackages = Set.of("java.util", "java.sql", "java.io");
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, Set.of(), jdkPackages);
+        AppModuleModel result = shaker.shake(Set.of());
+
+        ModuleInfo cleanedA = result.modulesByName().get("lib.a");
+        List<String> depNames = cleanedA.dependencies().stream().map(DependencyInfo::moduleName).toList();
+        assertThat(depNames).contains("java.base", "java.sql");
+        assertThat(depNames).doesNotContain("java.se");
+        assertThat(result.jdkModulesUsed()).doesNotContain("java.se");
+        assertThat(result.jdkModulesUsed()).contains("java.base", "java.sql");
+    }
+
+    @Test
+    void javaseExpansionDropsUnusedJdkModulesAfterDeadModuleRemoval() {
+        DependencyInfo javaSeDep = new DependencyInfo("java.se",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED, Dependency.Modifier.SYNTHETIC), Map.of());
+        DependencyInfo javaSqlDep = new DependencyInfo("java.sql",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+        DependencyInfo javaBaseDep = new DependencyInfo("java.base",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED, Dependency.Modifier.MANDATED), Map.of());
+
+        ModuleInfo appModule = module("app.module", APP_DEP,
+                Map.of(), List.of(javaBaseDep), List.of(), Map.of());
+        ModuleInfo libA = module("lib.a", LIB_A_DEP,
+                Map.of(), List.of(javaSeDep, javaBaseDep), List.of(), Map.of());
+        ModuleInfo libB = module("lib.b", LIB_B_DEP,
+                Map.of(), List.of(javaSqlDep), List.of(), Map.of());
+        AppModuleModel model = buildModel(appModule, List.of(libA, libB),
+                List.of("java.base", "java.se", "java.sql"), Set.of());
+
+        // only java.util and java.io are referenced — NOT java.sql
+        Set<String> jdkPackages = Set.of("java.util", "java.io");
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, Set.of(), jdkPackages);
+        // lib.b is dead — it was the only module requiring java.sql
+        AppModuleModel result = shaker.shake(Set.of("lib.b"));
+
+        assertThat(result.jdkModulesUsed()).contains("java.base");
+        assertThat(result.jdkModulesUsed()).doesNotContain("java.sql");
+        assertThat(result.jdkModulesUsed()).doesNotContain("java.se");
+    }
+
+    @Test
+    void noExpansionWhenNoJdkPackagesReferenced() {
+        DependencyInfo javaSeDep = new DependencyInfo("java.se",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED, Dependency.Modifier.SYNTHETIC), Map.of());
+
+        ModuleInfo appModule = module("app.module", APP_DEP);
+        ModuleInfo libA = module("lib.a", LIB_A_DEP,
+                Map.of(), List.of(javaSeDep), List.of(), Map.of());
+        AppModuleModel model = buildModel(appModule, List.of(libA),
+                List.of("java.se"), Set.of());
+
+        // empty JDK packages — tree shaking was not performed or no JDK refs found
+        ModuleTreeShaker shaker = new ModuleTreeShaker(model, Set.of(), Set.of());
+        AppModuleModel result = shaker.shake(Set.of());
+
+        // java.se should remain untouched
+        ModuleInfo cleanedA = result.modulesByName().get("lib.a");
+        assertThat(cleanedA.dependencies()).hasSize(1);
+        assertThat(cleanedA.dependencies().get(0).moduleName()).isEqualTo("java.se");
+    }
+}

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/JLinkTreeShakeIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/JLinkTreeShakeIT.java
@@ -1,0 +1,74 @@
+package io.quarkus.maven.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.maven.it.verifier.MavenProcessInvocationResult;
+import io.quarkus.maven.it.verifier.RunningInvoker;
+import io.quarkus.test.devmode.util.DevModeClient;
+
+@DisableForNative
+public class JLinkTreeShakeIT extends MojoTestBase {
+
+    private final DevModeClient devModeClient = new DevModeClient();
+
+    @Test
+    void testJLinkImageWithTreeShake() throws Exception {
+        File testDir = initProject("projects/jlink-tree-shake");
+        RunningInvoker running = new RunningInvoker(testDir, false);
+
+        MavenProcessInvocationResult result = running.execute(
+                List.of("package", "-DskipTests"), Map.of());
+        assertThat(result.getProcess().waitFor(10, TimeUnit.MINUTES))
+                .as("Maven build timed out").isTrue();
+        assertThat(result.getProcess().exitValue()).isEqualTo(0);
+        assertThat(running.log()).containsIgnoringCase("BUILD SUCCESS");
+
+        // verify module tree-shaking ran and removed modules
+        assertThat(running.log()).contains("Module tree-shaking removed");
+
+        running.stop();
+
+        // launch the image and verify it serves HTTP requests
+        Path imageDir = testDir.toPath().resolve("target/jlink-output/image");
+        assertThat(imageDir).isDirectory();
+        String launcherName = OS.current() == OS.WINDOWS ? "my-app.bat" : "my-app";
+        Path launcher = imageDir.resolve("bin").resolve(launcherName);
+        File outputLog = new File(testDir, "target/output.log");
+        outputLog.createNewFile();
+
+        ProcessBuilder pb = new ProcessBuilder(launcher.toAbsolutePath().toString());
+        pb.redirectOutput(ProcessBuilder.Redirect.appendTo(outputLog));
+        pb.redirectError(ProcessBuilder.Redirect.appendTo(outputLog));
+        Process process = pb.start();
+        try {
+            await().pollDelay(1, TimeUnit.SECONDS)
+                    .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                    .until(() -> devModeClient.getHttpResponse("/hello", 200));
+
+            assertThat(devModeClient.getHttpResponse("/hello")).isEqualTo("hello");
+        } catch (Exception e) {
+            String logs = Files.readString(outputLog.toPath());
+            System.out.println("####### APP LOG DUMP ON FAILURE ######");
+            System.out.println(logs);
+            System.out.println("######################################");
+            throw e;
+        } finally {
+            process.destroy();
+            process.waitFor(10, TimeUnit.SECONDS);
+            if (process.isAlive()) {
+                process.destroyForcibly();
+            }
+        }
+    }
+}

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/JLinkTreeShakeIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/JLinkTreeShakeIT.java
@@ -1,0 +1,79 @@
+package io.quarkus.maven.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.maven.it.verifier.MavenProcessInvocationResult;
+import io.quarkus.maven.it.verifier.RunningInvoker;
+import io.quarkus.test.devmode.util.DevModeClient;
+
+@DisableForNative
+public class JLinkTreeShakeIT extends MojoTestBase {
+
+    private final DevModeClient devModeClient = new DevModeClient();
+
+    @Test
+    void testJLinkImageWithTreeShake() throws Exception {
+        File testDir = initProject("projects/jlink-tree-shake");
+        RunningInvoker running = new RunningInvoker(testDir, false);
+
+        MavenProcessInvocationResult result = running.execute(
+                List.of("package", "-DskipTests"), Map.of());
+        assertThat(result.getProcess().waitFor(10, TimeUnit.MINUTES))
+                .as("Maven build timed out").isTrue();
+        assertThat(result.getProcess().exitValue()).isEqualTo(0);
+        assertThat(running.log()).containsIgnoringCase("BUILD SUCCESS");
+
+        // verify module tree-shaking ran and removed modules
+        assertThat(running.log()).contains("Module tree-shaking removed");
+
+        running.stop();
+
+        // launch the image and verify it serves HTTP requests
+        Path imageDir = testDir.toPath().resolve("target/jlink-output/image");
+        assertThat(imageDir).isDirectory();
+        String launcherName = OS.current() == OS.WINDOWS ? "my-app.bat" : "my-app";
+        Path launcher = imageDir.resolve("bin").resolve(launcherName);
+        File outputLog = new File(testDir, "target/output.log");
+        outputLog.createNewFile();
+
+        ProcessBuilder pb = new ProcessBuilder(launcher.toAbsolutePath().toString());
+        pb.redirectOutput(ProcessBuilder.Redirect.appendTo(outputLog));
+        pb.redirectError(ProcessBuilder.Redirect.appendTo(outputLog));
+        Process process = pb.start();
+        try {
+            await().pollDelay(1, TimeUnit.SECONDS)
+                    .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                    .until(() -> devModeClient.getHttpResponse("/hello", 200));
+
+            assertThat(devModeClient.getHttpResponse("/hello")).isEqualTo("hello");
+        } catch (Exception e) {
+            String logs = Files.readString(outputLog.toPath());
+            System.out.println("####### APP LOG DUMP ON FAILURE ######");
+            System.out.println(logs);
+            System.out.println("######################################");
+            throw e;
+        } finally {
+            // On Windows the .bat launcher runs java.exe as a child process;
+            // Process.destroy() only kills cmd.exe, so we must destroy descendants
+            // first to avoid leaking a JVM that holds port 8080.
+            process.descendants().forEach(ProcessHandle::destroy);
+            process.destroy();
+            process.waitFor(10, TimeUnit.SECONDS);
+            if (process.isAlive()) {
+                process.descendants().forEach(ProcessHandle::destroyForcibly);
+                process.destroyForcibly();
+            }
+        }
+    }
+}

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/JLinkTreeShakeIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/JLinkTreeShakeIT.java
@@ -64,9 +64,14 @@ public class JLinkTreeShakeIT extends MojoTestBase {
             System.out.println("######################################");
             throw e;
         } finally {
+            // On Windows the .bat launcher runs java.exe as a child process;
+            // Process.destroy() only kills cmd.exe, so we must destroy descendants
+            // first to avoid leaking a JVM that holds port 8080.
+            process.descendants().forEach(ProcessHandle::destroy);
             process.destroy();
             process.waitFor(10, TimeUnit.SECONDS);
             if (process.isAlive()) {
+                process.descendants().forEach(ProcessHandle::destroyForcibly);
                 process.destroyForcibly();
             }
         }

--- a/integration-tests/maven/src/test/resources-filtered/projects/jlink-tree-shake/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/jlink-tree-shake/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.acme</groupId>
+    <artifactId>jlink-tree-shake-app</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>quarkus</packaging>
+
+    <properties>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.version>@project.version@</quarkus.platform.version>
+        <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>\${quarkus.platform.group-id}</groupId>
+                <artifactId>\${quarkus.platform.artifact-id}</artifactId>
+                <version>\${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jlink</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>\${compiler-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>\${quarkus-plugin.version}</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/maven/src/test/resources-filtered/projects/jlink-tree-shake/src/main/java/org/acme/jlink/GreetingResource.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/jlink-tree-shake/src/main/java/org/acme/jlink/GreetingResource.java
@@ -1,0 +1,13 @@
+package org.acme.jlink;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/hello")
+public class GreetingResource {
+
+    @GET
+    public String hello() {
+        return "hello";
+    }
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/jlink-tree-shake/src/main/resources/application.properties
+++ b/integration-tests/maven/src/test/resources-filtered/projects/jlink-tree-shake/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.package.jar.tree-shake.mode=classes


### PR DESCRIPTION
This change adds `ModuleTreeShaker` that consumes the result of a class tree-shake, determines dead modules and eliminates them the `AppModuleModel`.