### PR TITLE
Copy executionMaxDelay and description in CompositeScheduler

### DIFF
--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/CompositeScheduler.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/CompositeScheduler.java
@@ -171,6 +171,8 @@ public class CompositeScheduler implements Scheduler {
             to.setOverdueGracePeriod(overdueGracePeriod);
             to.setConcurrentExecution(concurrentExecution);
             to.setTimeZone(timeZone);
+            to.setExecutionMaxDelay(executionMaxDelay);
+            to.setDescription(description);
             to.setExecuteWith(implementation);
             if (skipPredicateClass != null) {
                 to.setSkipPredicate(skipPredicateClass);


### PR DESCRIPTION
### Problem

When the composite scheduler is enabled (`quarkus.scheduler.use-composite-scheduler=true`
with multiple scheduler implementations, e.g. `quarkus-quartz` + the simple scheduler), the
injected `Scheduler` is a `CompositeScheduler`. `CompositeJobDefinition.schedule()` delegates
to the matching constituent by rebuilding a fresh `JobDefinition` and transferring the builder
state through `CompositeJobDefinition.copy(...)`.

`copy()` copies every `AbstractJobDefinition` property **except `executionMaxDelay` and
`description`**:

```java
private JobDefinition<?> copy(JobDefinition<?> to) {
    to.setCron(cron);
    to.setInterval(every);
    to.setDelayed(delayed);
    to.setOverdueGracePeriod(overdueGracePeriod);
    to.setConcurrentExecution(concurrentExecution);
    to.setTimeZone(timeZone);
    to.setExecuteWith(implementation);
    // executionMaxDelay and description are never copied
    ...
}
```

Both are settable via the public `Scheduler.JobDefinition` API. Looking at the history, this
is an omission rather than intent: `copy()` was written in `d4bd15a14e1` (*"run multiple
scheduler implementations"*), while `setExecutionMaxDelay` was added later in `6e5f9928085`
(*"introduce Scheduled#executionMaxDelay()"*) and `setDescription` in `6f230fb80e1` (*"Add
`description` property to `@Scheduled`"*) — neither commit updated `copy()`.

Result, with the composite scheduler active and a programmatic job:

```java
scheduler.newJob("cleanup")
    .setInterval("10s")
    .setExecutionMaxDelay("30s")   // silently dropped
    .setDescription("nightly cleanup")   // silently dropped
    .setTask(exec -> ...)
    .schedule();
```

- `executionMaxDelay` is lost, so `SchedulerUtils.parseExecutionMaxDelayAsMillis` returns
  empty, `BaseScheduler.initInvoker` never wraps with `DelayedExecutionInvoker`, and the job
  runs with **no jitter** and fires no `DelayedExecution` events — the thundering-herd behavior
  the setting exists to prevent.
- `description` is lost, so `trigger.getDescription()` (Dev UI, `getScheduledJobs()`, observers)
  is `null`.

No exception or log — silent configuration loss, only in composite-scheduler setups (which is
why existing tests don't catch it).

### Fix

Copy both fields alongside the other properties in `copy()`.

### A note on testing

Exercising this path needs a running composite scheduler, i.e. two scheduler implementations
on the classpath (`quarkus-quartz` + simple) plus `use-composite-scheduler=true`. There is
currently no composite-scheduler harness with two working implementations under
`extensions/scheduler` tests (the existing `composite` test only asserts the build-time
"implementation not discovered" failure), so I didn't add a unit test in this PR. Happy to add
an integration test under `integration-tests` (or wherever you prefer) if you'd like one — just
point me at the right place.
