### PR TITLE
[3.27] Upgrade to Jackson 2.21.5

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -90,7 +90,7 @@
         <graal-sdk.version>23.1.2</graal-sdk.version>
         <gizmo.version>1.9.0</gizmo.version>
         <gizmo2.version>2.0.0.Beta6</gizmo2.version>
-        <jackson-bom.version>2.21.4</jackson-bom.version>
+        <jackson-bom.version>2.21.5</jackson-bom.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <commons-codec.version>1.19.0</commons-codec.version>


### PR DESCRIPTION
https://www.cve.org/CVERecord?id=CVE-2026-59889 
https://www.cve.org/CVERecord?id=CVE-2026-54515