### PR TITLE
Fix flaky DrainTest

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stress/DrainTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stress/DrainTest.java
@@ -74,8 +74,8 @@ public class DrainTest {
     private void runTest(String path, HttpClientOptions options) throws Exception {
         int num = 10_000;
         Vertx vertx = Vertx.vertx();
+        HttpClient client = vertx.createHttpClient(options, new PoolOptions().setHttp1MaxSize(64));
         try {
-            HttpClient client = vertx.createHttpClient(options, new PoolOptions().setHttp1MaxSize(64));
             CountDownLatch latch = new CountDownLatch(num);
             AtomicLong sum = new AtomicLong();
             AtomicReference<Throwable> failure = new AtomicReference<>();
@@ -89,7 +89,9 @@ public class DrainTest {
                             latch.countDown();
                         })
                         .onFailure(err -> {
-                            failure.compareAndSet(null, err);
+                            if (!failure.compareAndSet(null, err)) {
+                                failure.get().addSuppressed(err);
+                            }
                             latch.countDown();
                         });
             }
@@ -100,7 +102,8 @@ public class DrainTest {
             }
             Assertions.assertThat(sum.get()).isEqualTo(1_000_000_000L);
         } finally {
-            vertx.close().toCompletionStage().toCompletableFuture().get();
+            client.shutdown().await();
+            vertx.close().await();
         }
     }
 

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stress/DrainTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stress/DrainTest.java
@@ -1,9 +1,12 @@
 package io.quarkus.resteasy.reactive.server.test.stress;
 
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -23,7 +26,6 @@ import org.assertj.core.api.Assertions;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusExtensionTest;
@@ -39,6 +41,8 @@ import io.vertx.core.http.PoolOptions;
 
 public class DrainTest {
 
+    private static final long RUN_TIMEOUT = System.getenv("CI") != null ? 120 : 30;
+
     @RegisterExtension
     static QuarkusExtensionTest test = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
@@ -48,27 +52,31 @@ public class DrainTest {
             .overrideConfigKey("quarkus.http.ssl.certificate.key-store-password", "secret");
 
     @Test
-    @Timeout(value = 30, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
     void testAsyncHttp1() throws Exception {
-        runTest("/test/bytesAsync", createHttp1Options());
+        assertTimeoutPreemptively(Duration.ofSeconds(RUN_TIMEOUT), () -> {
+            runTest("/test/bytesAsync", createHttp1Options());
+        });
     }
 
     @Test
-    @Timeout(value = 30, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
     void testSyncHttp1() throws Exception {
-        runTest("/test/bytesSync", createHttp1Options());
+        assertTimeoutPreemptively(Duration.ofSeconds(RUN_TIMEOUT), () -> {
+            runTest("/test/bytesSync", createHttp1Options());
+        });
     }
 
     @Test
-    @Timeout(value = 30, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
     void testAsyncHttp2() throws Exception {
-        runTest("/test/bytesAsync", createHttp2Options());
+        assertTimeoutPreemptively(Duration.ofSeconds(RUN_TIMEOUT), () -> {
+            runTest("/test/bytesAsync", createHttp2Options());
+        });
     }
 
     @Test
-    @Timeout(value = 30, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
     void testSyncHttp2() throws Exception {
-        runTest("/test/bytesSync", createHttp2Options());
+        assertTimeoutPreemptively(Duration.ofSeconds(RUN_TIMEOUT), () -> {
+            runTest("/test/bytesSync", createHttp2Options());
+        });
     }
 
     private void runTest(String path, HttpClientOptions options) throws Exception {
@@ -96,7 +104,7 @@ public class DrainTest {
                         });
             }
 
-            Assertions.assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
+            Assertions.assertThat(latch.await(RUN_TIMEOUT, TimeUnit.SECONDS)).isTrue();
             if (failure.get() != null) {
                 Assertions.fail("Request failed", failure.get());
             }


### PR DESCRIPTION
- Prevent GC-driven shutdown
- 2 steps shutdown on failure (client, then the full Vertx context)
- Capture all errors as suppressed exceptions

This has been tested locally with repeated tests and low heap settings, but needs confirmation in public CI.
