### PR TITLE
Bump MINIMUM GraalVM version to 25.0

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
@@ -18,7 +18,6 @@ import io.quarkus.deployment.GeneratedClassGizmo2Adaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.GeneratedNativeImageClassBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.JPMSExportBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedPackageBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
@@ -56,16 +55,6 @@ public class NativeImageFeatureStep {
             "registerAsUnsafeAccessed", void.class, Field.class);
     private static final MethodDesc GET_CONTEXT_CLASS_LOADER = MethodDesc.of(Thread.class, "getContextClassLoader",
             ClassLoader.class);
-
-    @BuildStep
-    void addExportsToNativeImage(BuildProducer<JPMSExportBuildItem> features) {
-        // required in order to access org.graalvm.nativeimage.impl.RuntimeClassInitializationSupport
-        // prior to 23.1 the class was provided by org.graalvm.sdk module and with 23.1 onwards, it's provided by org.graalvm.nativeimage instead
-        features.produce(new JPMSExportBuildItem("org.graalvm.sdk", "org.graalvm.nativeimage.impl", null,
-                GraalVM.Version.VERSION_23_1_0));
-        features.produce(new JPMSExportBuildItem("org.graalvm.nativeimage", "org.graalvm.nativeimage.impl",
-                GraalVM.Version.VERSION_23_1_0));
-    }
 
     @BuildStep
     void generateFeature(BuildProducer<GeneratedNativeImageClassBuildItem> nativeImageClass,

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
@@ -126,7 +126,7 @@ public final class GraalVM {
          *
          * See {@link #MINIMUM_SUPPORTED} for the minimum fully supported version.
          */
-        public static final Version MINIMUM = VERSION_23_1_0;
+        public static final Version MINIMUM = VERSION_25_0_0;
         /**
          * The current version of GraalVM supported by Quarkus.
          * This version is the one actively being tested and is expected to give the best experience.

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/graal/Brotli4jFeature.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/graal/Brotli4jFeature.java
@@ -20,8 +20,6 @@ import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
 import org.graalvm.nativeimage.hosted.RuntimeResourceAccess;
 
-import io.quarkus.runtime.graal.GraalVM;
-
 public class Brotli4jFeature implements Feature {
 
     @Override
@@ -43,12 +41,6 @@ public class Brotli4jFeature implements Feature {
 
         // Static initializer tries to load the native library in Brotli4jLoader; must be done at runtime.
         RuntimeClassInitialization.initializeAtRunTime("com.aayushatharva.brotli4j.Brotli4jLoader");
-        final GraalVM.Version v = GraalVM.Version.getCurrent();
-        // Newer 23.1+ GraalVM/Mandrel does not need this explicitly marked for runtime init thanks
-        // to a different strategy: https://github.com/oracle/graal/blob/vm-23.1.0/substratevm/CHANGELOG.md?plain=1#L10
-        if (v.compareTo(GraalVM.Version.VERSION_23_1_0) <= 0) {
-            RuntimeClassInitialization.initializeAtRunTime("io.netty.handler.codec.compression.Brotli");
-        }
     }
 
     // Verbatim copy from https://github.com/hyperxpro/Brotli4j/blob/32e3d3827fa3124ca945b75ae2138492c9c775b3/brotli4j/src/main/java/com/aayushatharva/brotli4j/Brotli4jLoader.java#L118C1-L150C6


### PR DESCRIPTION
Building native-images using any older GraalVM version than 25.0 is no longer working. The default native-image builder is Mandrel 25.0 and we can no longer ensure that native-image builds with 23.1 or lower work. Therefore, enforce that the native-image build fails immediately with those old versions.

