### PR TITLE
Share Gradle TestKit fixtures across plugin tests

### DIFF
--- a/devtools/gradle/build-logic/src/main/kotlin/io.quarkus.devtools.java-library.gradle.kts
+++ b/devtools/gradle/build-logic/src/main/kotlin/io.quarkus.devtools.java-library.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("java-library")
+    id("java-test-fixtures")
     id("maven-publish")
 }
 
@@ -13,13 +14,14 @@ dependencies {
     implementation(libs.getLibrary("quarkus-bootstrap-gradle-resolver"))
     implementation(libs.getLibrary("quarkus-core-deployment"))
 
-    testImplementation(platform("io.quarkus:quarkus-bom:$version"))
-    testImplementation(platform(libs.getLibrary("junit-bom")))
-    testImplementation(gradleTestKit())
-    testImplementation(libs.getLibrary("junit-api"))
-    testImplementation(libs.getLibrary("assertj"))
+    testFixturesApi(gradleTestKit())
 
-    testImplementation(libs.getLibrary("quarkus-devtools-testing"))
+    testFixturesApi(platform(libs.getLibrary("junit-bom")))
+    testFixturesApi(libs.getLibrary("junit-api"))
+    testFixturesApi(libs.getLibrary("assertj"))
+
+    testFixturesApi(platform("io.quarkus:quarkus-bom:$version"))
+    testFixturesApi(libs.getLibrary("quarkus-devtools-testing"))
 }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/devtools/gradle/gradle-application-plugin/build.gradle.kts
+++ b/devtools/gradle/gradle-application-plugin/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     implementation("io.quarkus:quarkus-analytics-common")
     compileOnly(libs.kotlin.gradle.plugin.api)
     testImplementation(libs.quarkus.project.core.extension.codestarts)
+    testImplementation(testFixtures(project(":gradle-model")))
 }
 
 group = "io.quarkus"

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/CachingTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/CachingTest.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -27,7 +28,6 @@ import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -37,8 +37,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import io.quarkus.gradle.testing.BaseGradleTest;
+
 @ExtendWith(SoftAssertionsExtension.class)
-public class CachingTest {
+public class CachingTest extends BaseGradleTest {
     private static final Map<String, TaskOutcome> ALL_SUCCESS = Map.of(
             ":quarkusGenerateCode", TaskOutcome.SUCCESS,
             ":quarkusGenerateCodeTests", TaskOutcome.SUCCESS,
@@ -65,9 +67,6 @@ public class CachingTest {
     @InjectSoftAssertions
     SoftAssertions soft;
 
-    @TempDir
-    Path testProjectDir;
-
     @Test
     void envChangeInvalidatesBuild() throws Exception {
         // Declare the environment variables FOO_ENV_VAR and FROM_DOT_ENV_FILE as relevant for the build.
@@ -75,28 +74,28 @@ public class CachingTest {
                 "cachingRelevantProperties.add(\"FOO_ENV_VAR\")",
                 "cachingRelevantProperties.add(\"FROM_DOT_ENV_FILE\")"));
 
-        String[] arguments = List.of("build", "--info", "--stacktrace", "--build-cache", "--configuration-cache",
+        String[] arguments = List.of("build", "--info", "--stacktrace", "--build-cache",
                 "-Dquarkus.package.jar.type=fast-jar",
                 "-Dquarkus.randomized.value=" + UUID.randomUUID())
                 .toArray(new String[0]);
 
         Map<String, String> env = Map.of();
-        assertBuildResult("initial", gradleBuild(rerunTasks(arguments), env), ALL_SUCCESS);
-        assertBuildResult("initial rebuild", gradleBuild(arguments, env), ALL_UP_TO_DATE);
+        assertBuildResult("initial", buildResult(env, rerunTasks(arguments)), ALL_SUCCESS);
+        assertBuildResult("initial rebuild", buildResult(env, arguments), ALL_UP_TO_DATE);
 
         // Change the relevant environment, must rebuild
         env = Map.of("FOO_ENV_VAR", "some-value");
-        assertBuildResult("set FOO_ENV_VAR", gradleBuild(arguments, env), ALL_SUCCESS);
-        assertBuildResult("set FOO_ENV_VAR rebuild", gradleBuild(arguments, env), ALL_UP_TO_DATE);
+        assertBuildResult("set FOO_ENV_VAR", buildResult(env, arguments), ALL_SUCCESS);
+        assertBuildResult("set FOO_ENV_VAR rebuild", buildResult(env, arguments), ALL_UP_TO_DATE);
 
         // Change the environment file again, must rebuild
         env = Map.of("FOO_ENV_VAR", "some-other-value");
-        assertBuildResult("change FOO_ENV_VAR", gradleBuild(arguments, env), ALL_SUCCESS);
-        assertBuildResult("change FOO_ENV_VAR rebuild", gradleBuild(arguments, env), ALL_UP_TO_DATE);
+        assertBuildResult("change FOO_ENV_VAR", buildResult(env, arguments), ALL_SUCCESS);
+        assertBuildResult("change FOO_ENV_VAR rebuild", buildResult(env, arguments), ALL_UP_TO_DATE);
 
         // Change an unrelated environment variable, all up-to-date
         env = Map.of("FOO_ENV_VAR", "some-other-value", "SOME_UNRELATED", "meep");
-        assertBuildResult("SOME_UNRELATED", gradleBuild(arguments, env), ALL_UP_TO_DATE);
+        assertBuildResult("SOME_UNRELATED", buildResult(env, arguments), ALL_UP_TO_DATE);
     }
 
     @Test
@@ -114,41 +113,41 @@ public class CachingTest {
                     "cachingRelevantProperties.add(\"FOO_ENV_VAR\")",
                     "cachingRelevantProperties.add(\"FROM_DOT_ENV_FILE\")"));
 
-            String[] arguments = List.of("build", "--info", "--stacktrace", "--build-cache", "--configuration-cache",
+            String[] arguments = List.of("build", "--info", "--stacktrace", "--build-cache",
                     "-Dquarkus.package.jar.type=fast-jar",
                     "-Dquarkus.randomized.value=" + UUID.randomUUID())
                     .toArray(new String[0]);
 
             Map<String, String> env = Map.of();
 
-            assertBuildResult("initial", gradleBuild(rerunTasks(arguments), env), ALL_SUCCESS);
-            assertBuildResult("initial rebuild", gradleBuild(arguments, env), ALL_UP_TO_DATE);
+            assertBuildResult("initial", buildResult(env, rerunTasks(arguments)), ALL_SUCCESS);
+            assertBuildResult("initial rebuild", buildResult(env, arguments), ALL_UP_TO_DATE);
 
             // Change the .env file, must rebuild
 
             Files.write(dotEnvFile, List.of("FROM_DOT_ENV_FILE=env file value"));
-            assertBuildResult("set FROM_DOT_ENV_FILE", gradleBuild(arguments, env), ALL_SUCCESS);
-            assertBuildResult("set FROM_DOT_ENV_FILE rebuild", gradleBuild(arguments, env), ALL_UP_TO_DATE);
+            assertBuildResult("set FROM_DOT_ENV_FILE", buildResult(env, arguments), ALL_SUCCESS);
+            assertBuildResult("set FROM_DOT_ENV_FILE rebuild", buildResult(env, arguments), ALL_UP_TO_DATE);
 
             // Change the .env file again, must rebuild
 
             Files.write(dotEnvFile, List.of("FROM_DOT_ENV_FILE=new value"));
-            assertBuildResult("change FROM_DOT_ENV_FILE", gradleBuild(arguments, env), ALL_SUCCESS);
-            assertBuildResult("change FROM_DOT_ENV_FILE rebuild", gradleBuild(arguments, env), ALL_UP_TO_DATE);
+            assertBuildResult("change FROM_DOT_ENV_FILE", buildResult(env, arguments), ALL_SUCCESS);
+            assertBuildResult("change FROM_DOT_ENV_FILE rebuild", buildResult(env, arguments), ALL_UP_TO_DATE);
 
             // OTHER_ENV_VAR is not declared as relevant for the build, skipping its check
             Files.write(dotEnvFile, List.of("FROM_DOT_ENV_FILE=new value", "OTHER_ENV_VAR=hello"));
-            assertBuildResult("OTHER_ENV_VAR", gradleBuild(arguments, env), ALL_UP_TO_DATE);
+            assertBuildResult("OTHER_ENV_VAR", buildResult(env, arguments), ALL_UP_TO_DATE);
 
             // remove relevant var from .env file
             Files.write(dotEnvFile, List.of("OTHER_ENV_VAR=hello"));
-            assertBuildResult("remove FROM_DOT_ENV_FILE", gradleBuild(arguments, env), FROM_CACHE);
+            assertBuildResult("remove FROM_DOT_ENV_FILE", buildResult(env, arguments), FROM_CACHE);
 
             // Delete the .env file, must rebuild
 
             Files.deleteIfExists(dotEnvFile);
 
-            BuildResult result = gradleBuild(arguments, env);
+            BuildResult result = buildResult(env, arguments);
             assertBuildResult("delete .env file", result, ALL_UP_TO_DATE);
         } finally {
             Files.deleteIfExists(dotEnvFile);
@@ -167,7 +166,7 @@ public class CachingTest {
     void gradleCaching(String packageType, boolean simulateCI, String outputDir, @TempDir Path saveDir) throws Exception {
         prepareGradleBuildProject("");
 
-        Map<String, String> env = simulateCI ? Map.of("CI", "yes") : Map.of();
+        Map<String, String> env = cachingTestEnvironment(simulateCI);
 
         List<String> args = new ArrayList<>();
         Collections.addAll(args, "build", "--info", "--stacktrace", "--build-cache", "--no-configuration-cache");
@@ -183,8 +182,8 @@ public class CachingTest {
         }
         String[] arguments = args.toArray(new String[0]);
 
-        assertBuildResult("initial", gradleBuild(rerunTasks(arguments), env), ALL_SUCCESS);
-        assertBuildResult("initial rebuild", gradleBuild(arguments, env), ALL_UP_TO_DATE);
+        assertBuildResult("initial", buildResult(env, rerunTasks(arguments)), ALL_SUCCESS);
+        assertBuildResult("initial rebuild", buildResult(env, arguments), ALL_UP_TO_DATE);
 
         // Purge the whole build/ directory
 
@@ -197,7 +196,7 @@ public class CachingTest {
 
         // A follow-up 'build', without a build/ directory should fetch everything from the cache / pull the dependencies
 
-        BuildResult result = gradleBuild(arguments, env);
+        BuildResult result = buildResult(env, arguments);
         Map<String, TaskOutcome> taskResults = taskResults(result);
 
         Path quarkusBuildGen = Paths.get("quarkus-build", "gen");
@@ -219,23 +218,24 @@ public class CachingTest {
 
         // A follow-up 'build' does nothing, everything's up-to-date
 
-        result = gradleBuild(arguments, env);
+        result = buildResult(env, arguments);
         assertBuildResult("follow-up", result, ALL_UP_TO_DATE);
+    }
+
+    private static Map<String, String> cachingTestEnvironment(boolean simulateCI) {
+        Map<String, String> env = new HashMap<>(System.getenv());
+        if (simulateCI) {
+            env.put("CI", "yes");
+        } else {
+            env.remove("CI");
+        }
+        return env;
     }
 
     private static String[] rerunTasks(String[] arguments) {
         String[] args = Arrays.copyOf(arguments, arguments.length + 1);
         args[arguments.length] = "--rerun-tasks";
         return args;
-    }
-
-    private BuildResult gradleBuild(String[] arguments, Map<String, String> env) {
-        return GradleRunner.create()
-                .withPluginClasspath()
-                .withProjectDir(testProjectDir.toFile())
-                .withArguments(arguments)
-                .withEnvironment(env)
-                .build();
     }
 
     private void assertBuildResult(String step, BuildResult result,

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/CryptoConfigTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/CryptoConfigTest.java
@@ -2,18 +2,15 @@ package io.quarkus.gradle.tasks;
 
 import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
+import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-public class CryptoConfigTest {
+import io.quarkus.gradle.testing.BaseGradleTest;
 
-    @TempDir
-    Path testProjectDir;
+public class CryptoConfigTest extends BaseGradleTest {
 
     @Test
     @Disabled("To be fixed via https://github.com/quarkusio/quarkus/issues/38007")
@@ -22,12 +19,7 @@ public class CryptoConfigTest {
         FileUtils.copyDirectory(new File(url.toURI()), testProjectDir.toFile());
         FileUtils.copyFile(new File("../gradle.properties"), testProjectDir.resolve("gradle.properties").toFile());
 
-        GradleRunner.create()
-                .withPluginClasspath()
-                .withProjectDir(testProjectDir.toFile())
-                .withArguments("build", "--info", "--stacktrace", "--build-cache", "--configuration-cache")
-                // .build() checks whether the build failed, which is good enough for this test
-                .build();
+        buildResult(Map.of(), "build", "--info", "--stacktrace", "--build-cache");
 
     }
 }

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/EagerResolutionTaskTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/EagerResolutionTaskTest.java
@@ -10,21 +10,18 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class EagerResolutionTaskTest {
+import io.quarkus.gradle.testing.BaseGradleTest;
 
-    @TempDir
-    Path testProjectDir;
+public class EagerResolutionTaskTest extends BaseGradleTest {
 
     private static Stream<String> tasksToTest() {
         return Stream.of(
@@ -67,16 +64,7 @@ public class EagerResolutionTaskTest {
             e.printStackTrace();
         }
 
-        BuildResult firstBuild = buildResult(taskName);
+        BuildResult firstBuild = buildResult(Map.of(), taskName);
         assertEquals(SUCCESS, firstBuild.task(":quarkusGenerateCode").getOutcome());
-
-    }
-
-    private BuildResult buildResult(String task) {
-        return GradleRunner.create()
-                .withPluginClasspath()
-                .withProjectDir(testProjectDir.toFile())
-                .withArguments(task, "--info", "--stacktrace", "--build-cache")
-                .build();
     }
 }

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/JvmArgsConfigTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/JvmArgsConfigTest.java
@@ -14,9 +14,9 @@ import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkus.gradle.testing.BaseGradleTest;
 
 /**
  * Test that verifies the Quarkus Gradle plugin properly configures JVM arguments and system property
@@ -26,16 +26,13 @@ import org.junit.jupiter.api.io.TempDir;
  * - jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
  * - jvmArgs("--add-exports=java.base/jdk.internal.module=ALL-UNNAMED")
  */
-public class JvmArgsConfigTest {
+public class JvmArgsConfigTest extends BaseGradleTest {
 
     private static final String LOGGING_MANAGER_PROP_NAME = "java.util.logging.manager";
     private static final String LOGGING_MANAGER_PROP_VALUE = "org.jboss.logmanager.LogManager";
     private static final String OPENS_LANG_INVOKE = "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED";
     private static final String OPENS_LANG = "--add-opens=java.base/java.lang=ALL-UNNAMED";
     private static final String EXPORTS_INTERNAL_MODULE = "--add-exports=java.base/jdk.internal.module=ALL-UNNAMED";
-
-    @TempDir
-    Path testProjectDir;
 
     @Test
     void testJvmArgsAndSystemPropsAreConfigured() throws IOException, URISyntaxException {
@@ -44,11 +41,7 @@ public class JvmArgsConfigTest {
         FileUtils.copyDirectory(new File(url.toURI()), testProjectDir.toFile());
         FileUtils.copyFile(new File("../gradle.properties"), testProjectDir.resolve("gradle.properties").toFile());
 
-        BuildResult result = GradleRunner.create()
-                .withPluginClasspath()
-                .withProjectDir(testProjectDir.toFile())
-                .withArguments("test", "--info", "--stacktrace")
-                .build();
+        BuildResult result = buildResult("test");
 
         BuildTask testResult = result.task(":test");
         assertThat(testResult).isNotNull();

--- a/devtools/gradle/gradle-model/src/testFixtures/java/io/quarkus/gradle/testing/BaseGradleTest.java
+++ b/devtools/gradle/gradle-model/src/testFixtures/java/io/quarkus/gradle/testing/BaseGradleTest.java
@@ -1,0 +1,160 @@
+package io.quarkus.gradle.testing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public abstract class BaseGradleTest {
+
+    public static final String CONFIGURATION_CACHE = "--configuration-cache";
+    public static final String NO_CONFIGURATION_CACHE = "--no-configuration-cache";
+    public static final String ISOLATED_PROJECTS = "-Dorg.gradle.unsafe.isolated-projects=true";
+    public static final String BUILD_CACHE = "--build-cache";
+    public static final String STACKTRACE = "--stacktrace";
+
+    @TempDir
+    protected Path testProjectDir;
+
+    protected BaseGradleTest() {
+    }
+
+    public static List<String> defaultGradleArguments(String... arguments) {
+        return defaultGradleArguments(Arrays.asList(arguments));
+    }
+
+    public static List<String> defaultGradleArguments(List<String> arguments) {
+        List<String> gradleArguments = new ArrayList<>(arguments);
+        if (!gradleArguments.contains(CONFIGURATION_CACHE) && !gradleArguments.contains(NO_CONFIGURATION_CACHE)) {
+            gradleArguments.add(CONFIGURATION_CACHE);
+        }
+        return gradleArguments;
+    }
+
+    public static List<String> isolatedProjectsGradleArguments(String... arguments) {
+        return isolatedProjectsGradleArguments(Arrays.asList(arguments));
+    }
+
+    public static List<String> isolatedProjectsGradleArguments(List<String> arguments) {
+        List<String> gradleArguments = defaultGradleArguments(arguments);
+        if (!gradleArguments.contains(ISOLATED_PROJECTS)) {
+            gradleArguments.add(ISOLATED_PROJECTS);
+        }
+        return gradleArguments;
+    }
+
+    public void writeFile(String fileName, String content) throws IOException {
+        writeFile(testProjectDir.resolve(fileName), content);
+    }
+
+    public static void writeFile(Path file, String content) throws IOException {
+        Files.createDirectories(file.getParent());
+        try (var writer = Files.newBufferedWriter(file)) {
+            writer.write(content);
+        }
+    }
+
+    public static boolean containsFileNamed(Path root, String fileName) throws IOException {
+        try (var paths = Files.walk(root)) {
+            return paths.anyMatch(path -> path.getFileName().toString().equals(fileName));
+        }
+    }
+
+    protected BuildResult buildResult(String task, String... extraArgs) {
+        return buildResult(task, List.of(extraArgs));
+    }
+
+    protected BuildResult buildResult(String task, List<String> extraArgs) {
+        return buildResult(task, extraArgs, Map.of());
+    }
+
+    protected BuildResult buildResult(String task, List<String> extraArgs, Map<String, String> env) {
+        List<String> args = new ArrayList<>();
+        args.add(task);
+        args.add("--info");
+        args.add(STACKTRACE);
+        args.add(BUILD_CACHE);
+        args.addAll(extraArgs);
+        return buildResult(env, args);
+    }
+
+    protected BuildResult buildResultWithIsolatedProjects(String... args) {
+        return prepareBuildWithIsolatedProjects(args).build();
+    }
+
+    protected BuildResult buildResult(Map<String, String> env, String... args) {
+        return buildResult(env, List.of(args));
+    }
+
+    protected BuildResult buildResult(Map<String, String> env, List<String> args) {
+        return prepareBuild(env, args).build();
+    }
+
+    protected BuildResult buildAndFailResult(String... args) {
+        return buildAndFailResult(Map.of(), List.of(args));
+    }
+
+    protected BuildResult buildAndFailResult(Map<String, String> env, String... args) {
+        return buildAndFailResult(env, List.of(args));
+    }
+
+    protected BuildResult buildAndFailResult(Map<String, String> env, List<String> args) {
+        List<String> gradleArguments = new ArrayList<>();
+        gradleArguments.add("--info");
+        gradleArguments.add(STACKTRACE);
+        gradleArguments.addAll(args);
+        return prepareBuild(env, gradleArguments).buildAndFail();
+    }
+
+    protected GradleRunner prepareBuildWithIsolatedProjects(String... args) {
+        List<String> gradleArguments = isolatedProjectsGradleArguments(args);
+        if (!gradleArguments.contains(STACKTRACE)) {
+            gradleArguments.add(STACKTRACE);
+        }
+        return prepareBuild(Map.of(), gradleArguments);
+    }
+
+    protected GradleRunner prepareBuild(Map<String, String> env, List<String> args) {
+        GradleRunner gradleRunner = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir.toFile())
+                .withArguments(defaultGradleArguments(args));
+        if (!env.isEmpty()) {
+            gradleRunner.withEnvironment(env);
+        }
+        return gradleRunner;
+    }
+
+    public static void assertTaskOutcomes(BuildResult result, TaskOutcome expectedOutcome, String... taskPaths) {
+        Map<String, TaskOutcome> expectedOutcomes = new LinkedHashMap<>();
+        for (String taskPath : taskPaths) {
+            expectedOutcomes.put(taskPath, expectedOutcome);
+        }
+        assertTaskOutcomes(result, expectedOutcomes);
+    }
+
+    public static void assertTaskOutcomes(BuildResult result, Map<String, TaskOutcome> expectedOutcomes) {
+        assertThat(taskOutcomes(result))
+                .as("Gradle task outcomes")
+                .containsAllEntriesOf(expectedOutcomes);
+    }
+
+    public static Map<String, TaskOutcome> taskOutcomes(BuildResult result) {
+        return result.getTasks().stream()
+                .collect(Collectors.toMap(BuildTask::getPath, BuildTask::getOutcome, (first, second) -> second,
+                        LinkedHashMap::new));
+    }
+}


### PR DESCRIPTION
Move the common `GradleRunner` setup used by application-plugin tests into a `:gradle-model` test fixture so later Gradle plugin tests can opt into the same default arguments and environment handling without duplicating boilerplate.

The added `BaseGradleTest` fixture also centralizes the configuration-cache default for TestKit builds, which makes follow-up compatibility tests easier to read and keeps per-test opt-outs explicit.