### PR TITLE
Register all Config components for native image

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -143,14 +143,27 @@ public class ConfigGenerationBuildStep {
                 "io.quarkus.runtime.configuration.RuntimeConfigBuilder$UuidConfigSource$Holder"));
     }
 
+    /**
+     * Registers all config components descriptors for native image.
+     * <p>
+     * The initialized Config used by Quarkus does not require them, but users may be instantiating their own Config.
+     */
     @BuildStep
     void nativeServiceProviders(BuildProducer<ServiceProviderBuildItem> providerProducer) throws IOException {
         providerProducer.produce(new ServiceProviderBuildItem(ConfigProviderResolver.class.getName(),
                 SmallRyeConfigProviderResolver.class.getName()));
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        // TODO - radcortez - Move these services to be registered directly with the builder
         for (Class<?> serviceClass : Arrays.asList(
+                Converter.class,
+                ConfigSource.class,
+                ConfigSourceProvider.class,
+                ConfigSourceFactory.class,
+                ConfigSourceInterceptor.class,
+                ConfigSourceInterceptorFactory.class,
+                SecretKeysHandler.class,
+                SecretKeysHandlerFactory.class,
                 ConfigValidator.class,
+                SmallRyeConfigBuilderCustomizer.class,
                 ConfigMappingHandler.class)) {
             String serviceName = serviceClass.getName();
             Set<String> names = ServiceUtil.classNamesNamedIn(classLoader, SERVICES_PREFIX + serviceName);


### PR DESCRIPTION
The initialized Config used by Quarkus does not require them, so I've tried to remove them with https://github.com/quarkusio/quarkus/pull/55372, but users may be instantiating their own Config, so I'm re-adding them.

- Fixes https://github.com/quarkusio/quarkus/issues/55582