### PR TITLE
ArC: `isKotlinSuspendMethod()` should throw on suspend methods with raw `Continuation`

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/KotlinUtils.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/KotlinUtils.java
@@ -23,9 +23,17 @@ public class KotlinUtils {
         if (method.parametersCount() == 0) {
             return false;
         }
-
         Type lastParameter = method.parameterType(method.parametersCount() - 1);
-        return KotlinDotNames.CONTINUATION.equals(lastParameter.name());
+        if (!KotlinDotNames.CONTINUATION.equals(lastParameter.name())) {
+            return false;
+        }
+        if (lastParameter.kind() == Type.Kind.PARAMETERIZED_TYPE) {
+            return true;
+        }
+        String msg = method.isSynthetic()
+                ? "Synthetic suspend function with raw Continuation parameter type: "
+                : "Suspend function with raw Continuation parameter type: ";
+        throw new IllegalArgumentException(msg + method);
     }
 
     public static boolean isKotlinContinuationParameter(MethodParameterInfo parameter) {

--- a/independent-projects/arc/tests/src/test/kotlin/io/quarkus/arc/test/KotlinSuspendMethodTest.kt
+++ b/independent-projects/arc/tests/src/test/kotlin/io/quarkus/arc/test/KotlinSuspendMethodTest.kt
@@ -1,0 +1,43 @@
+package io.quarkus.arc.test
+
+import io.quarkus.arc.processor.KotlinUtils
+import org.jboss.jandex.Index
+import org.jboss.jandex.Type
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class KotlinSuspendMethodTest {
+    private val index = Index.of(Base::class.java, Impl::class.java)
+
+    @Test
+    fun shouldThrowOnSuspendMethodWithNonParameterizedContinuation() {
+        val method = index.getClassByName(Impl::class.java)
+            .methods()
+            .first { it.name() == "update" && it.parameterTypes().last().kind() != Type.Kind.PARAMETERIZED_TYPE }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            KotlinUtils.isKotlinSuspendMethod(method)
+        }
+    }
+
+    @Test
+    fun shouldRecognizeMethodWithParameterizedContinuationAndProduceCorrectReturnType() {
+        val method = index.getClassByName(Impl::class.java)
+            .methods()
+            .first { it.name() == "update" && it.parameterTypes().last().kind() == Type.Kind.PARAMETERIZED_TYPE }
+
+        assertTrue(KotlinUtils.isKotlinSuspendMethod(method))
+
+        assertEquals("java.lang.String", KotlinUtils.getKotlinSuspendMethodResult(method).name().toString())
+    }
+}
+
+abstract class Base<T : Any> {
+    open suspend fun update(obj: T): T = throw UnsupportedOperationException()
+}
+
+class Impl : Base<String>() {
+    override suspend fun update(obj: String): String = obj
+}


### PR DESCRIPTION
As of Kotlin 2.4.0, bridge `suspend` methods (resulting from overriding a generic `suspend` function with a narrowed type parameter) include the original method's annotations. This results in bridge `suspend` methods getting discovered in annotation scans. This, in turn, results in `getKotlinSuspendMethodResult()` throwing an exception, because the bridge method doesn't have a parameterized `Continuation<...>` parameter.

This is OK, because it highlights that the caller doesn't filter out synthetic methods properly. However, callers do not necessarily have to call `getKotlinSuspendMethodResult()`, meaning they won't get the exception.

With this commit, the `isKotlinSuspendMethod()` method throws on these methods as well, because they look like `suspend` functions but their `Continuation` parameter doesn't have a parameterized type. This should be the bridge `suspend` methods.

Note again that this merely highlights a problem on the call site. Annotation scans should filter out bridge methods (and in fact all synthetic methods) on their own. This is because annotation scans usually search for user-defined concepts (such as CDI beans, JAX-RS resources, etc.) and synthetic methods are never user-defined.