### PR TITLE
Add regression test for HHH-20707 inner interface CDI accessor import

### DIFF
--- a/integration-tests/data-hibernate/src/main/java/io/quarkus/it/panache/next/CustomQueries.java
+++ b/integration-tests/data-hibernate/src/main/java/io/quarkus/it/panache/next/CustomQueries.java
@@ -1,0 +1,12 @@
+package io.quarkus.it.panache.next;
+
+/**
+ * A non-Panache interface used as a parent for an inner interface
+ * on a PanacheEntity. This triggers a bug in the Hibernate Processor
+ * where the generated CDI accessor in the metamodel class uses
+ * the unqualified inner interface name without importing it.
+ *
+ * @see EntityWithBareInnerInterface
+ */
+public interface CustomQueries {
+}

--- a/integration-tests/data-hibernate/src/main/java/io/quarkus/it/panache/next/EntityWithBareInnerInterface.java
+++ b/integration-tests/data-hibernate/src/main/java/io/quarkus/it/panache/next/EntityWithBareInnerInterface.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.panache.next;
+
+import jakarta.persistence.Entity;
+
+import io.quarkus.hibernate.panache.PanacheEntity;
+
+/**
+ * Regression test entity for hibernate/hibernate-orm#13090.
+ * <p>
+ * When a PanacheEntity has an inner interface that does NOT extend
+ * PanacheRepository and has no {@code @Find}/{@code @HQL} methods,
+ * the Hibernate Processor must still generate a correct import for
+ * the inner interface type in the CDI accessor of the metamodel class.
+ * <p>
+ * Without the fix, the generated {@code EntityWithBareInnerInterface_}
+ * uses the unqualified name {@code Queries} without an import statement,
+ * causing a compilation failure.
+ */
+@Entity
+public class EntityWithBareInnerInterface extends PanacheEntity {
+    public String name;
+
+    public interface Queries extends CustomQueries {
+    }
+}

--- a/integration-tests/data-hibernate/src/test/java/io/quarkus/it/panache/next/InnerInterfaceCdiAccessorTest.java
+++ b/integration-tests/data-hibernate/src/test/java/io/quarkus/it/panache/next/InnerInterfaceCdiAccessorTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.it.panache.next;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Regression test for hibernate/hibernate-orm#13090.
+ * <p>
+ * Verifies that the Hibernate Processor generates a compilable metamodel
+ * class for a PanacheEntity with an inner interface that extends a
+ * non-Panache type and has no {@code @Find}/{@code @HQL} methods.
+ * <p>
+ * The primary assertion is implicit: if the annotation processor emits
+ * the inner interface type without a proper import, the generated
+ * {@code EntityWithBareInnerInterface_} will not compile and this test
+ * class will never load.
+ */
+@QuarkusTest
+public class InnerInterfaceCdiAccessorTest {
+
+    @Test
+    void generatedMetamodelHasCdiAccessorForBareInnerInterface() throws Exception {
+        Class<?> metamodel = Class.forName("io.quarkus.it.panache.next.EntityWithBareInnerInterface_");
+        Method accessor = metamodel.getMethod("queries");
+
+        assertThat(Modifier.isStatic(accessor.getModifiers()))
+                .as("CDI accessor method 'queries()' should be static")
+                .isTrue();
+        assertThat(accessor.getReturnType())
+                .as("CDI accessor should return the inner interface type")
+                .isEqualTo(EntityWithBareInnerInterface.Queries.class);
+    }
+}


### PR DESCRIPTION
When a `PanacheEntity` has an inner interface that does **not** extend
`PanacheRepository` and has no `@Find`/`@HQL` methods, the Hibernate
Processor generates a CDI accessor in the metamodel class using the
unqualified inner interface name without an import statement. This causes
a compilation failure.

The fix is tracked upstream as [HHH-20707](https://hibernate.atlassian.net/browse/HHH-20707)
with PRs [hibernate-orm#13090](https://github.com/hibernate/hibernate-orm/pull/13090) (main)
and [hibernate-orm#13093](https://github.com/hibernate/hibernate-orm/pull/13093) (7.4 backport).

This PR adds a regression test to the `integration-tests/data-hibernate`
module that will fail on Hibernate ORM 7.4.4.Final (current) and pass
once the fix is released and Quarkus bumps the dependency.

The test entity `EntityWithBareInnerInterface` extends `PanacheEntity`
and contains `interface Queries extends CustomQueries {}` — a bare inner
interface with no Panache annotations or repository parent. The
generated `EntityWithBareInnerInterface_` currently emits
`Queries` without importing `EntityWithBareInnerInterface.Queries`,
failing compilation.