### PR TITLE
Ignore synthetic methods in RESTEasy Reactive sub-resource scan

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -773,6 +773,11 @@ public class ResteasyReactiveProcessor {
             for (DotName methodAnnotation : result.getHttpAnnotationToMethod().keySet()) {
                 for (AnnotationInstance instance : index.getAnnotations(methodAnnotation)) {
                     MethodInfo method = instance.target().asMethod();
+
+                    if (method.isSynthetic()) {
+                        continue;
+                    }
+
                     ClassInfo classInfo = method.declaringClass();
 
                     // Reject known client interfaces (See predicate above)
@@ -792,6 +797,11 @@ public class ResteasyReactiveProcessor {
             for (AnnotationInstance instance : index.getAnnotations(ResteasyReactiveDotNames.PATH)) {
                 if (instance.target().kind() == AnnotationTarget.Kind.METHOD) {
                     MethodInfo method = instance.target().asMethod();
+
+                    if (method.isSynthetic()) {
+                        continue;
+                    }
+
                     ClassInfo classInfo = method.declaringClass();
 
                     // Reject known client interfaces (See predicate above)


### PR DESCRIPTION
`ResteasyReactiveProcessor#setupEndpoints()` builds an index of possible sub-resource
  return types by scanning the Jandex index directly for methods with an HTTP or `@Path`
  annotation. This scan has no filter for synthetic methods, so any synthetic method that
  ends up carrying a matching annotation gets treated as a candidate, even though it was
  never written by a user.

  This follows up on [#55579](https://github.com/quarkusio/quarkus/pull/55579), where a Kotlin 2.4.0-specific case of this (a
  compiler-generated bridge method picking up a copied `@PUT` annotation) was fixed in
  `KotlinUtils`. This PR addresses the more general gap in the scan itself, as suggested
  during that review.

  Adds a synthetic-method check to both loops that build `returnsBySubResources`.

- Fixes: #55578