### PR TITLE
Fix Qute localization resolver delegation

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -1305,7 +1305,7 @@ public class MessageBundleProcessor {
                                 resolveMethodPrefix + "_resolve_" + (idx + 1),
                                 CompletableFuture.class, String.class,
                                 EvaluatedParams.class, CompletableFuture.class),
-                                bundleCreator.this_(), name, evaluatedParams, bundleCreator.this_()));
+                                bundleCreator.this_(), name, evaluatedParams, ret));
                     } else {
                         // Last group - return null
                         bc.returnNull();

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LargeMessageBundle.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LargeMessageBundle.java
@@ -1,0 +1,911 @@
+package io.quarkus.qute.deployment.i18n;
+
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+
+@MessageBundle("large")
+public interface LargeMessageBundle {
+
++    @Message("message-0")
+    String message0();
+
+    @Message("message-1")
+    String message1();
+
+    @Message("message-2")
+    String message2();
+
+    @Message("message-3")
+    String message3();
+
+    @Message("message-4")
+    String message4();
+
+    @Message("message-5")
+    String message5();
+
+    @Message("message-6")
+    String message6();
+
+    @Message("message-7")
+    String message7();
+
+    @Message("message-8")
+    String message8();
+
+    @Message("message-9")
+    String message9();
+
+    @Message("message-10")
+    String message10();
+
+    @Message("message-11")
+    String message11();
+
+    @Message("message-12")
+    String message12();
+
+    @Message("message-13")
+    String message13();
+
+    @Message("message-14")
+    String message14();
+
+    @Message("message-15")
+    String message15();
+
+    @Message("message-16")
+    String message16();
+
+    @Message("message-17")
+    String message17();
+
+    @Message("message-18")
+    String message18();
+
+    @Message("message-19")
+    String message19();
+
+    @Message("message-20")
+    String message20();
+
+    @Message("message-21")
+    String message21();
+
+    @Message("message-22")
+    String message22();
+
+    @Message("message-23")
+    String message23();
+
+    @Message("message-24")
+    String message24();
+
+    @Message("message-25")
+    String message25();
+
+    @Message("message-26")
+    String message26();
+
+    @Message("message-27")
+    String message27();
+
+    @Message("message-28")
+    String message28();
+
+    @Message("message-29")
+    String message29();
+
+    @Message("message-30")
+    String message30();
+
+    @Message("message-31")
+    String message31();
+
+    @Message("message-32")
+    String message32();
+
+    @Message("message-33")
+    String message33();
+
+    @Message("message-34")
+    String message34();
+
+    @Message("message-35")
+    String message35();
+
+    @Message("message-36")
+    String message36();
+
+    @Message("message-37")
+    String message37();
+
+    @Message("message-38")
+    String message38();
+
+    @Message("message-39")
+    String message39();
+
+    @Message("message-40")
+    String message40();
+
+    @Message("message-41")
+    String message41();
+
+    @Message("message-42")
+    String message42();
+
+    @Message("message-43")
+    String message43();
+
+    @Message("message-44")
+    String message44();
+
+    @Message("message-45")
+    String message45();
+
+    @Message("message-46")
+    String message46();
+
+    @Message("message-47")
+    String message47();
+
+    @Message("message-48")
+    String message48();
+
+    @Message("message-49")
+    String message49();
+
+    @Message("message-50")
+    String message50();
+
+    @Message("message-51")
+    String message51();
+
+    @Message("message-52")
+    String message52();
+
+    @Message("message-53")
+    String message53();
+
+    @Message("message-54")
+    String message54();
+
+    @Message("message-55")
+    String message55();
+
+    @Message("message-56")
+    String message56();
+
+    @Message("message-57")
+    String message57();
+
+    @Message("message-58")
+    String message58();
+
+    @Message("message-59")
+    String message59();
+
+    @Message("message-60")
+    String message60();
+
+    @Message("message-61")
+    String message61();
+
+    @Message("message-62")
+    String message62();
+
+    @Message("message-63")
+    String message63();
+
+    @Message("message-64")
+    String message64();
+
+    @Message("message-65")
+    String message65();
+
+    @Message("message-66")
+    String message66();
+
+    @Message("message-67")
+    String message67();
+
+    @Message("message-68")
+    String message68();
+
+    @Message("message-69")
+    String message69();
+
+    @Message("message-70")
+    String message70();
+
+    @Message("message-71")
+    String message71();
+
+    @Message("message-72")
+    String message72();
+
+    @Message("message-73")
+    String message73();
+
+    @Message("message-74")
+    String message74();
+
+    @Message("message-75")
+    String message75();
+
+    @Message("message-76")
+    String message76();
+
+    @Message("message-77")
+    String message77();
+
+    @Message("message-78")
+    String message78();
+
+    @Message("message-79")
+    String message79();
+
+    @Message("message-80")
+    String message80();
+
+    @Message("message-81")
+    String message81();
+
+    @Message("message-82")
+    String message82();
+
+    @Message("message-83")
+    String message83();
+
+    @Message("message-84")
+    String message84();
+
+    @Message("message-85")
+    String message85();
+
+    @Message("message-86")
+    String message86();
+
+    @Message("message-87")
+    String message87();
+
+    @Message("message-88")
+    String message88();
+
+    @Message("message-89")
+    String message89();
+
+    @Message("message-90")
+    String message90();
+
+    @Message("message-91")
+    String message91();
+
+    @Message("message-92")
+    String message92();
+
+    @Message("message-93")
+    String message93();
+
+    @Message("message-94")
+    String message94();
+
+    @Message("message-95")
+    String message95();
+
+    @Message("message-96")
+    String message96();
+
+    @Message("message-97")
+    String message97();
+
+    @Message("message-98")
+    String message98();
+
+    @Message("message-99")
+    String message99();
+
+    @Message("message-100")
+    String message100();
+
+    @Message("message-101")
+    String message101();
+
+    @Message("message-102")
+    String message102();
+
+    @Message("message-103")
+    String message103();
+
+    @Message("message-104")
+    String message104();
+
+    @Message("message-105")
+    String message105();
+
+    @Message("message-106")
+    String message106();
+
+    @Message("message-107")
+    String message107();
+
+    @Message("message-108")
+    String message108();
+
+    @Message("message-109")
+    String message109();
+
+    @Message("message-110")
+    String message110();
+
+    @Message("message-111")
+    String message111();
+
+    @Message("message-112")
+    String message112();
+
+    @Message("message-113")
+    String message113();
+
+    @Message("message-114")
+    String message114();
+
+    @Message("message-115")
+    String message115();
+
+    @Message("message-116")
+    String message116();
+
+    @Message("message-117")
+    String message117();
+
+    @Message("message-118")
+    String message118();
+
+    @Message("message-119")
+    String message119();
+
+    @Message("message-120")
+    String message120();
+
+    @Message("message-121")
+    String message121();
+
+    @Message("message-122")
+    String message122();
+
+    @Message("message-123")
+    String message123();
+
+    @Message("message-124")
+    String message124();
+
+    @Message("message-125")
+    String message125();
+
+    @Message("message-126")
+    String message126();
+
+    @Message("message-127")
+    String message127();
+
+    @Message("message-128")
+    String message128();
+
+    @Message("message-129")
+    String message129();
+
+    @Message("message-130")
+    String message130();
+
+    @Message("message-131")
+    String message131();
+
+    @Message("message-132")
+    String message132();
+
+    @Message("message-133")
+    String message133();
+
+    @Message("message-134")
+    String message134();
+
+    @Message("message-135")
+    String message135();
+
+    @Message("message-136")
+    String message136();
+
+    @Message("message-137")
+    String message137();
+
+    @Message("message-138")
+    String message138();
+
+    @Message("message-139")
+    String message139();
+
+    @Message("message-140")
+    String message140();
+
+    @Message("message-141")
+    String message141();
+
+    @Message("message-142")
+    String message142();
+
+    @Message("message-143")
+    String message143();
+
+    @Message("message-144")
+    String message144();
+
+    @Message("message-145")
+    String message145();
+
+    @Message("message-146")
+    String message146();
+
+    @Message("message-147")
+    String message147();
+
+    @Message("message-148")
+    String message148();
+
+    @Message("message-149")
+    String message149();
+
+    @Message("message-150")
+    String message150();
+
+    @Message("message-151")
+    String message151();
+
+    @Message("message-152")
+    String message152();
+
+    @Message("message-153")
+    String message153();
+
+    @Message("message-154")
+    String message154();
+
+    @Message("message-155")
+    String message155();
+
+    @Message("message-156")
+    String message156();
+
+    @Message("message-157")
+    String message157();
+
+    @Message("message-158")
+    String message158();
+
+    @Message("message-159")
+    String message159();
+
+    @Message("message-160")
+    String message160();
+
+    @Message("message-161")
+    String message161();
+
+    @Message("message-162")
+    String message162();
+
+    @Message("message-163")
+    String message163();
+
+    @Message("message-164")
+    String message164();
+
+    @Message("message-165")
+    String message165();
+
+    @Message("message-166")
+    String message166();
+
+    @Message("message-167")
+    String message167();
+
+    @Message("message-168")
+    String message168();
+
+    @Message("message-169")
+    String message169();
+
+    @Message("message-170")
+    String message170();
+
+    @Message("message-171")
+    String message171();
+
+    @Message("message-172")
+    String message172();
+
+    @Message("message-173")
+    String message173();
+
+    @Message("message-174")
+    String message174();
+
+    @Message("message-175")
+    String message175();
+
+    @Message("message-176")
+    String message176();
+
+    @Message("message-177")
+    String message177();
+
+    @Message("message-178")
+    String message178();
+
+    @Message("message-179")
+    String message179();
+
+    @Message("message-180")
+    String message180();
+
+    @Message("message-181")
+    String message181();
+
+    @Message("message-182")
+    String message182();
+
+    @Message("message-183")
+    String message183();
+
+    @Message("message-184")
+    String message184();
+
+    @Message("message-185")
+    String message185();
+
+    @Message("message-186")
+    String message186();
+
+    @Message("message-187")
+    String message187();
+
+    @Message("message-188")
+    String message188();
+
+    @Message("message-189")
+    String message189();
+
+    @Message("message-190")
+    String message190();
+
+    @Message("message-191")
+    String message191();
+
+    @Message("message-192")
+    String message192();
+
+    @Message("message-193")
+    String message193();
+
+    @Message("message-194")
+    String message194();
+
+    @Message("message-195")
+    String message195();
+
+    @Message("message-196")
+    String message196();
+
+    @Message("message-197")
+    String message197();
+
+    @Message("message-198")
+    String message198();
+
+    @Message("message-199")
+    String message199();
+
+    @Message("message-200")
+    String message200();
+
+    @Message("message-201")
+    String message201();
+
+    @Message("message-202")
+    String message202();
+
+    @Message("message-203")
+    String message203();
+
+    @Message("message-204")
+    String message204();
+
+    @Message("message-205")
+    String message205();
+
+    @Message("message-206")
+    String message206();
+
+    @Message("message-207")
+    String message207();
+
+    @Message("message-208")
+    String message208();
+
+    @Message("message-209")
+    String message209();
+
+    @Message("message-210")
+    String message210();
+
+    @Message("message-211")
+    String message211();
+
+    @Message("message-212")
+    String message212();
+
+    @Message("message-213")
+    String message213();
+
+    @Message("message-214")
+    String message214();
+
+    @Message("message-215")
+    String message215();
+
+    @Message("message-216")
+    String message216();
+
+    @Message("message-217")
+    String message217();
+
+    @Message("message-218")
+    String message218();
+
+    @Message("message-219")
+    String message219();
+
+    @Message("message-220")
+    String message220();
+
+    @Message("message-221")
+    String message221();
+
+    @Message("message-222")
+    String message222();
+
+    @Message("message-223")
+    String message223();
+
+    @Message("message-224")
+    String message224();
+
+    @Message("message-225")
+    String message225();
+
+    @Message("message-226")
+    String message226();
+
+    @Message("message-227")
+    String message227();
+
+    @Message("message-228")
+    String message228();
+
+    @Message("message-229")
+    String message229();
+
+    @Message("message-230")
+    String message230();
+
+    @Message("message-231")
+    String message231();
+
+    @Message("message-232")
+    String message232();
+
+    @Message("message-233")
+    String message233();
+
+    @Message("message-234")
+    String message234();
+
+    @Message("message-235")
+    String message235();
+
+    @Message("message-236")
+    String message236();
+
+    @Message("message-237")
+    String message237();
+
+    @Message("message-238")
+    String message238();
+
+    @Message("message-239")
+    String message239();
+
+    @Message("message-240")
+    String message240();
+
+    @Message("message-241")
+    String message241();
+
+    @Message("message-242")
+    String message242();
+
+    @Message("message-243")
+    String message243();
+
+    @Message("message-244")
+    String message244();
+
+    @Message("message-245")
+    String message245();
+
+    @Message("message-246")
+    String message246();
+
+    @Message("message-247")
+    String message247();
+
+    @Message("message-248")
+    String message248();
+
+    @Message("message-249")
+    String message249();
+
+    @Message("message-250")
+    String message250();
+
+    @Message("message-251")
+    String message251();
+
+    @Message("message-252")
+    String message252();
+
+    @Message("message-253")
+    String message253();
+
+    @Message("message-254")
+    String message254();
+
+    @Message("message-255")
+    String message255();
+
+    @Message("message-256")
+    String message256();
+
+    @Message("message-257")
+    String message257();
+
+    @Message("message-258")
+    String message258();
+
+    @Message("message-259")
+    String message259();
+
+    @Message("message-260")
+    String message260();
+
+    @Message("message-261")
+    String message261();
+
+    @Message("message-262")
+    String message262();
+
+    @Message("message-263")
+    String message263();
+
+    @Message("message-264")
+    String message264();
+
+    @Message("message-265")
+    String message265();
+
+    @Message("message-266")
+    String message266();
+
+    @Message("message-267")
+    String message267();
+
+    @Message("message-268")
+    String message268();
+
+    @Message("message-269")
+    String message269();
+
+    @Message("message-270")
+    String message270();
+
+    @Message("message-271")
+    String message271();
+
+    @Message("message-272")
+    String message272();
+
+    @Message("message-273")
+    String message273();
+
+    @Message("message-274")
+    String message274();
+
+    @Message("message-275")
+    String message275();
+
+    @Message("message-276")
+    String message276();
+
+    @Message("message-277")
+    String message277();
+
+    @Message("message-278")
+    String message278();
+
+    @Message("message-279")
+    String message279();
+
+    @Message("message-280")
+    String message280();
+
+    @Message("message-281")
+    String message281();
+
+    @Message("message-282")
+    String message282();
+
+    @Message("message-283")
+    String message283();
+
+    @Message("message-284")
+    String message284();
+
+    @Message("message-285")
+    String message285();
+
+    @Message("message-286")
+    String message286();
+
+    @Message("message-287")
+    String message287();
+
+    @Message("message-288")
+    String message288();
+
+    @Message("message-289")
+    String message289();
+
+    @Message("message-290")
+    String message290();
+
+    @Message("message-291")
+    String message291();
+
+    @Message("message-292")
+    String message292();
+
+    @Message("message-293")
+    String message293();
+
+    @Message("message-294")
+    String message294();
+
+    @Message("message-295")
+    String message295();
+
+    @Message("message-296")
+    String message296();
+
+    @Message("message-297")
+    String message297();
+
+    @Message("message-298")
+    String message298();
+
+    @Message("message-299")
+    String message299();
+
+    @Message("message-300")
+    String message300();
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LargeMessageBundle.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LargeMessageBundle.java
@@ -6,7 +6,7 @@ import io.quarkus.qute.i18n.MessageBundle;
 @MessageBundle("large")
 public interface LargeMessageBundle {
 
-+    @Message("message-0")
+    @Message("message-0")
     String message0();
 
     @Message("message-1")

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LargeMessageBundleTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LargeMessageBundleTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.qute.deployment.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.Engine;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class LargeMessageBundleTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClasses(LargeMessageBundle.class));
+
+    @Inject
+    Engine engine;
+
+    @Test
+    void resolveMessageFromSecondResolverGroup() {
+        assertEquals("message-300", engine.parse("{large:message300}").render());
+    }
+
+}


### PR DESCRIPTION
The generated resolver delegated to its next method with the bundle instance instead of the in-flight CompletableFuture. This produced invalid bytecode when a message bundle exceeded one resolver group. The added regression test exercises a bundle with 301 messages.