### PR TITLE
Add defaults to PackageConfig outputName, outputDirectory and outputTimestamp

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
@@ -80,8 +80,8 @@ public class QuarkusAugmentor {
         this.additionalApplicationArchives = new ArrayList<>(builder.additionalApplicationArchives);
         this.excludedFromIndexing = builder.excludedFromIndexing;
         this.liveReloadBuildItem = builder.liveReloadState;
-        this.buildSystemProperties = builder.buildSystemProperties;
-        this.runtimeProperties = builder.runtimeProperties;
+        this.buildSystemProperties = builder.buildSystemProperties != null ? builder.buildSystemProperties : new Properties();
+        this.runtimeProperties = builder.runtimeProperties != null ? builder.runtimeProperties : new Properties();
         this.targetDir = builder.targetDir;
         this.effectiveModel = builder.effectiveModel;
         this.baseName = builder.baseName;
@@ -93,6 +93,9 @@ public class QuarkusAugmentor {
         this.auxiliaryDevModeType = Optional.ofNullable(builder.auxiliaryDevModeType);
         this.test = builder.test;
         this.depInfoProvider = builder.depInfoProvider;
+        if (this.baseName != null) {
+            this.buildSystemProperties.put("quarkus.build.base-name", baseName);
+        }
     }
 
     public BuildResult run() throws Exception {
@@ -103,18 +106,14 @@ public class QuarkusAugmentor {
         log.debug("Beginning Quarkus augmentation");
         runtimeInitializeForAugmentation();
         ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
-        QuarkusBuildCloseablesBuildItem buildCloseables = new QuarkusBuildCloseablesBuildItem();
-        try {
+        try (QuarkusBuildCloseablesBuildItem buildCloseables = new QuarkusBuildCloseablesBuildItem()) {
             Thread.currentThread().setContextClassLoader(deploymentClassLoader);
 
-            final BuildChainBuilder chainBuilder = BuildChain.builder();
+            BuildChainBuilder chainBuilder = BuildChain.builder();
             chainBuilder.setClassLoader(deploymentClassLoader);
 
-            ExtensionLoader.loadStepsFrom(deploymentClassLoader,
-                    buildSystemProperties == null ? new Properties() : buildSystemProperties,
-                    runtimeProperties == null ? new Properties() : runtimeProperties,
-                    effectiveModel, launchMode, devModeType)
-                    .accept(chainBuilder);
+            ExtensionLoader.loadStepsFrom(deploymentClassLoader, buildSystemProperties, runtimeProperties, effectiveModel,
+                    launchMode, devModeType).accept(chainBuilder);
 
             Thread.currentThread().setContextClassLoader(classLoader);
             chainBuilder.loadProviders(classLoader);
@@ -203,7 +202,6 @@ public class QuarkusAugmentor {
 
             }
             Thread.currentThread().setContextClassLoader(originalClassLoader);
-            buildCloseables.close();
         }
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/cmd/RunCommandProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/cmd/RunCommandProcessor.java
@@ -1,6 +1,5 @@
 package io.quarkus.deployment.cmd;
 
-import static io.quarkus.deployment.pkg.jar.FastJarFormat.DEFAULT_FAST_JAR_DIRECTORY_NAME;
 import static io.quarkus.deployment.pkg.jar.FastJarFormat.QUARKUS_RUN_JAR;
 
 import java.io.File;
@@ -26,19 +25,19 @@ public class RunCommandProcessor {
 
     @SuppressWarnings("deprecation") // legacy jar
     @BuildStep
-    public void defaultJavaCommand(PackageConfig packageConfig,
+    public void defaultJavaCommand(
+            PackageConfig packageConfig,
             OutputTargetBuildItem jar,
             BuildProducer<RunCommandActionBuildItem> cmds,
             BuildSystemTargetBuildItem buildSystemTarget) {
 
         Path jarPath = switch (packageConfig.jar().type()) {
-            case UBER_JAR -> jar.getOutputDirectory()
+            case UBER_JAR -> jar.getPackageOutputDirectory()
                     .resolve(jar.getBaseName() + packageConfig.computedRunnerSuffix() + ".jar");
             // todo: legacy JAR should be using runnerSuffix()
-            case LEGACY_JAR -> jar.getOutputDirectory()
+            case LEGACY_JAR -> jar.getPackageOutputDirectory()
                     .resolve(jar.getBaseName() + packageConfig.computedRunnerSuffix() + ".jar");
-            case FAST_JAR, MUTABLE_JAR, AOT_JAR -> jar.getOutputDirectory()
-                    .resolve(DEFAULT_FAST_JAR_DIRECTORY_NAME).resolve(QUARKUS_RUN_JAR);
+            case FAST_JAR, MUTABLE_JAR, AOT_JAR -> jar.getPackageOutputDirectory().resolve(QUARKUS_RUN_JAR);
         };
 
         List<String> args = new ArrayList<>();

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigBuilderCustomizer.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigBuilderCustomizer.java
@@ -1,13 +1,29 @@
 package io.quarkus.deployment.configuration;
 
+import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.AOT_JAR;
+import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.FAST_JAR;
+import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.MUTABLE_JAR;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.Converter;
+
+import io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType;
+import io.quarkus.deployment.pkg.jar.FastJarFormat;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.console.ConsoleRuntimeConfig;
 import io.quarkus.runtime.logging.LogBuildTimeConfig;
 import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.runtime.logging.LoggingSetupRecorder;
+import io.smallrye.config.ConfigSourceContext;
+import io.smallrye.config.ConfigSourceFactory;
+import io.smallrye.config.ConfigValue;
+import io.smallrye.config.Converters;
+import io.smallrye.config.DefaultValuesConfigSource;
+import io.smallrye.config.PropertiesConfigSource;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
 
@@ -29,5 +45,31 @@ public class BuildTimeConfigBuilderCustomizer implements SmallRyeConfigBuilderCu
         builder.withMapping(LogBuildTimeConfig.class)
                 .withMapping(LogRuntimeConfig.class)
                 .withMapping(ConsoleRuntimeConfig.class);
+
+        builder.withSources(new ConfigSourceFactory() {
+            @Override
+            public Iterable<ConfigSource> getConfigSources(ConfigSourceContext context) {
+                ConfigValue outputDirectory = context.getValue("quarkus.package.output-directory");
+                if (outputDirectory.getValue() != null) {
+                    return Collections.emptyList();
+                }
+
+                ConfigValue jarType = context.getValue("quarkus.package.jar.type");
+                if (jarType.getValue() == null) {
+                    return Collections.emptyList();
+                }
+
+                Converter<JarType> jarTypeConverter = Converters.getImplicitConverter(JarType.class);
+                JarType type = jarTypeConverter.convert(jarType.getValue());
+                if (type.equals(FAST_JAR) || type.equals(MUTABLE_JAR) || type.equals(AOT_JAR)) {
+                    Map<String, String> map = Map.of("quarkus.package.output-directory",
+                            FastJarFormat.DEFAULT_FAST_JAR_DIRECTORY_NAME);
+                    return Collections.singletonList(new PropertiesConfigSource(map, "BuildTimeConfigSource",
+                            DefaultValuesConfigSource.ORDINAL + 1));
+                }
+
+                return Collections.emptyList();
+            }
+        });
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -99,10 +99,8 @@ import io.quarkus.deployment.console.SetCompleter;
 import io.quarkus.deployment.dev.ExceptionNotificationBuildItem;
 import io.quarkus.deployment.dev.testing.MessageFormat;
 import io.quarkus.deployment.dev.testing.TestSetupBuildItem;
-import io.quarkus.deployment.ide.EffectiveIdeBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
 import io.quarkus.deployment.metrics.MetricsFactoryConsumerBuildItem;
-import io.quarkus.deployment.pkg.builditem.BuildSystemTargetBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
@@ -402,12 +400,12 @@ public final class LoggingResourceProcessor {
     @Produce(TestSetupBuildItem.class)
     @Produce(LogConsoleFormatBuildItem.class)
     @Consume(ConsoleInstalledBuildItem.class)
-    void setupStackTraceFormatter(ApplicationArchivesBuildItem item, EffectiveIdeBuildItem ideSupport,
-            BuildSystemTargetBuildItem buildSystemTargetBuildItem,
+    void setupStackTraceFormatter(
+            ApplicationArchivesBuildItem item,
             List<ExceptionNotificationBuildItem> exceptionNotificationBuildItems,
             CuratedApplicationShutdownBuildItem curatedApplicationShutdownBuildItem,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
-            OutputTargetBuildItem outputTargetBuildItem,
+            Optional<OutputTargetBuildItem> outputTargetBuildItem,
             LaunchModeBuildItem launchMode,
             LogBuildTimeConfig logBuildTimeConfig,
             BuildProducer<LoggingDecorateBuildItem> loggingDecorateProducer) {
@@ -418,7 +416,7 @@ public final class LoggingResourceProcessor {
             }
         }
         Path srcMainJava = getSourceRoot(curateOutcomeBuildItem.getApplicationModel(),
-                outputTargetBuildItem.getOutputDirectory());
+                outputTargetBuildItem.map(OutputTargetBuildItem::getOutputDirectory).orElse(null));
 
         CompositeIndex index = CompositeIndex.create(indexList);
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/BuildConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/BuildConfig.java
@@ -1,0 +1,21 @@
+package io.quarkus.deployment.pkg;
+
+import java.util.Map;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithParentName;
+
+/**
+ * For Build properties to not be reported as unknowns.
+ */
+@ConfigMapping(prefix = "quarkus.build")
+@ConfigRoot
+public interface BuildConfig {
+    /**
+     * Build properties
+     */
+    @WithParentName
+    Map<String, Optional<String>> properties();
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
@@ -1,5 +1,9 @@
 package io.quarkus.deployment.pkg;
 
+import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.AOT_JAR;
+import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.FAST_JAR;
+import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.MUTABLE_JAR;
+
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
@@ -8,8 +12,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import io.quarkus.deployment.pkg.PackageConfig.JarConfig.AotConfig;
-import io.quarkus.deployment.pkg.PackageConfig.JarConfig.AppcdsConfig;
+import org.eclipse.microprofile.config.spi.Converter;
+
+import io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType;
 import io.quarkus.maven.dependency.GACT;
 import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
@@ -17,7 +22,9 @@ import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithConverter;
 import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
 /**
  * Packaging the application
@@ -47,19 +54,24 @@ public interface PackageConfig {
      * The directory into which the output package(s) should be written.
      * Relative paths are resolved from the build systems target directory.
      */
-    Optional<Path> outputDirectory();
+    @WithName("output-directory")
+    @WithConverter(OutputDirectoryConverter.class)
+    Path outputDirectory();
 
     /**
      * The name of the final artifact, excluding the suffix and file extension.
      */
-    Optional<String> outputName();
+    @WithDefault("${quarkus.build.base-name:application}")
+    String outputName();
 
     /**
      * The timestamp used as a reference for generating the packages (e.g. for the creation timestamp of ZIP entries).
      * <p>
      * The approach is similar to what is done by the maven-jar-plugin with `project.build.outputTimestamp`.
      */
-    Optional<Instant> outputTimestamp();
+    @WithDefault(("${quarkus.build.timestamp:now}"))
+    @WithConverter(InstantConverter.class)
+    Instant outputTimestamp();
 
     /**
      * Setting this switch to {@code true} will cause Quarkus to write the transformed application bytecode
@@ -509,5 +521,22 @@ public interface PackageConfig {
          */
         @WithDefault("${user.home}/.quarkus")
         String jarDirectory();
+    }
+
+    class OutputDirectoryConverter implements Converter<Path> {
+        @Override
+        public Path convert(String value) throws IllegalArgumentException, NullPointerException {
+            return value != null ? Path.of(value) : Path.of("");
+        }
+    }
+
+    class InstantConverter implements Converter<Instant> {
+        @Override
+        public Instant convert(String value) throws IllegalArgumentException, NullPointerException {
+            if (value != null) {
+                return value.equalsIgnoreCase("now") ? Instant.now() : Instant.parse(value);
+            }
+            return null;
+        }
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/OutputTargetBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/OutputTargetBuildItem.java
@@ -14,16 +14,23 @@ import io.quarkus.maven.dependency.ArtifactKey;
 public final class OutputTargetBuildItem extends SimpleBuildItem {
 
     private final Path outputDirectory;
+    private final Path packageOutputDirectory;
     private final String baseName;
     private final String originalBaseName;
     private final boolean rebuild;
     private final Properties buildSystemProperties;
     private final Optional<Set<ArtifactKey>> includedOptionalDependencies;
 
-    public OutputTargetBuildItem(Path outputDirectory, String baseName, String originalBaseName, boolean rebuild,
+    public OutputTargetBuildItem(
+            Path outputDirectory,
+            Path packageOutputDirectory,
+            String baseName,
+            String originalBaseName,
+            boolean rebuild,
             Properties buildSystemProperties,
             Optional<Set<ArtifactKey>> includedOptionalDependencies) {
         this.outputDirectory = outputDirectory;
+        this.packageOutputDirectory = packageOutputDirectory;
         this.baseName = baseName;
         this.originalBaseName = originalBaseName;
         this.rebuild = rebuild;
@@ -33,6 +40,10 @@ public final class OutputTargetBuildItem extends SimpleBuildItem {
 
     public Path getOutputDirectory() {
         return outputDirectory;
+    }
+
+    public Path getPackageOutputDirectory() {
+        return packageOutputDirectory;
     }
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractFastJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractFastJarBuilder.java
@@ -99,16 +99,9 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
 
     public JarBuildItem build() throws IOException {
         boolean rebuild = outputTarget.isRebuild();
+        Path buildDir = outputTarget.getPackageOutputDirectory();
 
-        Path buildDir;
-
-        if (packageConfig.outputDirectory().isPresent()) {
-            buildDir = outputTarget.getOutputDirectory();
-        } else {
-            buildDir = outputTarget.getOutputDirectory().resolve(FastJarFormat.DEFAULT_FAST_JAR_DIRECTORY_NAME);
-        }
-
-        final CoreSbomContributionConfig manifestConfig = new CoreSbomContributionConfig()
+        CoreSbomContributionConfig manifestConfig = new CoreSbomContributionConfig()
                 .setApplicationModel(curateOutcome.getApplicationModel())
                 .setDistributionDirectory(buildDir);
         //unmodified 3rd party dependencies
@@ -170,7 +163,7 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
             Path transformedZip = quarkus.resolve(FastJarFormat.TRANSFORMED_BYTECODE_JAR);
             fastJarJarsBuilder.setTransformedJar(transformedZip);
             try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(transformedZip,
-                    packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
+                    packageConfig.jar().compress(), packageConfig.outputTimestamp(),
                     executorService)) {
                 // we make sure the entries are added in a reproducible order
                 // we use Path#toString() to get a reproducible order on both Unix-based OSes and Windows
@@ -193,7 +186,7 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
         Path generatedZip = quarkus.resolve(FastJarFormat.GENERATED_BYTECODE_JAR);
         fastJarJarsBuilder.setGeneratedJar(generatedZip);
         try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(generatedZip,
-                packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
+                packageConfig.jar().compress(), packageConfig.outputTimestamp(),
                 executorService)) {
             // make sure we write the elements in order
             for (GeneratedClassBuildItem i : generatedClasses.stream()
@@ -239,7 +232,7 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
             manifestConfig.addComponent(appArtifact, runnerJar);
             Predicate<String> ignoredEntriesPredicate = getThinJarIgnoredEntriesPredicate(packageConfig);
             try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(runnerJar,
-                    packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
+                    packageConfig.jar().compress(), packageConfig.outputTimestamp(),
                     executorService)) {
                 copyFiles(applicationArchives.getRootArchive(), archiveCreator, null, ignoredEntriesPredicate);
 
@@ -337,7 +330,7 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
         }
         if (!rebuild) {
             try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(initJar,
-                    packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
+                    packageConfig.jar().compress(), packageConfig.outputTimestamp(),
                     executorService)) {
                 Manifest manifest = createManifest(packageConfig, appArtifact, applicationInfo);
                 attachRunnerMetadata(manifest, getEntryPoint().getName(), getClassPath(fastJarJars), jvmRequirements);
@@ -565,7 +558,7 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
     private static void packageClasses(Path resolvedDep, final Path targetPath, PackageConfig packageConfig,
             OutputTargetBuildItem outputTargetBuildItem, ExecutorService executorService) throws IOException {
         try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(targetPath,
-                packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
+                packageConfig.jar().compress(), packageConfig.outputTimestamp(),
                 executorService)) {
             Files.walkFileTree(resolvedDep, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
                     new SimpleFileVisitor<Path>() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractFastJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractFastJarBuilder.java
@@ -99,16 +99,9 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
 
     public JarBuildItem build() throws IOException {
         boolean rebuild = outputTarget.isRebuild();
+        Path buildDir = outputTarget.getPackageOutputDirectory();
 
-        Path buildDir;
-
-        if (packageConfig.outputDirectory().isPresent()) {
-            buildDir = outputTarget.getOutputDirectory();
-        } else {
-            buildDir = outputTarget.getOutputDirectory().resolve(FastJarFormat.DEFAULT_FAST_JAR_DIRECTORY_NAME);
-        }
-
-        final CoreSbomContributionConfig manifestConfig = new CoreSbomContributionConfig()
+        CoreSbomContributionConfig manifestConfig = new CoreSbomContributionConfig()
                 .setApplicationModel(curateOutcome.getApplicationModel())
                 .setDistributionDirectory(buildDir);
         //unmodified 3rd party dependencies
@@ -170,7 +163,7 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
             Path transformedZip = quarkus.resolve(FastJarFormat.TRANSFORMED_BYTECODE_JAR);
             fastJarJarsBuilder.setTransformedJar(transformedZip);
             try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(transformedZip,
-                    packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
+                    packageConfig.jar().compress(), packageConfig.outputTimestamp(),
                     executorService)) {
                 // we make sure the entries are added in a reproducible order
                 // we use Path#toString() to get a reproducible order on both Unix-based OSes and Windows
@@ -193,7 +186,7 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
         Path generatedZip = quarkus.resolve(FastJarFormat.GENERATED_BYTECODE_JAR);
         fastJarJarsBuilder.setGeneratedJar(generatedZip);
         try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(generatedZip,
-                packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
+                packageConfig.jar().compress(), packageConfig.outputTimestamp(),
                 executorService)) {
             // make sure we write the elements in order
             for (GeneratedClassBuildItem i : generatedClasses.stream()
@@ -239,7 +232,7 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
             manifestConfig.addComponent(appArtifact, runnerJar);
             Predicate<String> ignoredEntriesPredicate = getThinJarIgnoredEntriesPredicate(packageConfig);
             try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(runnerJar,
-                    packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
+                    packageConfig.jar().compress(), packageConfig.outputTimestamp(),
                     executorService)) {
                 copyFiles(applicationArchives.getRootArchive(), archiveCreator, null, ignoredEntriesPredicate);
 
@@ -337,7 +330,7 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
         }
         if (!rebuild) {
             try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(initJar,
-                    packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
+                    packageConfig.jar().compress(), packageConfig.outputTimestamp(),
                     executorService)) {
                 Manifest manifest = createManifest(packageConfig, appArtifact, applicationInfo);
                 attachRunnerMetadata(manifest, getEntryPoint().getName(), getClassPath(fastJarJars), jvmRequirements);
@@ -534,7 +527,7 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
     private static void packageClasses(Path resolvedDep, final Path targetPath, PackageConfig packageConfig,
             OutputTargetBuildItem outputTargetBuildItem, ExecutorService executorService) throws IOException {
         try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(targetPath,
-                packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
+                packageConfig.jar().compress(), packageConfig.outputTimestamp(),
                 executorService)) {
             Files.walkFileTree(resolvedDep, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
                     new SimpleFileVisitor<Path>() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
@@ -64,7 +64,7 @@ public abstract class AbstractLegacyThinJarBuilder<T extends BuildItem> extends 
 
     protected void doBuild(Path runnerJar, Path libDir) throws IOException {
         try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(runnerJar,
-                packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
+                packageConfig.jar().compress(), packageConfig.outputTimestamp(),
                 executorService)) {
             final StringBuilder classPath = new StringBuilder();
             final Map<String, List<byte[]>> services = new HashMap<>();

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/LegacyThinJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/LegacyThinJarBuilder.java
@@ -49,9 +49,9 @@ public class LegacyThinJarBuilder extends AbstractLegacyThinJarBuilder<JarBuildI
     }
 
     public JarBuildItem build() throws IOException {
-        Path runnerJar = outputTarget.getOutputDirectory()
+        Path runnerJar = outputTarget.getPackageOutputDirectory()
                 .resolve(outputTarget.getBaseName() + packageConfig.computedRunnerSuffix() + DOT_JAR);
-        Path libDir = outputTarget.getOutputDirectory().resolve(LegacyThinJarFormat.LIB);
+        Path libDir = outputTarget.getPackageOutputDirectory().resolve(LegacyThinJarFormat.LIB);
         Files.deleteIfExists(runnerJar);
         IoUtils.createOrEmptyDir(libDir);
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
@@ -91,9 +91,10 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
 
     @Override
     public JarBuildItem build() throws IOException {
+        Path outputDirectory = outputTarget.getPackageOutputDirectory();
 
         //we use the -runner jar name, unless we are building both types
-        final Path runnerJar = outputTarget.getOutputDirectory()
+        final Path runnerJar = outputDirectory
                 .resolve(outputTarget.getBaseName() + packageConfig.computedRunnerSuffix() + DOT_JAR);
 
         // If the runner jar appears to exist already we create a new one with a tmp suffix.
@@ -101,7 +102,7 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
         // which is used as a source of content for the runner jar.
         final Path tmpRunnerJar;
         if (Files.exists(runnerJar)) {
-            tmpRunnerJar = outputTarget.getOutputDirectory()
+            tmpRunnerJar = outputDirectory
                     .resolve(outputTarget.getBaseName() + packageConfig.computedRunnerSuffix() + ".tmp");
             Files.deleteIfExists(tmpRunnerJar);
         } else {
@@ -116,7 +117,7 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
         }
 
         //for uberjars we move the original jar, so there is only a single jar in the output directory
-        final Path standardJar = outputTarget.getOutputDirectory()
+        final Path standardJar = outputDirectory
                 .resolve(outputTarget.getOriginalBaseName() + DOT_JAR);
         final Path originalJar = Files.exists(standardJar) ? standardJar : null;
 
@@ -148,7 +149,7 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
     private void buildUberJar0(Path runnerJar) throws IOException {
 
         try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(runnerJar,
-                packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
+                packageConfig.jar().compress(), packageConfig.outputTimestamp(),
                 executorService)) {
             LOG.info("Building uber jar: " + runnerJar);
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
@@ -92,9 +92,10 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
 
     @Override
     public JarBuildItem build() throws IOException {
+        Path outputDirectory = outputTarget.getPackageOutputDirectory();
 
         //we use the -runner jar name, unless we are building both types
-        final Path runnerJar = outputTarget.getOutputDirectory()
+        final Path runnerJar = outputDirectory
                 .resolve(outputTarget.getBaseName() + packageConfig.computedRunnerSuffix() + DOT_JAR);
 
         // If the runner jar appears to exist already we create a new one with a tmp suffix.
@@ -102,7 +103,7 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
         // which is used as a source of content for the runner jar.
         final Path tmpRunnerJar;
         if (Files.exists(runnerJar)) {
-            tmpRunnerJar = outputTarget.getOutputDirectory()
+            tmpRunnerJar = outputDirectory
                     .resolve(outputTarget.getBaseName() + packageConfig.computedRunnerSuffix() + ".tmp");
             Files.deleteIfExists(tmpRunnerJar);
         } else {
@@ -117,7 +118,7 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
         }
 
         //for uberjars we move the original jar, so there is only a single jar in the output directory
-        final Path standardJar = outputTarget.getOutputDirectory()
+        final Path standardJar = outputDirectory
                 .resolve(outputTarget.getOriginalBaseName() + DOT_JAR);
         final Path originalJar = Files.exists(standardJar) ? standardJar : null;
 
@@ -149,7 +150,7 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
     private void buildUberJar0(Path runnerJar) throws IOException {
 
         try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(runnerJar,
-                packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
+                packageConfig.jar().compress(), packageConfig.outputTimestamp(),
                 executorService)) {
             LOG.info("Building uber jar: " + runnerJar);
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.AdditionalApplicationArchiveBuildItem;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
@@ -68,10 +69,17 @@ import io.quarkus.maven.dependency.GACT;
 public class JarResultBuildStep {
 
     @BuildStep
-    OutputTargetBuildItem outputTarget(BuildSystemTargetBuildItem bst, PackageConfig packageConfig) {
-        String name = packageConfig.outputName().orElseGet(bst::getBaseName);
-        Path path = packageConfig.outputDirectory().map(s -> bst.getOutputDirectory().resolve(s))
-                .orElseGet(bst::getOutputDirectory);
+    void outputTarget(
+            PackageConfig packageConfig,
+            BuildSystemTargetBuildItem bst,
+            BuildProducer<OutputTargetBuildItem> outputTarget) {
+
+        // QuarkusBootstrap does not force to set a targetDirectory (QuarkusDeployableContainer),
+        // so in that case, it doesn't make sense to generate an OutputTargetBuildItem
+        if (bst.getOutputDirectory() == null) {
+            return;
+        }
+
         Optional<Set<ArtifactKey>> includedOptionalDependencies;
         if (packageConfig.jar().filterOptionalDependencies()) {
             includedOptionalDependencies = Optional.of(packageConfig.jar().includedOptionalDependencies()
@@ -80,8 +88,12 @@ public class JarResultBuildStep {
         } else {
             includedOptionalDependencies = Optional.empty();
         }
-        return new OutputTargetBuildItem(path, name, bst.getOriginalBaseName(), bst.isRebuild(), bst.getBuildSystemProps(),
-                includedOptionalDependencies);
+
+        outputTarget.produce(new OutputTargetBuildItem(
+                bst.getOutputDirectory(),
+                bst.getOutputDirectory().resolve(packageConfig.outputDirectory()),
+                packageConfig.outputName(), bst.getOriginalBaseName(), bst.isRebuild(),
+                bst.getBuildSystemProps(), includedOptionalDependencies));
     }
 
     @BuildStep(onlyIf = JarRequired.class)

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -657,15 +657,11 @@ public class QuarkusPlugin implements Plugin<Project> {
         task.getNativeEnabled().set(quarkusExt.nativeConfig().enabled());
         task.getNativeSourcesOnly().set(quarkusExt.nativeConfig().sourcesOnly());
         task.getRunnerSuffix().set(quarkusExt.packageConfig().computedRunnerSuffix());
-        task.getRunnerName().set(
-                quarkusExt.packageConfig().outputName().orElseGet(quarkusExt::finalName));
-        task.getOutputDirectory()
-                .set(Path.of(quarkusExt.packageConfig().outputDirectory().map(Path::toString)
-                        .orElse(QuarkusPlugin.DEFAULT_OUTPUT_DIRECTORY)));
+        task.getRunnerName().set(quarkusExt.packageConfig().outputName());
+        task.getOutputDirectory().set(quarkusExt.packageConfig().outputDirectory());
         task.getJarType().set(quarkusExt.packageConfig().jar().type());
         task.getManifestAttributes().set(quarkusExt.manifest().getAttributes());
         task.getManifestSections().set(quarkusExt.manifest().getSections());
-
     }
 
     private static void configureGenerateCodeTask(QuarkusGenerateCode task,

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -671,15 +671,11 @@ public class QuarkusPlugin implements Plugin<Project> {
         task.getNativeEnabled().set(quarkusExt.nativeConfig().enabled());
         task.getNativeSourcesOnly().set(quarkusExt.nativeConfig().sourcesOnly());
         task.getRunnerSuffix().set(quarkusExt.packageConfig().computedRunnerSuffix());
-        task.getRunnerName().set(
-                quarkusExt.packageConfig().outputName().orElseGet(quarkusExt::finalName));
-        task.getOutputDirectory()
-                .set(Path.of(quarkusExt.packageConfig().outputDirectory().map(Path::toString)
-                        .orElse(QuarkusPlugin.DEFAULT_OUTPUT_DIRECTORY)));
+        task.getRunnerName().set(quarkusExt.packageConfig().outputName());
+        task.getOutputDirectory().set(quarkusExt.packageConfig().outputDirectory());
         task.getJarType().set(quarkusExt.packageConfig().jar().type());
         task.getManifestAttributes().set(quarkusExt.manifest().getAttributes());
         task.getManifestSections().set(quarkusExt.manifest().getSections());
-
     }
 
     private static void configureGenerateCodeTask(QuarkusGenerateCode task,

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/AbstractQuarkusExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/AbstractQuarkusExtension.java
@@ -65,6 +65,7 @@ public abstract class AbstractQuarkusExtension {
         this.classpath = dependencyClasspath(mainSourceSet);
         this.codeGenForkOptions = new ArrayList<>();
         this.buildForkOptions = new ArrayList<>();
+        this.quarkusBuildProperties.put("quarkus.build.base-name", finalName);
     }
 
     private BaseConfig buildBaseConfig() {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/BaseConfig.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/BaseConfig.java
@@ -51,6 +51,7 @@ final class BaseConfig {
                 .withMapping(PackageConfig.class)
                 .withMapping(NativeConfig.class)
                 .withInterceptors(ConfigCompatibility.FrontEnd.nonLoggingInstance(), ConfigCompatibility.BackEnd.instance())
+                .withDefaultValue("quarkus.package.output-directory", "quarkus-app")
                 .build();
 
         manifest = new Manifest();

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/extension/QuarkusExtensionTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/extension/QuarkusExtensionTest.java
@@ -27,6 +27,7 @@ public class QuarkusExtensionTest {
 
         extension.set("test.args", "value");
 
-        assertThat(extension.getQuarkusBuildProperties().get()).containsExactly(entry("quarkus.test.args", "value"));
+        assertThat(extension.getQuarkusBuildProperties().get()).contains(entry("quarkus.test.args", "value"));
+        assertThat(extension.getQuarkusBuildProperties().get()).containsKey("quarkus.build.base-name");
     }
 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
@@ -391,6 +391,9 @@ public class QuarkusBootstrapProvider implements Closeable {
 
             effectiveProperties.putIfAbsent("quarkus.application.name", mojo.mavenProject().getArtifactId());
             effectiveProperties.putIfAbsent("quarkus.application.version", mojo.mavenProject().getVersion());
+
+            effectiveProperties.put("quarkus.build.base-name", mojo.finalName());
+
             // pass the project.build.outputTimestamp to Quarkus packaging subsystem
             // check project properties from POM, then user properties (from -D on command line),
             // then system properties, matching Maven's own property resolution order
@@ -402,7 +405,7 @@ public class QuarkusBootstrapProvider implements Closeable {
                 outputTimestamp = mojo.mavenSession().getSystemProperties().getProperty("project.build.outputTimestamp");
             }
             if (outputTimestamp != null) {
-                effectiveProperties.putIfAbsent("quarkus.package.output-timestamp", outputTimestamp);
+                effectiveProperties.putIfAbsent("quarkus.build.timestamp", outputTimestamp);
             }
 
             for (Map.Entry<String, String> attribute : mojo.manifestEntries().entrySet()) {

--- a/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxProcessor.java
+++ b/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxProcessor.java
@@ -83,7 +83,7 @@ public class CycloneDxProcessor {
                     .setLibrariesOnly(cdxSbomConfig.librariesOnly())
                     .setRuntimeOnly(cdxSbomConfig.runtimeOnly())
                     .setIncludeQuarkusComponentScope(cdxSbomConfig.includeQuarkusComponentScope())
-                    .setOutputTimestamp(packageConfig.outputTimestamp().orElse(null))
+                    .setOutputTimestamp(packageConfig.outputTimestamp())
                     .setContributions(contributions)
                     .generate()) {
                 sbomProducer.produce(new SbomBuildItem(sbom));
@@ -152,7 +152,7 @@ public class CycloneDxProcessor {
         }
 
         byte[] sbomBytes = generateEmbeddedSbomBytes(cdxConfig, curateOutcomeBuildItem, appModelProviderBuildItem,
-                computePedigrees(treeShakeResult), sbomContributions, packageConfig.outputTimestamp().orElse(null));
+                computePedigrees(treeShakeResult), sbomContributions, packageConfig.outputTimestamp());
         String effectiveResourceName = effectiveResourceName(cdxConfig.embedded());
         if (cdxConfig.embedded().compress()) {
             sbomBytes = gzip(sbomBytes);

--- a/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoProcessor.java
+++ b/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoProcessor.java
@@ -230,9 +230,7 @@ public class InfoProcessor {
         buildData.put("artifact", artifact);
         String version = appArtifact.getVersion();
         buildData.put("version", version);
-        OffsetDateTime dateTime = packageConfig.outputTimestamp()
-                .map(i -> i.atZone(ZoneId.systemDefault()).toOffsetDateTime())
-                .orElseGet(() -> OffsetDateTime.now());
+        OffsetDateTime dateTime = packageConfig.outputTimestamp().atZone(ZoneId.systemDefault()).toOffsetDateTime();
         String time = ISO_OFFSET_DATE_TIME.format(dateTime);
         buildData.put("time", time); // TODO: what is the proper notion of build time?
         String quarkusVersion = Version.getVersion();

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -1,6 +1,5 @@
 package io.quarkus.kubernetes.deployment;
 
-import static io.quarkus.deployment.pkg.jar.FastJarFormat.DEFAULT_FAST_JAR_DIRECTORY_NAME;
 import static io.quarkus.deployment.pkg.jar.FastJarFormat.QUARKUS_RUN_JAR;
 import static io.quarkus.kubernetes.deployment.Constants.KUBERNETES;
 import static io.quarkus.kubernetes.spi.KubernetesDeploymentTargetBuildItem.mergeList;
@@ -268,20 +267,11 @@ class KubernetesProcessor {
             PackageConfig packageConfig) {
         PackageConfig.JarConfig.JarType jarType = packageConfig.jar().type();
         return switch (jarType) {
-            case LEGACY_JAR, UBER_JAR -> outputTarget.getOutputDirectory()
-                    .resolve(outputTarget.getBaseName() + packageConfig.computedRunnerSuffix() + ".jar");
-            case FAST_JAR, MUTABLE_JAR, AOT_JAR -> {
-                //thin JAR
-                Path buildDir;
-
-                if (packageConfig.outputDirectory().isPresent()) {
-                    buildDir = outputTarget.getOutputDirectory();
-                } else {
-                    buildDir = outputTarget.getOutputDirectory().resolve(DEFAULT_FAST_JAR_DIRECTORY_NAME);
-                }
-
-                yield buildDir.resolve(QUARKUS_RUN_JAR);
-            }
+            case LEGACY_JAR, UBER_JAR ->
+                outputTarget.getPackageOutputDirectory()
+                        .resolve(outputTarget.getBaseName() + packageConfig.computedRunnerSuffix() + ".jar");
+            case FAST_JAR, MUTABLE_JAR, AOT_JAR -> //thin JAR
+                outputTarget.getPackageOutputDirectory().resolve(QUARKUS_RUN_JAR);
         };
     }
 

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/UnknownBuildConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/UnknownBuildConfigTest.java
@@ -41,6 +41,6 @@ public class UnknownBuildConfigTest {
 
         assertEquals(2, unrecognized.size());
         assertTrue(unrecognized.contains("quarkus.unknown.prop"));
-        assertTrue(unrecognized.contains("quarkus.build.unknown.prop"));
+        assertTrue(unrecognized.contains("quarkus.build-time.unknown.prop"));
     }
 }

--- a/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/unknown/UnknownBuildPropertyConfigSourceFactory.java
+++ b/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/unknown/UnknownBuildPropertyConfigSourceFactory.java
@@ -17,7 +17,7 @@ public class UnknownBuildPropertyConfigSourceFactory implements ConfigSourceFact
     public Iterable<ConfigSource> getConfigSources(final ConfigSourceContext context) {
         ConfigValue value = context.getValue("skip.build.sources");
         if (value.getValue() == null || value.getValue().equals("false")) {
-            return List.of(new PropertiesConfigSource(Map.of("quarkus.build.unknown.prop", "value"), "", 100));
+            return List.of(new PropertiesConfigSource(Map.of("quarkus.build-time.unknown.prop", "value"), "", 100));
         } else {
             return emptyList();
         }


### PR DESCRIPTION
- Remove `Optional` wrappers from `PackageConfig` properties `outputName`, `outputDirectory`, and `outputTimestamp`, replacing them with non-optional types that have sensible defaults
- Introduce `quarkus.build.base-name` and `quarkus.build.timestamp` as build system properties set by Maven and Gradle, used as default value expressions in PackageConfig
- Add a `ConfigSourceFactory` in `BuildTimeConfigBuilderCustomizer` that dynamically defaults `quarkus.package.output-directory` to `quarkus-app` for fast-jar, mutable-jar, and aot-jar types
- Add `packageOutputDirectory` to `OutputTargetBuildItem` to separate the raw build target directory from the resolved package output directory, eliminating duplicated conditional quarkus-app resolution logic across jar builders
- Make `OutputTargetBuildItem` optional  since `QuarkusBootstrap` does not always set a target directory

Also, Gradle's `BaseConfig` hardcodes `quarkus-app` unconditionally for the outputDirectory regardless of jar type, but this also matches pre-existing behavior. In the end, this is fine because the Augmentor uses the `ConfigSourceFactory` which is jar-type-aware. There may be other implications in Gradle (pre-existent), that we are not aware.

- Fixes #54283 