### PR TITLE
ArC: use thread-safe list for synthetic injection points

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -2037,7 +2037,7 @@ public class BeanDeployment {
 
         BeanRegistrationContextImpl(BuildContext buildContext, BeanDeployment beanDeployment) {
             super(buildContext, beanDeployment);
-            this.syntheticInjectionPoints = new ArrayList<>();
+            this.syntheticInjectionPoints = new CopyOnWriteArrayList<>();
         }
 
         @Override


### PR DESCRIPTION
Related to https://github.com/quarkusio/quarkus/issues/55603 although I cannot be certain this is *the problem*.

I have just identified this as a place where a potential parallel processing of build items might lead to concurrent addition to the simple `ArrayList` and its corruption. Is it a long shot to assume this would create `null` entry in the list, but it's all I've got so far :-)

The code path leading to this is processing the synthetic bean and calling the `done()` method on it which eventually leads to [adding its synth. injection points into the list](https://github.com/quarkusio/quarkus/blob/3.38.0.CR1/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java#L2065).
This can be done by any extension on its own (unfortunately, historical reasons) but more importantly ArC does that automatically too. `SyntheticBeansProcessor` has [three separate methods](https://github.com/quarkusio/quarkus/blob/3.38.0.CR1/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SyntheticBeansProcessor.java#L34-L78) that process these beans and that can potentially run in parallel and clash with their modifications.