### PR TITLE
Add JDBC read only config option

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -33,7 +33,7 @@
         {
             "category": "Data5",
             "timeout": 90,
-            "test-modules": "jpa-postgresql, jpa-postgresql-withxml, narayana-stm, narayana-jta, reactive-pg-client, hibernate-reactive-postgresql, hibernate-orm-tenancy/schema, hibernate-orm-tenancy/schema-mariadb, hibernate-orm-spatial, hibernate-orm-vector",
+            "test-modules": "jpa-postgresql, jpa-postgresql-withxml, narayana-stm, narayana-jta, reactive-pg-client, hibernate-reactive-postgresql, hibernate-orm-tenancy/schema, hibernate-orm-tenancy/schema-mariadb, hibernate-orm-spatial, hibernate-orm-vector, agroal",
             "os-name": "ubuntu-latest"
         },
         {

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -96,6 +96,30 @@ Be aware that setting the pool size too low might cause some requests to time ou
 
 For more information about pool size adjustment properties, see the <<jdbc-configuration>> section.
 
+==== Read-only JDBC pools
+
+You can mark a JDBC pool as read-only so that connections are created with
+link:https://docs.oracle.com/en/java/javase/17/docs/api/java.sql/java/sql/Connection.html#setReadOnly(boolean)[`Connection.setReadOnly(true)`].
+The JDBC driver is responsible for enforcing read-only mode.
+
+This is useful for secondary pools that target read replicas.
+
+[source,properties]
+----
+quarkus.datasource.jdbc.read-only=true
+----
+
+For a named datasource:
+
+[source,properties]
+----
+quarkus.datasource."readonly".db-kind=postgresql
+quarkus.datasource."readonly".jdbc.url=jdbc:postgresql://replica:5432/mydb
+quarkus.datasource."readonly".jdbc.read-only=true
+----
+
+When the property is unset, Quarkus does not configure read-only mode and Agroal's default applies (connections are not read-only).
+
 
 === Configure a reactive datasource
 

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DefaultDataSourceConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DefaultDataSourceConfigTest.java
@@ -60,6 +60,7 @@ public class DefaultDataSourceConfigTest {
         assertTrue(configuration.transactionIntegration() instanceof NarayanaTransactionIntegration);
         assertEquals(AgroalConnectionFactoryConfiguration.TransactionIsolation.SERIALIZABLE,
                 agroalConnectionFactoryConfiguration.jdbcTransactionIsolation());
+        assertFalse(agroalConnectionFactoryConfiguration.readOnly());
         assertTrue(agroalConnectionFactoryConfiguration.trackJdbcResources());
         assertTrue(dataSource.getConfiguration().metricsEnabled());
         assertFalse(configuration.flushOnClose());

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/NamedDataSourceConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/NamedDataSourceConfigTest.java
@@ -59,6 +59,7 @@ public class NamedDataSourceConfigTest {
         assertEquals(username, configuration.connectionFactoryConfiguration().principal().getName());
         assertEquals(maxSize, configuration.maxSize());
         assertFalse(dataSource.getConfiguration().metricsEnabled()); // metrics not enabled by default
+        assertFalse(configuration.connectionFactoryConfiguration().readOnly());
 
         try (Connection connection = dataSource.getConnection()) {
         }

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/NamedReadOnlyDataSourceConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/NamedReadOnlyDataSourceConfigTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.agroal.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.agroal.DataSource;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Verifies that {@code quarkus.datasource."name".jdbc.read-only} is applied for named datasources.
+ */
+public class NamedReadOnlyDataSourceConfigTest {
+
+    @Inject
+    @DataSource("testing")
+    AgroalDataSource testingDataSource;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withConfigurationResource("application-named-datasource.properties")
+            .overrideConfigKey("quarkus.datasource.testing.jdbc.read-only", "true");
+
+    @Test
+    public void testNamedDataSourceIsReadOnly() {
+        assertThat(testingDataSource.getConfiguration()
+                .connectionPoolConfiguration()
+                .connectionFactoryConfiguration()
+                .readOnly()).isTrue();
+    }
+}

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/ReadOnlyDataSourceConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/ReadOnlyDataSourceConfigTest.java
@@ -1,0 +1,41 @@
+package io.quarkus.agroal.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.AgroalConnectionFactoryConfiguration;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class ReadOnlyDataSourceConfigTest {
+
+    @Inject
+    AgroalDataSource defaultDataSource;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withConfigurationResource("base.properties")
+            .overrideConfigKey("quarkus.datasource.jdbc.read-only", "true");
+
+    @Test
+    public void testReadOnlyDataSource() throws SQLException {
+        AgroalConnectionFactoryConfiguration connectionFactoryConfiguration = defaultDataSource.getConfiguration()
+                .connectionPoolConfiguration()
+                .connectionFactoryConfiguration();
+
+        // Quarkus wires quarkus.datasource.jdbc.read-only into Agroal's connection factory config.
+        // Actual enforcement of read-only mode is driver-dependent and may not be supported by all drivers.
+        assertThat(connectionFactoryConfiguration.readOnly()).isTrue();
+
+        try (Connection connection = defaultDataSource.getConnection()) {
+            assertThat(connection).isNotNull();
+        }
+    }
+}

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
@@ -93,6 +93,16 @@ public interface DataSourceJdbcRuntimeConfig {
     Optional<AgroalConnectionFactoryConfiguration.TransactionIsolation> transactionIsolationLevel();
 
     /**
+     * Whether connections from this pool should be created in read-only mode,
+     * according to {@link java.sql.Connection#setReadOnly(boolean)}.
+     * The JDBC driver is responsible for enforcing read-only mode.
+     * <p>
+     * This is useful for secondary pools that target read replicas.
+     */
+    @ConfigDocDefault("By default, the read-only mode of connections is not configured.")
+    Optional<Boolean> readOnly();
+
+    /**
      * Collect and display extra troubleshooting info on leaked connections.
      */
     @WithDefault("false")

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -266,6 +266,10 @@ public class DataSources {
                             dataSourceJdbcRuntimeConfig.transactionIsolationLevel().get());
         }
 
+        if (dataSourceJdbcRuntimeConfig.readOnly().isPresent()) {
+            connectionFactoryConfiguration.readOnly(dataSourceJdbcRuntimeConfig.readOnly().get());
+        }
+
         if (dataSourceJdbcBuildTimeConfig.transactions() != io.quarkus.agroal.runtime.TransactionIntegration.DISABLED) {
             TransactionIntegration txIntegration = new NarayanaTransactionIntegration(transactionManager,
                     transactionSynchronizationRegistry, null, false,

--- a/integration-tests/agroal/pom.xml
+++ b/integration-tests/agroal/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-agroal</artifactId>
+    <name>Quarkus - Integration Tests - Agroal</name>
+    <description>Agroal JDBC pool integration tests (for example read-only connections with PostgreSQL)</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-agroal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-agroal-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-postgresql-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/agroal/src/main/java/io/quarkus/it/agroal/ReadOnlyDataSourceResource.java
+++ b/integration-tests/agroal/src/main/java/io/quarkus/it/agroal/ReadOnlyDataSourceResource.java
@@ -1,0 +1,58 @@
+package io.quarkus.it.agroal;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.AgroalConnectionFactoryConfiguration;
+import io.quarkus.agroal.DataSource;
+
+/**
+ * Exposes Agroal and JDBC read-only status over HTTP so the same checks can run
+ * under {@code @QuarkusTest} and {@code @QuarkusIntegrationTest} (native).
+ */
+@Path("/agroal/read-only-test")
+public class ReadOnlyDataSourceResource {
+
+    @Inject
+    AgroalDataSource defaultDataSource;
+
+    @Inject
+    @DataSource("readonly")
+    AgroalDataSource readOnlyDataSource;
+
+    @GET
+    @Path("/default")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String defaultStatus() throws SQLException {
+        return status(defaultDataSource);
+    }
+
+    @GET
+    @Path("/readonly")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String readOnlyStatus() throws SQLException {
+        return status(readOnlyDataSource);
+    }
+
+    /**
+     * Format: {@code agroalReadOnly,connectionReadOnly}
+     */
+    private static String status(AgroalDataSource dataSource) throws SQLException {
+        AgroalConnectionFactoryConfiguration factory = dataSource.getConfiguration()
+                .connectionPoolConfiguration()
+                .connectionFactoryConfiguration();
+        boolean agroalReadOnly = factory.readOnly();
+        boolean connectionReadOnly;
+        try (Connection connection = dataSource.getConnection()) {
+            connectionReadOnly = connection.isReadOnly();
+        }
+        return agroalReadOnly + "," + connectionReadOnly;
+    }
+}

--- a/integration-tests/agroal/src/main/resources/application.properties
+++ b/integration-tests/agroal/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+quarkus.datasource.db-kind=postgresql
+
+quarkus.datasource."readonly".db-kind=postgresql
+quarkus.datasource."readonly".jdbc.read-only=true

--- a/integration-tests/agroal/src/test/java/io/quarkus/it/agroal/ReadOnlyDataSourceIT.java
+++ b/integration-tests/agroal/src/test/java/io/quarkus/it/agroal/ReadOnlyDataSourceIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.agroal;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class ReadOnlyDataSourceIT extends ReadOnlyDataSourceTest {
+}

--- a/integration-tests/agroal/src/test/java/io/quarkus/it/agroal/ReadOnlyDataSourceTest.java
+++ b/integration-tests/agroal/src/test/java/io/quarkus/it/agroal/ReadOnlyDataSourceTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.it.agroal;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Our Windows CI does not have Docker installed properly")
+public class ReadOnlyDataSourceTest {
+
+    @Test
+    public void defaultPoolIsNotReadOnly() {
+        when().get("/agroal/read-only-test/default")
+                .then()
+                .statusCode(200)
+                // agroalReadOnly,connectionReadOnly
+                .body(is("false,false"));
+    }
+
+    @Test
+    public void namedPoolIsReadOnly() {
+        when().get("/agroal/read-only-test/readonly")
+                .then()
+                .statusCode(200)
+                // agroalReadOnly,connectionReadOnly
+                .body(is("true,true"));
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -161,6 +161,7 @@
             </activation>
             <modules>
                 <module>core</module>
+                <module>agroal</module>
                 <module>avro-reload</module>
                 <module>awt</module>
                 <module>awt-packaging</module>


### PR DESCRIPTION
Agroal can mark connections from a pool as read only, but Quarkus did not expose that option.
This change adds an optional JDBC runtime property so applications can configure a read only pool.
When the property is unset, Quarkus still does not set Agroal's read only flag, so existing applications keep the previous default.

Fixes #55612

