### PR TITLE
Fix EnumMap ClassCastException in bytecode recorder on method split

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -2107,7 +2107,8 @@ public class BytecodeRecorderImpl implements RecorderContext {
         }
 
         DeferredArrayStoreParameter(Object target, Class<?> expectedType) {
-            if (expectedType == List.class) {
+            if (expectedType == List.class || expectedType == Map.class || expectedType == Set.class
+                    || expectedType == SortedMap.class || expectedType == SortedSet.class) {
                 returnType = expectedType.getName();
             } else if (target != null && !(target instanceof Proxy) && isAccessible(target.getClass())) {
                 returnType = target.getClass().getName();

--- a/core/deployment/src/test/java/io/quarkus/deployment/recording/BytecodeRecorderTestCase.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/recording/BytecodeRecorderTestCase.java
@@ -11,6 +11,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -79,6 +80,31 @@ public class BytecodeRecorderTestCase {
             TestRecorder recorder = generator.getRecordingProxy(TestRecorder.class);
             recorder.map(new HashMap<>(Collections.singletonMap("a", "b")));
         }, Collections.singletonMap("a", "b"));
+    }
+
+    @Test
+    public void testEnumMapWithMethodSplit() throws Exception {
+        // EnumMap has no no-arg constructor, so the recorder falls back to LinkedHashMap.
+        // When the generated method is split (>300 instruction groups), a checkcast to the
+        // original concrete type was emitted, causing ClassCastException. This test forces
+        // a method split by recording many EnumMap calls.
+        int count = 30;
+        EnumMap<Thread.State, String>[] maps = new EnumMap[count];
+        Map<Thread.State, String>[] expected = new LinkedHashMap[count];
+        for (int i = 0; i < count; i++) {
+            EnumMap<Thread.State, String> map = new EnumMap<>(Thread.State.class);
+            for (Thread.State state : Thread.State.values()) {
+                map.put(state, state.name() + "-" + i);
+            }
+            maps[i] = map;
+            expected[i] = new LinkedHashMap<>(map);
+        }
+        runTest(generator -> {
+            TestRecorder recorder = generator.getRecordingProxy(TestRecorder.class);
+            for (EnumMap<Thread.State, String> map : maps) {
+                recorder.map(map);
+            }
+        }, (Object[]) expected);
     }
 
     @Test


### PR DESCRIPTION
When the bytecode recorder serializes an `EnumMap` across a method-split boundary (>300 instruction groups), a `checkcast` to `java.util.EnumMap` is emitted. However, since `EnumMap` has no no-arg constructor, the recorder falls back to creating a `LinkedHashMap`, which then fails the cast at runtime:

```
ClassCastException: class java.util.LinkedHashMap cannot be cast to class java.util.EnumMap
```

The existing special case for `List.class`, which uses the interface name as the cast target instead of the concrete class, is extended to also cover `Map`, `Set`, `SortedMap`, and `SortedSet`. This ensures the `checkcast` targets the interface type (e.g., `java.util.Map`), which any implementation will satisfy.

The bug manifests in `quarkus-smallrye-openapi` when more than ~18 OpenAPI scan profiles are configured (enough to cross the 300 instruction group threshold), but the fix is in `quarkus-core-deployment` since it's a general bytecode recorder issue that could affect any extension passing collection types without no-arg constructors through the recorder boundary.

- Fixes: #55618