### PR TITLE
Prevent `CodeGenerator.readConfig` from mutating an immutable list

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
@@ -327,7 +327,7 @@ public class CodeGenerator {
                 } catch (IOException e) {
                     throw new CodeGenException("Failed to read resources from classpath", e);
                 }
-                final List<String> allServices = allConfigServices.getOrDefault(service, List.of());
+                final List<String> allServices = allConfigServices.getOrDefault(service, new ArrayList<>());
                 allServices.removeAll(appModuleServices.getValue());
                 if (allServices.isEmpty()) {
                     bannedConfigServices.put(service, new byte[0]);


### PR DESCRIPTION
Simple change to prevent calling `.removeAll(...)` on an immutable `List.of()` in case `service` is not present.

This is unlikely to happen in the current code base - I stumbled upon this one for the work on the Gradle plugin.