### PR TITLE
[3.27] Fix native image regression caused by Netty 4.1.136 SslContext API change

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -114,13 +114,6 @@ class NettyProcessor {
                 // Use small chunks to avoid a lot of wasted space. Default is 16mb * arenas (derived from core count)
                 // Since buffers are cached to threads, the malloc overhead is temporary anyway
                 .addNativeImageSystemProperty("io.netty.allocator.maxOrder", maxOrder)
-                // Spotted with Netty 4.1.136.Final
-                .addRuntimeInitializedClass("io.netty.internal.tcnative.SSLPrivateKeyMethod")
-                .addRuntimeInitializedClass("io.netty.internal.tcnative.AsyncSSLPrivateKeyMethod")
-                .addRuntimeInitializedClass("io.netty.internal.tcnative.CertificateCompressionAlgo")
-                .addRuntimeInitializedClass("io.netty.internal.tcnative.CertificateVerifier")
-                .addRuntimeInitializedClass("io.netty.handler.ssl.OpenSslAsyncPrivateKeyMethod")
-                .addRuntimeInitializedClass("io.netty.handler.ssl.OpenSslPrivateKeyMethod")
                 // Spotted with Netty 4.1.135.Final
                 .addRuntimeInitializedClass("io.netty.internal.tcnative.SSL")
                 // Runtime initialize to respect io.netty.handler.ssl.conscrypt.useBufferAllocator

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
@@ -355,6 +355,20 @@ final class Target_io_netty_handler_ssl_SslContext {
             long sessionCacheSize, long sessionTimeout, boolean enableOcsp,
             SecureRandom secureRandom, String keyStoreType, String endpointIdentificationAlgorithm,
             Map.Entry<SslContextOption<?>, Object>... options) throws SSLException {
+        return newClientContextInternal(provider, sslContextProvider, trustCert, trustManagerFactory, keyCertChain, key,
+                keyPassword, keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout, false,
+                enableOcsp, secureRandom, keyStoreType, endpointIdentificationAlgorithm, options);
+    }
+
+    @Substitute
+    static SslContext newClientContextInternal(SslProvider provider,
+            Provider sslContextProvider,
+            X509Certificate[] trustCert, TrustManagerFactory trustManagerFactory,
+            X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
+            long sessionCacheSize, long sessionTimeout, boolean startTls, boolean enableOcsp,
+            SecureRandom secureRandom, String keyStoreType, String endpointIdentificationAlgorithm,
+            Map.Entry<SslContextOption<?>, Object>... options) throws SSLException {
         if (enableOcsp) {
             throw new IllegalArgumentException("OCSP is not supported with this SslProvider: " + provider);
         }


### PR DESCRIPTION
This is a backport of #55626 on 3.27