### PR TITLE
Reuse Quarkus application per fork

### DIFF
--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import io.quarkus.bootstrap.app.RunningQuarkusApplication;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.dev.testing.TestConfig;
 import io.quarkus.deployment.dev.testing.TestConfigCustomizer;
 import io.quarkus.runtime.LaunchMode;
@@ -156,12 +157,27 @@ public class AbstractJvmQuarkusTestExtension extends AbstractQuarkusTestWithCont
 
     protected boolean isNewApplication(QuarkusTestExtensionState state, Class<?> currentJUnitTestClass) {
 
-        // How do we know how to stop the current application - compare the classloader and see if it changed
-        // We could also look at the running application attached to the junit test and see if it's started
+        // Different test classloaders may still belong to the same curated application.
 
-        return (runningQuarkusApplication == null
-                || runningQuarkusApplication.getClassLoader() != currentJUnitTestClass.getClassLoader());
+        if (runningQuarkusApplication == null) {
+            return true;
+        }
 
+        ClassLoader runningApplicationClassLoader = runningQuarkusApplication.getClassLoader();
+        ClassLoader testClassLoader = currentJUnitTestClass.getClassLoader();
+        return !isSameApplication(runningApplicationClassLoader, testClassLoader);
+
+    }
+
+    static boolean isSameApplication(ClassLoader runningApplicationClassLoader, ClassLoader testClassLoader) {
+        if (runningApplicationClassLoader == testClassLoader) {
+            return true;
+        }
+        if (runningApplicationClassLoader instanceof QuarkusClassLoader runningQuarkusClassLoader
+                && testClassLoader instanceof QuarkusClassLoader testQuarkusClassLoader) {
+            return runningQuarkusClassLoader.getCuratedApplication() == testQuarkusClassLoader.getCuratedApplication();
+        }
+        return false;
     }
 
     @Override

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/AbstractQuarkusTestWithContextExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/AbstractQuarkusTestWithContextExtension.java
@@ -20,6 +20,8 @@ public abstract class AbstractQuarkusTestWithContextExtension extends AbstractTe
 
     public static final String IO_QUARKUS_TESTING_TYPE = "io.quarkus.testing.type";
 
+    private static final String MAVEN_FORK_STATE = "io.quarkus.test.junit.internal.MavenForkState";
+
     @Override
     public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
         markTestAsFailed(context, throwable);
@@ -62,7 +64,9 @@ public abstract class AbstractQuarkusTestWithContextExtension extends AbstractTe
 
     protected QuarkusTestExtensionState getState(ExtensionContext context) {
         ExtensionContext.Store store = getStoreFromContext(context);
-        Object o = store.get(QuarkusTestExtensionState.class.getName());
+        boolean mavenFork = isMavenFork();
+        Object[] mavenForkState = mavenFork ? getMavenForkState() : null;
+        Object o = mavenFork ? mavenForkState[0] : store.get(QuarkusTestExtensionState.class.getName());
         if (o != null) {
 
             QuarkusTestExtensionState state;
@@ -74,8 +78,11 @@ public abstract class AbstractQuarkusTestWithContextExtension extends AbstractTe
                 state = QuarkusTestExtensionState.clone(o);
             }
 
-            Class<?> testingTypeOfState = store.get(IO_QUARKUS_TESTING_TYPE, Class.class);
-            if (!this.getTestingType().equals(testingTypeOfState)) {
+            Object testingTypeOfState = mavenFork ? mavenForkState[1]
+                    : store.get(IO_QUARKUS_TESTING_TYPE, Class.class);
+            boolean sameTestingType = mavenFork ? this.getTestingType().getName().equals(testingTypeOfState)
+                    : this.getTestingType().equals(testingTypeOfState);
+            if (!sameTestingType) {
                 // The current state was created by a different testing type, so we need to renew it, so the new state is
                 // compatible with the current testing type.
                 try {
@@ -85,7 +92,11 @@ public abstract class AbstractQuarkusTestWithContextExtension extends AbstractTe
                     // ignoring exceptions when closing state.
 
                 } finally {
-                    getStoreFromContext(context).remove(QuarkusTestExtensionState.class.getName());
+                    if (mavenFork) {
+                        setMavenForkState(null, null);
+                    } else {
+                        store.remove(QuarkusTestExtensionState.class.getName());
+                    }
                 }
 
                 return null;
@@ -102,8 +113,12 @@ public abstract class AbstractQuarkusTestWithContextExtension extends AbstractTe
         ExtensionContext.Store store = getStoreFromContext(context);
         store.put(ValueRegistry.class.getName(), context.getStore(GLOBAL).get(ValueRegistry.class.getName()));
         store.put(Config.class.getName(), context.getStore(GLOBAL).get(Config.class.getName()));
-        store.put(QuarkusTestExtensionState.class.getName(), state);
-        store.put(IO_QUARKUS_TESTING_TYPE, this.getTestingType());
+        if (isMavenFork()) {
+            setMavenForkState(state, state == null ? null : this.getTestingType().getName());
+        } else {
+            store.put(QuarkusTestExtensionState.class.getName(), state);
+            store.put(IO_QUARKUS_TESTING_TYPE, this.getTestingType());
+        }
     }
 
     protected ExtensionContext.Store getStoreFromContext(ExtensionContext context) {
@@ -120,6 +135,35 @@ public abstract class AbstractQuarkusTestWithContextExtension extends AbstractTe
         QuarkusTestExtensionState state = getState(context);
         if (state != null) {
             state.setTestFailed(throwable);
+        }
+    }
+
+    private static boolean isMavenFork() {
+        return System.getProperty("surefire.real.class.path") != null;
+    }
+
+    private static Object[] getMavenForkState() {
+        try {
+            return (Object[]) getMavenForkStateStore().getMethod("get").invoke(null);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Unable to read Quarkus test state for the Maven fork", e);
+        }
+    }
+
+    private static void setMavenForkState(Object state, String testingType) {
+        try {
+            getMavenForkStateStore().getMethod("set", Object.class, String.class).invoke(null, state, testingType);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Unable to store Quarkus test state for the Maven fork", e);
+        }
+    }
+
+    private static Class<?> getMavenForkStateStore() {
+        try {
+            // Quarkus test classloaders can change when profiles do, while the system classloader spans the Maven fork.
+            return ClassLoader.getSystemClassLoader().loadClass(MAVEN_FORK_STATE);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Unable to load the Quarkus test state store for the Maven fork", e);
         }
     }
 }

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -630,7 +630,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
 
         // We want to start if the profile changed (or there are new test resources),
         // or if we don't have an app and that's not because the previous attempt to start it failed
-        if ((state == null && !failedBoot) || (runningQuarkusApplication != null && isNewApplication)) {
+        if ((state == null && !failedBoot) || (state != null && isNewApplication)) {
             if (isNewApplication) {
                 if (state != null) {
                     try {
@@ -941,10 +941,8 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         resetHangTimeout();
 
         try {
-            Class<?> testClassFromTCCL = extensionContext.getRequiredTestClass();
             Map<Class<?>, Object> allTestsClasses = new HashMap<>();
-            // static loading
-            allTestsClasses.put(testClassFromTCCL, actualTestInstance);
+            allTestsClasses.put(actualTestInstance.getClass(), actualTestInstance);
             // this is needed to support before*** and after*** methods that are part of class that encloses the test class
             // (the test class is in this case a @Nested test)
             outerInstances.forEach(i -> allTestsClasses.put(i.getClass(), i));

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/internal/MavenForkState.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/internal/MavenForkState.java
@@ -1,0 +1,22 @@
+package io.quarkus.test.junit.internal;
+
+/**
+ * Holds Quarkus test state across JUnit launcher sessions and Quarkus test classloaders in a Maven fork.
+ */
+public final class MavenForkState {
+
+    private static Object state;
+    private static String testingType;
+
+    private MavenForkState() {
+    }
+
+    public static synchronized Object[] get() {
+        return new Object[] { state, testingType };
+    }
+
+    public static synchronized void set(Object newState, String newTestingType) {
+        state = newState;
+        testingType = newTestingType;
+    }
+}

--- a/test-framework/junit/src/test/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtensionTest.java
+++ b/test-framework/junit/src/test/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtensionTest.java
@@ -1,0 +1,25 @@
+package io.quarkus.test.junit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.bootstrap.app.CuratedApplication;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+
+class AbstractJvmQuarkusTestExtensionTest {
+
+    @Test
+    void reusesApplicationForDifferentClassLoaderFromSameCuratedApplication() {
+        QuarkusClassLoader applicationClassLoader = mock(QuarkusClassLoader.class);
+        QuarkusClassLoader testClassLoader = mock(QuarkusClassLoader.class);
+        CuratedApplication curatedApplication = mock(CuratedApplication.class);
+
+        when(applicationClassLoader.getCuratedApplication()).thenReturn(curatedApplication);
+        when(testClassLoader.getCuratedApplication()).thenReturn(curatedApplication);
+
+        assertThat(AbstractJvmQuarkusTestExtension.isSameApplication(applicationClassLoader, testClassLoader)).isTrue();
+    }
+}

--- a/test-framework/junit/src/test/java/io/quarkus/test/junit/QuarkusTestExtensionStateStoreTest.java
+++ b/test-framework/junit/src/test/java/io/quarkus/test/junit/QuarkusTestExtensionStateStoreTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.test.junit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.GLOBAL;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+class QuarkusTestExtensionStateStoreTest {
+
+    @Test
+    void reusesStateAcrossMavenExecutionRequests() {
+        String surefireClassPath = System.getProperty("surefire.real.class.path");
+        System.setProperty("surefire.real.class.path", "test");
+
+        ExtensionContext firstContext = context();
+        ExtensionContext secondContext = context();
+        QuarkusTestExtensionState state = mock(QuarkusTestExtensionState.class);
+        QuarkusTestExtension extension = new QuarkusTestExtension();
+
+        try {
+            extension.setState(firstContext, state);
+
+            assertThat(extension.getState(secondContext)).isSameAs(state);
+        } finally {
+            extension.setState(firstContext, null);
+            restoreSurefireClassPath(surefireClassPath);
+        }
+    }
+
+    private static ExtensionContext context() {
+        ExtensionContext context = mock(ExtensionContext.class);
+        ExtensionContext root = mock(ExtensionContext.class);
+        ExtensionContext.Store rootStore = mock(ExtensionContext.Store.class);
+        ExtensionContext.Store contextStore = mock(ExtensionContext.Store.class);
+
+        when(context.getRoot()).thenReturn(root);
+        when(root.getStore(GLOBAL)).thenReturn(rootStore);
+        when(context.getStore(GLOBAL)).thenReturn(contextStore);
+
+        return context;
+    }
+
+    private static void restoreSurefireClassPath(String surefireClassPath) {
+        if (surefireClassPath == null) {
+            System.clearProperty("surefire.real.class.path");
+        } else {
+            System.setProperty("surefire.real.class.path", surefireClassPath);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #43979

When Surefire uses multiple forks, it may create a separate JUnit launcher session for each test class. This caused the Quarkus test state to be discarded and the application to restart for every class.

This change keeps the test state for the lifetime of each Maven fork and recognizes test classloaders that belong to the same Quarkus application. Restarts caused by test profile changes are preserved.

Testing:

- `./mvnw -pl test-framework/junit test`
- Verified with Surefire 3.1.2 and 3.5.6 using two forks
- Verified two application startups for two forked JVMs
- Verified that changing `TestProfile` still stops and restarts the application