### PR TITLE
DEV UI: fix sub-menu link from dynamic URL method

### DIFF
--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-header.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-header.js
@@ -390,6 +390,8 @@ export class QwcHeader extends observeState(QwcHotReloadElement) {
             path="${relativePath}"
             ?embed=${link.page.embed}
             externalUrl="${link.page.metadata.externalUrl}"
+            dynamicUrlMethodName="${link.page.metadata.dynamicUrlMethodName}"
+            dynamicUrlMethodNameParams="${link.page.metadata.dynamicUrlMethodNameParams}"
             webcomponent="${link.page.componentLink}"
             staticLabel="${link.page.staticLabel}"
             dynamicLabel="${link.page.dynamicLabel}"


### PR DESCRIPTION
* closes: https://github.com/quarkusio/quarkus/issues/55606

How to test it:

```bash
quarkus create app app -x=oidc
cd app
echo "quarkus.oidc.application-type=service" >> src/main/resources/application.properties
sed -i 's|<quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>|<quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>|' pom.xml
sed -i 's|<quarkus.platform.version>3.37.4</quarkus.platform.version>|<quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>|' pom.xml
quarkus dev 
```

then go to `http://localhost:8080/q/dev-ui/quarkus-oidc/keycloak-provider` and click on `Keycloak Admin`.