### PR TITLE
Fix JaCoCo coverage for QuarkusExtensionTest

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
@@ -419,6 +419,9 @@ public class QuarkusBootstrap implements Serializable {
 
         public Builder setMode(Mode mode) {
             this.mode = mode;
+            if (mode == Mode.TEST) {
+                this.test = true;
+            }
             return this;
         }
 

--- a/test-framework/arquillian/src/main/java/io/quarkus/arquillian/QuarkusDeployableContainer.java
+++ b/test-framework/arquillian/src/main/java/io/quarkus/arquillian/QuarkusDeployableContainer.java
@@ -177,7 +177,8 @@ public class QuarkusDeployableContainer implements DeployableContainer<QuarkusCo
                     .setProjectRoot(appLocation)
                     .setIsolateDeployment(false)
                     .setFlatClassPath(true)
-                    .setMode(QuarkusBootstrap.Mode.TEST);
+                    .setMode(QuarkusBootstrap.Mode.TEST)
+                    .setTest(true);
             for (Path i : libraries) {
                 bootstrapBuilder.addAdditionalApplicationArchive(new AdditionalDependency(i, false, true));
             }

--- a/test-framework/jacoco/deployment/pom.xml
+++ b/test-framework/jacoco/deployment/pom.xml
@@ -29,6 +29,16 @@
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
+++ b/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
@@ -44,6 +44,7 @@ import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.paths.OpenPathTree;
+import io.quarkus.runtime.LaunchMode;
 
 public class JacocoProcessor {
 
@@ -62,9 +63,9 @@ public class JacocoProcessor {
             CurateOutcomeBuildItem curateOutcomeBuildItem,
             LaunchModeBuildItem launchModeBuildItem,
             JacocoConfig config) throws Exception {
-        // LaunchModeBuildItem.isTest() is used instead of IsTest BooleanSupplier
-        // so that dev mode tests (QuarkusDevModeTest) are also covered
-        if (!launchModeBuildItem.isTest()) {
+        // LaunchModeBuildItem.isTest() covers dev mode tests (QuarkusDevModeTest),
+        // which do not use LaunchMode.TEST.
+        if (!launchModeBuildItem.isTest() && launchModeBuildItem.getLaunchMode() != LaunchMode.TEST) {
             return;
         }
         if (launchModeBuildItem.isAuxiliaryApplication()) {

--- a/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
+++ b/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
@@ -44,7 +44,6 @@ import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.paths.OpenPathTree;
-import io.quarkus.runtime.LaunchMode;
 
 public class JacocoProcessor {
 
@@ -63,9 +62,9 @@ public class JacocoProcessor {
             CurateOutcomeBuildItem curateOutcomeBuildItem,
             LaunchModeBuildItem launchModeBuildItem,
             JacocoConfig config) throws Exception {
-        // LaunchModeBuildItem.isTest() covers dev mode tests (QuarkusDevModeTest),
-        // which do not use LaunchMode.TEST.
-        if (!launchModeBuildItem.isTest() && launchModeBuildItem.getLaunchMode() != LaunchMode.TEST) {
+        // LaunchModeBuildItem.isTest() is used instead of IsTest BooleanSupplier
+        // so that dev mode tests (QuarkusDevModeTest) are also covered
+        if (!launchModeBuildItem.isTest()) {
             return;
         }
         if (launchModeBuildItem.isAuxiliaryApplication()) {

--- a/test-framework/jacoco/deployment/src/test/java/io/quarkus/jacoco/deployment/JacocoProcessorTest.java
+++ b/test-framework/jacoco/deployment/src/test/java/io/quarkus/jacoco/deployment/JacocoProcessorTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.jacoco.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+class JacocoProcessorTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withApplicationRoot(root -> root.addClass(Covered.class))
+            .overrideConfigKey("quarkus.jacoco.report", "false");
+
+    @Test
+    void shouldInstrumentClassesInQuarkusExtensionTest() {
+        assertThat(Covered.class.getDeclaredMethods())
+                .extracting(Method::getName)
+                .contains("$jacocoInit");
+    }
+
+    static class Covered {
+
+        void ping() {
+        }
+    }
+}

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/AbstractQuarkusExtensionTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/AbstractQuarkusExtensionTest.java
@@ -1065,6 +1065,7 @@ public abstract class AbstractQuarkusExtensionTest<S extends AbstractQuarkusExte
                 .setBaseName(extensionContext.getDisplayName() + " (AbstractQuarkusExtensionTest)")
                 .setApplicationRoot(deploymentDir.resolve(APP_ROOT))
                 .setMode(QuarkusBootstrap.Mode.TEST)
+                .setTest(true)
                 .addExcludedPath(testLocation)
                 .setProjectRoot(projectDir)
                 .setTargetDirectory(PathTestHelper.getProjectBuildDir(projectDir, testLocation))


### PR DESCRIPTION
`QuarkusExtensionTest` builds use `LaunchMode.TEST` without setting the dev-mode test flag, so the JaCoCo processor stopped instrumenting their application classes after the dev-mode coverage change. Accepting both test signals restores their coverage while preserving instrumentation for `QuarkusDevModeTest`.

- Fixes: #55525