### PR TITLE
Use a unique log file per integration-test launcher to fix concurrent fork log sharing

### DIFF
--- a/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/OidcClientFilterDevModeTest.java
+++ b/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/OidcClientFilterDevModeTest.java
@@ -10,18 +10,20 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.core.ThrowingRunnable;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.test.QuarkusDevModeTest;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 import io.restassured.RestAssured;
+import io.smallrye.config.SmallRyeConfig;
 
 @QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
 public class OidcClientFilterDevModeTest {
@@ -71,20 +73,21 @@ public class OidcClientFilterDevModeTest {
                 .body(equalTo("jdoe"));
     }
 
+    protected Path getLogPath() {
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
+        return logRuntimeConfig.file().path().toPath();
+    }
+
     private void checkLog() {
-        final Path logDirectory = Paths.get(".", "target");
         given().await().pollInterval(100, TimeUnit.MILLISECONDS)
                 .atMost(10, TimeUnit.SECONDS)
                 .untilAsserted(new ThrowingRunnable() {
                     @Override
                     public void run() throws Throwable {
-                        Path accessLogFilePath = logDirectory.resolve("quarkus.log");
+                        Path accessLogFilePath = getLogPath();
                         boolean fileExists = Files.exists(accessLogFilePath);
-                        if (!fileExists) {
-                            accessLogFilePath = logDirectory.resolve("target/quarkus.log");
-                            fileExists = Files.exists(accessLogFilePath);
-                        }
-                        Assertions.assertTrue(Files.exists(accessLogFilePath),
+                        Assertions.assertTrue(fileExists,
                                 "quarkus log file " + accessLogFilePath + " is missing");
 
                         int tokenAcquisitionCount = 0;

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
@@ -15,11 +15,11 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.awaitility.core.ThrowingRunnable;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.htmlunit.FailingHttpStatusCodeException;
 import org.htmlunit.SilentCssErrorHandler;
@@ -35,9 +35,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.test.QuarkusDevModeTest;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
+import io.smallrye.config.SmallRyeConfig;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
@@ -196,6 +198,12 @@ public class CodeFlowDevModeTestCase {
         return webClient;
     }
 
+    protected static Path getLogPath() {
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
+        return logRuntimeConfig.file().path().toPath();
+    }
+
     protected static void checkPkceSecretGenerated() {
         AtomicBoolean checkPassed = new AtomicBoolean();
         given().pollInterval(100, TimeUnit.MILLISECONDS)
@@ -203,13 +211,8 @@ public class CodeFlowDevModeTestCase {
                 .untilAsserted(new ThrowingRunnable() {
                     @Override
                     public void run() throws Throwable {
-                        final Path logDirectory = Paths.get(".", "target");
-                        Path accessLogFilePath = logDirectory.resolve("quarkus.log");
+                        Path accessLogFilePath = getLogPath();
                         boolean fileExists = Files.exists(accessLogFilePath);
-                        if (!fileExists) {
-                            accessLogFilePath = logDirectory.resolve("target/quarkus.log");
-                            fileExists = Files.exists(accessLogFilePath);
-                        }
                         assertTrue(fileExists, "quarkus log is missing");
 
                         try (BufferedReader reader = new BufferedReader(

--- a/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageDecodersIT.java
+++ b/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageDecodersIT.java
@@ -1,7 +1,23 @@
 package io.quarkus.awt.it;
 
+import static io.quarkus.test.junit.QuarkusIntegrationTestExtension.TEST_LOG_PATH;
+
+import java.nio.file.Path;
+
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.value.registry.ValueRegistry;
 
 @QuarkusIntegrationTest
 public class ImageDecodersIT extends ImageDecodersTest {
+
+    // Injected automatically by QuarkusIntegrationTestExtension
+    private ValueRegistry valueRegistry;
+
+    @Override
+    protected Path getLogPath() {
+        if (valueRegistry != null && valueRegistry.containsKey(TEST_LOG_PATH)) {
+            return valueRegistry.get(TEST_LOG_PATH);
+        }
+        return super.getLogPath();
+    }
 }

--- a/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageDecodersTest.java
+++ b/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageDecodersTest.java
@@ -13,14 +13,18 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.regex.Pattern;
 
 import javax.imageio.ImageIO;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.config.SmallRyeConfig;
 
 /**
  * Tests image decoders, both raster data and image metadata.
@@ -162,13 +166,13 @@ public class ImageDecodersTest {
             case "NOK":
                 assertNull(image, "The image " + fileName + " should have triggered a parsing error.");
                 if (pattern != null) {
-                    checkLog(pattern, fileName);
+                    checkLog(pattern, fileName, getLogPath());
                 }
                 break;
             case "NA":
                 if (pattern != null) {
                     if (image == null) {
-                        checkLog(pattern, fileName);
+                        checkLog(pattern, fileName, getLogPath());
                     } else {
                         assertTrue(pattern.matcher(image.toString()).matches(),
                                 "Image description should have matched " + pattern);
@@ -179,5 +183,11 @@ public class ImageDecodersTest {
                 fail("Bogus test data: unknown condition: " + okNoKNA);
                 break;
         }
+    }
+
+    protected Path getLogPath() {
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
+        return logRuntimeConfig.file().path().toPath();
     }
 }

--- a/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageEncodersIT.java
+++ b/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageEncodersIT.java
@@ -1,7 +1,23 @@
 package io.quarkus.awt.it;
 
+import static io.quarkus.test.junit.QuarkusIntegrationTestExtension.TEST_LOG_PATH;
+
+import java.nio.file.Path;
+
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.value.registry.ValueRegistry;
 
 @QuarkusIntegrationTest
 public class ImageEncodersIT extends ImageEncodersTest {
+
+    // Injected automatically by QuarkusIntegrationTestExtension
+    private ValueRegistry valueRegistry;
+
+    @Override
+    protected Path getLogPath() {
+        if (valueRegistry != null && valueRegistry.containsKey(TEST_LOG_PATH)) {
+            return valueRegistry.get(TEST_LOG_PATH);
+        }
+        return super.getLogPath();
+    }
 }

--- a/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageEncodersTest.java
+++ b/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageEncodersTest.java
@@ -10,16 +10,20 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 
 import javax.imageio.ImageIO;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.config.SmallRyeConfig;
 
 /**
  * Tests image encoders.
@@ -98,6 +102,12 @@ public class ImageEncodersTest {
         }
         Assertions.assertTrue(errors.isEmpty(),
                 "There were errors verifying image data, see:\n" + String.join("\n", errors) + "\n");
-        checkLog(null, "Encoders");
+        checkLog(null, "Encoders", getLogPath());
+    }
+
+    protected Path getLogPath() {
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
+        return logRuntimeConfig.file().path().toPath();
     }
 }

--- a/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageGeometryFontsIT.java
+++ b/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageGeometryFontsIT.java
@@ -1,7 +1,23 @@
 package io.quarkus.awt.it;
 
+import static io.quarkus.test.junit.QuarkusIntegrationTestExtension.TEST_LOG_PATH;
+
+import java.nio.file.Path;
+
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.value.registry.ValueRegistry;
 
 @QuarkusIntegrationTest
 public class ImageGeometryFontsIT extends ImageGeometryFontsTest {
+
+    // Injected automatically by QuarkusIntegrationTestExtension
+    private ValueRegistry valueRegistry;
+
+    @Override
+    protected Path getLogPath() {
+        if (valueRegistry != null && valueRegistry.containsKey(TEST_LOG_PATH)) {
+            return valueRegistry.get(TEST_LOG_PATH);
+        }
+        return super.getLogPath();
+    }
 }

--- a/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageGeometryFontsTest.java
+++ b/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageGeometryFontsTest.java
@@ -8,18 +8,22 @@ import static io.restassured.RestAssured.given;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 import javax.imageio.ImageIO;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.config.SmallRyeConfig;
 
 /**
  * Tests generated geometry, primitive shapes, fonts,
@@ -92,7 +96,7 @@ public class ImageGeometryFontsTest {
                             expected[0], expected[1], expected[2], expected[3],
                             actual[0], actual[1], actual[2], actual[3]));
         }
-        checkLog(null, "Geometry and Fonts");
+        checkLog(null, "Geometry and Fonts", getLogPath());
     }
 
     /**
@@ -131,5 +135,11 @@ public class ImageGeometryFontsTest {
                 .extract().asString();
         Assertions.assertTrue(response.contains("HBShaper invoked successfully"),
                 "Expected HBShaper to process text successfully, but got: " + response);
+    }
+
+    protected Path getLogPath() {
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
+        return logRuntimeConfig.file().path().toPath();
     }
 }

--- a/integration-tests/awt/src/test/java/io/quarkus/awt/it/TestUtil.java
+++ b/integration-tests/awt/src/test/java/io/quarkus/awt/it/TestUtil.java
@@ -8,7 +8,6 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -35,9 +34,10 @@ public class TestUtil {
      *
      * @param lineMatchRegexp pattern
      * @param name identifier
+     * @param logPath logPath
      */
-    public static void checkLog(final Pattern lineMatchRegexp, final String name) {
-        final Path accessLogFilePath = Paths.get(".", "target", "quarkus.log").toAbsolutePath();
+    public static void checkLog(final Pattern lineMatchRegexp, final String name, final Path logPath) {
+        final Path accessLogFilePath = logPath.toAbsolutePath();
         org.awaitility.Awaitility.given().pollInterval(100, TimeUnit.MILLISECONDS)
                 .atMost(3, TimeUnit.SECONDS)
                 .untilAsserted(() -> {

--- a/integration-tests/bouncycastle-fips-jsse/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleFipsJsseITCase.java
+++ b/integration-tests/bouncycastle-fips-jsse/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleFipsJsseITCase.java
@@ -1,12 +1,28 @@
 package io.quarkus.it.bouncycastle;
 
+import static io.quarkus.test.junit.QuarkusIntegrationTestExtension.TEST_LOG_PATH;
+
+import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.value.registry.ValueRegistry;
 
 @QuarkusIntegrationTest
 public class BouncyCastleFipsJsseITCase extends BouncyCastleFipsJsseTestCase {
+
+    // Injected automatically by QuarkusIntegrationTestExtension
+    private ValueRegistry valueRegistry;
+
+    @Override
+    protected Path getLogPath() {
+        if (valueRegistry != null && valueRegistry.containsKey(TEST_LOG_PATH)) {
+            return valueRegistry.get(TEST_LOG_PATH);
+        }
+        return super.getLogPath();
+    }
 
     @Test
     @DisabledOnIntegrationTest

--- a/integration-tests/bouncycastle-fips-jsse/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleFipsJsseTestCase.java
+++ b/integration-tests/bouncycastle-fips-jsse/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleFipsJsseTestCase.java
@@ -17,13 +17,16 @@ import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.core.ThrowingRunnable;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.runtime.util.ClassPathUtils;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.config.SmallRyeConfig;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.net.KeyStoreOptions;
@@ -82,19 +85,20 @@ public class BouncyCastleFipsJsseTestCase {
         return webClientOptions;
     }
 
+    protected Path getLogPath() {
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
+        return logRuntimeConfig.file().path().toPath();
+    }
+
     protected void checkLog(boolean serverOnly) {
-        final Path logDirectory = Paths.get(".", "target");
         given().pollInterval(100, TimeUnit.MILLISECONDS)
                 .atMost(10, TimeUnit.SECONDS)
                 .untilAsserted(new ThrowingRunnable() {
                     @Override
                     public void run() throws Throwable {
-                        Path accessLogFilePath = logDirectory.resolve("quarkus.log");
+                        Path accessLogFilePath = getLogPath();
                         boolean fileExists = Files.exists(accessLogFilePath);
-                        if (!fileExists) {
-                            accessLogFilePath = logDirectory.resolve("target/quarkus.log");
-                            fileExists = Files.exists(accessLogFilePath);
-                        }
                         Assertions.assertTrue(fileExists, "access log file " + accessLogFilePath + " is missing");
 
                         boolean checkClientPassed = serverOnly;

--- a/integration-tests/bouncycastle-jsse/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleJsseITCase.java
+++ b/integration-tests/bouncycastle-jsse/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleJsseITCase.java
@@ -1,11 +1,28 @@
 package io.quarkus.it.bouncycastle;
 
+import static io.quarkus.test.junit.QuarkusIntegrationTestExtension.TEST_LOG_PATH;
+
+import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.value.registry.ValueRegistry;
 
 @QuarkusIntegrationTest
 public class BouncyCastleJsseITCase extends BouncyCastleJsseTestCase {
+
+    // Injected automatically by QuarkusIntegrationTestExtension
+    private ValueRegistry valueRegistry;
+
+    @Override
+    protected Path getLogPath() {
+        if (valueRegistry != null && valueRegistry.containsKey(TEST_LOG_PATH)) {
+            return valueRegistry.get(TEST_LOG_PATH);
+        }
+        return super.getLogPath();
+    }
+
     @Test
     @Override
     public void testListProviders() {

--- a/integration-tests/bouncycastle-jsse/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleJsseTestCase.java
+++ b/integration-tests/bouncycastle-jsse/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleJsseTestCase.java
@@ -12,19 +12,21 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.core.ThrowingRunnable;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
+import io.smallrye.config.SmallRyeConfig;
 
 @QuarkusTest
 public class BouncyCastleJsseTestCase {
@@ -56,19 +58,20 @@ public class BouncyCastleJsseTestCase {
                 .body(startsWith("Identity: CN=client"), containsString("BC,BCJSSE,SunJSSE"));
     }
 
+    protected Path getLogPath() {
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
+        return logRuntimeConfig.file().path().toPath();
+    }
+
     protected void checkLog(boolean serverOnly) {
-        final Path logDirectory = Paths.get(".", "target");
         given().pollInterval(100, TimeUnit.MILLISECONDS)
                 .atMost(10, TimeUnit.SECONDS)
                 .untilAsserted(new ThrowingRunnable() {
                     @Override
                     public void run() throws Throwable {
-                        Path accessLogFilePath = logDirectory.resolve("quarkus.log");
+                        Path accessLogFilePath = getLogPath();
                         boolean fileExists = Files.exists(accessLogFilePath);
-                        if (!fileExists) {
-                            accessLogFilePath = logDirectory.resolve("target/quarkus.log");
-                            fileExists = Files.exists(accessLogFilePath);
-                        }
                         Assertions.assertTrue(fileExists, "access log file " + accessLogFilePath + " is missing");
 
                         boolean checkClientPassed = serverOnly;

--- a/integration-tests/jaxb/src/test/java/io/quarkus/it/jaxb/JaxbAWTIT.java
+++ b/integration-tests/jaxb/src/test/java/io/quarkus/it/jaxb/JaxbAWTIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.jaxb;
 
 import static io.quarkus.runtime.graal.AwtImageIO.AWT_EXTENSION_HINT;
+import static io.quarkus.test.junit.QuarkusIntegrationTestExtension.TEST_LOG_PATH;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -10,15 +11,18 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import org.apache.http.HttpStatus;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.value.registry.ValueRegistry;
 import io.restassured.RestAssured;
+import io.smallrye.config.SmallRyeConfig;
 
 @QuarkusIntegrationTest
 public class JaxbAWTIT {
@@ -34,6 +38,9 @@ public class JaxbAWTIT {
             "</book>";
 
     public static final String CONTENT_TYPE = "application/xml; charset=UTF-8";
+
+    // Injected automatically by QuarkusIntegrationTestExtension
+    private ValueRegistry valueRegistry;
 
     @Test
     public void bookNoCover() {
@@ -67,8 +74,8 @@ public class JaxbAWTIT {
      *
      * @param lineMatchRegexp pattern
      */
-    private static void checkLog(final Pattern lineMatchRegexp) {
-        final Path logFilePath = Paths.get(".", "target", "quarkus.log").toAbsolutePath();
+    private void checkLog(final Pattern lineMatchRegexp) {
+        final Path logFilePath = getLogPath();
         org.awaitility.Awaitility.given().pollInterval(100, TimeUnit.MILLISECONDS)
                 .atMost(3, TimeUnit.SECONDS)
                 .untilAsserted(() -> {
@@ -90,5 +97,14 @@ public class JaxbAWTIT {
                     assertTrue(found, "Pattern " + lineMatchRegexp.pattern() + " not found in log " + logFilePath + ". \n" +
                             "The log was: " + sbLog);
                 });
+    }
+
+    protected Path getLogPath() {
+        if (valueRegistry != null && valueRegistry.containsKey(TEST_LOG_PATH)) {
+            return valueRegistry.get(TEST_LOG_PATH);
+        }
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
+        return logRuntimeConfig.file().path().toPath();
     }
 }

--- a/integration-tests/no-awt/src/test/java/io/quarkus/awt/it/GraphicsIT.java
+++ b/integration-tests/no-awt/src/test/java/io/quarkus/awt/it/GraphicsIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.awt.it;
 
 import static io.quarkus.runtime.graal.AwtImageIO.AWT_EXTENSION_HINT;
+import static io.quarkus.test.junit.QuarkusIntegrationTestExtension.TEST_LOG_PATH;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
@@ -10,17 +11,20 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import org.apache.http.HttpStatus;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.value.registry.ValueRegistry;
 import io.restassured.RestAssured;
+import io.smallrye.config.SmallRyeConfig;
 
 @QuarkusIntegrationTest
 public class GraphicsIT {
@@ -28,6 +32,9 @@ public class GraphicsIT {
     private static final Logger LOG = Logger.getLogger(GraphicsIT.class);
 
     public static Pattern AWT_EXTENSION_HINT_PATTERN = Pattern.compile(".*" + AWT_EXTENSION_HINT + ".*");
+
+    // Injected automatically by QuarkusIntegrationTestExtension
+    private ValueRegistry valueRegistry;
 
     @ParameterizedTest
     @ValueSource(strings = {
@@ -57,8 +64,8 @@ public class GraphicsIT {
      *
      * @param lineMatchRegexp pattern
      */
-    static void checkLog(final Pattern lineMatchRegexp) {
-        final Path logFilePath = Paths.get(".", "target", "quarkus.log").toAbsolutePath();
+    private void checkLog(final Pattern lineMatchRegexp) {
+        final Path logFilePath = getLogPath();
         org.awaitility.Awaitility.given().pollInterval(100, TimeUnit.MILLISECONDS)
                 .atMost(3, TimeUnit.SECONDS)
                 .untilAsserted(() -> {
@@ -82,4 +89,12 @@ public class GraphicsIT {
                 });
     }
 
+    private Path getLogPath() {
+        if (valueRegistry != null && valueRegistry.containsKey(TEST_LOG_PATH)) {
+            return valueRegistry.get(TEST_LOG_PATH);
+        }
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
+        return logRuntimeConfig.file().path().toPath();
+    }
 }

--- a/integration-tests/oidc-client-reactive/src/test/java/io/quarkus/it/keycloak/OidcClientInGraalITCase.java
+++ b/integration-tests/oidc-client-reactive/src/test/java/io/quarkus/it/keycloak/OidcClientInGraalITCase.java
@@ -1,7 +1,23 @@
 package io.quarkus.it.keycloak;
 
+import static io.quarkus.test.junit.QuarkusIntegrationTestExtension.TEST_LOG_PATH;
+
+import java.nio.file.Path;
+
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.value.registry.ValueRegistry;
 
 @QuarkusIntegrationTest
 public class OidcClientInGraalITCase extends OidcClientTest {
+
+    // Injected automatically by QuarkusIntegrationTestExtension
+    private ValueRegistry valueRegistry;
+
+    @Override
+    protected Path getLogPath() {
+        if (valueRegistry != null && valueRegistry.containsKey(TEST_LOG_PATH)) {
+            return valueRegistry.get(TEST_LOG_PATH);
+        }
+        return super.getLogPath();
+    }
 }

--- a/integration-tests/oidc-client-reactive/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-reactive/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -13,17 +13,19 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.core.ThrowingRunnable;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
+import io.smallrye.config.SmallRyeConfig;
 
 @QuarkusTest
 public class OidcClientTest {
@@ -100,20 +102,21 @@ public class OidcClientTest {
         checkLog();
     }
 
+    protected Path getLogPath() {
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
+        return logRuntimeConfig.file().path().toPath();
+    }
+
     private void checkLog() {
-        final Path logDirectory = Paths.get(".", "target");
         given().await().pollInterval(100, TimeUnit.MILLISECONDS)
                 .atMost(10, TimeUnit.SECONDS)
                 .untilAsserted(new ThrowingRunnable() {
                     @Override
                     public void run() throws Throwable {
-                        Path accessLogFilePath = logDirectory.resolve("quarkus.log");
+                        Path accessLogFilePath = getLogPath();
                         boolean fileExists = Files.exists(accessLogFilePath);
-                        if (!fileExists) {
-                            accessLogFilePath = logDirectory.resolve("target/quarkus.log");
-                            fileExists = Files.exists(accessLogFilePath);
-                        }
-                        Assertions.assertTrue(Files.exists(accessLogFilePath),
+                        Assertions.assertTrue(fileExists,
                                 "quarkus log file " + accessLogFilePath + " is missing");
 
                         int tokenAcquisitionCount = 0;

--- a/integration-tests/oidc-client-registration/src/test/java/io/quarkus/it/keycloak/OidcClientRegistrationInGraalITCase.java
+++ b/integration-tests/oidc-client-registration/src/test/java/io/quarkus/it/keycloak/OidcClientRegistrationInGraalITCase.java
@@ -1,7 +1,23 @@
 package io.quarkus.it.keycloak;
 
+import static io.quarkus.test.junit.QuarkusIntegrationTestExtension.TEST_LOG_PATH;
+
+import java.nio.file.Path;
+
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.value.registry.ValueRegistry;
 
 @QuarkusIntegrationTest
 public class OidcClientRegistrationInGraalITCase extends OidcClientRegistrationTest {
+
+    // Injected automatically by QuarkusIntegrationTestExtension
+    private ValueRegistry valueRegistry;
+
+    @Override
+    protected Path getLogPath() {
+        if (valueRegistry != null && valueRegistry.containsKey(TEST_LOG_PATH)) {
+            return valueRegistry.get(TEST_LOG_PATH);
+        }
+        return super.getLogPath();
+    }
 }

--- a/integration-tests/oidc-client-registration/src/test/java/io/quarkus/it/keycloak/OidcClientRegistrationTest.java
+++ b/integration-tests/oidc-client-registration/src/test/java/io/quarkus/it/keycloak/OidcClientRegistrationTest.java
@@ -11,10 +11,10 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.core.ThrowingRunnable;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.htmlunit.SilentCssErrorHandler;
 import org.htmlunit.TextPage;
 import org.htmlunit.WebClient;
@@ -23,7 +23,9 @@ import org.htmlunit.html.HtmlPage;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.config.SmallRyeConfig;
 
 @QuarkusTest
 public class OidcClientRegistrationTest {
@@ -161,20 +163,21 @@ public class OidcClientRegistrationTest {
         return webClient;
     }
 
+    protected Path getLogPath() {
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
+        return logRuntimeConfig.file().path().toPath();
+    }
+
     private void checkLog() {
-        final Path logDirectory = Paths.get(".", "target");
         given().await().pollInterval(100, TimeUnit.MILLISECONDS)
                 .atMost(10, TimeUnit.SECONDS)
                 .untilAsserted(new ThrowingRunnable() {
                     @Override
                     public void run() throws Throwable {
-                        Path accessLogFilePath = logDirectory.resolve("quarkus.log");
+                        Path accessLogFilePath = getLogPath();
                         boolean fileExists = Files.exists(accessLogFilePath);
-                        if (!fileExists) {
-                            accessLogFilePath = logDirectory.resolve("target/quarkus.log");
-                            fileExists = Files.exists(accessLogFilePath);
-                        }
-                        Assertions.assertTrue(Files.exists(accessLogFilePath),
+                        Assertions.assertTrue(fileExists,
                                 "quarkus log file " + accessLogFilePath + " is missing");
 
                         boolean clientRegistrationRequest = false;

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientInGraalITCase.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientInGraalITCase.java
@@ -1,7 +1,23 @@
 package io.quarkus.it.keycloak;
 
+import static io.quarkus.test.junit.QuarkusIntegrationTestExtension.TEST_LOG_PATH;
+
+import java.nio.file.Path;
+
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.value.registry.ValueRegistry;
 
 @QuarkusIntegrationTest
 public class OidcClientInGraalITCase extends OidcClientTest {
+
+    // Injected automatically by QuarkusIntegrationTestExtension
+    private ValueRegistry valueRegistry;
+
+    @Override
+    protected Path getLogPath() {
+        if (valueRegistry != null && valueRegistry.containsKey(TEST_LOG_PATH)) {
+            return valueRegistry.get(TEST_LOG_PATH);
+        }
+        return super.getLogPath();
+    }
 }

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -14,7 +14,6 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -22,6 +21,7 @@ import java.util.stream.IntStream;
 
 import org.awaitility.Awaitility;
 import org.awaitility.core.ThrowingRunnable;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -31,10 +31,12 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.CountMatchingStrategy;
 import com.github.tomakehurst.wiremock.client.WireMock;
 
+import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
+import io.smallrye.config.SmallRyeConfig;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -357,20 +359,21 @@ public class OidcClientTest {
         assertEquals("Not Ready", data.getString("Client with status not ready"));
     }
 
+    protected Path getLogPath() {
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
+        return logRuntimeConfig.file().path().toPath();
+    }
+
     private void checkLog() {
-        final Path logDirectory = Paths.get(".", "target");
         given().await().pollInterval(100, TimeUnit.MILLISECONDS)
                 .atMost(10, TimeUnit.SECONDS)
                 .untilAsserted(new ThrowingRunnable() {
                     @Override
                     public void run() throws Throwable {
-                        Path accessLogFilePath = logDirectory.resolve("quarkus.log");
+                        Path accessLogFilePath = getLogPath();
                         boolean fileExists = Files.exists(accessLogFilePath);
-                        if (!fileExists) {
-                            accessLogFilePath = logDirectory.resolve("target/quarkus.log");
-                            fileExists = Files.exists(accessLogFilePath);
-                        }
-                        assertTrue(Files.exists(accessLogFilePath),
+                        assertTrue(fileExists,
                                 "quarkus log file " + accessLogFilePath + " is missing");
 
                         int tokenAcquisitionCount = 0;

--- a/integration-tests/oidc-client/src/test/java/io/quarkus/it/keycloak/OidcClientInGraalITCase.java
+++ b/integration-tests/oidc-client/src/test/java/io/quarkus/it/keycloak/OidcClientInGraalITCase.java
@@ -1,7 +1,23 @@
 package io.quarkus.it.keycloak;
 
+import static io.quarkus.test.junit.QuarkusIntegrationTestExtension.TEST_LOG_PATH;
+
+import java.nio.file.Path;
+
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.value.registry.ValueRegistry;
 
 @QuarkusIntegrationTest
 public class OidcClientInGraalITCase extends OidcClientTest {
+
+    // Injected automatically by QuarkusIntegrationTestExtension
+    private ValueRegistry valueRegistry;
+
+    @Override
+    protected Path getLogPath() {
+        if (valueRegistry != null && valueRegistry.containsKey(TEST_LOG_PATH)) {
+            return valueRegistry.get(TEST_LOG_PATH);
+        }
+        return super.getLogPath();
+    }
 }

--- a/integration-tests/oidc-client/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -12,18 +12,20 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.core.ThrowingRunnable;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
+import io.smallrye.config.SmallRyeConfig;
 
 @QuarkusTest
 @QuarkusTestResource(KeycloakRealmResourceManager.class)
@@ -104,19 +106,20 @@ public class OidcClientTest {
 
     }
 
+    protected Path getLogPath() {
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
+        return logRuntimeConfig.file().path().toPath();
+    }
+
     private void checkLog() {
-        final Path logDirectory = Paths.get(".", "target");
         given().await().pollInterval(100, TimeUnit.MILLISECONDS)
                 .atMost(10, TimeUnit.SECONDS)
                 .untilAsserted(new ThrowingRunnable() {
                     @Override
                     public void run() throws Throwable {
-                        Path accessLogFilePath = logDirectory.resolve("quarkus.log");
+                        Path accessLogFilePath = getLogPath();
                         boolean fileExists = Files.exists(accessLogFilePath);
-                        if (!fileExists) {
-                            accessLogFilePath = logDirectory.resolve("target/quarkus.log");
-                            fileExists = Files.exists(accessLogFilePath);
-                        }
                         Assertions.assertTrue(Files.exists(accessLogFilePath),
                                 "quarkus log file " + accessLogFilePath + " is missing");
 

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationInGraalITCase.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationInGraalITCase.java
@@ -1,7 +1,23 @@
 package io.quarkus.it.keycloak;
 
+import static io.quarkus.test.junit.QuarkusIntegrationTestExtension.TEST_LOG_PATH;
+
+import java.nio.file.Path;
+
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.value.registry.ValueRegistry;
 
 @QuarkusIntegrationTest
 public class CodeFlowAuthorizationInGraalITCase extends CodeFlowAuthorizationTest {
+
+    // Injected automatically by QuarkusIntegrationTestExtension
+    private ValueRegistry valueRegistry;
+
+    @Override
+    protected Path getLogPath() {
+        if (valueRegistry != null && valueRegistry.containsKey(TEST_LOG_PATH)) {
+            return valueRegistry.get(TEST_LOG_PATH);
+        }
+        return super.getLogPath();
+    }
 }

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -27,7 +27,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.PrivateKey;
 import java.time.Instant;
 import java.util.Date;
@@ -41,6 +40,7 @@ import java.util.stream.IntStream;
 import javax.crypto.SecretKey;
 
 import org.awaitility.core.ThrowingRunnable;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.jwt.Claims;
 import org.hamcrest.Matchers;
 import org.htmlunit.FailingHttpStatusCodeException;
@@ -62,6 +62,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.oidc.runtime.OidcUtils;
+import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.oidc.server.OidcWireMock;
@@ -69,6 +70,7 @@ import io.quarkus.test.oidc.server.OidcWiremockTestResource;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
+import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.jwt.algorithm.KeyEncryptionAlgorithm;
 import io.smallrye.jwt.algorithm.SignatureAlgorithm;
 import io.smallrye.jwt.build.Jwt;
@@ -531,20 +533,21 @@ public class CodeFlowAuthorizationTest {
         checkSignedUserInfoRecordInLog();
     }
 
+    protected Path getLogPath() {
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
+        return logRuntimeConfig.file().path().toPath();
+    }
+
     private void checkSignedUserInfoRecordInLog() {
-        final Path logDirectory = Paths.get(".", "target");
         given().await().pollInterval(100, TimeUnit.MILLISECONDS)
                 .atMost(10, TimeUnit.SECONDS)
                 .untilAsserted(new ThrowingRunnable() {
                     @Override
                     public void run() throws Throwable {
-                        Path accessLogFilePath = logDirectory.resolve("quarkus.log");
+                        Path accessLogFilePath = getLogPath();
                         boolean fileExists = Files.exists(accessLogFilePath);
-                        if (!fileExists) {
-                            accessLogFilePath = logDirectory.resolve("target/quarkus.log");
-                            fileExists = Files.exists(accessLogFilePath);
-                        }
-                        Assertions.assertTrue(Files.exists(accessLogFilePath),
+                        Assertions.assertTrue(fileExists,
                                 "quarkus log file " + accessLogFilePath + " is missing");
 
                         boolean lineConfirmingVerificationDetected = false;

--- a/integration-tests/vertx/src/test/java/io/quarkus/it/vertx/VerticleIT.java
+++ b/integration-tests/vertx/src/test/java/io/quarkus/it/vertx/VerticleIT.java
@@ -1,8 +1,23 @@
 package io.quarkus.it.vertx;
 
+import static io.quarkus.test.junit.QuarkusIntegrationTestExtension.TEST_LOG_PATH;
+
+import java.nio.file.Path;
+
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.value.registry.ValueRegistry;
 
 @QuarkusIntegrationTest
 public class VerticleIT extends VerticleTest {
 
+    // Injected automatically by QuarkusIntegrationTestExtension
+    private ValueRegistry valueRegistry;
+
+    @Override
+    protected Path getLogPath() {
+        if (valueRegistry != null && valueRegistry.containsKey(TEST_LOG_PATH)) {
+            return valueRegistry.get(TEST_LOG_PATH);
+        }
+        return super.getLogPath();
+    }
 }

--- a/integration-tests/vertx/src/test/java/io/quarkus/it/vertx/VerticleTest.java
+++ b/integration-tests/vertx/src/test/java/io/quarkus/it/vertx/VerticleTest.java
@@ -8,18 +8,26 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
 import org.awaitility.core.ThrowingRunnable;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.config.SmallRyeConfig;
 
 @QuarkusTest
 public class VerticleTest {
+
+    protected Path getLogPath() {
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
+        return logRuntimeConfig.file().path().toPath();
+    }
 
     @Test
     public void testBareVerticle() {
@@ -35,7 +43,7 @@ public class VerticleTest {
 
     @Test
     public void testMdcVerticle() {
-        Path logDirectory = Paths.get(".", "target");
+        Path logFilePath = getLogPath();
         String value = UUID.randomUUID().toString();
         given().queryParam("value", value)
                 .get("/vertx-test/verticles/mdc")
@@ -46,7 +54,6 @@ public class VerticleTest {
                 .untilAsserted(new ThrowingRunnable() {
                     @Override
                     public void run() throws Throwable {
-                        final Path logFilePath = logDirectory.resolve("quarkus.log");
                         assertTrue(Files.exists(logFilePath),
                                 "quarkus log file " + logFilePath + " is missing");
                         String data = Files.readString(logFilePath);

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
@@ -36,7 +36,7 @@ import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.common.utils.StringUtil;
 
-public class DefaultDockerContainerLauncher implements DockerContainerArtifactLauncher {
+public class DefaultDockerContainerLauncher implements DockerContainerArtifactLauncher, LogPathProvider {
     private static final Logger log = Logger.getLogger(DefaultDockerContainerLauncher.class);
 
     private static final String AOT_DIR = "aot";
@@ -68,6 +68,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
     private Optional<String> containerWorkingDirectory;
     private String outputTargetDirectory;
     private Process containerProcess;
+    private Path logFile;
 
     @Override
     public void init(DockerContainerArtifactLauncher.DockerInitContext initContext) {
@@ -293,13 +294,14 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
         args.addAll(programArgs);
 
         final Path logPath = logRuntimeConfig.file().path().toPath();
+        logFile = resolveLogFile(logPath);
         try {
-            Files.deleteIfExists(logPath);
-            if (logPath.getParent() != null) {
-                Files.createDirectories(logPath.getParent());
+            Files.deleteIfExists(logFile);
+            if (logFile.getParent() != null) {
+                Files.createDirectories(logFile.getParent());
             }
         } catch (FileSystemException e) {
-            log.warnf("Log file %s deletion failed, could happen on Windows, we can carry on.", logPath);
+            log.warnf("Log file %s deletion failed, could happen on Windows, we can carry on.", logFile);
         }
 
         log.infof("Executing \"%s\"", String.join(" ", args));
@@ -310,18 +312,30 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
         // to mount /work/ directory to get quarkus.log.
         containerProcess = new ProcessBuilder(args)
                 .redirectErrorStream(true)
-                .redirectOutput(ProcessBuilder.Redirect.appendTo(logPath.toFile()))
+                .redirectOutput(ProcessBuilder.Redirect.appendTo(logFile.toFile()))
                 .start();
 
         if (startedFunction != null) {
-            waitForStartedFunction(startedFunction, containerProcess, waitTimeSeconds, logPath);
+            waitForStartedFunction(startedFunction, containerProcess, waitTimeSeconds, logFile);
             return ListeningAddresses.EMPTY;
         } else {
             log.info("Wait for server to start by capturing listening data...");
-            ListeningAddresses result = waitForCapturedListeningData(containerProcess, logPath, waitTimeSeconds);
+            ListeningAddresses result = waitForCapturedListeningData(containerProcess, logFile, waitTimeSeconds);
             result.address().ifPresent(listeningAddress -> log.infof("Server started on port %s", listeningAddress.port()));
             return result;
         }
+    }
+
+    private Path resolveLogFile(Path configuredLogPath) {
+        String suffix = containerName.substring(containerName.lastIndexOf('-') + 1);
+        Path logPath = LauncherUtil.buildUniqueLogPath(configuredLogPath, suffix);
+        log.infof("Using unique log path \"%s\".", logPath);
+        return logPath;
+    }
+
+    @Override
+    public Path getLogPath() {
+        return logFile;
     }
 
     private void handleAotFileArgs(List<String> args, ContainerRuntime containerRuntime) throws IOException {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
@@ -19,13 +19,14 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.smallrye.config.SmallRyeConfig;
 
-public class DefaultJarLauncher implements JarArtifactLauncher {
+public class DefaultJarLauncher implements JarArtifactLauncher, LogPathProvider {
     private static final Logger log = Logger.getLogger(DefaultJarLauncher.class);
 
     private static final String JAVA_HOME_SYS = "java.home";
@@ -58,6 +59,7 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
     private String aotResultDescription;
 
     private final Map<String, String> systemProps = new HashMap<>();
+    private final String instanceId = RandomStringUtils.insecure().next(5, true, false);
     private Process quarkusProcess;
 
     private Path logFile;
@@ -82,15 +84,13 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
     @Override
     public ListeningAddresses start() throws IOException {
         start(new String[0], true);
+        // logFile is already resolved to a unique path by the inner start() call
         Function<IntegrationTestStartedNotifier.Context, IntegrationTestStartedNotifier.Result> startedFunction = createStartedFunction();
-        LogRuntimeConfig logRuntimeConfig = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class)
-                .getConfigMapping(LogRuntimeConfig.class);
-        logFile = logRuntimeConfig.file().path().toPath();
         if (startedFunction != null) {
             waitForStartedFunction(startedFunction, quarkusProcess, waitTimeSeconds, logFile);
             return ListeningAddresses.EMPTY;
         } else {
-            return waitForCapturedListeningData(quarkusProcess, logRuntimeConfig.file().path().toPath(), waitTimeSeconds);
+            return waitForCapturedListeningData(quarkusProcess, logFile, waitTimeSeconds);
         }
     }
 
@@ -115,7 +115,7 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
     public void start(String[] programArgs, boolean handleIo) throws IOException {
         SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
         LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
-        logFile = logRuntimeConfig.file().path().toPath();
+        logFile = resolveLogFile(logRuntimeConfig);
 
         List<String> args = new ArrayList<>();
         args.add(determineJavaPath());
@@ -186,6 +186,18 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
     @Override
     public void includeAsSysProps(Map<String, String> systemProps) {
         this.systemProps.putAll(systemProps);
+    }
+
+    private Path resolveLogFile(LogRuntimeConfig logRuntimeConfig) {
+        Path base = logRuntimeConfig.file().path().toPath();
+        Path logPath = LauncherUtil.buildUniqueLogPath(base, instanceId);
+        log.infof("Using unique log path \"%s\".", logPath);
+        return logPath;
+    }
+
+    @Override
+    public Path getLogPath() {
+        return logFile;
     }
 
     @Override

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
@@ -22,13 +22,14 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.smallrye.config.SmallRyeConfig;
 
-public class DefaultNativeImageLauncher implements NativeImageLauncher {
+public class DefaultNativeImageLauncher implements NativeImageLauncher, LogPathProvider {
     private static final Logger log = Logger.getLogger(DefaultNativeImageLauncher.class);
 
     private static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("windows");
@@ -47,6 +48,7 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
 
     private Process quarkusProcess;
     private final Map<String, String> systemProps = new HashMap<>();
+    private final String instanceId = RandomStringUtils.insecure().next(5, true, false);
 
     private Path logFile;
 
@@ -88,15 +90,13 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
     @Override
     public ListeningAddresses start() throws IOException {
         start(new String[0], true);
-        LogRuntimeConfig logRuntimeConfig = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class)
-                .getConfigMapping(LogRuntimeConfig.class);
-        logFile = logRuntimeConfig.file().path().toPath();
+        // logFile is already resolved to a unique path by the inner start() call
         Function<IntegrationTestStartedNotifier.Context, IntegrationTestStartedNotifier.Result> startedFunction = createStartedFunction();
         if (startedFunction != null) {
-            waitForStartedFunction(startedFunction, quarkusProcess, waitTimeSeconds, logRuntimeConfig.file().path().toPath());
+            waitForStartedFunction(startedFunction, quarkusProcess, waitTimeSeconds, logFile);
             return ListeningAddresses.EMPTY;
         } else {
-            return waitForCapturedListeningData(quarkusProcess, logRuntimeConfig.file().path().toPath(), waitTimeSeconds);
+            return waitForCapturedListeningData(quarkusProcess, logFile, waitTimeSeconds);
         }
     }
 
@@ -117,7 +117,7 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
             args.add("-Dquarkus.http.ssl-port=" + httpsPort);
             args.add("-Dtest.url=" + LauncherUtil.generateTestUrl());
         }
-        logFile = logRuntimeConfig.file().path().toPath();
+        logFile = resolveLogFile(logRuntimeConfig);
         args.add("-Dquarkus.log.file.path=" + logFile.toAbsolutePath());
         args.add("-Dquarkus.log.file.enabled=true");
         args.add("-Dquarkus.log.category.\"io.quarkus\".level=INFO");
@@ -275,6 +275,18 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
     @Override
     public void includeAsSysProps(Map<String, String> systemProps) {
         this.systemProps.putAll(systemProps);
+    }
+
+    private Path resolveLogFile(LogRuntimeConfig logRuntimeConfig) {
+        Path base = logRuntimeConfig.file().path().toPath();
+        Path logPath = LauncherUtil.buildUniqueLogPath(base, instanceId);
+        log.infof("Using unique log path \"%s\".", logPath);
+        return logPath;
+    }
+
+    @Override
+    public Path getLogPath() {
+        return logFile;
     }
 
     @Override

--- a/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
@@ -41,6 +41,29 @@ public final class LauncherUtil {
     }
 
     /**
+     * Derives a unique log file path from the configured base path by inserting {@code suffix} before the file
+     * extension (or appending it when there is no extension).
+     *
+     * <pre>
+     *   target/quarkus.log + "xKpQm" → target/quarkus-xKpQm.log
+     *   target/quarkus     + "xKpQm" → target/quarkus-xKpQm
+     * </pre>
+     *
+     * @param baseLogPath the configured log file path (e.g. from {@code quarkus.log.file.path})
+     * @param suffix the per-instance suffix to insert (e.g. a random string or a container-name fragment)
+     * @return a sibling path of {@code baseLogPath} with {@code suffix} embedded in the filename
+     */
+    static Path buildUniqueLogPath(Path baseLogPath, String suffix) {
+        String baseName = baseLogPath.getFileName().toString();
+        int dotIndex = baseName.lastIndexOf('.');
+        String uniqueName = dotIndex >= 0
+                ? baseName.substring(0, dotIndex) + "-" + suffix + baseName.substring(dotIndex)
+                : baseName + "-" + suffix;
+        Path parent = baseLogPath.getParent();
+        return parent != null ? parent.resolve(uniqueName) : Path.of(uniqueName);
+    }
+
+    /**
      * Generates the value of <code>test.url</code> to pass as an argument to integration tests launchers.
      * <p>
      * Ideally, we shouldn't be using the configuration system to discover the url. We are keeping this for

--- a/test-framework/common/src/main/java/io/quarkus/test/common/LogPathProvider.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/LogPathProvider.java
@@ -1,0 +1,19 @@
+package io.quarkus.test.common;
+
+import java.nio.file.Path;
+
+/**
+ * Implemented by artifact launchers that resolve a unique, per-instance log file.
+ * Allows JUnit extensions and test callbacks to discover the exact log file
+ * used by this launcher instance, which is particularly important when
+ * {@code maven-failsafe-plugin} is configured with {@code forkCount > 1}.
+ */
+public interface LogPathProvider {
+
+    /**
+     * Returns the path of the log file used by this launcher instance.
+     *
+     * @return the log file path, or {@code null} if the launcher has not been started yet
+     */
+    Path getLogPath();
+}

--- a/test-framework/common/src/main/java/io/quarkus/test/common/RunCommandLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/RunCommandLauncher.java
@@ -24,6 +24,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.input.TeeInputStream;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
@@ -36,7 +37,7 @@ import io.quarkus.deployment.cmd.RunCommandHandler;
 import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.smallrye.config.SmallRyeConfig;
 
-public class RunCommandLauncher implements ArtifactLauncher<ArtifactLauncher.InitContext> {
+public class RunCommandLauncher implements ArtifactLauncher<ArtifactLauncher.InitContext>, LogPathProvider {
     private static final Logger log = Logger.getLogger(RunCommandLauncher.class);
 
     Process quarkusProcess = null;
@@ -45,7 +46,9 @@ public class RunCommandLauncher implements ArtifactLauncher<ArtifactLauncher.Ini
     private Path workingDir;
     private String startedExpression;
     private boolean needsLogFile;
-    private Path logFilePath;
+    private Path configuredLogFile;
+    private Path logFile;
+    private final String instanceId = RandomStringUtils.insecure().next(5, true, false);
 
     private final Map<String, String> systemProps = new HashMap<>();
 
@@ -93,7 +96,7 @@ public class RunCommandLauncher implements ArtifactLauncher<ArtifactLauncher.Ini
         launcher.workingDir = (Path) cmd.get(1);
         launcher.startedExpression = (String) cmd.get(2);
         launcher.needsLogFile = (Boolean) cmd.get(3);
-        launcher.logFilePath = (Path) cmd.get(4);
+        launcher.configuredLogFile = (Path) cmd.get(4);
         launcher.waitTimeSeconds = waitTime.getSeconds();
         return launcher;
     }
@@ -110,14 +113,14 @@ public class RunCommandLauncher implements ArtifactLauncher<ArtifactLauncher.Ini
 
     @Override
     public ListeningAddresses start() throws IOException {
-        Path logFile = logFilePath;
+        logFile = configuredLogFile;
 
         System.out.println("Executing \"" + String.join(" ", args) + "\"");
         if (needsLogFile) {
-            if (logFilePath == null) {
+            if (configuredLogFile == null) {
                 SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
                 LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
-                logFile = logRuntimeConfig.file().path().toPath();
+                logFile = buildUniqueLogPath(logRuntimeConfig.file().path().toPath(), instanceId);
             }
             System.out.println("Creating Logfile for custom extension run: " + logFile.toString());
             try {
@@ -164,6 +167,11 @@ public class RunCommandLauncher implements ArtifactLauncher<ArtifactLauncher.Ini
 
     public void includeAsSysProps(Map<String, String> systemProps) {
         this.systemProps.putAll(systemProps);
+    }
+
+    @Override
+    public Path getLogPath() {
+        return logFile;
     }
 
     @Override

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/IntegrationTestExtensionState.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/IntegrationTestExtensionState.java
@@ -2,18 +2,29 @@ package io.quarkus.test.junit;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.file.Path;
 
 import io.quarkus.test.common.TestResourceManager;
 
 public class IntegrationTestExtensionState extends QuarkusTestExtensionState {
 
-    public IntegrationTestExtensionState(TestResourceManager testResourceManager, Closeable resource, Runnable clearCallbacks) {
+    private final Path logPath;
+
+    public IntegrationTestExtensionState(TestResourceManager testResourceManager,
+            Closeable resource,
+            Runnable clearCallbacks,
+            Path logPath) {
         super(testResourceManager, resource, clearCallbacks);
+        this.logPath = logPath;
     }
 
     @Override
     protected void doClose() throws IOException {
         testResourceManager.close();
         resource.close();
+    }
+
+    public Path getLogPath() {
+        return logPath;
     }
 }

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -26,6 +26,8 @@ import java.util.function.Consumer;
 import jakarta.inject.Inject;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.jboss.jandex.Index;
@@ -48,9 +50,11 @@ import io.quarkus.deployment.builditem.DevServicesRegistryBuildItem;
 import io.quarkus.deployment.dev.testing.TestConfig;
 import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.paths.PathList;
+import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.runtime.logging.LoggingSetupRecorder;
 import io.quarkus.test.common.ArtifactLauncher;
 import io.quarkus.test.common.ListeningAddresses;
+import io.quarkus.test.common.LogPathProvider;
 import io.quarkus.test.common.PathTestHelper;
 import io.quarkus.test.common.TestClassIndexer;
 import io.quarkus.test.common.TestResourceManager;
@@ -124,11 +128,13 @@ public final class IntegrationTestUtil {
         ((TestResourceManager) state.getTestResourceManager()).inject(valueRegistry, testInstance);
     }
 
-    static ListeningAddresses startLauncher(ArtifactLauncher<?> launcher, Map<String, String> additionalProperties)
+    static Pair<ListeningAddresses, Path> startLauncher(ArtifactLauncher<?> launcher, Map<String, String> additionalProperties)
             throws IOException {
         try {
             launcher.includeAsSysProps(additionalProperties);
-            return launcher.start();
+            ListeningAddresses listeningAddresses = launcher.start();
+            Path logPath = resolveLogFilePath(launcher);
+            return new ImmutablePair<>(listeningAddresses, logPath);
         } catch (IOException e) {
             try {
                 launcher.close();
@@ -461,6 +467,30 @@ public final class IntegrationTestUtil {
                     "The determined Quarkus build output '" + result.toAbsolutePath().toString() + "' is not a directory");
         }
         return result;
+    }
+
+    /**
+     * Resolves the log file path for the given artifact launcher.
+     * <p>
+     * If the launcher provides a log path (implements {@link LogPathProvider}), this method:
+     * <ul>
+     * <li>Returns the launcher's log path</li>
+     * </ul>
+     * <p>
+     * Otherwise, the method falls back to retrieving the log file path from the Quarkus runtime
+     * configuration via {@link LogRuntimeConfig}.
+     *
+     * @param launcher the artifact launcher for which to resolve the log path; must not be null
+     * @return the {@link Path} to the application's log file
+     * @see LogPathProvider
+     * @see LogRuntimeConfig
+     */
+    static Path resolveLogFilePath(ArtifactLauncher<?> launcher) {
+        if (launcher instanceof LogPathProvider lp && lp.getLogPath() != null) {
+            return lp.getLogPath();
+        }
+        LogRuntimeConfig logRuntimeConfig = Config.get().getConfigMapping(LogRuntimeConfig.class);
+        return logRuntimeConfig.file().path().toPath();
     }
 
     private static Path determineBuildOutputDirectory(final URL url) {

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -36,6 +36,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -85,6 +86,9 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
         BeforeAllCallback, AfterAllCallback, TestInstancePostProcessor, ParameterResolver {
 
     private static final int APP_LOG_TAIL_LINES = 50;
+
+    public static final ValueRegistry.RuntimeKey<Path> TEST_LOG_PATH = ValueRegistry.RuntimeKey
+            .key("quarkus.test.log.file.path");
 
     private static boolean failedBoot;
 
@@ -202,8 +206,16 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
                 setState(extensionContext, state);
             } catch (Throwable e) {
                 try {
-                    LogRuntimeConfig logRuntimeConfig = Config.get().getConfigMapping(LogRuntimeConfig.class);
-                    File appLogFile = logRuntimeConfig.file().path();
+                    ValueRegistry valueRegistry = ValueRegistryInjector.get(extensionContext);
+                    Path logPath = null;
+                    if (valueRegistry != null && valueRegistry.containsKey(TEST_LOG_PATH)) {
+                        logPath = valueRegistry.get(TEST_LOG_PATH);
+                    }
+                    if (logPath == null) {
+                        LogRuntimeConfig logRuntimeConfig = Config.get().getConfigMapping(LogRuntimeConfig.class);
+                        logPath = logRuntimeConfig.file().path().toPath();
+                    }
+                    File appLogFile = logPath.toFile();
                     if (appLogFile.exists() && (appLogFile.length() > 0)) {
                         System.err.println("Failed to launch the application. The application logs can be found at: "
                                 + appLogFile.getAbsolutePath());
@@ -358,7 +370,10 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
             activateLogging();
 
             // Start Quarkus, capture the listening port if available and register it in ValueRegistry
-            ListeningAddresses listeningData = startLauncher(launcher, additionalProperties);
+            Pair<ListeningAddresses, Path> startLauncherPair = startLauncher(launcher, additionalProperties);
+            ListeningAddresses listeningData = startLauncherPair.getLeft();
+            Path logPath = startLauncherPair.getRight();
+
             Optional<ListeningAddress> listeningAddress = listeningData.address();
             if (listeningAddress.isPresent()) {
                 listeningAddress.get().register(valueRegistry, newConfig);
@@ -373,13 +388,15 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
             } else {
                 valueRegistry.register(MANAGEMENT_LISTENING_ADDRESS, Optional.empty());
             }
+            valueRegistry.register(TEST_LOG_PATH, logPath);
 
             testHttpEndpointProviders = TestHttpEndpointProvider.load();
 
             return new IntegrationTestExtensionState(
                     testResourceManager,
                     new IntegrationTestExtensionStateResource(launcher, devServicesLaunchResult.getCuratedApplication()),
-                    AbstractTestWithCallbacksExtension::clearCallbacks);
+                    AbstractTestWithCallbacksExtension::clearCallbacks,
+                    logPath);
         } catch (Throwable e) {
             if (!InitialConfigurator.DELAYED_HANDLER.isActivated()) {
                 activateLogging();

--- a/test-framework/junit/src/test/java/io/quarkus/test/junit/TestResourceUtilTest.java
+++ b/test-framework/junit/src/test/java/io/quarkus/test/junit/TestResourceUtilTest.java
@@ -1,15 +1,23 @@
 package io.quarkus.test.junit;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.runtime.logging.LogRuntimeConfig;
+import io.quarkus.test.common.ArtifactLauncher;
+import io.quarkus.test.common.ListeningAddresses;
+import io.quarkus.test.common.LogPathProvider;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.smallrye.config.Config;
 
 public class TestResourceUtilTest {
 
@@ -33,6 +41,99 @@ public class TestResourceUtilTest {
         String identifier1 = TestResourceUtil.getReloadGroupIdentifier(TestClass.class, ProfileClassWithResources.class);
         String identifier2 = TestResourceUtil.getReloadGroupIdentifier(TestClass.class, ProfileClass.class);
         assertNotEquals(identifier2, identifier1);
+    }
+
+    @Test
+    void resolveLogFilePathShouldGetLogPathWhenLauncherIsLogPathProvider() {
+        Path path = Path.of("target", "quarkus-abcde.log");
+        Path logPath = IntegrationTestUtil.resolveLogFilePath(new LogPathProviderLauncher(path));
+        assertThat(logPath).isEqualTo(path);
+    }
+
+    @Test
+    void resolveLogFileShouldNotGetPathWhenLauncherIsNotLogPathProvider() {
+        Path expected = runtimeConfiguredLogPath();
+        Path logPath = IntegrationTestUtil.resolveLogFilePath(new NonLogPathProviderLauncher());
+        assertThat(logPath).isEqualTo(expected);
+    }
+
+    @Test
+    void resolveLogFileShouldNotGetPathWhenLogFilePathIsNull() {
+        Path expected = runtimeConfiguredLogPath();
+        Path logPath = IntegrationTestUtil.resolveLogFilePath(new LogPathProviderLauncher(null));
+        assertThat(logPath).isEqualTo(expected);
+    }
+
+    private static Path runtimeConfiguredLogPath() {
+        LogRuntimeConfig logRuntimeConfig = Config.get().getConfigMapping(LogRuntimeConfig.class);
+        return logRuntimeConfig.file().path().toPath();
+    }
+
+    // -------------------------------------------------------------------------
+    // Stubs
+    // -------------------------------------------------------------------------
+
+    /** Minimal ArtifactLauncher stub that also implements LogPathProvider. */
+    @SuppressWarnings("rawtypes")
+    private static class LogPathProviderLauncher implements ArtifactLauncher, LogPathProvider {
+        private final Path path;
+
+        LogPathProviderLauncher(Path path) {
+            this.path = path;
+        }
+
+        @Override
+        public Path getLogPath() {
+            return path;
+        }
+
+        @Override
+        public void init(InitContext initContext) {
+        }
+
+        @Override
+        public ListeningAddresses start() throws IOException {
+            return ListeningAddresses.EMPTY;
+        }
+
+        @Override
+        public ArtifactLauncher.LaunchResult runToCompletion(String[] args) {
+            return null;
+        }
+
+        @Override
+        public void includeAsSysProps(Map systemProps) {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    /** Minimal ArtifactLauncher stub that does NOT implement LogPathProvider. */
+    @SuppressWarnings("rawtypes")
+    private static class NonLogPathProviderLauncher implements ArtifactLauncher {
+        @Override
+        public void init(InitContext initContext) {
+        }
+
+        @Override
+        public ListeningAddresses start() throws IOException {
+            return ListeningAddresses.EMPTY;
+        }
+
+        @Override
+        public ArtifactLauncher.LaunchResult runToCompletion(String[] args) {
+            return null;
+        }
+
+        @Override
+        public void includeAsSysProps(Map systemProps) {
+        }
+
+        @Override
+        public void close() {
+        }
     }
 }
 


### PR DESCRIPTION
When `maven-failsafe-plugin` is configured with `forkCount > 1` and `reuseForks=false`, each fork launches a separate JVM and a separate `@QuarkusIntegrationTest` instance. All three default launchers (`DefaultJarLauncher`, `DefaultNativeImageLauncher`, `DefaultDockerContainerLauncher`) resolved the log file from the same config property (`quarkus.log.file.path`, defaulting to `target/quarkus.log`). `RunCommandLauncher` (used by extensions such as Azure Functions) had the same problem in its null-path fallback. This caused two failure modes:

- **False readiness**: the first fork to write the "started" marker satisfies all forks waiting on the same file, so some forks detect a started application that isn't theirs.
- **Port collision**: all forks read the same port number from the shared file and attempt to bind to the same port.

This fix makes each launcher instance resolve a unique log file path at start time:
- `DefaultDockerContainerLauncher` derives the suffix from its already-unique `containerName`.
- `DefaultJarLauncher`, `DefaultNativeImageLauncher`, and `RunCommandLauncher` (null-path fallback) generate a short random suffix via `RandomStringUtils`.
- The shared naming logic is extracted to `LauncherUtil.buildUniqueLogPath(Path, String)`, which inserts the suffix before the file extension (e.g. `target/quarkus.log` → `target/quarkus-AbCdE.log`).
- `QuarkusIntegrationTestExtension` publishes the path as the `quarkus.test.log.file.path` system property after the launcher starts. It also provides a `TestLog` class that can be injected or used as Test Parameter in the quarkus integration tests.

---

- Fixes: #55634