### PR TITLE
Enforce managed versions on direct dependencies of an application artifact provided as a JAR

### DIFF
--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/ManagedDependencyOverridesDirectDepVersionTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/ManagedDependencyOverridesDirectDepVersionTestCase.java
@@ -1,0 +1,50 @@
+package io.quarkus.bootstrap.resolver.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.bootstrap.resolver.ResolverSetupCleanup;
+import io.quarkus.bootstrap.resolver.TsArtifact;
+import io.quarkus.bootstrap.resolver.TsDependency;
+import io.quarkus.maven.dependency.ResolvedDependency;
+
+/**
+ * When a managing project (platform BOM) specifies a version for a dependency,
+ * that version should override the version declared as a direct dependency of
+ * the application artifact.
+ */
+public class ManagedDependencyOverridesDirectDepVersionTestCase extends ResolverSetupCleanup {
+
+    @Test
+    public void testManagedVersionOverridesDirectDep() throws Exception {
+        final TsArtifact libV1 = TsArtifact.jar("lib", "1");
+        install(libV1);
+
+        final TsArtifact libV2 = TsArtifact.jar("lib", "2");
+        install(libV2);
+
+        // app declares lib:1 as a direct dependency
+        final TsArtifact app = TsArtifact.jar("app", "1");
+        app.addDependency(new TsDependency(libV1));
+        install(app);
+
+        // managing project manages lib to version 2
+        final TsArtifact managingProject = TsArtifact.jar("managing-project", "1");
+        managingProject.addManagedDependency(new TsDependency(libV2));
+        install(managingProject);
+
+        final var model = resolver.resolveManagedModel(
+                app.toArtifact(),
+                List.of(), Set.of(),
+                managingProject.toArtifact(),
+                Set.of());
+        final var resolved = model.getDependencies();
+        assertThat(resolved).hasSize(1);
+        final ResolvedDependency dep = resolved.iterator().next();
+        assertThat(dep.getVersion()).isEqualTo("2");
+    }
+}

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
@@ -336,8 +336,14 @@ public class BootstrapAppModelResolver implements AppModelResolver {
             managedDeps = DependencyUtils.toMap(appArtifactDescr.getManagedDependencies());
         }
 
-        directMvnDeps = DependencyUtils.mergeDependencies(directMvnDeps, appArtifactDescr.getDependencies(),
-                excludedArtifacts, managedDeps, Set.of());
+        if (managingProject != null) {
+            directMvnDeps = DependencyUtils.enforceManagedDependencies(directMvnDeps, appArtifactDescr.getDependencies(),
+                    excludedArtifacts, managedDeps, Set.of());
+        } else {
+            directMvnDeps = DependencyUtils.mergeDependencies(directMvnDeps, appArtifactDescr.getDependencies(),
+                    excludedArtifacts, managedDeps, Set.of());
+        }
+
         aggregatedRepos = mvn.aggregateRepositories(aggregatedRepos,
                 mvn.newResolutionRepositories(appArtifactDescr.getRepositories()));
 

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/util/DependencyUtils.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/util/DependencyUtils.java
@@ -98,6 +98,41 @@ public class DependencyUtils {
         return result;
     }
 
+    public static List<Dependency> enforceManagedDependencies(List<Dependency> dominant, List<Dependency> recessive,
+            Set<ArtifactKey> excluded,
+            Map<ArtifactKey, Dependency> managedVersions, Set<String> excludedScopes) {
+        if (dominant.isEmpty() && recessive.isEmpty()) {
+            return List.of();
+        }
+        final List<Dependency> result = new ArrayList<>(dominant.size() + recessive.size());
+        final Map<ArtifactKey, Dependency> dominantMap = new HashMap<>(dominant.size());
+        for (Dependency dep : dominant) {
+            final ArtifactKey key = getKey(dep.getArtifact());
+            if (!excludedScopes.contains(dep.getScope()) && !excluded.contains(key)) {
+                result.add(dep);
+                if (!managedVersions.containsKey(key)) {
+                    dominantMap.put(key, dep);
+                }
+            }
+        }
+        for (Dependency dep : recessive) {
+            if (!excludedScopes.contains(dep.getScope())) {
+                final ArtifactKey key = getKey(dep.getArtifact());
+                if (!dominantMap.containsKey(key) && !excluded.contains(key)) {
+                    final Dependency managed = managedVersions.get(key);
+                    if (managed != null) {
+                        if (dep.getArtifact().getVersion() == null
+                                || !dep.getArtifact().getVersion().equals(managed.getArtifact().getVersion())) {
+                            dep = dep.setArtifact(dep.getArtifact().setVersion(managed.getArtifact().getVersion()));
+                        }
+                    }
+                    result.add(dep);
+                }
+            }
+        }
+        return result;
+    }
+
     public static Artifact toArtifact(String str) {
         final String groupId;
         final String artifactId;


### PR DESCRIPTION
Fixes a dependency alignment issue in native platform tests. It doesn't affect the JVM platform tests.