### PR TITLE
Hibernate ORM: allow to configure dialect for additional PUs

### DIFF
--- a/extensions/hibernate-orm/deployment-spi/src/main/java/io/quarkus/hibernate/orm/deployment/spi/AdditionalPersistenceUnitBuildItem.java
+++ b/extensions/hibernate-orm/deployment-spi/src/main/java/io/quarkus/hibernate/orm/deployment/spi/AdditionalPersistenceUnitBuildItem.java
@@ -25,6 +25,7 @@ public final class AdditionalPersistenceUnitBuildItem extends MultiBuildItem {
 
     private final String persistenceUnitName;
     private final Optional<String> dataSourceName;
+    private final Optional<String> explicitDialect;
     private final Set<String> managedClassNames;
     private final Set<String> mappingFileNames;
     private final Map<String, String> properties;
@@ -32,6 +33,7 @@ public final class AdditionalPersistenceUnitBuildItem extends MultiBuildItem {
     private AdditionalPersistenceUnitBuildItem(Builder builder) {
         this.persistenceUnitName = builder.persistenceUnitName;
         this.dataSourceName = builder.dataSourceName;
+        this.explicitDialect = builder.explicitDialect;
         this.managedClassNames = Collections.unmodifiableSet(new LinkedHashSet<>(builder.managedClassNames));
         this.mappingFileNames = Collections.unmodifiableSet(new LinkedHashSet<>(builder.mappingFileNames));
         this.properties = Collections.unmodifiableMap(new LinkedHashMap<>(builder.properties));
@@ -43,6 +45,10 @@ public final class AdditionalPersistenceUnitBuildItem extends MultiBuildItem {
 
     public Optional<String> getDataSourceName() {
         return dataSourceName;
+    }
+
+    public Optional<String> getExplicitDialect() {
+        return explicitDialect;
     }
 
     public Set<String> getManagedClassNames() {
@@ -65,6 +71,7 @@ public final class AdditionalPersistenceUnitBuildItem extends MultiBuildItem {
 
         private final String persistenceUnitName;
         private Optional<String> dataSourceName = Optional.empty();
+        private Optional<String> explicitDialect = Optional.empty();
         private final Set<String> managedClassNames = new LinkedHashSet<>();
         private final Set<String> mappingFileNames = new LinkedHashSet<>();
         private final Map<String, String> properties = new LinkedHashMap<>();
@@ -86,6 +93,18 @@ public final class AdditionalPersistenceUnitBuildItem extends MultiBuildItem {
          */
         public Builder dataSourceName(String dataSourceName) {
             this.dataSourceName = Optional.ofNullable(dataSourceName);
+            return this;
+        }
+
+        /**
+         * Sets the Hibernate ORM dialect for this persistence unit. When not set, the dialect is auto-detected
+         * from the datasource's database kind.
+         *
+         * @param dialect The fully-qualified class name of the Hibernate dialect.
+         * @return This builder.
+         */
+        public Builder dialect(String dialect) {
+            this.explicitDialect = Optional.ofNullable(dialect);
             return this;
         }
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -543,7 +543,7 @@ public final class HibernateOrmProcessor {
         Optional<DatabaseKind.SupportedDatabaseKind> supportedDatabaseKind = setDialectAndStorageEngine(
                 persistenceUnitName,
                 dbKind,
-                Optional.empty(),
+                additionalPersistenceUnit.getExplicitDialect(),
                 jdbcDataSource.flatMap(JdbcDataSourceBuildItem::getDbVersion),
                 null,
                 dbKindMetadataBuildItems,
@@ -564,7 +564,7 @@ public final class HibernateOrmProcessor {
                                 supportedDatabaseKind.map(DatabaseKind.SupportedDatabaseKind::getMainName),
                                 jdbcDataSource.flatMap(JdbcDataSourceBuildItem::getDbVersion),
                                 jdbcDataSource.map(JdbcDataSourceBuildItem::isDbVersionUserSpecified).orElse(false),
-                                Optional.empty(),
+                                additionalPersistenceUnit.getExplicitDialect(),
                                 entityClassNames,
                                 multiTenancyStrategy,
                                 hibernateOrmConfig.database().ormCompatibilityVersion(),

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/spi/AdditionalPersistenceUnitExternalEntityTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/spi/AdditionalPersistenceUnitExternalEntityTest.java
@@ -12,6 +12,9 @@ import jakarta.persistence.Id;
 import jakarta.transaction.Transactional;
 
 import org.hibernate.Session;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -67,6 +70,15 @@ class AdditionalPersistenceUnitExternalEntityTest {
         }
     }
 
+    @Test
+    void explicitDialectIsApplied() {
+        SessionFactoryImplementor sf = externalSession.getSessionFactory().unwrap(SessionFactoryImplementor.class);
+        assertThat(sf.getJdbcServices().getDialect()).isInstanceOf(H2Dialect.class);
+        assertThat(sf.getProperties().get(AvailableSettings.DIALECT))
+                .as("hibernate.dialect property must be explicitly set when .dialect() is used")
+                .isEqualTo(H2Dialect.class.getName());
+    }
+
     private static Consumer<BuildChainBuilder> buildCustomizer() {
         return new Consumer<>() {
             @Override
@@ -76,6 +88,7 @@ class AdditionalPersistenceUnitExternalEntityTest {
                     public void execute(BuildContext context) {
                         context.produce(AdditionalPersistenceUnitBuildItem.builder(PERSISTENCE_UNIT_NAME)
                                 .dataSourceName("vector")
+                                .dialect(H2Dialect.class.getName())
                                 .managedClass(EXTERNAL_ENTITY_CLASS_NAME)
                                 .build());
                     }


### PR DESCRIPTION
Dialect configured via `io.quarkus.hibernate.orm.deployment.spi.AdditionalPersistenceUnitBuildItem#getProperties` is overridden by auto-detected dialect based on the DB kind. Keycloak needs to be able to configure additional PU's dialect so that we can avoid breaking changes when migrating from `persistence.xml` to Quarkus Hibernate properties (just a transitional period).

The test I added is failing without this PR (hence verifying this PR) even though the auto-detected dialect is same :-)