### PR TITLE
OIDC and Keycloak Dev Services: remove XOR trap workaround for a config mapping workaround

### DIFF
--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -26,7 +26,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
@@ -192,45 +191,13 @@ public class KeycloakDevServicesProcessor {
         // same if the config and the realm file modified times are same and the other way around
         StringBuilder serviceConfigIdentifier = new StringBuilder();
 
-        // TODO: use the builtin hashcode once https://github.com/smallrye/smallrye-config/issues/1462 is fixed
-        int configHashCode = Objects.hash(
-                config.enabled(),
-                config.imageName(),
-                config.keycloakXImage(),
-                config.shared(),
-                config.serviceName(),
-                config.realmPath(),
-                safeMapHash(config.resourceAliases()),
-                safeMapHash(config.resourceMappings()),
-                config.javaOpts(),
-                config.showLogs(),
-                config.startCommand(),
-                config.features(),
-                config.realmName(),
-                config.createRealm(),
-                config.createClient(),
-                config.startWithDisabledTenant(),
-                safeMapHash(config.users()),
-                safeMapHash(config.roles()),
-                config.port(),
-                safeMapHash(config.containerEnv()),
-                config.containerMemoryLimit(),
-                config.webClientTimeout(),
-                config.disableHttps());
-        serviceConfigIdentifier.append(configHashCode);
+        serviceConfigIdentifier.append(config.hashCode());
 
         for (int fileTimeHashCode : getRealmFileLastModifiedDateHashCode(config.realmPath())) {
             serviceConfigIdentifier.append(";"); // separator
             serviceConfigIdentifier.append(fileTimeHashCode);
         }
         return serviceConfigIdentifier.toString();
-    }
-
-    private static int safeMapHash(Map<?, ?> map) {
-        if (map == null)
-            return 0;
-
-        return map.entrySet().stream().mapToInt(e -> Objects.hash(e.getKey(), e.getValue())).sum();
     }
 
     private static Map<String, Function<StartableContainer<QuarkusOidcContainer>, String>> createLazyConfigMap(

--- a/extensions/devservices/oidc/src/main/java/io/quarkus/devservices/oidc/OidcDevServicesProcessor.java
+++ b/extensions/devservices/oidc/src/main/java/io/quarkus/devservices/oidc/OidcDevServicesProcessor.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringTokenizer;
@@ -87,14 +86,7 @@ class OidcDevServicesProcessor {
         // Dev Services are restarted if the "service config" is different then the previous one
         // we can't rely on the static variables, hence the idea in this method is to trust the hash code is
 
-        // TODO: use the builtin hashcode once https://github.com/smallrye/smallrye-config/issues/1462 is fixed
-        int configHashCode = Objects.hash(
-                config.enabled().orElse(true), // goal is to have deterministic value, not correct 'enabled' flag
-                config.accessTokenExpiresIn(),
-                config.idTokenExpiresIn(),
-                safeMapHash(config.roles()));
-
-        return configHashCode + SERVICE_CONFIG_IDENTIFIER_SEPARATOR + getOidcClientSecret()
+        return config.hashCode() + SERVICE_CONFIG_IDENTIFIER_SEPARATOR + getOidcClientSecret()
                 + SERVICE_CONFIG_IDENTIFIER_SEPARATOR + getOidcClientId() + SERVICE_CONFIG_IDENTIFIER_SEPARATOR
                 + getOidcApplicationType();
     }
@@ -109,13 +101,6 @@ class OidcDevServicesProcessor {
             lazyConfigMap.put(CLIENT_ID_CONFIG_KEY, s -> s.oidcClientId);
         }
         return Collections.unmodifiableMap(lazyConfigMap);
-    }
-
-    private static int safeMapHash(Map<?, ?> map) {
-        if (map == null)
-            return 0;
-
-        return map.entrySet().stream().mapToInt(e -> Objects.hash(e.getKey(), e.getValue())).sum();
     }
 
     private static boolean shouldStartServer(OidcDevServicesConfig devServicesConfig,


### PR DESCRIPTION
https://github.com/smallrye/smallrye-config/pull/1541 fixed this in SmallRye Config 3.18.0 and Quarkus is currently on 3.18.1, so it is safe to remove this workaround.

I am pretty sure I added this because some tests in OIDC or OIDC client deployment module tests were failing after our migration to a new dev service model, therefore PR CI will verify these changes.
