### PR TITLE
Serialize application model set-valued fields in a deterministic order

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ApplicationModel.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ApplicationModel.java
@@ -193,15 +193,23 @@ public interface ApplicationModel extends Mappable {
             map.put(BootstrapConstants.MAPPABLE_CAPABILITIES, Mappable.asMaps(getExtensionCapabilities(), factory));
         }
         if (!getReloadableWorkspaceDependencies().isEmpty()) {
+            // Sort so the serialized form is deterministic across JVMs: Set.copyOf iteration
+            // order is salted per JVM, which busts the Gradle build cache (see #55619).
             map.put(BootstrapConstants.MAPPABLE_LOCAL_PROJECTS,
-                    Mappable.toStringCollection(getReloadableWorkspaceDependencies(), factory));
+                    Mappable.toStringCollection(
+                            getReloadableWorkspaceDependencies().stream().sorted().toList(), factory));
         }
         if (!getRemovedResources().isEmpty()) {
             final Map<ArtifactKey, Set<String>> removedResources = getRemovedResources();
             final Map<String, Object> mappedExcludedResources = factory.newMap(removedResources.size());
-            for (Map.Entry<ArtifactKey, Set<String>> entry : removedResources.entrySet()) {
-                mappedExcludedResources.put(entry.getKey().toString(), Mappable.toStringCollection(entry.getValue(), factory));
-            }
+            // getRemovedResources() is a per-JVM-salted Map.copyOf, so sort by key: this fixes the
+            // insertion order into the (HashMap-backed) JSON object, keeping its output stable across
+            // JVMs even when keys collide in a bucket. Sort each value collection for the same reason
+            // as local-projects above (see #55619).
+            removedResources.entrySet().stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .forEach(entry -> mappedExcludedResources.put(entry.getKey().toString(),
+                            Mappable.toStringCollection(entry.getValue().stream().sorted().toList(), factory)));
             map.put(BootstrapConstants.MAPPABLE_EXCLUDED_RESOURCES, mappedExcludedResources);
         }
         if (!getExtensionDevModeConfig().isEmpty()) {

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/app/ApplicationModelSerializerTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/app/ApplicationModelSerializerTest.java
@@ -5,9 +5,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
@@ -18,6 +21,7 @@ import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.model.ApplicationModelBuilder;
 import io.quarkus.bootstrap.model.ExtensionDevModeConfig;
 import io.quarkus.bootstrap.model.JvmOption;
+import io.quarkus.bootstrap.model.MappableCollectionFactory;
 import io.quarkus.bootstrap.model.PlatformImports;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.Dependency;
@@ -169,6 +173,105 @@ class ApplicationModelSerializerTest {
                                 assertThat(directDep.getScope()).isEqualTo("test");
                             });
                 });
+    }
+
+    @Test
+    void testReloadableWorkspaceModulesSerializedInDeterministicOrder() throws IOException {
+        // Add the reloadable workspace modules in a deliberately non-sorted order
+        ApplicationModel model = createBasicApplicationModelBuilder()
+                .addReloadableWorkspaceModule(ArtifactKey.of("org.example", "z-module"))
+                .addReloadableWorkspaceModule(ArtifactKey.of("org.example", "a-module"))
+                .addReloadableWorkspaceModule(ArtifactKey.of("org.example", "m-module"))
+                .addReloadableWorkspaceModule(ArtifactKey.of("org.example", "1-module"))
+                .build();
+
+        Path serializedFile = tempDir.resolve("app-model-local-projects.json");
+        ApplicationModelSerializer.serialize(model, serializedFile);
+
+        // local-projects must be serialized in natural (sorted) order regardless of insertion
+        // order so the output is byte-stable across JVMs and doesn't bust the Gradle build cache
+        String json = Files.readString(serializedFile);
+        assertThat(json.indexOf("1-module")).isLessThan(json.indexOf("a-module"));
+        assertThat(json.indexOf("a-module")).isLessThan(json.indexOf("m-module"));
+        assertThat(json.indexOf("m-module")).isLessThan(json.indexOf("z-module"));
+    }
+
+    @Test
+    void testRemovedResourcesSerializedInDeterministicOrder() throws IOException {
+        // Populate removed resources through the extension-descriptor path, which stores each
+        // artifact's resources as a per-JVM-salted Set.of(value.split(",")) -- the actual source of
+        // nondeterminism the value sort defends against (see ApplicationModelBuilder#addRemovedResources).
+        ApplicationModelBuilder builder = createBasicApplicationModelBuilder();
+        Properties props = new Properties();
+        props.setProperty(ApplicationModelBuilder.REMOVED_RESOURCES_DOT + "org.example:lib-a",
+                "c-one.txt,a-one.txt,b-one.txt");
+        props.setProperty(ApplicationModelBuilder.REMOVED_RESOURCES_DOT + "org.example:lib-b",
+                "z-two.txt,x-two.txt,y-two.txt");
+        builder.handleExtensionProperties(props, ArtifactKey.ga("io.quarkus", "some-extension"));
+        ApplicationModel model = builder.build();
+
+        Path serializedFile = tempDir.resolve("app-model-removed-resources.json");
+        ApplicationModelSerializer.serialize(model, serializedFile);
+
+        // The resources of each artifact must be serialized in natural (sorted) order regardless of the
+        // salted Set.of iteration order, so the output is byte-stable across JVMs and does not bust the
+        // Gradle build cache. (The map keys serialize in HashMap order, which is already JVM-stable.)
+        String json = Files.readString(serializedFile);
+        assertThat(json.indexOf("a-one.txt")).isLessThan(json.indexOf("b-one.txt"));
+        assertThat(json.indexOf("b-one.txt")).isLessThan(json.indexOf("c-one.txt"));
+        assertThat(json.indexOf("x-two.txt")).isLessThan(json.indexOf("y-two.txt"));
+        assertThat(json.indexOf("y-two.txt")).isLessThan(json.indexOf("z-two.txt"));
+    }
+
+    @Test
+    void testRemovedResourceKeysMappedInSortedOrder() {
+        // Add removed resources for several artifacts in a deliberately non-sorted key order
+        List<ArtifactKey> keys = List.of(
+                ArtifactKey.of("org.example", "lib-c"),
+                ArtifactKey.of("org.example", "lib-a"),
+                ArtifactKey.of("org.example", "lib-d"),
+                ArtifactKey.of("org.example", "lib-b"));
+        ApplicationModelBuilder builder = createBasicApplicationModelBuilder();
+        keys.forEach(key -> builder.addRemovedResources(key, List.of("r.txt")));
+        ApplicationModel model = builder.build();
+
+        // The production JSON writer is HashMap-backed, so the serialized excluded-resources keys come
+        // out in (JVM-stable) hash order, which we cannot assert as sorted. But asMap() is factory-
+        // parameterized: mapping with an insertion-order-preserving factory exposes the order in which
+        // asMap() emits the keys. That insertion order is what Map.Entry.comparingByKey() pins, and what
+        // keeps the serialized output stable across JVMs (getRemovedResources() is a salted Map.copyOf).
+        MappableCollectionFactory orderedFactory = new MappableCollectionFactory() {
+            @Override
+            public Map<String, Object> newMap() {
+                return new LinkedHashMap<>();
+            }
+
+            @Override
+            public Map<String, Object> newMap(int initialCapacity) {
+                return new LinkedHashMap<>(initialCapacity);
+            }
+
+            @Override
+            public Collection<Object> newCollection() {
+                return new ArrayList<>();
+            }
+
+            @Override
+            public Collection<Object> newCollection(int initialCapacity) {
+                return new ArrayList<>(initialCapacity);
+            }
+        };
+
+        Map<String, Object> mapped = model.asMap(orderedFactory);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> excludedResources = (Map<String, Object>) mapped
+                .get(BootstrapConstants.MAPPABLE_EXCLUDED_RESOURCES);
+
+        // asMap() must emit the keys in ArtifactKey natural order (what Map.Entry.comparingByKey uses),
+        // rendered with the serializer's own toString -- compare against the keys' sorted order rather
+        // than hardcoding the GACT string format.
+        List<String> expectedKeyOrder = keys.stream().sorted().map(ArtifactKey::toString).toList();
+        assertThat(excludedResources.keySet()).containsExactlyElementsOf(expectedKeyOrder);
     }
 
     @Test


### PR DESCRIPTION
The Gradle plugin serializes the resolved application model to `build/quarkus/application-model/*.dat`, which is an input to several cacheable tasks (`quarkusGenerateCode`, `quarkusGenerateCodeTests`, `quarkusAppPartsBuild`, `quarkusBuild`, and the `Test` tasks). `local-projects` is serialized from a `Set.copyOf(...)` and the `excluded-resources` values from `Set.of(...)`; the iteration order of those JDK immutable collections is randomized once per JVM, so the `.dat` bytes differ across fresh Gradle JVMs even when the model is unchanged, and the affected tasks miss the build cache.

This sorts those set-valued fields when building the serialized map, and pins the insertion order of the `excluded-resources` map keys so their (HashMap-backed) serialization stays stable across JVMs even under hash collisions. Only the in-memory serialization order changes; deserialization is order-independent.

Fixes #55619
