### PR TITLE
List alias and unalias commands in help output

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleProcessor.java
@@ -230,6 +230,8 @@ public class ConsoleProcessor {
                 commandInvocation.getShell().writeln(
                         c.getParser().getProcessedCommand().name() + "\t" + c.getParser().getProcessedCommand().description());
             }
+            commandInvocation.getShell().writeln("alias\tDefine or list user-defined aliases");
+            commandInvocation.getShell().writeln("unalias\tRemove a user-defined alias");
 
             return CommandResult.SUCCESS;
         }


### PR DESCRIPTION
The alias and unalias commands are registered directly by Aesh at the
library level, bypassing Quarkus' ConsoleCliManager. As a result they
were invisible to users typing 'help' in terminal mode.

Add them manually to the HelpCommand output so users can discover them.

Partially addresses #33528