### PR TITLE
Add tests for @Transactional on Quarkus Data repository methods

### DIFF
--- a/extensions/data/hibernate/deployment/src/test/java/io/quarkus/data/hibernate/deployment/test/transactional/TransactionalRepositoryTest.java
+++ b/extensions/data/hibernate/deployment/src/test/java/io/quarkus/data/hibernate/deployment/test/transactional/TransactionalRepositoryTest.java
@@ -1,0 +1,68 @@
+package io.quarkus.data.hibernate.deployment.test.transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.lang.reflect.Method;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.transaction.Transactional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusExtensionTest;
+
+@ActivateRequestContext
+class TransactionalRepositoryTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("application-test.properties", "application.properties")
+                    .addPackage(TransactionalTestEntity.class.getPackage()));
+
+    @Test
+    void testTransactionalCopiedToAnnotatedRepoImpl() throws Exception {
+        assertTransactionalOnFindMethod(TransactionalTestEntity_.AnnotatedRepo_.class);
+    }
+
+    @Test
+    void testTransactionalCopiedToUnannotatedRepoImpl() throws Exception {
+        assertTransactionalOnFindMethod(TransactionalTestEntity_.UnannotatedRepo_.class);
+    }
+
+    @Test
+    void testTransactionalCopiedToManagedRepoImpl() throws Exception {
+        assertTransactionalOnFindMethod(TransactionalTestEntity_.ManagedRepo_.class);
+    }
+
+    @Test
+    void testAnnotatedRepoDefaultMethodTransaction() {
+        assertThatNoException().isThrownBy(
+                () -> Arc.container().select(TransactionalTestEntity.AnnotatedRepo.class).get()
+                        .checkTransactionActive());
+    }
+
+    @Test
+    void testUnannotatedRepoDefaultMethodTransaction() {
+        assertThatNoException().isThrownBy(
+                () -> Arc.container().select(TransactionalTestEntity.UnannotatedRepo.class).get()
+                        .checkTransactionActive());
+    }
+
+    @Test
+    void testManagedRepoDefaultMethodTransaction() {
+        assertThatNoException().isThrownBy(
+                () -> Arc.container().select(TransactionalTestEntity.ManagedRepo.class).get()
+                        .checkTransactionActive());
+    }
+
+    private void assertTransactionalOnFindMethod(Class<?> implClass) throws Exception {
+        Method method = implClass.getMethod("findByName", String.class);
+        assertThat(method.isAnnotationPresent(Transactional.class))
+                .as("@Transactional should be present on %s.findByName", implClass.getSimpleName())
+                .isTrue();
+    }
+}

--- a/extensions/data/hibernate/deployment/src/test/java/io/quarkus/data/hibernate/deployment/test/transactional/TransactionalTestEntity.java
+++ b/extensions/data/hibernate/deployment/src/test/java/io/quarkus/data/hibernate/deployment/test/transactional/TransactionalTestEntity.java
@@ -1,0 +1,67 @@
+package io.quarkus.data.hibernate.deployment.test.transactional;
+
+import java.util.List;
+
+import jakarta.data.repository.Find;
+import jakarta.data.repository.Repository;
+import jakarta.persistence.Entity;
+import jakarta.transaction.Status;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.Transactional;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.data.hibernate.ManagedEntity;
+import io.quarkus.data.hibernate.ManagedRepository;
+
+@Entity
+public class TransactionalTestEntity extends ManagedEntity {
+
+    public String name;
+
+    @Repository
+    public interface AnnotatedRepo {
+        @Transactional
+        @Find
+        List<TransactionalTestEntity> findByName(String name);
+
+        @Transactional
+        default void checkTransactionActive() {
+            TransactionalTestEntity.assertTransactionActive();
+        }
+    }
+
+    public interface UnannotatedRepo {
+        @Transactional
+        @Find
+        List<TransactionalTestEntity> findByName(String name);
+
+        @Transactional
+        default void checkTransactionActive() {
+            TransactionalTestEntity.assertTransactionActive();
+        }
+    }
+
+    public interface ManagedRepo extends ManagedRepository<TransactionalTestEntity> {
+        @Transactional
+        @Find
+        List<TransactionalTestEntity> findByName(String name);
+
+        @Transactional
+        default void checkTransactionActive() {
+            TransactionalTestEntity.assertTransactionActive();
+        }
+    }
+
+    static void assertTransactionActive() {
+        try {
+            TransactionManager tm = Arc.container().select(TransactionManager.class).get();
+            jakarta.transaction.Transaction tx = tm.getTransaction();
+            if (tx == null || tx.getStatus() != Status.STATUS_ACTIVE) {
+                throw new IllegalStateException("No active transaction");
+            }
+        } catch (SystemException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Test that `@Transactional` is properly inherited by generated repository implementations for three repository variants:
- `@Repository`-annotated interface (no superclass)
- Unannotated interface (no superclass)
- Unannotated interface extending ManagedRepository

Each variant has an abstract `@Find` method (verified via reflection on the generated impl class) and a default method (invoked at runtime to confirm an active transaction exists).

Fixes #53622

