### PR TITLE
Optional access to application host ports from Keycloak Container

### DIFF
--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfig.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfig.java
@@ -229,4 +229,13 @@ public interface KeycloakDevServicesConfig {
     @WithDefault("false")
     boolean disableHttps();
 
+    /**
+     * The host ports to expose to the Keycloak container.
+     *
+     * When this list is non-empty, the host is made accessible from the container
+     * using the {@code host.testcontainers.internal} hostname, and only the listed ports are exposed.
+     * This may be necessary when Keycloak needs to make HTTP callbacks to the application running on the host.
+     */
+    Optional<List<Integer>> hostAccessiblePorts();
+
 }

--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -43,6 +43,7 @@ import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.RolesRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.util.JsonSerialization;
+import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -525,6 +526,12 @@ public class KeycloakDevServicesProcessor {
                 }
             } else {
                 addExposedPort(KEYCLOAK_PORT);
+            }
+
+            if (config.hostAccessiblePorts().isPresent()) {
+                for (int port : config.hostAccessiblePorts().get()) {
+                    Testcontainers.exposeHostPorts(port);
+                }
             }
 
             if (sharedContainer && LaunchMode.current() == LaunchMode.DEVELOPMENT) {


### PR DESCRIPTION
We already have 3 cases for Keycloak to callback from the container to the application host port:

* Spiffe devservice relies on a custom test factory to do provide JWKS to Keycloak
* OIDC client attestation PR (draft)
* OAuth Client ID Metadata Doc (PR to be opened soon)