### PR TITLE
Add quarkus.devservices.license-acceptance config property

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/DevServicesConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/DevServicesConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.deployment.dev.devservices;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
 
@@ -32,6 +33,18 @@ public interface DevServicesConfig {
      * The timeout for starting a container
      */
     Optional<Duration> timeout();
+
+    /**
+     * Container images for which license acceptance will be handled automatically.
+     * <p>
+     * Certain container images (e.g. MS SQL Server, IBM DB2) require explicit license acceptance
+     * before they can be started. Setting this property generates a
+     * {@code container-license-acceptance.txt} classpath resource containing the given image names,
+     * which Testcontainers uses to verify license acceptance.
+     * <p>
+     * Example: {@code quarkus.devservices.license-acceptance=mcr.microsoft.com/mssql/server:2022-latest}
+     */
+    Optional<List<String>> licenseAcceptance();
 
     class Enabled implements BooleanSupplier {
 

--- a/docs/src/main/asciidoc/databases-dev-services.adoc
+++ b/docs/src/main/asciidoc/databases-dev-services.adoc
@@ -49,27 +49,19 @@ If your environment does not support Docker, you will need to start the server m
 === Proprietary Databases - License Acceptance
 
 If you are using a proprietary database such as DB2 or MSSQL you will need to accept the license agreement.
-To do this create a `src/main/resources/container-license-acceptance.txt` files in your project and add a line with the image name and tag of the database.
-By default, Quarkus uses the default image for the current version of Testcontainers, if you attempt to start Quarkus the resulting failure will tell you the exact image name in use for you to add to the file.
+To do this, add the `quarkus.devservices.license-acceptance` property to your `application.properties` with the image name and tag of the database.
+If you attempt to start Quarkus without accepting the license, the error message will tell you the exact image name to use.
 
-An example file is shown below:
-
-.src/main/resources/container-license-acceptance.txt
-[source,subs=attributes+]
-----
-{db2-image}
-{mssql-image}
-----
-
-Alternatively, add these entries to your `application.properties`:
-
-[source,properties]
+[source,properties,subs=attributes+]
 ----
 # For mssql
-quarkus.datasource.devservices.container-env.ACCEPT_EULA=Y
+quarkus.devservices.license-acceptance={mssql-image}
 
 # For db2
-quarkus.datasource.devservices.container-env.LICENSE=accept
+quarkus.devservices.license-acceptance={db2-image}
+
+# For both
+quarkus.devservices.license-acceptance={mssql-image},{db2-image}
 ----
 
 === Capturing Logs

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -122,6 +122,13 @@ public class DB2DevServicesProcessor {
 
                 container.withEnv(containerConfig.getContainerEnv());
 
+                String effectiveImageName = containerConfig.getImageName()
+                        .orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("db2"));
+                if (devServicesConfig.licenseAcceptance()
+                        .map(images -> images.contains(effectiveImageName)).orElse(false)) {
+                    container.addEnv("LICENSE", "accept");
+                }
+
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);
                 containerConfig.getInitScriptPath().ifPresent(container::withInitScripts);
@@ -165,7 +172,19 @@ public class DB2DevServicesProcessor {
 
         @Override
         protected void configure() {
-            super.configure();
+            try {
+                super.configure();
+            } catch (IllegalStateException e) {
+                if (e.getMessage() != null && e.getMessage().contains("license agreement")) {
+                    throw new IllegalStateException(
+                            "The container image " + getDockerImageName()
+                                    + " requires you to accept a license agreement."
+                                    + " To accept, add the following to your Quarkus configuration:"
+                                    + " quarkus.devservices.license-acceptance=" + getDockerImageName(),
+                            e);
+                }
+                throw e;
+            }
 
             if (useSharedNetwork) {
                 return;

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
@@ -21,6 +21,7 @@ import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
@@ -42,7 +43,8 @@ public class MSSQLDevServicesProcessor {
     @BuildStep
     DevServicesDatasourceProviderBuildItem setupMSSQL(
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
-            DevServicesComposeProjectBuildItem composeProjectBuildItem) {
+            DevServicesComposeProjectBuildItem composeProjectBuildItem,
+            DevServicesConfig devServicesConfig) {
 
         return new DevServicesDatasourceProviderBuildItem(DatabaseKind.MSSQL, new DevServicesDatasourceProvider() {
             @Override
@@ -77,6 +79,13 @@ public class MSSQLDevServicesProcessor {
                 Volumes.addVolumes(container, containerConfig.getVolumes());
 
                 container.withEnv(containerConfig.getContainerEnv());
+
+                String effectiveImageName = containerConfig.getImageName()
+                        .orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("mssql"));
+                if (devServicesConfig.licenseAcceptance()
+                        .map(images -> images.contains(effectiveImageName)).orElse(false)) {
+                    container.addEnv("ACCEPT_EULA", "Y");
+                }
 
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);
@@ -120,7 +129,19 @@ public class MSSQLDevServicesProcessor {
 
         @Override
         protected void configure() {
-            super.configure();
+            try {
+                super.configure();
+            } catch (IllegalStateException e) {
+                if (e.getMessage() != null && e.getMessage().contains("license agreement")) {
+                    throw new IllegalStateException(
+                            "The container image " + getDockerImageName()
+                                    + " requires you to accept a license agreement."
+                                    + " To accept, add the following to your Quarkus configuration:"
+                                    + " quarkus.devservices.license-acceptance=" + getDockerImageName(),
+                            e);
+                }
+                throw e;
+            }
 
             if (useSharedNetwork) {
                 return;

--- a/extensions/jdbc/jdbc-db2/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-db2/deployment/pom.xml
@@ -94,6 +94,7 @@
                     </excludes>
                     <systemPropertyVariables combine.children="append">
                         <db2.default.version>${db2.default.version}</db2.default.version>
+                        <quarkus.devservices.license-acceptance>${db2.image}</quarkus.devservices.license-acceptance>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/extensions/jdbc/jdbc-db2/deployment/src/test/resources/application.properties
+++ b/extensions/jdbc/jdbc-db2/deployment/src/test/resources/application.properties
@@ -1,1 +1,0 @@
-quarkus.datasource.devservices.container-env.LICENSE=accept

--- a/extensions/jdbc/jdbc-mssql/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-mssql/deployment/pom.xml
@@ -94,6 +94,7 @@
                     </excludes>
                     <systemPropertyVariables combine.children="append">
                         <mssql.default.version>${mssql.default.version}</mssql.default.version>
+                        <quarkus.devservices.license-acceptance>${mssql.image}</quarkus.devservices.license-acceptance>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/extensions/jdbc/jdbc-mssql/deployment/src/test/java/io/quarkus/jdbc/mssql/deployment/DevServicesMsSQLLicenseErrorTestCase.java
+++ b/extensions/jdbc/jdbc-mssql/deployment/src/test/java/io/quarkus/jdbc/mssql/deployment/DevServicesMsSQLLicenseErrorTestCase.java
@@ -1,0 +1,34 @@
+package io.quarkus.jdbc.mssql.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class DevServicesMsSQLLicenseErrorTestCase {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withConfigurationResource("application-no-license.properties")
+            .assertException(t -> {
+                Throwable current = t;
+                boolean found = false;
+                while (current != null) {
+                    if (current.getMessage() != null
+                            && current.getMessage().contains("quarkus.devservices.license-acceptance")) {
+                        found = true;
+                        break;
+                    }
+                    current = current.getCause();
+                }
+                assertThat(found)
+                        .as("Expected exception mentioning quarkus.devservices.license-acceptance, but got: %s", t)
+                        .isTrue();
+            });
+
+    @Test
+    public void testErrorMessage() {
+    }
+}

--- a/extensions/jdbc/jdbc-mssql/deployment/src/test/resources/application-no-license.properties
+++ b/extensions/jdbc/jdbc-mssql/deployment/src/test/resources/application-no-license.properties
@@ -1,0 +1,2 @@
+config_ordinal=500
+quarkus.devservices.license-acceptance=nonexistent-image:for-error-test

--- a/extensions/jdbc/jdbc-mssql/deployment/src/test/resources/application.properties
+++ b/extensions/jdbc/jdbc-mssql/deployment/src/test/resources/application.properties
@@ -1,1 +1,0 @@
-quarkus.datasource.devservices.container-env.ACCEPT_EULA=Y

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/Db2DbTokenStateManagerTest.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/Db2DbTokenStateManagerTest.java
@@ -1,6 +1,5 @@
 package io.quarkus.oidc.db.token.state.manager;
 
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -14,7 +13,7 @@ import io.quarkus.test.QuarkusExtensionTest;
 public class Db2DbTokenStateManagerTest extends AbstractDbTokenStateManagerTest {
 
     @RegisterExtension
-    static final QuarkusExtensionTest test = createQuarkusExtensionTest("quarkus-reactive-db2-client",
-            jar -> jar.addAsResource(new StringAsset(System.getProperty("db2.image")), "container-license-acceptance.txt"));
+    static final QuarkusExtensionTest test = createQuarkusExtensionTest("quarkus-reactive-db2-client")
+            .overrideConfigKey("quarkus.devservices.license-acceptance", System.getProperty("db2.image"));
 
 }

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/MsSqlDbTokenStateManagerTest.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/MsSqlDbTokenStateManagerTest.java
@@ -1,6 +1,5 @@
 package io.quarkus.oidc.db.token.state.manager;
 
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -11,7 +10,7 @@ import io.quarkus.test.QuarkusExtensionTest;
 public class MsSqlDbTokenStateManagerTest extends AbstractDbTokenStateManagerTest {
 
     @RegisterExtension
-    static final QuarkusExtensionTest test = createQuarkusExtensionTest("quarkus-reactive-mssql-client",
-            jar -> jar.addAsResource(new StringAsset(System.getProperty("mssql.image")), "container-license-acceptance.txt"));
+    static final QuarkusExtensionTest test = createQuarkusExtensionTest("quarkus-reactive-mssql-client")
+            .overrideConfigKey("quarkus.devservices.license-acceptance", System.getProperty("mssql.image"));
 
 }

--- a/extensions/reactive-mssql-client/deployment/pom.xml
+++ b/extensions/reactive-mssql-client/deployment/pom.xml
@@ -146,6 +146,7 @@
                     <skip>true</skip>
                     <systemPropertyVariables combine.children="append">
                         <mssql.default.version>${mssql.default.version}</mssql.default.version>
+                        <quarkus.devservices.license-acceptance>${mssql.image}</quarkus.devservices.license-acceptance>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/extensions/reactive-mssql-client/deployment/src/test/resources/application-changing-credentials.properties
+++ b/extensions/reactive-mssql-client/deployment/src/test/resources/application-changing-credentials.properties
@@ -4,4 +4,3 @@ quarkus.datasource.reactive.url=${reactive-mssql.url}
 quarkus.datasource.reactive.max-size=1
 quarkus.datasource.reactive.idle-timeout=PT1S
 quarkus.datasource.reactive.max-lifetime=PT2s
-quarkus.datasource.devservices.container-env.ACCEPT_EULA=Y

--- a/extensions/reactive-mssql-client/deployment/src/test/resources/application-credentials-with-erroneous-url.properties
+++ b/extensions/reactive-mssql-client/deployment/src/test/resources/application-credentials-with-erroneous-url.properties
@@ -1,4 +1,3 @@
 quarkus.datasource.db-kind=mssql
 quarkus.datasource.credentials-provider=custom
 quarkus.datasource.reactive.url=vertx-reactive:sqlserver://test:12345
-quarkus.datasource.devservices.container-env.ACCEPT_EULA=Y

--- a/extensions/reactive-mssql-client/deployment/src/test/resources/application-credentials.properties
+++ b/extensions/reactive-mssql-client/deployment/src/test/resources/application-credentials.properties
@@ -1,4 +1,3 @@
 quarkus.datasource.db-kind=mssql
 quarkus.datasource.credentials-provider=custom
 quarkus.datasource.reactive.url=${reactive-mssql.url}
-quarkus.datasource.devservices.container-env.ACCEPT_EULA=Y

--- a/extensions/reactive-mssql-client/deployment/src/test/resources/application-datasources-with-health.properties
+++ b/extensions/reactive-mssql-client/deployment/src/test/resources/application-datasources-with-health.properties
@@ -2,12 +2,10 @@ quarkus.datasource.db-kind=mssql
 quarkus.datasource.username=sa
 quarkus.datasource.password=yourStrong(!)Password
 quarkus.datasource.reactive.url=${reactive-mssql.url}
-quarkus.datasource.devservices.container-env.ACCEPT_EULA=Y
 # this data source is broken, but will be excluded from the health check, so the overall check should pass
 quarkus.datasource."broken".db-kind=mssql
 quarkus.datasource."broken".username=BROKEN
 quarkus.datasource."broken".password=yourStrong(!)Password
 quarkus.datasource."broken".reactive.url=${reactive-mssql.url}
 quarkus.datasource."broken".health-exclude=true
-quarkus.datasource."broken".devservices.container-env.ACCEPT_EULA=Y
 quarkus.datasource.health.enabled=true

--- a/extensions/reactive-mssql-client/deployment/src/test/resources/application-default-datasource.properties
+++ b/extensions/reactive-mssql-client/deployment/src/test/resources/application-default-datasource.properties
@@ -2,4 +2,3 @@ quarkus.datasource.db-kind=mssql
 quarkus.datasource.username=sa
 quarkus.datasource.password=yourStrong(!)Password
 quarkus.datasource.reactive.url=${reactive-mssql.url}
-quarkus.datasource.devservices.container-env.ACCEPT_EULA=Y

--- a/extensions/reactive-mssql-client/deployment/src/test/resources/application-multiple-datasources-with-erroneous-url.properties
+++ b/extensions/reactive-mssql-client/deployment/src/test/resources/application-multiple-datasources-with-erroneous-url.properties
@@ -2,10 +2,8 @@ quarkus.datasource.db-kind=mssql
 quarkus.datasource.username=sa
 quarkus.datasource.password=yourStrong(!)Password
 quarkus.datasource.reactive.url=vertx-reactive:sqlserver://test:12345
-quarkus.datasource.devservices.container-env.ACCEPT_EULA=Y
 
 quarkus.datasource."hibernate".db-kind=mssql
 quarkus.datasource."hibernate".username=sa
 quarkus.datasource."hibernate".password=yourStrong(!)Password
 quarkus.datasource."hibernate".reactive.url=vertx-reactive:sqlserver://test:55555
-quarkus.datasource."hibernate".devservices.container-env.ACCEPT_EULA=Y

--- a/extensions/reactive-mssql-client/deployment/src/test/resources/application-multiple-datasources.properties
+++ b/extensions/reactive-mssql-client/deployment/src/test/resources/application-multiple-datasources.properties
@@ -2,10 +2,8 @@ quarkus.datasource.db-kind=mssql
 quarkus.datasource.username=sa
 quarkus.datasource.password=yourStrong(!)Password
 quarkus.datasource.reactive.url=${reactive-mssql.url}
-quarkus.datasource.devservices.container-env.ACCEPT_EULA=Y
 
 quarkus.datasource."hibernate".db-kind=mssql
 quarkus.datasource."hibernate".username=sa
 quarkus.datasource."hibernate".password=yourStrong(!)Password
 quarkus.datasource."hibernate".reactive.url=${reactive-mssql.url}
-quarkus.datasource."hibernate".devservices.container-env.ACCEPT_EULA=Y

--- a/extensions/reactive-mssql-client/deployment/src/test/resources/application.properties
+++ b/extensions/reactive-mssql-client/deployment/src/test/resources/application.properties
@@ -1,1 +1,0 @@
-quarkus.datasource.devservices.container-env.ACCEPT_EULA=Y

--- a/integration-tests/hibernate-reactive-db2/pom.xml
+++ b/integration-tests/hibernate-reactive-db2/pom.xml
@@ -107,6 +107,7 @@
                     <systemPropertyVariables combine.children="append">
                         <db2.default.version>${db2.default.version}</db2.default.version>
                         <org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>true</org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>
+                        <quarkus.devservices.license-acceptance>${db2.image}</quarkus.devservices.license-acceptance>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -117,6 +118,7 @@
                     <systemPropertyVariables combine.children="append">
                         <db2.default.version>${db2.default.version}</db2.default.version>
                         <org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>true</org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>
+                        <quarkus.devservices.license-acceptance>${db2.image}</quarkus.devservices.license-acceptance>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/integration-tests/hibernate-reactive-db2/src/test/resources/application.properties
+++ b/integration-tests/hibernate-reactive-db2/src/test/resources/application.properties
@@ -1,1 +1,0 @@
-quarkus.datasource.devservices.container-env.LICENSE=accept

--- a/integration-tests/hibernate-reactive-mssql/pom.xml
+++ b/integration-tests/hibernate-reactive-mssql/pom.xml
@@ -112,6 +112,7 @@
                     <systemPropertyVariables combine.children="append">
                         <mssql.default.version>${mssql.default.version}</mssql.default.version>
                         <org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>true</org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>
+                        <quarkus.devservices.license-acceptance>${mssql.image}</quarkus.devservices.license-acceptance>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -122,6 +123,7 @@
                     <systemPropertyVariables combine.children="append">
                         <mssql.default.version>${mssql.default.version}</mssql.default.version>
                         <org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>true</org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>
+                        <quarkus.devservices.license-acceptance>${mssql.image}</quarkus.devservices.license-acceptance>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/integration-tests/hibernate-reactive-mssql/src/test/resources/application.properties
+++ b/integration-tests/hibernate-reactive-mssql/src/test/resources/application.properties
@@ -1,1 +1,0 @@
-quarkus.datasource.devservices.container-env.ACCEPT_EULA=Y

--- a/integration-tests/jpa-db2/pom.xml
+++ b/integration-tests/jpa-db2/pom.xml
@@ -110,6 +110,7 @@
                     <skip>true</skip>
                     <systemPropertyVariables combine.children="append">
                         <db2.default.version>${db2.default.version}</db2.default.version>
+                        <quarkus.devservices.license-acceptance>${db2.image}</quarkus.devservices.license-acceptance>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -119,6 +120,7 @@
                     <skip>true</skip>
                     <systemPropertyVariables combine.children="append">
                         <db2.default.version>${db2.default.version}</db2.default.version>
+                        <quarkus.devservices.license-acceptance>${db2.image}</quarkus.devservices.license-acceptance>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/integration-tests/jpa-db2/src/test/resources/application.properties
+++ b/integration-tests/jpa-db2/src/test/resources/application.properties
@@ -1,1 +1,0 @@
-quarkus.datasource.devservices.container-env.LICENSE=accept

--- a/integration-tests/jpa-mssql/pom.xml
+++ b/integration-tests/jpa-mssql/pom.xml
@@ -114,6 +114,7 @@
                     <skip>true</skip>
                     <systemPropertyVariables combine.children="append">
                         <mssql.default.version>${mssql.default.version}</mssql.default.version>
+                        <quarkus.devservices.license-acceptance>${mssql.image}</quarkus.devservices.license-acceptance>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -123,6 +124,7 @@
                     <skip>true</skip>
                     <systemPropertyVariables combine.children="append">
                         <mssql.default.version>${mssql.default.version}</mssql.default.version>
+                        <quarkus.devservices.license-acceptance>${mssql.image}</quarkus.devservices.license-acceptance>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/integration-tests/jpa-mssql/src/test/resources/application.properties
+++ b/integration-tests/jpa-mssql/src/test/resources/application.properties
@@ -1,1 +1,0 @@
-quarkus.datasource.devservices.container-env.ACCEPT_EULA=Y

--- a/integration-tests/reactive-db2-client/pom.xml
+++ b/integration-tests/reactive-db2-client/pom.xml
@@ -99,12 +99,18 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                    <systemPropertyVariables>
+                        <quarkus.devservices.license-acceptance>${db2.image}</quarkus.devservices.license-acceptance>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                    <systemPropertyVariables>
+                        <quarkus.devservices.license-acceptance>${db2.image}</quarkus.devservices.license-acceptance>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/integration-tests/reactive-db2-client/src/main/resources/application.properties
+++ b/integration-tests/reactive-db2-client/src/main/resources/application.properties
@@ -1,4 +1,2 @@
 quarkus.datasource.db-kind=db2
-quarkus.datasource.devservices.container-env.LICENSE=accept
 quarkus.datasource."additional".db-kind=db2
-quarkus.datasource."additional".devservices.container-env.LICENSE=accept

--- a/integration-tests/reactive-db2-client/src/test/resources/application.properties
+++ b/integration-tests/reactive-db2-client/src/test/resources/application.properties
@@ -1,1 +1,0 @@
-quarkus.datasource.devservices.container-env.LICENSE=accept

--- a/integration-tests/reactive-mssql-client/pom.xml
+++ b/integration-tests/reactive-mssql-client/pom.xml
@@ -99,12 +99,18 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                    <systemPropertyVariables>
+                        <quarkus.devservices.license-acceptance>${mssql.image}</quarkus.devservices.license-acceptance>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                    <systemPropertyVariables>
+                        <quarkus.devservices.license-acceptance>${mssql.image}</quarkus.devservices.license-acceptance>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/integration-tests/reactive-mssql-client/src/main/resources/application.properties
+++ b/integration-tests/reactive-mssql-client/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 quarkus.datasource.db-kind=mssql
-quarkus.datasource.devservices.container-env.ACCEPT_EULA=Y
 #Uncomment to connect over SSL/TLS
 #quarkus.datasource.reactive.trust-all=true
 #quarkus.datasource.reactive.mssql.ssl=true

--- a/integration-tests/reactive-mssql-client/src/test/resources/application-tl.properties
+++ b/integration-tests/reactive-mssql-client/src/test/resources/application-tl.properties
@@ -2,7 +2,6 @@ quarkus.datasource.db-kind=mssql
 quarkus.datasource.username=sa
 quarkus.datasource.password=yourStrong(!)Password
 quarkus.datasource.reactive.url=${reactive-mssql.url}
-quarkus.datasource.devservices.container-env.ACCEPT_EULA=Y
 quarkus.log.category."io.quarkus.reactive.datasource".level=DEBUG
 #Uncomment to connect over SSL/TLS
 #quarkus.datasource.reactive.trust-all=true


### PR DESCRIPTION
## Summary

- Add `quarkus.devservices.license-acceptance` config property for MSSQL/DB2 dev services that require explicit license acceptance
- Set the appropriate license env var (`ACCEPT_EULA`/`LICENSE`) directly on the container when the image matches the configured list
- Improve error messages when license acceptance is missing, pointing users to the new config property
- Migrate all existing tests to use the new property instead of `container-env.ACCEPT_EULA=Y` / `container-env.LICENSE=accept`

Closes #44832

## Test plan

- [x] MSSQL extension tests pass (happy path + error message assertion)
- [ ] DB2 extension tests (DB2 container timed out locally — unrelated flaky infra issue)
- [ ] CI green on all affected modules