### PR TITLE
Update buildpack lib to 0.0.17

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -211,7 +211,7 @@
         <strimzi-oauth.version>0.16.1</strimzi-oauth.version>
         <strimzi-oauth.nimbus.version>10.9.1</strimzi-oauth.nimbus.version>
         <jose4j.version>0.9.6</jose4j.version>
-        <java-buildpack-client.version>0.0.14</java-buildpack-client.version>
+        <java-buildpack-client.version>0.0.17</java-buildpack-client.version>
         <crac.version>1.5.0</crac.version>
         <sshd-common.version>2.19.0</sshd-common.version>
         <mime4j.version>0.8.12</mime4j.version>

--- a/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackConfig.java
+++ b/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackConfig.java
@@ -16,7 +16,7 @@ public interface BuildpackConfig {
     /**
      * The buildpacks builder image to use when building the project in jvm mode.
      */
-    @WithDefault("paketocommunity/builder-ubi-base:latest")
+    @WithDefault("docker.io/paketobuildpacks/ubi-9-builder")
     String jvmBuilderImage();
 
     /**

--- a/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackProcessor.java
+++ b/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackProcessor.java
@@ -294,7 +294,7 @@ public class BuildpackProcessor {
                         //configure dockerhost/socket if required
                         DockerConfigNested<BuildConfigBuilder> dc = b.editDockerConfig();
                         dc.withHostAndSocketConfig(new HostAndSocketConfig(buildpackConfig.dockerHost().orElse(null),
-                            buildpackConfig.dockerSocket().orElse(null)));
+                                buildpackConfig.dockerSocket().orElse(null)));
                         dc.endDockerConfig();
 
                         //configure lifecycle override image if present

--- a/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackProcessor.java
+++ b/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackProcessor.java
@@ -24,11 +24,11 @@ import com.github.dockerjava.api.model.PushResponseItem;
 import dev.snowdrop.buildpack.BuildConfig;
 import dev.snowdrop.buildpack.BuildConfigBuilder;
 import dev.snowdrop.buildpack.BuildConfigFluent.DockerConfigNested;
+import dev.snowdrop.buildpack.config.HostAndSocketConfig;
 import dev.snowdrop.buildpack.config.ImageReference;
 import dev.snowdrop.buildpack.config.RegistryAuthConfig;
 import dev.snowdrop.buildpack.config.RegistryAuthConfigBuilder;
 import dev.snowdrop.buildpack.docker.DockerClientUtils;
-import dev.snowdrop.buildpack.docker.DockerClientUtils.HostAndSocket;
 import io.quarkus.container.image.deployment.ContainerImageConfig;
 import io.quarkus.container.image.deployment.util.NativeBinaryUtil;
 import io.quarkus.container.spi.AvailableContainerImageExtensionBuildItem;
@@ -325,8 +325,9 @@ public class BuildpackProcessor {
             log.info("Pushing image to registry");
             Stream.concat(Stream.of(containerImage.getImage()), containerImage.getAdditionalImageTags().stream()).forEach(i -> {
 
-                HostAndSocket hns = DockerClientUtils.probeContainerRuntime(
-                        new HostAndSocket(buildpackConfig.dockerHost().orElse(""), buildpackConfig.dockerSocket().orElse("")));
+                HostAndSocketConfig hns = DockerClientUtils.probeContainerRuntime(
+                        new HostAndSocketConfig(buildpackConfig.dockerHost().orElse(null),
+                                buildpackConfig.dockerSocket().orElse(null)));
                 DockerClient dockerClient = DockerClientUtils.getDockerClient(hns, authConfigs);
 
                 ResultCallback.Adapter<PushResponseItem> callback = new ResultCallback.Adapter<>() {

--- a/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackProcessor.java
+++ b/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackProcessor.java
@@ -293,8 +293,8 @@ public class BuildpackProcessor {
 
                         //configure dockerhost/socket if required
                         DockerConfigNested<BuildConfigBuilder> dc = b.editDockerConfig();
-                        buildpackConfig.dockerHost().ifPresent(dh -> dc.withDockerHost(dh));
-                        buildpackConfig.dockerSocket().ifPresent(ds -> dc.withDockerSocket(ds));
+                        dc.withHostAndSocketConfig(new HostAndSocketConfig(buildpackConfig.dockerHost().orElse(null),
+                                buildpackConfig.dockerSocket().orElse(null)));
                         dc.endDockerConfig();
 
                         //configure lifecycle override image if present

--- a/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackProcessor.java
+++ b/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackProcessor.java
@@ -293,8 +293,8 @@ public class BuildpackProcessor {
 
                         //configure dockerhost/socket if required
                         DockerConfigNested<BuildConfigBuilder> dc = b.editDockerConfig();
-                        buildpackConfig.dockerHost().ifPresent(dh -> dc.withDockerHost(dh));
-                        buildpackConfig.dockerSocket().ifPresent(ds -> dc.withDockerSocket(ds));
+                        dc.withHostAndSocketConfig(new HostAndSocketConfig(buildpackConfig.dockerHost().orElse(null),
+                            buildpackConfig.dockerSocket().orElse(null)));
                         dc.endDockerConfig();
 
                         //configure lifecycle override image if present


### PR DESCRIPTION
Updates buildpack platform impl to 0.0.17 to address Quarkus Buildpack Build issue reported with Windows. 

Adds support for later buildpack platform revisions, and updates Quarkus to use the Paketo UBI9 builder by default.

- Fixes: https://github.com/quarkusio/quarkus/issues/55360

