### PR TITLE
Fire SSE close listeners once when closing the broadcaster

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/sse/SseBroadcasterCloseResource.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/sse/SseBroadcasterCloseResource.java
@@ -1,0 +1,53 @@
+package io.quarkus.resteasy.reactive.server.test.sse;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.sse.Sse;
+import jakarta.ws.rs.sse.SseBroadcaster;
+import jakarta.ws.rs.sse.SseEventSink;
+
+@Path("sse-broadcaster")
+public class SseBroadcasterCloseResource {
+
+    private static volatile SseBroadcaster broadcaster;
+    private static final AtomicInteger onCloseCount = new AtomicInteger();
+
+    @GET
+    @Path("register")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    public void register(SseEventSink eventSink, Sse sse) {
+        // Register the sink with the shared broadcaster and keep it open; it is closed when the
+        // broadcaster is closed. Send one event so the client knows it is connected.
+        broadcaster(sse).register(eventSink);
+        eventSink.send(sse.newEvent("connected"));
+    }
+
+    @GET
+    @Path("close")
+    public String close() {
+        SseBroadcaster current = broadcaster;
+        if (current != null) {
+            current.close();
+        }
+        return "OK";
+    }
+
+    @GET
+    @Path("close-count")
+    public String closeCount() {
+        return String.valueOf(onCloseCount.get());
+    }
+
+    private static synchronized SseBroadcaster broadcaster(Sse sse) {
+        if (broadcaster == null) {
+            SseBroadcaster created = sse.newBroadcaster();
+            created.onClose(sink -> onCloseCount.incrementAndGet());
+            broadcaster = created;
+        }
+        return broadcaster;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/sse/SseBroadcasterCloseTestCase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/sse/SseBroadcasterCloseTestCase.java
@@ -1,0 +1,54 @@
+package io.quarkus.resteasy.reactive.server.test.sse;
+
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.sse.SseEventSource;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class SseBroadcasterCloseTestCase {
+
+    @TestHTTPResource
+    URI uri;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(SseBroadcasterCloseResource.class));
+
+    @Test
+    public void onCloseFiresExactlyOncePerSinkWhenBroadcasterClosed() throws Exception {
+        Client client = ClientBuilder.newBuilder().build();
+        try {
+            // Open an SSE connection so a sink is registered with the broadcaster.
+            WebTarget registerTarget = client.target(uri.toString() + "sse-broadcaster/register");
+            CountDownLatch connected = new CountDownLatch(1);
+            try (SseEventSource source = SseEventSource.target(registerTarget).build()) {
+                source.register(event -> connected.countDown());
+                source.open();
+                Assertions.assertTrue(connected.await(10, TimeUnit.SECONDS),
+                        "client did not receive the initial SSE event");
+
+                // Close the broadcaster on the server side.
+                client.target(uri.toString() + "sse-broadcaster/close").request().get(String.class);
+
+                // The registered sink's onClose listener must fire exactly once, not twice.
+                Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> Assertions.assertEquals("1",
+                        client.target(uri.toString() + "sse-broadcaster/close-count").request().get(String.class)));
+            }
+        } finally {
+            client.close();
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/SseBroadcasterImpl.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/SseBroadcasterImpl.java
@@ -181,7 +181,9 @@ public class SseBroadcasterImpl implements SseBroadcaster {
         for (Consumer<SseEventSink> listener : closeConsumers) {
             listener.accept(sseEventSink);
         }
-        if (!closed.get())
-            outputQueue.remove(sseEventSink);
+        // Always remove the sink from the queue, even while the broadcaster is closing. Otherwise
+        // the enclosing close() loop's notifyOnCloseListeners() removes it afterwards and fires the
+        // close listeners a second time for the same sink.
+        outputQueue.remove(sseEventSink);
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/jaxrs/SseServerBroadcasterTests.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/jaxrs/SseServerBroadcasterTests.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import jakarta.ws.rs.sse.OutboundSseEvent;
 import jakarta.ws.rs.sse.SseBroadcaster;
@@ -70,6 +71,22 @@ public class SseServerBroadcasterTests {
             // run closeHandler to simulate closing context
             closeHandler.getValue().run();
             Assertions.assertTrue(executed.get());
+        }
+    }
+
+    @Test
+    public void shouldExecuteOnCloseExactlyOnceWhenBroadcasterClosed() {
+        SseBroadcaster broadcaster = SseImpl.INSTANCE.newBroadcaster();
+        AtomicInteger onCloseCount = new AtomicInteger(0);
+        broadcaster.onClose(sink -> onCloseCount.incrementAndGet());
+        SseEventSinkImpl sseEventSink = Mockito.spy(new SseEventSinkImpl(getMockContext()));
+        broadcaster.register(sseEventSink);
+        try (MockedStatic<SseUtil> utilities = Mockito.mockStatic(SseUtil.class)) {
+            utilities.when(() -> SseUtil.send(any(), any(), any())).thenReturn(CompletableFuture.completedFuture(null));
+            broadcaster.close();
+            // Closing the broadcaster must notify each registered sink's close listeners exactly
+            // once, not twice.
+            Assertions.assertEquals(1, onCloseCount.get());
         }
     }
 


### PR DESCRIPTION
### Summary

`SseBroadcasterImpl.close()` can fire the registered `onClose` listeners **twice** for the same
`SseEventSink`. The close path notifies the listeners and then, if the broadcaster had not already
been marked closed, iterates the sinks and closes each one — which notifies the listeners again.

### Fix

Fire the `onClose` listeners exactly once per sink when the broadcaster is closed.

### Test

Added `SseServerBroadcasterTests.shouldExecuteOnCloseExactlyOnceWhenBroadcasterClosed`, which
registers an `onClose` callback backed by an `AtomicInteger` and asserts it runs exactly once
(`== 1`). Without the fix the counter reaches `2`.
