### PR TITLE
Update DB2 image from 12.1.0.0 to 12.1.5.0

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -83,7 +83,7 @@
 
         <!-- Database default versions for `quarkus.datasource.db-version` and images for devservices -->
         <db2.version>12.1</db2.version>
-        <db2.image>icr.io/db2_community/db2:${db2.version}.0.0</db2.image>
+        <db2.image>icr.io/db2_community/db2:${db2.version}.5.0</db2.image>
         <!-- Default build-time version: latest version at least 2 years old -->
         <!-- See https://github.com/quarkusio/quarkus/issues/53277 -->
         <!-- See https://endoflife.date/ibm-db2 -->


### PR DESCRIPTION
The DB2 driver was bumped "recently" to 12.1.5.0, This bumping image to same version. DB2 driver PR https://github.com/quarkusio/quarkus/pull/55121

Probably should be backported to 3.x as the driver was also backported 
