### PR TITLE
Enhancements around build time dependencies in CycloneDX SBOMs

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DependencySbomMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DependencySbomMojo.java
@@ -91,7 +91,7 @@ public class DependencySbomMojo extends AbstractMojo {
     /**
      * Whether to limit application dependencies to only those that are included in the runtime
      */
-    @Parameter(property = "quarkus.dependency.sbom.runtime-only")
+    @Parameter(property = "quarkus.dependency.sbom.runtime-only", defaultValue = "false")
     boolean runtimeOnly;
 
     /**
@@ -121,6 +121,7 @@ public class DependencySbomMojo extends AbstractMojo {
                 .setSchemaVersion(schemaVersion)
                 .setIncludeLicenseText(includeLicenseText)
                 .setPrettyPrint(prettyPrint)
+                .setRuntimeOnly(runtimeOnly)
                 .setIncludeQuarkusComponentScope(includeQuarkusComponentScope)
                 .generate();
         getLog().info("The SBOM has been saved in " + outputFilePath);

--- a/devtools/maven/src/main/java/io/quarkus/maven/DependencySbomMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DependencySbomMojo.java
@@ -94,6 +94,13 @@ public class DependencySbomMojo extends AbstractMojo {
     @Parameter(property = "quarkus.dependency.sbom.runtime-only")
     boolean runtimeOnly;
 
+    /**
+     * Whether to include the {@code quarkus:component:scope} custom property on each component.
+     * The default is {@code false}.
+     */
+    @Parameter(property = "quarkus.dependency.sbom.include-quarkus-component-scope", defaultValue = "false")
+    boolean includeQuarkusComponentScope;
+
     protected MavenArtifactResolver resolver;
 
     @Override
@@ -114,6 +121,7 @@ public class DependencySbomMojo extends AbstractMojo {
                 .setSchemaVersion(schemaVersion)
                 .setIncludeLicenseText(includeLicenseText)
                 .setPrettyPrint(prettyPrint)
+                .setIncludeQuarkusComponentScope(includeQuarkusComponentScope)
                 .generate();
         getLog().info("The SBOM has been saved in " + outputFilePath);
     }

--- a/docs/src/main/asciidoc/cyclonedx.adoc
+++ b/docs/src/main/asciidoc/cyclonedx.adoc
@@ -197,6 +197,17 @@ quarkus.cyclonedx.libraries-only=true
 
 When enabled, components that would be classified as `file` type in CycloneDX (generic PURL components with a file system path or distribution path) are excluded from the generated SBOM along with their dependency relationships.
 
+=== Runtime-only mode
+
+By default, the generated SBOM includes both runtime and development/build-time dependencies. To include only runtime dependencies, use:
+
+[source,properties]
+----
+quarkus.cyclonedx.runtime-only=true
+----
+
+When enabled, development/build-time dependencies (those with CycloneDX `scope` set to `excluded`) are excluded entirely from the generated SBOM along with their dependency relationships. This can be useful when the SBOM is intended for runtime vulnerability scanning and build-time components are not relevant.
+
 === CycloneDX schema version
 
 By default, the SBOM is generated using the latest CycloneDX schema version supported by the integrated library. A specific version can be requested:

--- a/docs/src/main/asciidoc/cyclonedx.adoc
+++ b/docs/src/main/asciidoc/cyclonedx.adoc
@@ -47,7 +47,9 @@ For Quarkus Maven projects, dependency SBOMs can be generated with the `quarkus:
 
 `XML` format can be requested by setting the `format` goal parameter (or `quarkus.dependency.sbom.format` property) to `xml`.
 
-Each component in the generated SBOM will include the `quarkus:component:scope` property indicating whether the component is used at runtime or only at development/build time.
+Development/build-time dependencies will have their CycloneDX `scope` set to `excluded` (see <<build-time-dependencies>>), while runtime dependencies omit the `scope` field (defaulting to `required` per the specification).
+
+Optionally, the `quarkus:component:scope` custom property can be included on each component by setting `includeQuarkusComponentScope` to `true` (or `-Dquarkus.dependency.sbom.include-quarkus-component-scope=true`). When enabled, each component will carry a property indicating whether it is a `runtime` or `development` dependency:
 
 [source,json]
 ----
@@ -87,7 +89,7 @@ cyclonedxBom {
 }
 ----
 
-Given that the plugin is not aware of how Quarkus uses these dependencies, it will not be able to set the `quarkus:component:scope` property for components. On the other hand, the requested configuration name can be used to indicate which scope to target.
+Given that the plugin is not aware of how Quarkus uses these dependencies, it will not be able to set the CycloneDX `scope` field or the `quarkus:component:scope` property for components. On the other hand, the requested configuration name can be used to indicate which scope to target.
 
 [[embedded-dependency-sboms]]
 == Embedded Dependency SBOMs
@@ -245,17 +247,11 @@ SBOMs for Fast JAR packaging type will use the executable JAR file as their main
 
 ==== Runtime Components
 
-Every file in the resulting Fast JAR distribution will appear in the SBOM with the `quarkus:component:scope` property set to `runtime` and `evidence.occurrences.location` field pointing to the location of the component in the application distribution directory, for example:
+Every file in the resulting Fast JAR distribution will appear in the SBOM with an `evidence.occurrences.location` field pointing to the location of the component in the application distribution directory. Runtime components do not set the CycloneDX `scope` field, which defaults to `required` per the specification. For example:
 
 [source,json]
 ----
       "purl" : "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@2.0.0.Final?type=jar",
-      "properties" : [
-        {
-          "name" : "quarkus:component:scope",
-          "value" : "runtime"
-        }
-      ],
       "evidence" : {
         "occurrences" : [
           {
@@ -270,20 +266,18 @@ Every file in the resulting Fast JAR distribution will appear in the SBOM with t
 `evidence.occurrences.location` was introduced in CycloneDX schema version 1.5, for older versions the location will be indicated using the `quarkus:component:location` property.
 ====
 
+[[build-time-dependencies]]
 ==== Build time dependencies
 
-Build time dependencies will be recorded with the `quarkus:component:scope` property set to `development`:
+Build time dependencies will have their CycloneDX `scope` set to `excluded`:
 
 [source,json]
 ----
       "purl" : "pkg:maven/org.apache.httpcomponents/httpclient@4.5.14?type=jar",
-      "properties" : [
-        {
-          "name" : "quarkus:component:scope",
-          "value" : "development"
-        }
-      ]
+      "scope" : "excluded"
 ----
+
+The `excluded` scope indicates that these components are not reachable within a call graph at runtime, as defined by the CycloneDX specification. Runtime components omit the `scope` field, which defaults to `required` per the specification.
 
 They will not include `evidence.occurrences.location` since they will not be found in the distribution.
 
@@ -331,17 +325,12 @@ NOTE: The SBOM is always GZIP-compressed before being embedded as a global symbo
 
 Mutable JAR distribution is similar to the Fast JAR one except it also includes build time dependencies to support re-augmentation (re-building) of an application.
 
-SBOMs generated for Mutable JAR distributions will also record locations of components that will be used during re-augmentation process using `evidence.occurrences.location` but keeping their `quarkus:component:scope` property set to `development`. For example:
+SBOMs generated for Mutable JAR distributions will also record locations of components that will be used during re-augmentation process using `evidence.occurrences.location` but keeping their CycloneDX `scope` set to `excluded`. For example:
 
 [source,json]
 ----
       "purl" : "pkg:maven/org.apache.httpcomponents/httpcore@4.4.16?type=jar",
-      "properties" : [
-        {
-          "name" : "quarkus:component:scope",
-          "value" : "development"
-        }
-      ],
+      "scope" : "excluded",
       "evidence" : {
         "occurrences" : [
           {
@@ -509,7 +498,7 @@ When `project.build.outputTimestamp` is configured in the Maven project (the sta
 |===
 |Name |Value range |Description
 
-|`quarkus:component:scope` |`runtime` or `development` |Indicates whether a component is a runtime or a build/development time dependency of an application.
+|`quarkus:component:scope` |`runtime` or `development` |Indicates whether a component is a runtime or a build/development time dependency of an application. Disabled by default; enable with `quarkus.cyclonedx.include-quarkus-component-scope=true`. Development components always have their CycloneDX `scope` set to `excluded` regardless of this setting.
 |`quarkus:component:location` |String representing a file system path using `/` as a path element |Used in SBOMs with schema versions 1.4 or older. Starting from schema 1.5, `evidence.occurrences.location` is used instead. This property is used only if a component is found in the distribution. The value is a relative path to a file pointing to the location of a component in a distribution using `/` as a path element separator.
 |===
 
@@ -584,7 +573,7 @@ SbomContributionBuildItem contributeNpmComponents() {
 * Extensions must not designate a main component — only the core application contribution does that.
 * Components from any package ecosystem can be contributed using the appropriate `Purl` type (e.g., `Purl.npm(...)`, `Purl.maven(...)`, `Purl.generic(...)`, or `Purl.of(type, ...)` for other ecosystems).
 * Set `topLevel(true)` on components that are direct dependencies of the application (e.g., packages declared in `package.json`). Transitive dependencies should not be marked as top-level.
-* The `scope` field classifies components as `runtime` or `development` dependencies, which is recorded in the SBOM as the `quarkus:component:scope` property.
+* The `scope` field classifies components as `runtime` or `development` dependencies. Development components have their CycloneDX `scope` set to `excluded`. When `quarkus.cyclonedx.include-quarkus-component-scope` is enabled, the scope is also recorded as the `quarkus:component:scope` custom property.
 * The `integrity` field can carry an SRI-format hash (e.g., from lock files) for component verification.
 * Dependency relationships are optional. If you only need to list components without expressing their dependency graph, use `SbomContribution.ofComponents(...)`.
 

--- a/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxConfig.java
+++ b/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxConfig.java
@@ -63,6 +63,15 @@ public interface CycloneDxConfig {
     boolean librariesOnly();
 
     /**
+     * Whether to include only runtime dependencies in generated SBOMs, excluding
+     * development/build-time dependencies entirely.
+     *
+     * @return whether to include only runtime dependencies
+     */
+    @WithDefault("false")
+    boolean runtimeOnly();
+
+    /**
      * Whether to include the {@code quarkus:component:scope} custom property on each component
      * in generated SBOMs. This property indicates whether a component is a {@code runtime} or
      * {@code development} dependency. Since development dependencies are now also marked with the

--- a/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxConfig.java
+++ b/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxConfig.java
@@ -63,6 +63,18 @@ public interface CycloneDxConfig {
     boolean librariesOnly();
 
     /**
+     * Whether to include the {@code quarkus:component:scope} custom property on each component
+     * in generated SBOMs. This property indicates whether a component is a {@code runtime} or
+     * {@code development} dependency. Since development dependencies are now also marked with the
+     * standard CycloneDX {@code scope} set to {@code excluded}, the custom property is redundant
+     * for most consumers and is disabled by default.
+     *
+     * @return whether to include the quarkus:component:scope property
+     */
+    @WithDefault("false")
+    boolean includeQuarkusComponentScope();
+
+    /**
      * Embedded dependency SBOM configuration
      */
     @ConfigDocSection

--- a/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxProcessor.java
+++ b/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxProcessor.java
@@ -77,6 +77,7 @@ public class CycloneDxProcessor {
                     .setIncludeLicenseText(cdxSbomConfig.includeLicenseText())
                     .setPrettyPrint(cdxSbomConfig.prettyPrint())
                     .setLibrariesOnly(cdxSbomConfig.librariesOnly())
+                    .setRuntimeOnly(cdxSbomConfig.runtimeOnly())
                     .setIncludeQuarkusComponentScope(cdxSbomConfig.includeQuarkusComponentScope())
                     .setContributions(contributions)
                     .generate()) {
@@ -173,6 +174,7 @@ public class CycloneDxProcessor {
                 .setIncludeLicenseText(cdxConfig.includeLicenseText())
                 .setPrettyPrint(cdxConfig.prettyPrint())
                 .setLibrariesOnly(cdxConfig.librariesOnly())
+                .setRuntimeOnly(cdxConfig.runtimeOnly())
                 .setIncludeQuarkusComponentScope(cdxConfig.includeQuarkusComponentScope())
                 .setContributions(collectContributions(coreContribution, sbomContributions))
                 .generateText();

--- a/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxProcessor.java
+++ b/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxProcessor.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 
+import org.jboss.logging.Logger;
+
 import io.quarkus.bootstrap.app.DependencyInfoProvider;
 import io.quarkus.bootstrap.app.SbomResult;
 import io.quarkus.cyclonedx.deployment.spi.EmbeddedSbomMetadataBuildItem;
@@ -33,6 +35,8 @@ import io.quarkus.sbom.SbomContribution;
  * Generates CycloneDX SBOMs for Quarkus applications.
  */
 public class CycloneDxProcessor {
+
+    private static final Logger log = Logger.getLogger(CycloneDxProcessor.class);
 
     /**
      * Generates CycloneDX SBOM files for the packaged application.
@@ -73,6 +77,7 @@ public class CycloneDxProcessor {
                     .setIncludeLicenseText(cdxSbomConfig.includeLicenseText())
                     .setPrettyPrint(cdxSbomConfig.prettyPrint())
                     .setLibrariesOnly(cdxSbomConfig.librariesOnly())
+                    .setIncludeQuarkusComponentScope(cdxSbomConfig.includeQuarkusComponentScope())
                     .setContributions(contributions)
                     .generate()) {
                 sbomProducer.produce(new SbomBuildItem(sbom));
@@ -82,7 +87,11 @@ public class CycloneDxProcessor {
 
     private static DependencyInfoProvider getDependencyInfoProvider(AppModelProviderBuildItem appModelProviderBuildItem) {
         var supplier = appModelProviderBuildItem.getDependencyInfoProvider();
-        return supplier == null ? null : supplier.get();
+        var depInfoProvider = supplier == null ? null : supplier.get();
+        if (depInfoProvider == null) {
+            log.warn("Dependency info provider is not available; generated SBOMs may be missing license information");
+        }
+        return depInfoProvider;
     }
 
     private static List<SbomContribution> collectContributions(SbomContribution coreContribution,
@@ -164,6 +173,7 @@ public class CycloneDxProcessor {
                 .setIncludeLicenseText(cdxConfig.includeLicenseText())
                 .setPrettyPrint(cdxConfig.prettyPrint())
                 .setLibrariesOnly(cdxConfig.librariesOnly())
+                .setIncludeQuarkusComponentScope(cdxConfig.includeQuarkusComponentScope())
                 .setContributions(collectContributions(coreContribution, sbomContributions))
                 .generateText();
 

--- a/extensions/cyclonedx/generator/src/main/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGenerator.java
+++ b/extensions/cyclonedx/generator/src/main/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGenerator.java
@@ -85,6 +85,7 @@ public class CycloneDxSbomGenerator {
     private boolean includeLicenseText;
     private boolean prettyPrint;
     private boolean librariesOnly;
+    private boolean runtimeOnly;
     private boolean includeQuarkusComponentScope;
     private Instant outputTimestamp;
     private List<SbomContribution> contributions = List.of();
@@ -143,6 +144,12 @@ public class CycloneDxSbomGenerator {
     public CycloneDxSbomGenerator setLibrariesOnly(boolean librariesOnly) {
         ensureNotGenerated();
         this.librariesOnly = librariesOnly;
+        return this;
+    }
+
+    public CycloneDxSbomGenerator setRuntimeOnly(boolean runtimeOnly) {
+        ensureNotGenerated();
+        this.runtimeOnly = runtimeOnly;
         return this;
     }
 
@@ -242,15 +249,19 @@ public class CycloneDxSbomGenerator {
             allDependencies.addAll(contribution.dependencies());
         }
 
-        // Filter out non-library components when librariesOnly is enabled
+        // Filter out components based on librariesOnly and runtimeOnly settings
         final Set<String> excludedBomRefs;
-        if (librariesOnly) {
+        if (librariesOnly || runtimeOnly) {
             excludedBomRefs = new HashSet<>();
             allDescriptors.removeIf(d -> {
                 if (d.getBomRef().equals(mainComponentBomRef)) {
                     return false;
                 }
-                if (isFileComponent(d)) {
+                if (librariesOnly && isFileComponent(d)) {
+                    excludedBomRefs.add(d.getBomRef());
+                    return true;
+                }
+                if (runtimeOnly && ComponentDescriptor.SCOPE_DEVELOPMENT.equals(d.getScope())) {
                     excludedBomRefs.add(d.getBomRef());
                     return true;
                 }

--- a/extensions/cyclonedx/generator/src/main/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGenerator.java
+++ b/extensions/cyclonedx/generator/src/main/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGenerator.java
@@ -85,6 +85,7 @@ public class CycloneDxSbomGenerator {
     private boolean includeLicenseText;
     private boolean prettyPrint;
     private boolean librariesOnly;
+    private boolean includeQuarkusComponentScope;
     private Instant outputTimestamp;
     private List<SbomContribution> contributions = List.of();
 
@@ -142,6 +143,12 @@ public class CycloneDxSbomGenerator {
     public CycloneDxSbomGenerator setLibrariesOnly(boolean librariesOnly) {
         ensureNotGenerated();
         this.librariesOnly = librariesOnly;
+        return this;
+    }
+
+    public CycloneDxSbomGenerator setIncludeQuarkusComponentScope(boolean includeQuarkusComponentScope) {
+        ensureNotGenerated();
+        this.includeQuarkusComponentScope = includeQuarkusComponentScope;
         return this;
     }
 
@@ -448,11 +455,16 @@ public class CycloneDxSbomGenerator {
             c.setType(Component.Type.LIBRARY);
         }
 
-        // Scope property
+        // Scope
         List<Property> props = new ArrayList<>(2);
         String scope = descriptor.getScope() != null ? descriptor.getScope()
                 : ComponentDescriptor.SCOPE_RUNTIME;
-        addProperty(props, QUARKUS_COMPONENT_SCOPE, scope);
+        if (includeQuarkusComponentScope) {
+            addProperty(props, QUARKUS_COMPONENT_SCOPE, scope);
+        }
+        if (ComponentDescriptor.SCOPE_DEVELOPMENT.equals(scope)) {
+            c.setScope(Component.Scope.EXCLUDED);
+        }
 
         // POM metadata for Maven components
         if (Purl.TYPE_MAVEN.equals(purl.getType())) {

--- a/extensions/cyclonedx/generator/src/test/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGeneratorTest.java
+++ b/extensions/cyclonedx/generator/src/test/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGeneratorTest.java
@@ -11,6 +11,7 @@ import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Dependency;
 import org.cyclonedx.model.Property;
+import org.cyclonedx.parsers.JsonParser;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -447,11 +448,19 @@ class CycloneDxSbomGeneratorTest {
 
     @Test
     void developmentScopeRenderedAsExcluded() {
-        ComponentDescriptor runtimeComp = ComponentDescriptor.builder()
+        ComponentDescriptor mavenRuntime = ComponentDescriptor.builder()
+                .setPurl(Purl.maven("io.quarkus", "quarkus-rest", "3.0.0", "jar", null))
+                .setScope(ComponentDescriptor.SCOPE_RUNTIME)
+                .build();
+        ComponentDescriptor mavenDev = ComponentDescriptor.builder()
+                .setPurl(Purl.maven("io.quarkus", "quarkus-rest-deployment", "3.0.0", "jar", null))
+                .setScope(ComponentDescriptor.SCOPE_DEVELOPMENT)
+                .build();
+        ComponentDescriptor npmRuntime = ComponentDescriptor.builder()
                 .setPurl(Purl.npm(null, "react", "18.0.0"))
                 .setScope(ComponentDescriptor.SCOPE_RUNTIME)
                 .build();
-        ComponentDescriptor devComp = ComponentDescriptor.builder()
+        ComponentDescriptor npmDev = ComponentDescriptor.builder()
                 .setPurl(Purl.npm(null, "eslint", "9.0.0"))
                 .setScope(ComponentDescriptor.SCOPE_DEVELOPMENT)
                 .build();
@@ -462,32 +471,43 @@ class CycloneDxSbomGeneratorTest {
         Bom bom = parseBom(CycloneDxSbomGenerator.newInstance()
                 .setFormat("json")
                 .setContributions(List.of(SbomContribution.ofComponents(
-                        List.of(runtimeComp, devComp, noScopeComp))))
+                        List.of(mavenRuntime, mavenDev, npmRuntime, npmDev, noScopeComp))))
                 .generateText().get(0));
 
-        Component runtime = bom.getComponents().stream()
-                .filter(c -> "react".equals(c.getName())).findFirst().orElseThrow();
-        Component dev = bom.getComponents().stream()
-                .filter(c -> "eslint".equals(c.getName())).findFirst().orElseThrow();
-        Component noScope = bom.getComponents().stream()
-                .filter(c -> "lodash".equals(c.getName())).findFirst().orElseThrow();
+        Component mvnRt = findComponent(bom, "quarkus-rest");
+        Component mvnDev = findComponent(bom, "quarkus-rest-deployment");
+        Component npmRt = findComponent(bom, "react");
+        Component npmDv = findComponent(bom, "eslint");
+        Component noScope = findComponent(bom, "lodash");
 
-        assertThat(dev.getScope()).isEqualTo(Component.Scope.EXCLUDED);
-        assertThat(runtime.getScope()).isNull();
+        assertThat(mvnDev.getScope()).isEqualTo(Component.Scope.EXCLUDED);
+        assertThat(npmDv.getScope()).isEqualTo(Component.Scope.EXCLUDED);
+        assertThat(mvnRt.getScope()).isNull();
+        assertThat(npmRt.getScope()).isNull();
         assertThat(noScope.getScope()).isNull();
 
         // quarkus:component:scope property should not be present by default
-        assertThat(hasProperty(dev, "quarkus:component:scope")).isFalse();
-        assertThat(hasProperty(runtime, "quarkus:component:scope")).isFalse();
+        assertThat(hasProperty(mvnDev, "quarkus:component:scope")).isFalse();
+        assertThat(hasProperty(mvnRt, "quarkus:component:scope")).isFalse();
+        assertThat(hasProperty(npmDv, "quarkus:component:scope")).isFalse();
+        assertThat(hasProperty(npmRt, "quarkus:component:scope")).isFalse();
     }
 
     @Test
     void quarkusComponentScopePropertyIncludedWhenEnabled() {
-        ComponentDescriptor runtimeComp = ComponentDescriptor.builder()
+        ComponentDescriptor mavenRuntime = ComponentDescriptor.builder()
+                .setPurl(Purl.maven("io.quarkus", "quarkus-rest", "3.0.0", "jar", null))
+                .setScope(ComponentDescriptor.SCOPE_RUNTIME)
+                .build();
+        ComponentDescriptor mavenDev = ComponentDescriptor.builder()
+                .setPurl(Purl.maven("io.quarkus", "quarkus-rest-deployment", "3.0.0", "jar", null))
+                .setScope(ComponentDescriptor.SCOPE_DEVELOPMENT)
+                .build();
+        ComponentDescriptor npmRuntime = ComponentDescriptor.builder()
                 .setPurl(Purl.npm(null, "react", "18.0.0"))
                 .setScope(ComponentDescriptor.SCOPE_RUNTIME)
                 .build();
-        ComponentDescriptor devComp = ComponentDescriptor.builder()
+        ComponentDescriptor npmDev = ComponentDescriptor.builder()
                 .setPurl(Purl.npm(null, "eslint", "9.0.0"))
                 .setScope(ComponentDescriptor.SCOPE_DEVELOPMENT)
                 .build();
@@ -496,21 +516,85 @@ class CycloneDxSbomGeneratorTest {
                 .setFormat("json")
                 .setIncludeQuarkusComponentScope(true)
                 .setContributions(List.of(SbomContribution.ofComponents(
-                        List.of(runtimeComp, devComp))))
+                        List.of(mavenRuntime, mavenDev, npmRuntime, npmDev))))
                 .generateText().get(0));
 
-        Component runtime = bom.getComponents().stream()
-                .filter(c -> "react".equals(c.getName())).findFirst().orElseThrow();
-        Component dev = bom.getComponents().stream()
-                .filter(c -> "eslint".equals(c.getName())).findFirst().orElseThrow();
+        assertThat(propertyValue(findComponent(bom, "quarkus-rest"), "quarkus:component:scope")).isEqualTo("runtime");
+        assertThat(propertyValue(findComponent(bom, "quarkus-rest-deployment"), "quarkus:component:scope"))
+                .isEqualTo("development");
+        assertThat(propertyValue(findComponent(bom, "react"), "quarkus:component:scope")).isEqualTo("runtime");
+        assertThat(propertyValue(findComponent(bom, "eslint"), "quarkus:component:scope")).isEqualTo("development");
+    }
 
-        assertThat(propertyValue(runtime, "quarkus:component:scope")).isEqualTo("runtime");
-        assertThat(propertyValue(dev, "quarkus:component:scope")).isEqualTo("development");
+    @Test
+    void runtimeOnlyExcludesDevelopmentComponents() {
+        ComponentDescriptor mavenRuntime = ComponentDescriptor.builder()
+                .setPurl(Purl.maven("io.quarkus", "quarkus-rest", "3.0.0", "jar", null))
+                .setScope(ComponentDescriptor.SCOPE_RUNTIME)
+                .build();
+        ComponentDescriptor mavenDev = ComponentDescriptor.builder()
+                .setPurl(Purl.maven("io.quarkus", "quarkus-rest-deployment", "3.0.0", "jar", null))
+                .setScope(ComponentDescriptor.SCOPE_DEVELOPMENT)
+                .build();
+        ComponentDescriptor npmRuntime = ComponentDescriptor.builder()
+                .setPurl(Purl.npm(null, "react", "18.0.0"))
+                .setScope(ComponentDescriptor.SCOPE_RUNTIME)
+                .build();
+        ComponentDescriptor npmDev = ComponentDescriptor.builder()
+                .setPurl(Purl.npm(null, "eslint", "9.0.0"))
+                .setScope(ComponentDescriptor.SCOPE_DEVELOPMENT)
+                .build();
+        ComponentDescriptor noScopeComp = ComponentDescriptor.builder()
+                .setPurl(Purl.npm(null, "lodash", "4.17.21"))
+                .build();
+
+        SbomContribution contribution = SbomContribution.of(
+                List.of(mavenRuntime, mavenDev, npmRuntime, npmDev, noScopeComp),
+                List.of(
+                        ComponentDependencies.of(
+                                mavenRuntime.getBomRef(),
+                                List.of(mavenDev.getBomRef())),
+                        ComponentDependencies.of(
+                                npmRuntime.getBomRef(),
+                                List.of(npmDev.getBomRef(), noScopeComp.getBomRef()))));
+
+        Bom bom = parseBom(CycloneDxSbomGenerator.newInstance()
+                .setFormat("json")
+                .setRuntimeOnly(true)
+                .setContributions(List.of(contribution))
+                .generateText().get(0));
+
+        List<String> componentNames = bom.getComponents().stream()
+                .map(Component::getName)
+                .toList();
+        assertThat(componentNames).contains("quarkus-rest", "react", "lodash");
+        assertThat(componentNames).doesNotContain("quarkus-rest-deployment", "eslint");
+
+        List<String> allDepRefs = bom.getDependencies().stream()
+                .map(Dependency::getRef)
+                .toList();
+        assertThat(allDepRefs).doesNotContain(mavenDev.getBomRef(), npmDev.getBomRef());
+
+        Dependency mavenRtDep = bom.getDependencies().stream()
+                .filter(d -> d.getRef().equals(mavenRuntime.getBomRef()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(mavenRtDep.getDependencies()).isNullOrEmpty();
+
+        Dependency npmRtDep = bom.getDependencies().stream()
+                .filter(d -> d.getRef().equals(npmRuntime.getBomRef()))
+                .findFirst()
+                .orElseThrow();
+        List<String> npmRtDependsOn = npmRtDep.getDependencies().stream()
+                .map(Dependency::getRef)
+                .toList();
+        assertThat(npmRtDependsOn).contains(noScopeComp.getBomRef());
+        assertThat(npmRtDependsOn).doesNotContain(npmDev.getBomRef());
     }
 
     private static Bom parseBom(String json) {
         try {
-            return new org.cyclonedx.parsers.JsonParser().parse(json.getBytes());
+            return new JsonParser().parse(json.getBytes());
         } catch (Exception e) {
             throw new RuntimeException("Failed to parse BOM JSON", e);
         }
@@ -527,6 +611,13 @@ class CycloneDxSbomGeneratorTest {
                 .setDependencies(dependencies)
                 .setRuntimeCp()
                 .build();
+    }
+
+    private static Component findComponent(Bom bom, String name) {
+        return bom.getComponents().stream()
+                .filter(c -> name.equals(c.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Component " + name + " not found"));
     }
 
     private static boolean hasProperty(Component component, String propertyName) {

--- a/extensions/cyclonedx/generator/src/test/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGeneratorTest.java
+++ b/extensions/cyclonedx/generator/src/test/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGeneratorTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Dependency;
+import org.cyclonedx.model.Property;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -444,6 +445,69 @@ class CycloneDxSbomGeneratorTest {
         assertThat(componentNames).contains("react", "quarkus-run.jar");
     }
 
+    @Test
+    void developmentScopeRenderedAsExcluded() {
+        ComponentDescriptor runtimeComp = ComponentDescriptor.builder()
+                .setPurl(Purl.npm(null, "react", "18.0.0"))
+                .setScope(ComponentDescriptor.SCOPE_RUNTIME)
+                .build();
+        ComponentDescriptor devComp = ComponentDescriptor.builder()
+                .setPurl(Purl.npm(null, "eslint", "9.0.0"))
+                .setScope(ComponentDescriptor.SCOPE_DEVELOPMENT)
+                .build();
+        ComponentDescriptor noScopeComp = ComponentDescriptor.builder()
+                .setPurl(Purl.npm(null, "lodash", "4.17.21"))
+                .build();
+
+        Bom bom = parseBom(CycloneDxSbomGenerator.newInstance()
+                .setFormat("json")
+                .setContributions(List.of(SbomContribution.ofComponents(
+                        List.of(runtimeComp, devComp, noScopeComp))))
+                .generateText().get(0));
+
+        Component runtime = bom.getComponents().stream()
+                .filter(c -> "react".equals(c.getName())).findFirst().orElseThrow();
+        Component dev = bom.getComponents().stream()
+                .filter(c -> "eslint".equals(c.getName())).findFirst().orElseThrow();
+        Component noScope = bom.getComponents().stream()
+                .filter(c -> "lodash".equals(c.getName())).findFirst().orElseThrow();
+
+        assertThat(dev.getScope()).isEqualTo(Component.Scope.EXCLUDED);
+        assertThat(runtime.getScope()).isNull();
+        assertThat(noScope.getScope()).isNull();
+
+        // quarkus:component:scope property should not be present by default
+        assertThat(hasProperty(dev, "quarkus:component:scope")).isFalse();
+        assertThat(hasProperty(runtime, "quarkus:component:scope")).isFalse();
+    }
+
+    @Test
+    void quarkusComponentScopePropertyIncludedWhenEnabled() {
+        ComponentDescriptor runtimeComp = ComponentDescriptor.builder()
+                .setPurl(Purl.npm(null, "react", "18.0.0"))
+                .setScope(ComponentDescriptor.SCOPE_RUNTIME)
+                .build();
+        ComponentDescriptor devComp = ComponentDescriptor.builder()
+                .setPurl(Purl.npm(null, "eslint", "9.0.0"))
+                .setScope(ComponentDescriptor.SCOPE_DEVELOPMENT)
+                .build();
+
+        Bom bom = parseBom(CycloneDxSbomGenerator.newInstance()
+                .setFormat("json")
+                .setIncludeQuarkusComponentScope(true)
+                .setContributions(List.of(SbomContribution.ofComponents(
+                        List.of(runtimeComp, devComp))))
+                .generateText().get(0));
+
+        Component runtime = bom.getComponents().stream()
+                .filter(c -> "react".equals(c.getName())).findFirst().orElseThrow();
+        Component dev = bom.getComponents().stream()
+                .filter(c -> "eslint".equals(c.getName())).findFirst().orElseThrow();
+
+        assertThat(propertyValue(runtime, "quarkus:component:scope")).isEqualTo("runtime");
+        assertThat(propertyValue(dev, "quarkus:component:scope")).isEqualTo("development");
+    }
+
     private static Bom parseBom(String json) {
         try {
             return new org.cyclonedx.parsers.JsonParser().parse(json.getBytes());
@@ -463,5 +527,21 @@ class CycloneDxSbomGeneratorTest {
                 .setDependencies(dependencies)
                 .setRuntimeCp()
                 .build();
+    }
+
+    private static boolean hasProperty(Component component, String propertyName) {
+        return component.getProperties() != null && component.getProperties().stream()
+                .anyMatch(p -> propertyName.equals(p.getName()));
+    }
+
+    private static String propertyValue(Component component, String propertyName) {
+        if (component.getProperties() == null) {
+            return null;
+        }
+        return component.getProperties().stream()
+                .filter(p -> propertyName.equals(p.getName()))
+                .map(Property::getValue)
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/CycloneDxTestUtils.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/CycloneDxTestUtils.java
@@ -12,7 +12,6 @@ import java.util.zip.GZIPInputStream;
 
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
-import org.cyclonedx.model.Property;
 import org.cyclonedx.model.component.evidence.Occurrence;
 import org.cyclonedx.parsers.JsonParser;
 
@@ -67,16 +66,9 @@ final class CycloneDxTestUtils {
     }
 
     static void assertComponentScope(Component component, String expectedScope) {
-        final List<Property> properties = component.getProperties();
-        assertThat(properties).isNotNull();
-        final String scope = properties.stream()
-                .filter(p -> "quarkus:component:scope".equals(p.getName()))
-                .map(Property::getValue)
-                .findFirst()
-                .orElse(null);
-        assertThat(scope)
-                .as("quarkus:component:scope of %s:%s", component.getGroup(), component.getName())
-                .isEqualTo(expectedScope);
+        assertThat(component.getScope())
+                .as("CycloneDX scope of %s:%s", component.getGroup(), component.getName())
+                .isEqualTo("development".equals(expectedScope) ? Component.Scope.EXCLUDED : null);
     }
 
     /**


### PR DESCRIPTION
The first commit adds `scope=excluded` to build time dependencies, which is how non-runtime dependencies are meant to be represented following the CycloneDX specification. Missing scope implies `required`, i.e. runtime in case of Quarkus applications.

`quarkus:component:scope` is made optional and can be enabled by setting `quarkus.cyclonedx.include-quarkus-component-scope=true`, which is potentially a breaking change.

The second commit introduces `quarkus.cyclonedx.runtime-only` option that, when enabled, will make only runtime dependencies be recorded in the SBOM.