### PR TITLE
Preserve persistence unit startup failure

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/JPAConfig.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/JPAConfig.java
@@ -161,6 +161,7 @@ public class JPAConfig {
         private final String name;
         private final boolean isReactive;
         private volatile EntityManagerFactory value;
+        private RuntimeException startupFailure;
         private volatile boolean closed = false;
 
         LazyPersistenceUnit(String name, boolean isReactive) {
@@ -174,9 +175,17 @@ public class JPAConfig {
                     if (closed) {
                         throw new IllegalStateException("Persistence unit is closed");
                     }
+                    if (startupFailure != null) {
+                        throw startupFailure;
+                    }
                     if (value == null) {
-                        value = Persistence.createEntityManagerFactory(name,
-                                Collections.singletonMap(IS_REACTIVE_KEY, isReactive));
+                        try {
+                            value = Persistence.createEntityManagerFactory(name,
+                                    Collections.singletonMap(IS_REACTIVE_KEY, isReactive));
+                        } catch (RuntimeException e) {
+                            startupFailure = e;
+                            throw e;
+                        }
                     }
                 }
             }

--- a/extensions/hibernate-orm/runtime/src/test/java/io/quarkus/hibernate/orm/runtime/JPAConfigTest.java
+++ b/extensions/hibernate-orm/runtime/src/test/java/io/quarkus/hibernate/orm/runtime/JPAConfigTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.hibernate.orm.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceException;
+import jakarta.persistence.spi.PersistenceProviderResolver;
+import jakarta.persistence.spi.PersistenceProviderResolverHolder;
+
+import org.hibernate.jpa.HibernatePersistenceProvider;
+import org.junit.jupiter.api.Test;
+
+class JPAConfigTest {
+
+    @Test
+    void failedPersistenceUnitStartIsNotRetried() {
+        PersistenceProviderResolver originalResolver = PersistenceProviderResolverHolder.getPersistenceProviderResolver();
+        PersistenceException initialFailure = new PersistenceException("initial persistence unit startup failure");
+        AtomicInteger attempts = new AtomicInteger();
+        HibernatePersistenceProvider provider = new HibernatePersistenceProvider() {
+            @Override
+            public EntityManagerFactory createEntityManagerFactory(String persistenceUnitName, Map<?, ?> properties) {
+                if (attempts.incrementAndGet() > 1) {
+                    throw new PersistenceException("retry hid the initial startup failure");
+                }
+                throw initialFailure;
+            }
+        };
+
+        try {
+            PersistenceProviderResolverHolder
+                    .setPersistenceProviderResolver(new SingletonPersistenceProviderResolver(provider));
+            JPAConfig.LazyPersistenceUnit persistenceUnit = new JPAConfig.LazyPersistenceUnit("test", false);
+
+            assertThatThrownBy(persistenceUnit::get).isSameAs(initialFailure);
+            assertThatThrownBy(persistenceUnit::get).isSameAs(initialFailure);
+            assertThat(attempts).hasValue(1);
+        } finally {
+            PersistenceProviderResolverHolder.setPersistenceProviderResolver(originalResolver);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Cache the first persistence-unit startup failure in JPAConfig.LazyPersistenceUnit.
- Rethrow the original failure on subsequent access instead of retrying initialization and masking it with a later recordedState NPE.
- Add a regression test verifying that initialization is attempted once and the original exception is preserved.

## Root cause

A failed Persistence.createEntityManagerFactory invocation left the lazy persistence unit uninitialized. A later access retried startup after Hibernate recorded state had already been consumed, replacing the actionable startup exception with an unrelated NPE.

----

- Fixes: #55502