### PR TITLE
Centralize Container Image Names

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -153,6 +153,12 @@
         <redis.image>docker.io/library/redis:8</redis.image>
         <infinispan.image>quay.io/infinispan/server:latest</infinispan.image>
         <mailpit.image>docker.io/axllent/mailpit:latest</mailpit.image>
+        <kafka.redpanda.image>docker.io/redpandadata/redpanda:v24.1.2</kafka.redpanda.image>
+        <kafka.strimzi.image>quay.io/strimzi-test-container/test-container:0.115.0-kafka-4.2.0</kafka.strimzi.image>
+        <kafka.native.image>quay.io/ogunalp/kafka-native:latest</kafka.native.image>
+        <kafka.upstream.image>docker.io/apache/kafka:4.2.0</kafka.upstream.image>
+        <kafka.upstream.native.image>docker.io/apache/kafka-native:4.2.0</kafka.upstream.native.image>
+        <observability.lgtm.image>docker.io/grafana/otel-lgtm:0.24.0</observability.lgtm.image>
 
         <!-- Code Coverage Properties-->
         <jacoco.agent.argLine></jacoco.agent.argLine>

--- a/extensions/kafka-client/deployment/pom.xml
+++ b/extensions/kafka-client/deployment/pom.xml
@@ -70,6 +70,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
@@ -46,21 +46,21 @@ public interface KafkaDevServicesBuildTimeConfig {
     Provider provider();
 
     enum Provider {
-        REDPANDA("docker.io/redpandadata/redpanda:v24.1.2"),
-        STRIMZI("quay.io/strimzi-test-container/test-container:0.115.0-kafka-4.2.0"),
+        REDPANDA("kafka.redpanda"),
+        STRIMZI("kafka.strimzi"),
         @Deprecated(forRemoval = true)
-        KAFKA_NATIVE("quay.io/ogunalp/kafka-native:latest"),
-        UPSTREAM_KAFKA("docker.io/apache/kafka:4.2.0"),
-        UPSTREAM_KAFKA_NATIVE("docker.io/apache/kafka-native:4.2.0");
+        KAFKA_NATIVE("kafka.native"),
+        UPSTREAM_KAFKA("kafka.upstream"),
+        UPSTREAM_KAFKA_NATIVE("kafka.upstream.native");
 
-        private final String defaultImageName;
+        private final String imageNameKey;
 
-        Provider(String imageName) {
-            this.defaultImageName = imageName;
+        Provider(String imageNameKey) {
+            this.imageNameKey = imageNameKey;
         }
 
         public String getDefaultImageName() {
-            return defaultImageName;
+            return io.quarkus.devservices.common.ConfigureUtil.getDefaultImageNameFor(imageNameKey);
         }
     }
 

--- a/extensions/kafka-client/deployment/src/main/resources/kafka.native-devservice.properties
+++ b/extensions/kafka-client/deployment/src/main/resources/kafka.native-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${kafka.native.image}

--- a/extensions/kafka-client/deployment/src/main/resources/kafka.redpanda-devservice.properties
+++ b/extensions/kafka-client/deployment/src/main/resources/kafka.redpanda-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${kafka.redpanda.image}

--- a/extensions/kafka-client/deployment/src/main/resources/kafka.strimzi-devservice.properties
+++ b/extensions/kafka-client/deployment/src/main/resources/kafka.strimzi-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${kafka.strimzi.image}

--- a/extensions/kafka-client/deployment/src/main/resources/kafka.upstream-devservice.properties
+++ b/extensions/kafka-client/deployment/src/main/resources/kafka.upstream-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${kafka.upstream.image}

--- a/extensions/kafka-client/deployment/src/main/resources/kafka.upstream.native-devservice.properties
+++ b/extensions/kafka-client/deployment/src/main/resources/kafka.upstream.native-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${kafka.upstream.native.image}

--- a/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarContainer.java
+++ b/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarContainer.java
@@ -18,7 +18,8 @@ import io.quarkus.devservices.common.ConfigureUtil;
 
 public class PulsarContainer extends GenericContainer<PulsarContainer> implements Startable {
 
-    public static final DockerImageName PULSAR_IMAGE = DockerImageName.parse("apachepulsar/pulsar:3.2.4");
+    public static final DockerImageName PULSAR_IMAGE = DockerImageName
+            .parse(ConfigureUtil.getDefaultImageNameFor("pulsar"));
 
     public static final String STARTER_SCRIPT = "/run_pulsar.sh";
 

--- a/tcks/microprofile-lra/src/main/java/io/quarkus/tck/lra/LRACoordinatorManager.java
+++ b/tcks/microprofile-lra/src/main/java/io/quarkus/tck/lra/LRACoordinatorManager.java
@@ -26,7 +26,8 @@ public class LRACoordinatorManager {
         Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(LOGGER);
         if (System.getProperty("lra.coordinator.url") == null) {
             LOGGER.debug("Starting LRA coordinator on port " + coordinatorPort);
-            coordinatorContainer = new GenericContainer<>(DockerImageName.parse("quay.io/jbosstm/lra-coordinator:latest"))
+            coordinatorContainer = new GenericContainer<>(
+                    DockerImageName.parse(io.quarkus.test.common.DockerImageNames.getImage("narayana-lra.image")))
                     // lra-coordinator is a Quarkus service
                     .withEnv("QUARKUS_HTTP_PORT", String.valueOf(coordinatorPort))
                     // need to run with host network because coordinator calls the TCK services from the container

--- a/test-framework/common/src/main/resources/quarkus-test-container-images.properties
+++ b/test-framework/common/src/main/resources/quarkus-test-container-images.properties
@@ -14,3 +14,4 @@ pulsar.image=${pulsar.image}
 rabbitmq.image=${rabbitmq.image}
 redis.image=${redis.image}
 mailpit.image=${mailpit.image}
+narayana-lra.image=${narayana-lra.image}

--- a/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/server/KeycloakContainer.java
+++ b/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/server/KeycloakContainer.java
@@ -18,12 +18,17 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
     private final boolean legacy;
 
     private static String getKeycloakImageName() {
-        if (KEYCLOAK_DOCKER_IMAGE != null) {
-            return KEYCLOAK_DOCKER_IMAGE;
-        } else if (KEYCLOAK_VERSION != null) {
-            return "quay.io/keycloak/keycloak:" + KEYCLOAK_VERSION;
-        } else {
-            throw new ConfigurationException("Please set either 'keycloak.docker.image' or 'keycloak.version' system property");
+        try {
+            return io.quarkus.test.common.DockerImageNames.getImage("keycloak.docker.image");
+        } catch (IllegalArgumentException e) {
+            if (KEYCLOAK_DOCKER_IMAGE != null) {
+                return KEYCLOAK_DOCKER_IMAGE;
+            } else if (KEYCLOAK_VERSION != null) {
+                return "quay.io/keycloak/keycloak:" + KEYCLOAK_VERSION;
+            } else {
+                throw new ConfigurationException(
+                        "Please set either 'keycloak.docker.image' or 'keycloak.version' system property", e);
+            }
         }
     }
 


### PR DESCRIPTION
### Description

This PR addresses #45746 by centralizing the remaining scattered container images across the codebase. 

I've leveraged the two existing Quarkus patterns for centralization: `ConfigureUtil.getDefaultImageNameFor` (for DevServices) and `DockerImageNames.getImage` (for the Test Framework).

**Changes included:**
* **Kafka providers:** Centralized `redpanda`, `strimzi`, `kafka-native`, `upstream`, and `upstream.native`.
* **Others:** Centralized `observability.lgtm`, `narayana-lra`, and `keycloak` (added a defensive fallback for Keycloak to ensure backward compatibility).
* **Build Configs:** Fixed the missing trailing newline in `quarkus-test-container-images.properties` and explicitly enabled Maven resource `<filtering>` for the `kafka-client` and `observability-devservices` modules so the properties resolve correctly.

**A few notes for reviewers:**
* **Pulsar:** `apachepulsar/pulsar` now uses the explicit registry prefix (`docker.io/apachepulsar/pulsar`), which matches the pom properties and is more explicit. It leverages the existing `pulsar-devservice.properties` already on `main`.
* **LGTM Constant:** `ContainerConstants.LGTM` is no longer a compile-time constant since it now uses the `getDefaultImageNameFor` method. I verified it is only used at runtime for container instantiation, so this shouldn't break anything.
* **Mailpit & RabbitMQ:** I verified that both `mailpit` and `rabbitmq` are already fully centralized via `DockerImageNames` and `getDefaultImageNameFor` in the current `main` branch, so no further changes were needed for them. (Also, `fake-smtp-server` no longer exists in the codebase).

All tests are passing locally. Let me know if any further tweaks are needed!
