### PR TITLE
[3.27] Backport changes related to raising level of some of OIDC log messages

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
@@ -195,7 +195,7 @@ public final class BackChannelLogoutHandler implements Handler<RoutingContext> {
                                             context.response().setStatusCode(400);
                                         }
                                     } catch (InvalidJwtException e) {
-                                        LOG.debug("Back channel logout token is invalid");
+                                        LOG.warn("Back channel logout token is invalid");
                                         context.response().setStatusCode(400);
 
                                     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
@@ -64,11 +64,11 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
 
             List<String> proofs = context.request().headers().getAll(OidcConstants.DPOP_SCHEME);
             if (proofs == null || proofs.isEmpty()) {
-                LOG.warn("DPOP proof header must be present to verify the DPOP access token binding");
+                LOG.warn("DPoP proof header must be present to verify the DPoP access token binding");
                 throw new AuthenticationFailedException(tokenMap(token));
             }
             if (proofs.size() != 1) {
-                LOG.warn("Only a single DPOP proof header is accepted");
+                LOG.warnf("Only a single DPoP proof header is accepted, %d headers are available", proofs.size());
                 throw new AuthenticationFailedException(tokenMap(token));
             }
             String proof = proofs.get(0);
@@ -78,20 +78,20 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
             JsonObject proofJwtClaims = OidcCommonUtils.decodeJwtContent(proof);
 
             if (!OidcConstants.DPOP_TOKEN_TYPE.equals(proofJwtHeaders.getString(OidcConstants.TOKEN_TYPE_HEADER))) {
-                LOG.warn("Invalid DPOP proof token type ('typ') header");
+                LOG.warn("Invalid DPoP proof token type ('typ') header");
                 throw new AuthenticationFailedException(tokenMap(token));
             }
 
             // Check HTTP method and request URI
             String proofHttpMethod = proofJwtClaims.getString(OidcConstants.DPOP_HTTP_METHOD);
             if (proofHttpMethod == null) {
-                LOG.warn("DPOP proof HTTP method claim is missing");
+                LOG.warn("DPoP proof HTTP method claim is missing");
                 throw new AuthenticationFailedException(tokenMap(token));
             }
 
             String httpMethod = context.request().method().name();
             if (!httpMethod.equals(proofHttpMethod)) {
-                LOG.warnf("DPOP proof HTTP method claim %s does not match the request HTTP method %s", proofHttpMethod,
+                LOG.warnf("DPoP proof HTTP method claim %s does not match the request HTTP method %s", proofHttpMethod,
                         httpMethod);
                 throw new AuthenticationFailedException(tokenMap(token));
             }
@@ -99,7 +99,7 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
             // Check HTTP request URI
             String proofHttpRequestUri = proofJwtClaims.getString(OidcConstants.DPOP_HTTP_REQUEST_URI);
             if (proofHttpRequestUri == null) {
-                LOG.warn("DPOP proof HTTP request uri claim is missing");
+                LOG.warn("DPoP proof HTTP request uri claim is missing");
                 throw new AuthenticationFailedException(tokenMap(token));
             }
 
@@ -109,7 +109,7 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
                 httpRequestUri = httpRequestUri.substring(0, queryIndex);
             }
             if (!httpRequestUri.equals(proofHttpRequestUri)) {
-                LOG.warnf("DPOP proof HTTP request uri claim %s does not match the request HTTP uri %s", proofHttpRequestUri,
+                LOG.warnf("DPoP proof HTTP request uri claim %s does not match the request HTTP uri %s", proofHttpRequestUri,
                         httpRequestUri);
                 throw new AuthenticationFailedException(tokenMap(token));
             }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -201,7 +201,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
             String error = requestParams.get(OidcConstants.CODE_FLOW_ERROR);
             String errorDescription = requestParams.get(OidcConstants.CODE_FLOW_ERROR_DESCRIPTION);
 
-            LOG.debugf("Authentication has failed, error: %s, description: %s", error, errorDescription);
+            LOG.warnf("Authentication has failed, error: %s, description: %s", error, errorDescription);
 
             if (oidcTenantConfig.authentication().errorPath().isPresent()) {
                 Uni<TenantConfigContext> resolvedContext = resolver.resolveContext(context);
@@ -1408,7 +1408,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                                     }).onFailure().transform(new Function<Throwable, Throwable>() {
                                         @Override
                                         public Throwable apply(Throwable tInner) {
-                                            LOG.debugf("Verifying the refreshed ID token failed %s", errorMessage(tInner));
+                                            LOG.warnf("Verifying the refreshed ID token failed %s", errorMessage(tInner));
                                             return new AuthenticationFailedException(tInner, tokenMap(currentIdToken));
                                         }
                                     });

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
@@ -145,7 +145,7 @@ public class DefaultTokenStateManager implements TokenStateManager {
                 }
             } catch (ArrayIndexOutOfBoundsException ex) {
                 final String error = "Session cookie is malformed";
-                LOG.debug(ex);
+                LOG.error(error);
                 return Uni.createFrom().failure(new AuthenticationFailedException(error));
             } catch (AuthenticationFailedException ex) {
                 return Uni.createFrom().failure(ex);
@@ -170,7 +170,7 @@ public class DefaultTokenStateManager implements TokenStateManager {
                         }
                     } catch (ArrayIndexOutOfBoundsException ex) {
                         final String error = "Session cookie is malformed";
-                        LOG.debug(ex);
+                        LOG.error(error);
                         // Make this error message visible in the dev mode
                         return Uni.createFrom().failure(new AuthenticationFailedException(error));
                     } catch (AuthenticationFailedException ex) {
@@ -209,10 +209,9 @@ public class DefaultTokenStateManager implements TokenStateManager {
         try {
             return Long.valueOf(accessTokenExpiresInString);
         } catch (NumberFormatException ex) {
-            final String error = """
-                    Access token expires_in property in the session cookie must be a number, found %s
-                    """.formatted(accessTokenExpiresInString);
-            LOG.debug(ex);
+            final String error = "Access token expires_in property in the session cookie must be a number, found %s"
+                    .formatted(accessTokenExpiresInString);
+            LOG.error(error);
             // Make this error message visible in the dev mode
             throw new AuthenticationFailedException(error);
         }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -216,8 +216,9 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             }
         } else {
             final boolean idToken = isIdToken(request);
-            Uni<TokenVerificationResult> result = verifyTokenUni(requestData, resolvedContext, request.getToken(), idToken,
-                    idToken, false, userInfo);
+            final TokenType tokenType = idToken ? TokenType.ID_TOKEN : TokenType.BEARER_ACCESS_TOKEN;
+            Uni<TokenVerificationResult> result = verifyTokenUni(requestData, resolvedContext, request.getToken(), tokenType,
+                    idToken, userInfo);
             if (!idToken) {
                 if (resolvedContext.oidcConfig().token().binding().certificate()) {
                     result = result.onItem().transform(new Function<TokenVerificationResult, TokenVerificationResult>() {
@@ -630,19 +631,19 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 codeAccessToken = OidcUtils.decryptToken(resolvedContext, codeAccessToken);
                 requestData.put(OidcConstants.ACCESS_TOKEN_VALUE, codeAccessToken);
             }
-            return verifyTokenUni(requestData, resolvedContext, new AccessTokenCredential(codeAccessToken), false,
-                    false, true, userInfo);
+            return verifyTokenUni(requestData, resolvedContext, new AccessTokenCredential(codeAccessToken),
+                    TokenType.CODE_FLOW_ACCESS_TOKEN, false, userInfo);
         } else {
             return NULL_CODE_ACCESS_TOKEN_UNI;
         }
     }
 
     private Uni<TokenVerificationResult> verifyTokenUni(Map<String, Object> requestData, TenantConfigContext resolvedContext,
-            TokenCredential tokenCred, boolean idToken, boolean enforceAudienceVerification, boolean codeFlowAccessToken,
+            TokenCredential tokenCred, TokenType tokenType, boolean enforceAudienceVerification,
             UserInfo userInfo) {
         final String token = tokenCred.getToken();
         Long expiresIn = null;
-        if (codeFlowAccessToken) {
+        if (tokenType == TokenType.CODE_FLOW_ACCESS_TOKEN) {
             expiresIn = ((AuthorizationCodeTokens) requestData.get(AuthorizationCodeTokens.class.getName()))
                     .getAccessTokenExpiresIn();
         }
@@ -664,12 +665,12 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 }
             }
             LOG.debug("Starting the opaque token introspection");
-            return introspectTokenUni(resolvedContext, token, idToken, expiresIn, false);
+            return introspectTokenUni(resolvedContext, token, tokenType, expiresIn, false);
         } else if (resolvedContext.provider().getMetadata().getJsonWebKeySetUri() == null
                 || resolvedContext.oidcConfig().token().requireJwtIntrospectionOnly()) {
             // Verify JWT token with the remote introspection
             LOG.debug("Starting the JWT token introspection");
-            return introspectTokenUni(resolvedContext, token, idToken, expiresIn, false);
+            return introspectTokenUni(resolvedContext, token, tokenType, expiresIn, false);
         } else if (resolvedContext.oidcConfig().jwks().resolveEarly()) {
             // Verify JWT token with the local JWK keys with a possible remote introspection fallback
             final String nonce = tokenCred instanceof IdTokenCredential ? (String) requestData.get(OidcConstants.NONCE) : null;
@@ -681,16 +682,15 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             } catch (Throwable t) {
                 if (t.getCause() instanceof UnresolvableKeyException) {
                     LOG.debug("No matching JWK key is found, refreshing and repeating the token verification");
-                    return refreshJwksAndVerifyTokenUni(resolvedContext, token, idToken, enforceAudienceVerification,
+                    return refreshJwksAndVerifyTokenUni(resolvedContext, token, tokenType, enforceAudienceVerification,
                             resolvedContext.oidcConfig().token().subjectRequired(), nonce, expiresIn);
                 } else {
-                    LOG.debugf("Token verification has failed: %s", t.getMessage());
                     return Uni.createFrom().failure(t);
                 }
             }
         } else {
             final String nonce = (String) requestData.get(OidcConstants.NONCE);
-            return resolveJwksAndVerifyTokenUni(resolvedContext, tokenCred, enforceAudienceVerification,
+            return resolveJwksAndVerifyTokenUni(resolvedContext, tokenCred, tokenType, enforceAudienceVerification,
                     resolvedContext.oidcConfig().token().subjectRequired(), nonce, expiresIn);
         }
     }
@@ -705,23 +705,22 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
     }
 
     private Uni<TokenVerificationResult> refreshJwksAndVerifyTokenUni(TenantConfigContext resolvedContext, String token,
-            boolean idToken,
+            TokenType tokenType,
             boolean enforceAudienceVerification, boolean subjectRequired, String nonce, Long expiresIn) {
         return resolvedContext.provider()
                 .refreshJwksAndVerifyJwtToken(token, enforceAudienceVerification, subjectRequired, nonce)
                 .onFailure(f -> fallbackToIntrospectionIfNoMatchingKey(f, resolvedContext))
-                .recoverWithUni(f -> introspectTokenUni(resolvedContext, token, idToken, expiresIn, true));
+                .recoverWithUni(f -> introspectTokenUni(resolvedContext, token, tokenType, expiresIn, true));
     }
 
     private Uni<TokenVerificationResult> resolveJwksAndVerifyTokenUni(TenantConfigContext resolvedContext,
-            TokenCredential tokenCred,
+            TokenCredential tokenCred, TokenType tokenType,
             boolean enforceAudienceVerification, boolean subjectRequired, String nonce, Long expiresIn) {
         return resolvedContext.provider()
                 .getKeyResolverAndVerifyJwtToken(tokenCred, enforceAudienceVerification, subjectRequired, nonce,
                         (tokenCred instanceof IdTokenCredential))
                 .onFailure(f -> fallbackToIntrospectionIfNoMatchingKey(f, resolvedContext))
-                .recoverWithUni(f -> introspectTokenUni(resolvedContext, tokenCred.getToken(),
-                        isIdToken(tokenCred), expiresIn, true));
+                .recoverWithUni(f -> introspectTokenUni(resolvedContext, tokenCred.getToken(), tokenType, expiresIn, true));
     }
 
     private static boolean fallbackToIntrospectionIfNoMatchingKey(Throwable f, TenantConfigContext resolvedContext) {
@@ -739,28 +738,30 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
     }
 
     private Uni<TokenVerificationResult> introspectTokenUni(TenantConfigContext resolvedContext, final String token,
-            boolean idToken, Long expiresIn, boolean fallbackFromJwkMatch) {
+            TokenType tokenType, Long expiresIn, boolean fallbackFromJwkMatch) {
         TokenIntrospectionCache tokenIntrospectionCache = tenantResolver.getTokenIntrospectionCache();
         Uni<TokenIntrospection> tokenIntrospectionUni = tokenIntrospectionCache == null ? null
                 : tokenIntrospectionCache
                         .getIntrospection(token, resolvedContext.oidcConfig(), getIntrospectionRequestContext);
         if (tokenIntrospectionUni == null) {
-            tokenIntrospectionUni = newTokenIntrospectionUni(resolvedContext, token, idToken, expiresIn, fallbackFromJwkMatch);
+            tokenIntrospectionUni = newTokenIntrospectionUni(resolvedContext, token, tokenType, expiresIn,
+                    fallbackFromJwkMatch);
         } else {
             tokenIntrospectionUni = tokenIntrospectionUni.onItem().ifNull()
                     .switchTo(new Supplier<Uni<? extends TokenIntrospection>>() {
                         @Override
                         public Uni<TokenIntrospection> get() {
-                            return newTokenIntrospectionUni(resolvedContext, token, idToken, expiresIn, fallbackFromJwkMatch);
+                            return newTokenIntrospectionUni(resolvedContext, token, tokenType, expiresIn, fallbackFromJwkMatch);
                         }
                     });
         }
         return tokenIntrospectionUni.onItem().transform(t -> new TokenVerificationResult(null, t));
     }
 
-    private Uni<TokenIntrospection> newTokenIntrospectionUni(TenantConfigContext resolvedContext, String token, boolean idToken,
+    private Uni<TokenIntrospection> newTokenIntrospectionUni(TenantConfigContext resolvedContext, String token,
+            TokenType tokenType,
             Long expiresIn, boolean fallbackFromJwkMatch) {
-        Uni<TokenIntrospection> tokenIntrospectionUni = resolvedContext.provider().introspectToken(token, idToken, expiresIn,
+        Uni<TokenIntrospection> tokenIntrospectionUni = resolvedContext.provider().introspectToken(token, tokenType, expiresIn,
                 fallbackFromJwkMatch);
         if (tenantResolver.getTokenIntrospectionCache() == null
                 || !resolvedContext.oidcConfig().allowTokenIntrospectionCache()) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -191,10 +191,17 @@ public class OidcProvider implements Closeable {
         if (!enforceExpReq) {
             // Expiry check was skipped during the initial verification but if the logout token contains the exp claim
             // then it must be verified
-            if (isTokenExpired(result.localVerificationResult.getLong(Claims.exp.name()))) {
-                String error = String.format("Logout token for client %s has expired", oidcConfig.clientId().get());
-                LOG.debugf(error);
-                throw new InvalidJwtException(error, List.of(new ErrorCodeValidator.Error(ErrorCodes.EXPIRED, error)), null);
+            final Long exp = result.localVerificationResult.getLong(Claims.exp.name());
+            if (exp != null) {
+                final long secondsAfterExpiry = now() / 1000 - (exp + getLifespanGrace());
+                if (secondsAfterExpiry > 0) {
+                    String error = """
+                            Logout token issued to client %s expired %d seconds ago""".formatted(oidcConfig.clientId().get(),
+                            secondsAfterExpiry);
+                    LOG.debug(error);
+                    throw new InvalidJwtException(error, List.of(new ErrorCodeValidator.Error(ErrorCodes.EXPIRED, error)),
+                            null);
+                }
             }
         }
         return result;
@@ -433,7 +440,7 @@ public class OidcProvider implements Closeable {
                                 try {
                                     actualClaimValueArray = requireNonNull(introspectionResult.getArray(requiredClaimName));
                                 } catch (Exception ignored) {
-                                    LOG.debugf("Introspection claim %s is neither string or array", requiredClaimName);
+                                    LOG.debugf("Introspection claim %s is neither string nor array", requiredClaimName);
                                     throw new AuthenticationFailedException(tokenMap(token, idToken));
                                 }
                                 requiredClaimValuesLoop: for (String requiredClaimValue : requiredClaimValues) {
@@ -461,18 +468,20 @@ public class OidcProvider implements Closeable {
     }
 
     private void verifyTokenExpiry(String token, boolean idToken, Long exp) {
-        if (isTokenExpired(exp)) {
-            String error = String.format("Token issued to client %s has expired", oidcConfig.clientId().get());
-            LOG.debugf(error);
+        if (exp == null) {
+            return;
+        }
+        final long secondsAfterExpiry = now() / 1000 - (exp + getLifespanGrace());
+        if (secondsAfterExpiry > 0) {
+            String error = """
+                    Token issued to client %s expired %d seconds ago""".formatted(oidcConfig.clientId().get(),
+                    secondsAfterExpiry);
+            LOG.debug(error);
             throw new AuthenticationFailedException(
                     new InvalidJwtException(error,
                             List.of(new ErrorCodeValidator.Error(ErrorCodes.EXPIRED, error)), null),
                     tokenMap(token, idToken));
         }
-    }
-
-    private boolean isTokenExpired(Long exp) {
-        return exp != null && now() / 1000 > exp + getLifespanGrace();
     }
 
     private int getLifespanGrace() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -195,10 +195,10 @@ public class OidcProvider implements Closeable {
             if (exp != null) {
                 final long secondsAfterExpiry = now() / 1000 - (exp + getLifespanGrace());
                 if (secondsAfterExpiry > 0) {
-                    String error = """
-                            Logout token issued to client %s expired %d seconds ago""".formatted(oidcConfig.clientId().get(),
+                    String error = "Logout token issued to client %s expired %d seconds ago".formatted(
+                            oidcConfig.clientId().get(),
                             secondsAfterExpiry);
-                    LOG.debug(error);
+                    LOG.warn(error);
                     throw new InvalidJwtException(error, List.of(new ErrorCodeValidator.Error(ErrorCodes.EXPIRED, error)),
                             null);
                 }
@@ -283,13 +283,13 @@ public class OidcProvider implements Closeable {
                 detail = details.get(0).getErrorMessage();
             }
             if (oidcConfig.clientId().isPresent()) {
-                LOG.debugf("Verification of the token issued to client %s has failed: %s.", oidcConfig.clientId().get(),
+                LOG.warnf("Verification of the token issued to client %s has failed: %s.", oidcConfig.clientId().get(),
                         detail);
                 if (oidcConfig.clientName().isPresent()) {
-                    LOG.debugf(" Client name: %s", oidcConfig.clientName().get());
+                    LOG.warnf(" Client name: %s", oidcConfig.clientName().get());
                 }
             } else {
-                LOG.debugf("Token verification has failed: %s", detail);
+                LOG.warnf("Token verification has failed: %s", detail);
             }
             throw ex;
         }
@@ -330,7 +330,7 @@ public class OidcProvider implements Closeable {
 
             if (now - iat > oidcConfig.token().age().get().toSeconds() + getLifespanGrace()) {
                 final String errorMessage = "Token age exceeds the configured token age property";
-                LOG.debugf(errorMessage);
+                LOG.warn(errorMessage);
                 throw new InvalidJwtException(errorMessage,
                         List.of(new ErrorCodeValidator.Error(ErrorCodes.ISSUED_AT_INVALID_PAST, errorMessage)), null);
             }
@@ -379,7 +379,7 @@ public class OidcProvider implements Closeable {
                 });
     }
 
-    public Uni<TokenIntrospection> introspectToken(String token, boolean idToken, Long expiresIn,
+    public Uni<TokenIntrospection> introspectToken(String token, TokenType tokenType, Long expiresIn,
             boolean fallbackFromJwkMatch) {
         if (client.getMetadata().getIntrospectionUri() == null) {
             String errorMessage = String.format("Token issued to client %s "
@@ -388,7 +388,7 @@ public class OidcProvider implements Closeable {
                     + "please check if your OpenId Connect Provider supports the token introspection",
                     oidcConfig.clientId().get());
 
-            throw new AuthenticationFailedException(errorMessage, tokenMap(token, idToken));
+            throw new AuthenticationFailedException(errorMessage, tokenMap(token, tokenType));
         }
         return client.introspectAccessToken(token).onItemOrFailure()
                 .transform(new BiFunction<TokenIntrospection, Throwable, TokenIntrospection>() {
@@ -396,7 +396,7 @@ public class OidcProvider implements Closeable {
                     @Override
                     public TokenIntrospection apply(TokenIntrospection introspectionResult, Throwable t) {
                         if (t != null) {
-                            throw new AuthenticationFailedException(t, tokenMap(token, idToken));
+                            throw new AuthenticationFailedException(t, tokenMap(token, tokenType));
                         }
                         Long introspectionExpiresIn = introspectionResult.getLong(OidcConstants.INTROSPECTION_TOKEN_EXP);
                         if (introspectionExpiresIn == null && expiresIn != null) {
@@ -404,16 +404,16 @@ public class OidcProvider implements Closeable {
                             introspectionExpiresIn = now() + expiresIn;
                         }
                         if (!introspectionResult.isActive()) {
-                            verifyTokenExpiry(token, idToken, introspectionExpiresIn);
+                            verifyTokenExpiry(token, tokenType, introspectionExpiresIn);
                             throw new AuthenticationFailedException(
                                     String.format("Token issued to client %s is not active", oidcConfig.clientId().get()),
-                                    tokenMap(token, idToken));
+                                    tokenMap(token, tokenType));
                         }
-                        verifyTokenExpiry(token, idToken, introspectionExpiresIn);
+                        verifyTokenExpiry(token, tokenType, introspectionExpiresIn);
                         try {
                             verifyTokenAge(introspectionResult.getLong(OidcConstants.INTROSPECTION_TOKEN_IAT));
                         } catch (InvalidJwtException ex) {
-                            throw new AuthenticationFailedException(ex, tokenMap(token, idToken));
+                            throw new AuthenticationFailedException(ex, tokenMap(token, tokenType));
                         }
 
                         if (requiredClaims != null) {
@@ -421,7 +421,7 @@ public class OidcProvider implements Closeable {
                                 final String requiredClaimName = requiredClaim.getKey();
                                 if (!introspectionResult.contains(requiredClaimName)) {
                                     LOG.debugf("Introspection claim %s is missing", requiredClaimName);
-                                    throw new AuthenticationFailedException(tokenMap(token, idToken));
+                                    throw new AuthenticationFailedException(tokenMap(token, tokenType));
                                 }
                                 final Set<String> requiredClaimValues = requiredClaim.getValue();
                                 if (requiredClaimValues.size() == 1) {
@@ -441,7 +441,7 @@ public class OidcProvider implements Closeable {
                                     actualClaimValueArray = requireNonNull(introspectionResult.getArray(requiredClaimName));
                                 } catch (Exception ignored) {
                                     LOG.debugf("Introspection claim %s is neither string nor array", requiredClaimName);
-                                    throw new AuthenticationFailedException(tokenMap(token, idToken));
+                                    throw new AuthenticationFailedException(tokenMap(token, tokenType));
                                 }
                                 requiredClaimValuesLoop: for (String requiredClaimValue : requiredClaimValues) {
                                     for (int i = 0; i < actualClaimValueArray.size(); i++) {
@@ -456,7 +456,7 @@ public class OidcProvider implements Closeable {
                                     }
                                     LOG.debugf("Value of the introspection claim %s does not match required value of %s",
                                             requiredClaimName, requiredClaimValue);
-                                    throw new AuthenticationFailedException(tokenMap(token, idToken));
+                                    throw new AuthenticationFailedException(tokenMap(token, tokenType));
                                 }
                             }
                         }
@@ -467,20 +467,23 @@ public class OidcProvider implements Closeable {
                 });
     }
 
-    private void verifyTokenExpiry(String token, boolean idToken, Long exp) {
+    private void verifyTokenExpiry(String token, TokenType tokenType, Long exp) {
         if (exp == null) {
             return;
         }
         final long secondsAfterExpiry = now() / 1000 - (exp + getLifespanGrace());
         if (secondsAfterExpiry > 0) {
-            String error = """
-                    Token issued to client %s expired %d seconds ago""".formatted(oidcConfig.clientId().get(),
+            String error = "Token issued to client %s expired %d seconds ago".formatted(oidcConfig.clientId().get(),
                     secondsAfterExpiry);
-            LOG.debug(error);
+            if (tokenType == TokenType.BEARER_ACCESS_TOKEN) {
+                LOG.warn(error);
+            } else {
+                LOG.debug(error);
+            }
             throw new AuthenticationFailedException(
                     new InvalidJwtException(error,
                             List.of(new ErrorCodeValidator.Error(ErrorCodes.EXPIRED, error)), null),
-                    tokenMap(token, idToken));
+                    tokenMap(token, tokenType));
         }
     }
 
@@ -751,8 +754,9 @@ public class OidcProvider implements Closeable {
         }
     }
 
-    private static Map<String, Object> tokenMap(String token, boolean idToken) {
-        return Map.of(idToken ? OidcConstants.ID_TOKEN_VALUE : OidcConstants.ACCESS_TOKEN_VALUE, token);
+    private static Map<String, Object> tokenMap(String token, TokenType tokenType) {
+        return Map.of(tokenType == TokenType.ID_TOKEN ? OidcConstants.ID_TOKEN_VALUE : OidcConstants.ACCESS_TOKEN_VALUE,
+                token);
     }
 
     private static final class CatchingErrorCodeValidator extends ErrorCodeValidatorAdapter {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
@@ -195,7 +195,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
                                         return oidcProvider.refreshJwksAndVerifyJwtToken(response.data(), true, false, null)
                                                 .onItem().transform(v -> new UserInfo(v.localVerificationResult.encode()));
                                     } else {
-                                        LOG.debugf("Signed UserInfo verification has failed: %s", t.getMessage());
+                                        LOG.warnf("Signed UserInfo verification has failed: %s", t.getMessage());
                                         return Uni.createFrom().failure(t);
                                     }
                                 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -929,7 +929,7 @@ public final class OidcUtils {
             try {
                 return OidcUtils.decryptString(token, decryptionKey, encryptionAlgorithm);
             } catch (JoseException ex) {
-                LOG.debugf("Failed to decrypt a token: %s", ex.getMessage());
+                LOG.warnf("Failed to decrypt a token: %s", ex.getMessage());
             }
         }
         return token;

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TokenType.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TokenType.java
@@ -1,0 +1,21 @@
+package io.quarkus.oidc.runtime;
+
+/**
+ * Represents the type of token being verified during OIDC authentication.
+ */
+enum TokenType {
+    /**
+     * Bearer access token from HTTP Authorization header.
+     */
+    BEARER_ACCESS_TOKEN,
+
+    /**
+     * Access token obtained via authorization code flow.
+     */
+    CODE_FLOW_ACCESS_TOKEN,
+
+    /**
+     * ID token from authorization code flow.
+     */
+    ID_TOKEN
+}


### PR DESCRIPTION
Backport changes related to raising level of some of OIDC log messages to 3.27,

I'm not sure if it is done right - I have 2 commits here, perhaps #55671 can be closed.

As far as backporting #54909 is concerned - the only thing is does it makes some error log messages reported at a higher warn or error level as the customer expressed concerns they could not see them in prod. It also introduces a `TokenType` to make some logging conditional on a token type. It should be safe - but I'm happy to address any concerns 