### PR TITLE
Support resolving the JDBC driver of an Agroal datasource at runtime

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1859,6 +1859,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-jdbc-runtime</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-jdbc-runtime-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-modular</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/core/deployment/src/main/java/io/quarkus/deployment/Feature.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Feature.java
@@ -55,6 +55,7 @@ public enum Feature {
     JDBC_MSSQL,
     JDBC_MYSQL,
     JDBC_ORACLE,
+    JDBC_RUNTIME,
     JFR,
     KAFKA_CLIENT,
     KAFKA_STREAMS,

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -1378,6 +1378,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-jdbc-runtime</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-jfr</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -1342,6 +1342,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-runtime-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jfr-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -272,6 +272,40 @@ quarkus.datasource.password=tiger
 
 For details about JDBC configuration options and configuring other aspects, such as the connection pool size, refer to the <<jdbc-configuration,JDBC configuration reference>> section.
 
+[[runtime-resolved-driver]]
+===== Runtime-resolved drivers
+
+With `db-kind=other`, the driver class set with `quarkus.datasource.jdbc.driver` is fixed at build time.
+If the driver class must instead be chosen at runtime, for example when the same build artifact is deployed against different databases, use the `quarkus-jdbc-runtime` extension and the `runtime` database kind:
+
+[source,properties]
+----
+quarkus.datasource.db-kind=runtime <1>
+quarkus.datasource.jdbc-runtime.driver=oracle.jdbc.driver.OracleDriver <2>
+quarkus.datasource.jdbc.url=jdbc:oracle:thin:@192.168.1.12:1521/ORCL_SVC
+quarkus.datasource.username=scott
+quarkus.datasource.password=tiger
+----
+<1> Build-time property selecting the runtime-resolved driver support.
+<2> Runtime property; the class is loaded with reflection from the application classpath when the datasource is created.
+
+The rest of the datasource configuration (JDBC URL, credentials, pool sizing, and so on) is unchanged and read at runtime as usual.
+Depending on the actual type of the configured class (`java.sql.Driver`, `javax.sql.DataSource`, or `javax.sql.XADataSource` when `quarkus.datasource.jdbc.transactions=xa`), the matching Agroal connection provider implementation is used.
+
+NOTE: The driver JAR must be part of the application classpath; only the choice of the driver class is deferred to runtime.
+
+====== Runtime-resolved drivers in native executables
+
+In a native executable, the closed-world assumption still applies: every candidate driver must be part of the application classpath when the native image is built, and the classes actually used with reflection must be registered at build time.
+With a runtime-resolved driver:
+
+* When `quarkus.datasource[."datasource-name"].jdbc-runtime.driver` is set in a configuration source visible at build time, such as `application.properties`, the configured class is automatically registered for reflection in the native image.
+* `java.sql.Driver` implementations declared through the standard `META-INF/services/java.sql.Driver` file of the driver JAR are registered automatically in all cases.
+* When the property is only provided at runtime, for example through an environment variable, and the class is not a service-declared `java.sql.Driver` (typically a `javax.sql.DataSource` or `javax.sql.XADataSource` implementation), register the candidate classes yourself with xref:writing-native-applications-tips.adoc#registerForReflection[`@RegisterForReflection(targets = ...)`] or a `reflection-config.json` file.
+
+WARNING: Reflection registration is often not enough for a JDBC driver in native mode: drivers may also require runtime initialization of some classes, bundled resources, or JNI configuration, which the dedicated `quarkus-jdbc-*` extensions normally provide.
+As for <<other-databases,custom databases and drivers>>, prefer an existing Quarkus JDBC extension when building native executables.
+
 ===== Consuming the datasource
 
 With Hibernate ORM, the Hibernate layer automatically picks up the datasource and uses it.
@@ -910,6 +944,10 @@ a|* JDBC: `oracle.jdbc.driver.OracleDriver`
 a|* JDBC: `org.postgresql.Driver`
 
 * XA: `org.postgresql.xa.PGXADataSource`
+
+|`runtime`
+|`quarkus-jdbc-runtime`
+a|* Resolved at runtime from `quarkus.datasource[.optional name].jdbc-runtime.driver`, see <<runtime-resolved-driver,Runtime-resolved drivers>>
 |===
 
 

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalDriverResolver.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalDriverResolver.java
@@ -1,0 +1,25 @@
+package io.quarkus.agroal.runtime;
+
+/**
+ * Allows a JDBC driver extension to resolve the driver class name of a datasource at runtime,
+ * overriding the driver class name resolved at build time.
+ * <p>
+ * Implementations must be exposed as CDI beans qualified with {@link JdbcDriver} for the database
+ * kind they support. When no bean matches the resolved database kind of a datasource, the driver
+ * class name resolved at build time is used as-is.
+ * <p>
+ * The returned class name is loaded from the {@link Thread#getContextClassLoader() TCCL} and passed
+ * to Agroal which selects the proper connection provider implementation based on the actual type
+ * ({@link java.sql.Driver}, {@link javax.sql.DataSource} or {@link javax.sql.XADataSource}).
+ */
+public interface AgroalDriverResolver {
+
+    /**
+     * Resolves the driver class name to use for the given datasource.
+     *
+     * @param dataSourceName the name of the datasource being created
+     * @param buildTimeDriverClass the driver class name resolved at build time
+     * @return the fully qualified name of the driver class to load, never {@code null}
+     */
+    String resolveDriverClassName(String dataSourceName, String buildTimeDriverClass);
+}

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -161,7 +161,14 @@ public class DataSources {
         loadDriversInTCCL();
 
         AgroalDataSourceSupport.Entry matchingSupportEntry = agroalDataSourceSupport.entries.get(dataSourceName);
-        String resolvedDriverClass = matchingSupportEntry.resolvedDriverClass;
+        String resolvedDbKind = matchingSupportEntry.resolvedDbKind;
+        // a driver extension may override at runtime the driver class resolved at build time
+        AgroalDriverResolver driverResolver = Arc.container()
+                .instance(AgroalDriverResolver.class, new JdbcDriverLiteral(resolvedDbKind))
+                .orElse(null);
+        String resolvedDriverClass = driverResolver != null
+                ? driverResolver.resolveDriverClassName(dataSourceName, matchingSupportEntry.resolvedDriverClass)
+                : matchingSupportEntry.resolvedDriverClass;
         Class<?> driver;
         try {
             driver = Class.forName(resolvedDriverClass, true, Thread.currentThread().getContextClassLoader());
@@ -172,7 +179,6 @@ public class DataSources {
 
         String jdbcUrl = dataSourceJdbcRuntimeConfig.url().get();
 
-        String resolvedDbKind = matchingSupportEntry.resolvedDbKind;
         AgroalConnectionConfigurer agroalConnectionConfigurer = Arc.container()
                 .instance(AgroalConnectionConfigurer.class, new JdbcDriverLiteral(resolvedDbKind))
                 .orElse(new UnknownDbAgroalConnectionConfigurer());

--- a/extensions/jdbc/jdbc-runtime/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-runtime/deployment/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-jdbc-runtime-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-jdbc-runtime-deployment</artifactId>
+    <name>Quarkus - JDBC - Runtime Resolved Driver - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-datasource-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-agroal-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-agroal-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-runtime</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${project.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/jdbc/jdbc-runtime/deployment/src/main/java/io/quarkus/jdbc/runtime/deployment/JdbcRuntimeProcessor.java
+++ b/extensions/jdbc/jdbc-runtime/deployment/src/main/java/io/quarkus/jdbc/runtime/deployment/JdbcRuntimeProcessor.java
@@ -1,0 +1,68 @@
+package io.quarkus.jdbc.runtime.deployment;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.quarkus.agroal.spi.JdbcDriverBuildItem;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.processor.BuiltinScope;
+import io.quarkus.datasource.common.runtime.DataSourceUtil;
+import io.quarkus.datasource.deployment.spi.DefaultDataSourceDbKindBuildItem;
+import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.jdbc.runtime.runtime.RuntimeJdbc;
+import io.quarkus.jdbc.runtime.runtime.RuntimeJdbcDriverPlaceholder;
+import io.quarkus.jdbc.runtime.runtime.RuntimeJdbcDriverResolver;
+import io.quarkus.jdbc.runtime.runtime.RuntimeJdbcXADataSourcePlaceholder;
+
+public class JdbcRuntimeProcessor {
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(Feature.JDBC_RUNTIME);
+    }
+
+    @BuildStep
+    JdbcDriverBuildItem registerPlaceholderDriver() {
+        // placeholder classes satisfying the build-time validation of the Agroal extension,
+        // the actual driver is substituted at runtime by RuntimeJdbcDriverResolver
+        return new JdbcDriverBuildItem(RuntimeJdbc.DB_KIND, RuntimeJdbcDriverPlaceholder.class.getName(),
+                RuntimeJdbcXADataSourcePlaceholder.class.getName());
+    }
+
+    @BuildStep
+    DefaultDataSourceDbKindBuildItem registerDefaultDbKind() {
+        return new DefaultDataSourceDbKindBuildItem(RuntimeJdbc.DB_KIND);
+    }
+
+    @BuildStep
+    void registerConfiguredDriversForReflection(final DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig,
+            final BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+        final var config = ConfigProvider.getConfig();
+        for (final var dataSourceName : dataSourcesBuildTimeConfig.dataSources().keySet()) {
+            for (final var key : DataSourceUtil.dataSourcePropertyKeys(dataSourceName, "jdbc-runtime.driver")) {
+                final var driver = config.getOptionalValue(key, String.class);
+                if (driver.isPresent()) {
+                    // best effort for native images: the driver is a runtime choice but when the property is
+                    // already visible at build time (e.g. set in application.properties) the configured class
+                    // is registered for reflection; methods are needed for the XADataSource/DataSource
+                    // property injection done by Agroal
+                    reflectiveClass.produce(ReflectiveClassBuildItem.builder(driver.get()).methods().build());
+                    break;
+                }
+            }
+        }
+    }
+
+    @BuildStep
+    AdditionalBeanBuildItem registerDriverResolver() {
+        return new AdditionalBeanBuildItem.Builder()
+                .addBeanClass(RuntimeJdbcDriverResolver.class)
+                .setDefaultScope(BuiltinScope.APPLICATION.getName())
+                .setUnremovable()
+                .build();
+    }
+}

--- a/extensions/jdbc/jdbc-runtime/deployment/src/test/java/io/quarkus/jdbc/runtime/test/RuntimeResolvedDriverConfigTest.java
+++ b/extensions/jdbc/jdbc-runtime/deployment/src/test/java/io/quarkus/jdbc/runtime/test/RuntimeResolvedDriverConfigTest.java
@@ -1,0 +1,64 @@
+package io.quarkus.jdbc.runtime.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.agroal.DataSource;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class RuntimeResolvedDriverConfigTest {
+
+    @Inject
+    AgroalDataSource defaultDataSource;
+
+    @Inject
+    @DataSource("users")
+    AgroalDataSource usersDataSource;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withConfigurationResource("application-runtime-resolved-driver.properties");
+
+    @Test
+    public void defaultDataSourceUsesRuntimeResolvedDriver() throws SQLException {
+        final var poolConfiguration = defaultDataSource.getConfiguration().connectionPoolConfiguration();
+        final var connectionFactoryConfiguration = poolConfiguration.connectionFactoryConfiguration();
+
+        assertThat(connectionFactoryConfiguration.connectionProviderClass().getName()).isEqualTo("org.h2.Driver");
+        assertThat(connectionFactoryConfiguration.jdbcUrl()).isEqualTo("jdbc:h2:mem:runtime-default");
+        assertThat(connectionFactoryConfiguration.principal().getName()).isEqualTo("username-default");
+        assertThat(poolConfiguration.minSize()).isEqualTo(3);
+        assertThat(poolConfiguration.maxSize()).isEqualTo(13);
+        assertThat(poolConfiguration.initialSize()).isEqualTo(7);
+
+        assertSelectOne(defaultDataSource);
+    }
+
+    @Test
+    public void namedDataSourceUsesRuntimeResolvedDriver() throws SQLException {
+        final var connectionFactoryConfiguration = usersDataSource.getConfiguration().connectionPoolConfiguration()
+                .connectionFactoryConfiguration();
+
+        assertThat(connectionFactoryConfiguration.connectionProviderClass().getName()).isEqualTo("org.h2.Driver");
+        assertThat(connectionFactoryConfiguration.jdbcUrl()).isEqualTo("jdbc:h2:mem:runtime-users");
+        assertThat(connectionFactoryConfiguration.principal().getName()).isEqualTo("username-users");
+
+        assertSelectOne(usersDataSource);
+    }
+
+    private static void assertSelectOne(final AgroalDataSource dataSource) throws SQLException {
+        try (final var connection = dataSource.getConnection();
+                final var statement = connection.createStatement();
+                final var resultSet = statement.executeQuery("SELECT 1")) {
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getInt(1)).isEqualTo(1);
+        }
+    }
+}

--- a/extensions/jdbc/jdbc-runtime/deployment/src/test/java/io/quarkus/jdbc/runtime/test/RuntimeResolvedDriverMissingConfigTest.java
+++ b/extensions/jdbc/jdbc-runtime/deployment/src/test/java/io/quarkus/jdbc/runtime/test/RuntimeResolvedDriverMissingConfigTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.jdbc.runtime.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class RuntimeResolvedDriverMissingConfigTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .overrideConfigKey("quarkus.datasource.db-kind", "runtime")
+            .overrideRuntimeConfigKey("quarkus.datasource.jdbc.url", "jdbc:h2:mem:runtime-missing-driver")
+            .assertException(t -> assertThat(t)
+                    .hasStackTraceContaining("does not configure the JDBC driver class to load")
+                    .hasStackTraceContaining("quarkus.datasource.jdbc-runtime.driver"));
+
+    @Inject
+    AgroalDataSource dataSource;
+
+    @Test
+    public void startupShouldFail() {
+        Assertions.fail("Startup should have failed");
+    }
+}

--- a/extensions/jdbc/jdbc-runtime/deployment/src/test/java/io/quarkus/jdbc/runtime/test/RuntimeResolvedDriverWrongTypeTest.java
+++ b/extensions/jdbc/jdbc-runtime/deployment/src/test/java/io/quarkus/jdbc/runtime/test/RuntimeResolvedDriverWrongTypeTest.java
@@ -1,0 +1,32 @@
+package io.quarkus.jdbc.runtime.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class RuntimeResolvedDriverWrongTypeTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .overrideConfigKey("quarkus.datasource.db-kind", "runtime")
+            .overrideRuntimeConfigKey("quarkus.datasource.jdbc.url", "jdbc:h2:mem:runtime-wrong-type")
+            .overrideRuntimeConfigKey("quarkus.datasource.jdbc-runtime.driver", "java.lang.String")
+            .assertException(t -> assertThat(t)
+                    .hasStackTraceContaining("java.lang.String")
+                    .hasStackTraceContaining("is neither an implementation of"));
+
+    @Inject
+    AgroalDataSource dataSource;
+
+    @Test
+    public void startupShouldFail() {
+        Assertions.fail("Startup should have failed");
+    }
+}

--- a/extensions/jdbc/jdbc-runtime/deployment/src/test/java/io/quarkus/jdbc/runtime/test/RuntimeResolvedXaDriverTest.java
+++ b/extensions/jdbc/jdbc-runtime/deployment/src/test/java/io/quarkus/jdbc/runtime/test/RuntimeResolvedXaDriverTest.java
@@ -1,0 +1,41 @@
+package io.quarkus.jdbc.runtime.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class RuntimeResolvedXaDriverTest {
+
+    @Inject
+    AgroalDataSource dataSource;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .overrideConfigKey("quarkus.datasource.db-kind", "runtime")
+            .overrideConfigKey("quarkus.datasource.jdbc.transactions", "xa")
+            .overrideRuntimeConfigKey("quarkus.datasource.jdbc.url", "jdbc:h2:mem:runtime-xa")
+            .overrideRuntimeConfigKey("quarkus.datasource.jdbc-runtime.driver", "org.h2.jdbcx.JdbcDataSource");
+
+    @Test
+    public void xaDataSourceIsRuntimeResolved() throws SQLException {
+        final var connectionFactoryConfiguration = dataSource.getConfiguration().connectionPoolConfiguration()
+                .connectionFactoryConfiguration();
+        assertThat(connectionFactoryConfiguration.connectionProviderClass().getName())
+                .isEqualTo("org.h2.jdbcx.JdbcDataSource");
+
+        try (final var connection = dataSource.getConnection();
+                final var statement = connection.createStatement();
+                final var resultSet = statement.executeQuery("SELECT 1")) {
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getInt(1)).isEqualTo(1);
+        }
+    }
+}

--- a/extensions/jdbc/jdbc-runtime/deployment/src/test/resources/application-runtime-resolved-driver.properties
+++ b/extensions/jdbc/jdbc-runtime/deployment/src/test/resources/application-runtime-resolved-driver.properties
@@ -1,0 +1,12 @@
+quarkus.datasource.db-kind=runtime
+quarkus.datasource.username=username-default
+quarkus.datasource.jdbc.url=jdbc:h2:mem:runtime-default
+quarkus.datasource.jdbc-runtime.driver=org.h2.Driver
+quarkus.datasource.jdbc.min-size=3
+quarkus.datasource.jdbc.max-size=13
+quarkus.datasource.jdbc.initial-size=7
+
+quarkus.datasource."users".db-kind=runtime
+quarkus.datasource."users".username=username-users
+quarkus.datasource."users".jdbc.url=jdbc:h2:mem:runtime-users
+quarkus.datasource."users".jdbc-runtime.driver=org.h2.Driver

--- a/extensions/jdbc/jdbc-runtime/pom.xml
+++ b/extensions/jdbc/jdbc-runtime/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-jdbc-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-jdbc-runtime-parent</artifactId>
+    <name>Quarkus - JDBC - Runtime Resolved Driver</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+
+</project>

--- a/extensions/jdbc/jdbc-runtime/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-runtime/runtime/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-jdbc-runtime-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-jdbc-runtime</artifactId>
+    <name>Quarkus - JDBC - Runtime Resolved Driver - Runtime</name>
+    <description>Connect to any database via a JDBC driver resolved with reflection at runtime</description>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-agroal</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <configuration>
+                    <capabilities>
+                        <provides>io.quarkus.jdbc.runtime</provides>
+                    </capabilities>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${project.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/extensions/jdbc/jdbc-runtime/runtime/src/main/java/io/quarkus/jdbc/runtime/runtime/DataSourcesJdbcRuntimeDriverConfig.java
+++ b/extensions/jdbc/jdbc-runtime/runtime/src/main/java/io/quarkus/jdbc/runtime/runtime/DataSourcesJdbcRuntimeDriverConfig.java
@@ -1,0 +1,54 @@
+package io.quarkus.jdbc.runtime.runtime;
+
+import java.util.Map;
+import java.util.Optional;
+
+import io.quarkus.datasource.common.runtime.DataSourceUtil;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
+import io.smallrye.config.WithUnnamedKey;
+
+@ConfigMapping(prefix = "quarkus.datasource")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface DataSourcesJdbcRuntimeDriverConfig {
+
+    /**
+     * Datasources.
+     */
+    @ConfigDocMapKey("datasource-name")
+    @WithParentName
+    @WithDefaults
+    @WithUnnamedKey(DataSourceUtil.DEFAULT_DATASOURCE_NAME)
+    Map<String, DataSourceJdbcRuntimeDriverOuterNamedConfig> dataSources();
+
+    @ConfigGroup
+    interface DataSourceJdbcRuntimeDriverOuterNamedConfig {
+
+        /**
+         * The configuration of the JDBC driver resolved at runtime.
+         */
+        DataSourceJdbcRuntimeDriverConfig jdbcRuntime();
+    }
+
+    @ConfigGroup
+    interface DataSourceJdbcRuntimeDriverConfig {
+
+        /**
+         * The fully qualified name of the JDBC driver class to use for this datasource.
+         * <p>
+         * The class must be present in the application classpath and is loaded with reflection
+         * from the TCCL when the datasource is created. Depending on the actual type of the class
+         * ({@code java.sql.Driver}, {@code javax.sql.DataSource} or {@code javax.sql.XADataSource}
+         * when XA transactions are enabled), the matching Agroal connection provider implementation
+         * is used.
+         * <p>
+         * Only used when the database kind of the datasource is {@code runtime}.
+         */
+        Optional<String> driver();
+    }
+}

--- a/extensions/jdbc/jdbc-runtime/runtime/src/main/java/io/quarkus/jdbc/runtime/runtime/RuntimeJdbc.java
+++ b/extensions/jdbc/jdbc-runtime/runtime/src/main/java/io/quarkus/jdbc/runtime/runtime/RuntimeJdbc.java
@@ -1,0 +1,16 @@
+package io.quarkus.jdbc.runtime.runtime;
+
+/**
+ * Constants for the runtime-resolved JDBC driver support.
+ */
+public final class RuntimeJdbc {
+
+    /**
+     * The database kind of datasources whose JDBC driver is resolved at runtime from the
+     * {@code quarkus.datasource[."datasource-name"].jdbc-runtime.driver} configuration property.
+     */
+    public static final String DB_KIND = "runtime";
+
+    private RuntimeJdbc() {
+    }
+}

--- a/extensions/jdbc/jdbc-runtime/runtime/src/main/java/io/quarkus/jdbc/runtime/runtime/RuntimeJdbcDriverPlaceholder.java
+++ b/extensions/jdbc/jdbc-runtime/runtime/src/main/java/io/quarkus/jdbc/runtime/runtime/RuntimeJdbcDriverPlaceholder.java
@@ -1,0 +1,60 @@
+package io.quarkus.jdbc.runtime.runtime;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverPropertyInfo;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+/**
+ * Build-time placeholder driver for datasources of database kind {@link RuntimeJdbc#DB_KIND}.
+ * <p>
+ * It only exists to satisfy the build-time validation and recording of the Agroal extension:
+ * before the pool is created, {@link RuntimeJdbcDriverResolver} substitutes it with the driver
+ * class configured with {@code quarkus.datasource[."datasource-name"].jdbc-runtime.driver},
+ * so this class is never instantiated.
+ */
+public final class RuntimeJdbcDriverPlaceholder implements Driver {
+
+    @Override
+    public Connection connect(final String url, final Properties info) {
+        throw placeholderUsed();
+    }
+
+    @Override
+    public boolean acceptsURL(final String url) {
+        throw placeholderUsed();
+    }
+
+    @Override
+    public DriverPropertyInfo[] getPropertyInfo(final String url, final Properties info) {
+        throw placeholderUsed();
+    }
+
+    @Override
+    public int getMajorVersion() {
+        throw placeholderUsed();
+    }
+
+    @Override
+    public int getMinorVersion() {
+        throw placeholderUsed();
+    }
+
+    @Override
+    public boolean jdbcCompliant() {
+        throw placeholderUsed();
+    }
+
+    @Override
+    public Logger getParentLogger() {
+        throw placeholderUsed();
+    }
+
+    private static IllegalStateException placeholderUsed() {
+        return new IllegalStateException(RuntimeJdbcDriverPlaceholder.class.getName()
+                + " is a build-time placeholder and should never be used at runtime."
+                + " The actual JDBC driver must be set with the"
+                + " 'quarkus.datasource[.\"datasource-name\"].jdbc-runtime.driver' configuration property.");
+    }
+}

--- a/extensions/jdbc/jdbc-runtime/runtime/src/main/java/io/quarkus/jdbc/runtime/runtime/RuntimeJdbcDriverResolver.java
+++ b/extensions/jdbc/jdbc-runtime/runtime/src/main/java/io/quarkus/jdbc/runtime/runtime/RuntimeJdbcDriverResolver.java
@@ -1,0 +1,80 @@
+package io.quarkus.jdbc.runtime.runtime;
+
+import java.sql.Driver;
+import java.util.Set;
+
+import javax.sql.DataSource;
+import javax.sql.XADataSource;
+
+import io.quarkus.agroal.runtime.AgroalDriverResolver;
+import io.quarkus.agroal.runtime.DataSourcesJdbcBuildTimeConfig;
+import io.quarkus.agroal.runtime.JdbcDriver;
+import io.quarkus.agroal.runtime.TransactionIntegration;
+import io.quarkus.datasource.common.runtime.DataSourceUtil;
+import io.quarkus.runtime.configuration.ConfigurationException;
+
+/**
+ * Resolves the JDBC driver of datasources of database kind {@link RuntimeJdbc#DB_KIND} at runtime,
+ * from the {@code quarkus.datasource[."datasource-name"].jdbc-runtime.driver} configuration
+ * property, instead of the driver class resolved at build time.
+ */
+@JdbcDriver(RuntimeJdbc.DB_KIND)
+public class RuntimeJdbcDriverResolver implements AgroalDriverResolver {
+
+    private static final String DRIVER_PROPERTY_RADICAL = "jdbc-runtime.driver";
+
+    private final DataSourcesJdbcRuntimeDriverConfig runtimeDriverConfig;
+    private final DataSourcesJdbcBuildTimeConfig jdbcBuildTimeConfig;
+
+    public RuntimeJdbcDriverResolver(final DataSourcesJdbcRuntimeDriverConfig runtimeDriverConfig,
+            final DataSourcesJdbcBuildTimeConfig jdbcBuildTimeConfig) {
+        this.runtimeDriverConfig = runtimeDriverConfig;
+        this.jdbcBuildTimeConfig = jdbcBuildTimeConfig;
+    }
+
+    @Override
+    public String resolveDriverClassName(final String dataSourceName, final String buildTimeDriverClass) {
+        final var driverProperty = DataSourceUtil.dataSourcePropertyKey(dataSourceName, DRIVER_PROPERTY_RADICAL);
+        final var driverClassName = runtimeDriverConfig.dataSources().get(dataSourceName).jdbcRuntime().driver()
+                .orElseThrow(() -> new ConfigurationException(
+                        "Datasource '" + dataSourceName + "' uses the '" + RuntimeJdbc.DB_KIND + "' database kind"
+                                + " but does not configure the JDBC driver class to load."
+                                + " To solve this, set the '" + driverProperty
+                                + "' configuration property to the fully qualified name of a JDBC driver class"
+                                + " present in the application classpath.",
+                        Set.of(driverProperty)));
+        validate(dataSourceName, driverProperty, driverClassName);
+        return driverClassName;
+    }
+
+    private void validate(final String dataSourceName, final String driverProperty, final String driverClassName) {
+        final Class<?> driverClass;
+        try {
+            driverClass = Class.forName(driverClassName, true, Thread.currentThread().getContextClassLoader());
+        } catch (ClassNotFoundException e) {
+            throw new ConfigurationException(
+                    "Unable to load the JDBC driver class '" + driverClassName + "' configured with '" + driverProperty
+                            + "' for datasource '" + dataSourceName
+                            + "'. Ensure the driver is present in the application classpath.",
+                    e, Set.of(driverProperty));
+        }
+
+        final var xa = jdbcBuildTimeConfig.dataSources().get(dataSourceName).jdbc()
+                .transactions() == TransactionIntegration.XA;
+        if (xa) {
+            if (!XADataSource.class.isAssignableFrom(driverClass)) {
+                throw new ConfigurationException(
+                        "Datasource '" + dataSourceName + "' uses XA transactions but the driver class '" + driverClassName
+                                + "' configured with '" + driverProperty + "' is not an implementation of "
+                                + XADataSource.class.getName() + ".",
+                        Set.of(driverProperty));
+            }
+        } else if (!Driver.class.isAssignableFrom(driverClass) && !DataSource.class.isAssignableFrom(driverClass)) {
+            throw new ConfigurationException(
+                    "The driver class '" + driverClassName + "' configured with '" + driverProperty + "' for datasource '"
+                            + dataSourceName + "' is neither an implementation of " + Driver.class.getName() + " nor of "
+                            + DataSource.class.getName() + ".",
+                    Set.of(driverProperty));
+        }
+    }
+}

--- a/extensions/jdbc/jdbc-runtime/runtime/src/main/java/io/quarkus/jdbc/runtime/runtime/RuntimeJdbcXADataSourcePlaceholder.java
+++ b/extensions/jdbc/jdbc-runtime/runtime/src/main/java/io/quarkus/jdbc/runtime/runtime/RuntimeJdbcXADataSourcePlaceholder.java
@@ -1,0 +1,61 @@
+package io.quarkus.jdbc.runtime.runtime;
+
+import java.io.PrintWriter;
+
+import javax.sql.XAConnection;
+import javax.sql.XADataSource;
+
+/**
+ * Build-time placeholder XA datasource for datasources of database kind {@link RuntimeJdbc#DB_KIND}
+ * using XA transactions.
+ * <p>
+ * It only exists to satisfy the build-time validation and recording of the Agroal extension:
+ * before the pool is created, {@link RuntimeJdbcDriverResolver} substitutes it with the
+ * {@link XADataSource} implementation configured with
+ * {@code quarkus.datasource[."datasource-name"].jdbc-runtime.driver}, so this class is never
+ * instantiated.
+ */
+public final class RuntimeJdbcXADataSourcePlaceholder implements XADataSource {
+
+    @Override
+    public XAConnection getXAConnection() {
+        throw placeholderUsed();
+    }
+
+    @Override
+    public XAConnection getXAConnection(final String user, final String password) {
+        throw placeholderUsed();
+    }
+
+    @Override
+    public PrintWriter getLogWriter() {
+        throw placeholderUsed();
+    }
+
+    @Override
+    public void setLogWriter(final PrintWriter out) {
+        throw placeholderUsed();
+    }
+
+    @Override
+    public void setLoginTimeout(final int seconds) {
+        throw placeholderUsed();
+    }
+
+    @Override
+    public int getLoginTimeout() {
+        throw placeholderUsed();
+    }
+
+    @Override
+    public java.util.logging.Logger getParentLogger() {
+        throw placeholderUsed();
+    }
+
+    private static IllegalStateException placeholderUsed() {
+        return new IllegalStateException(RuntimeJdbcXADataSourcePlaceholder.class.getName()
+                + " is a build-time placeholder and should never be used at runtime."
+                + " The actual XA datasource implementation must be set with the"
+                + " 'quarkus.datasource[.\"datasource-name\"].jdbc-runtime.driver' configuration property.");
+    }
+}

--- a/extensions/jdbc/jdbc-runtime/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jdbc/jdbc-runtime/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,13 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+name: "JDBC Driver - Runtime Resolved"
+metadata:
+  keywords:
+  - "jdbc-runtime"
+  - "jdbc"
+  - "driver"
+  - "reflection"
+  guide: "https://quarkus.io/guides/datasource"
+  categories:
+  - "data"
+  status: "preview"

--- a/extensions/jdbc/pom.xml
+++ b/extensions/jdbc/pom.xml
@@ -21,6 +21,7 @@
         <module>jdbc-mssql</module>
         <module>jdbc-mysql</module>
         <module>jdbc-oracle</module>
+        <module>jdbc-runtime</module>
     </modules>
 
 </project>


### PR DESCRIPTION
Hi,

I let the more detailled description below rephrased by claude but I want to emphasis this is not a random PR but it comes from the Apache Polaris need.
There are two use cases needed to be adressed and missing in Quarkus today:

* Be able to resolve a driver in JVM mode (at least, best effort for native mode) which is not provided in default image (think a Pod with a init container copying the driver in the classpath using an emptyDir or alike to provide it to the quarkus application), one reason is to be able to use driver the Apache license forbids to provide OOTB
* Be able to use the same image and switch driver depending the environment/customer (standard java JDBC usage)

High level the PR is super simple, providing a new "runtime" datasource type with runtime resolution.

[rest of the description was generated from the diff using claude]

The JDBC driver of an Agroal datasource is currently fixed at build time: it is either derived
 from db-kind by a quarkus-jdbc-* extension or set explicitly with the build-time property
 quarkus.datasource.jdbc.driver (db-kind=other). This prevents shipping a single build
 artifact that is pointed at different databases per deployment, where the driver can only be
 decided at startup, like the JDBC URL or the pool sizing already can.

 This PR makes the driver a runtime decision, in two parts:

 - quarkus-agroal gains a small runtime SPI, `AgroalDriverResolver`, resolved through the
 existing `@JdbcDriver(db-kind)` qualifier (same pattern as `AgroalConnectionConfigurer`).
 When no resolver bean matches the datasource db-kind, the build-time resolved driver is used
 as before, so existing driver extensions are not affected.
 - A new extension, quarkus-jdbc-runtime (extensions/jdbc/jdbc-runtime, consistent with its
 jdbc-* siblings), contributes the runtime database kind. The driver class name is read
 from the new runtime property quarkus.datasource[."datasource-name"].jdbc-runtime.driver,
 loaded with reflection from the TCCL and validated with actionable errors
 (java.sql.Driver/javax.sql.DataSource, or javax.sql.XADataSource when
 jdbc.transactions=xa). Agroal then selects the proper connection provider implementation
 from the actual class type. Build-time validation is satisfied by placeholder classes, and
 the rest of the datasource configuration (URL, credentials, pool sizing, XA recovery,
 metrics, health, OpenTelemetry) goes through the standard Agroal code path unchanged.

 In native executables the closed-world assumption still applies: candidate drivers must be in
 the classpath at image build time and only the class choice is deferred. When the property is
 visible at build time (for example in application.properties) the configured class is
 registered for reflection automatically; java.sql.Driver service providers were already
 registered by the Agroal processor. The datasource guide documents these cases as well as the
 `@RegisterForReflection`/`reflection-config.json` fallback, and keeps recommending dedicated
 quarkus-jdbc-* extensions for native images since drivers may need more than reflection.

 Tested with `QuarkusExtensionTest` in the new deployment module (default and named
 datasources, XA, missing property, invalid class type); the full Agroal test suite passes
 unchanged.

 Release note: A datasource can now use a JDBC driver chosen at runtime: set
 quarkus.datasource.db-kind=runtime with the new quarkus-jdbc-runtime extension and provide
 the driver class with the runtime property quarkus.datasource[."datasource-name"].jdbc-runtime.driver.
[/]