### PR TITLE
Fix serialization of formatted date in reflection-free Jackson serializers

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
@@ -608,7 +608,7 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
                 writeStringShapedValue(fieldSpecs, bytecode, ctx, pkgName, typeName, arg);
             } else if ("STRING".equals(formatShape) && fieldSpecs.formatPattern() == null && isJavaTimeDateType(typeName)) {
                 writeToStringValue(fieldSpecs, bytecode, ctx, pkgName, arg);
-            } else if ("STRING".equals(formatShape) && isJavaUtilDateType(typeName)) {
+            } else if ("STRING".equals(formatShape) && fieldSpecs.formatPattern() == null && isJavaUtilDateType(typeName)) {
                 writeToStringValue(fieldSpecs, bytecode, ctx, pkgName, arg);
             } else if (fieldSpecs.isFormatShapeNumber() && isBooleanType(typeName)) {
                 writeNumberShapedBoolean(fieldSpecs, bytecode, ctx, pkgName, typeName, arg);

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
@@ -670,6 +670,28 @@ public abstract class AbstractGeneratedAnnotationTest {
                 .body("duration", Matchers.is("PT21H22M55S"));
     }
 
+    // --- @JsonFormat(shape = STRING, pattern = "...") on java.util.Date ---
+
+    @Test
+    public void testFormatDateStringShapeWithPatternSerialization() {
+        RestAssured.get("/generated/date-string-shape-pattern")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("date-string-shape"))
+                .body("directDate", Matchers.is("2026-07-20T11:11:11Z"));
+    }
+
+    @Test
+    public void testFormatDateStringShapeWithPatternListSerialization() {
+        RestAssured.get("/generated/date-string-shape-pattern-list")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("[0].name", Matchers.is("date-string-shape"))
+                .body("[0].directDate", Matchers.is("2026-07-20T11:11:11Z"));
+    }
+
     // --- @JsonFormat ---
 
     @Test

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/DateStringShapeWithPatternBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/DateStringShapeWithPatternBean.java
@@ -1,0 +1,29 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+public class DateStringShapeWithPatternBean {
+
+    private String name;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+    private Date directDate;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Date getDirectDate() {
+        return directDate;
+    }
+
+    public void setDirectDate(Date directDate) {
+        this.directDate = directDate;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
@@ -601,6 +601,26 @@ public class GeneratedAnnotationResource {
         return bean;
     }
 
+    // --- DateStringShapeWithPatternBean: @JsonFormat(shape = STRING, pattern = "...") on java.util.Date ---
+
+    @GET
+    @Path("/date-string-shape-pattern")
+    public DateStringShapeWithPatternBean getDateStringShapePattern() {
+        DateStringShapeWithPatternBean bean = new DateStringShapeWithPatternBean();
+        bean.setName("date-string-shape");
+        bean.setDirectDate(Date.from(Instant.parse("2026-07-20T11:11:11Z")));
+        return bean;
+    }
+
+    @GET
+    @Path("/date-string-shape-pattern-list")
+    public List<DateStringShapeWithPatternBean> getDateStringShapePatternList() {
+        DateStringShapeWithPatternBean bean = new DateStringShapeWithPatternBean();
+        bean.setName("date-string-shape");
+        bean.setDirectDate(Date.from(Instant.parse("2026-07-20T11:11:11Z")));
+        return List.of(bean);
+    }
+
     // --- FormatArrayShapeBean: @JsonFormat(shape = ARRAY) on class ---
 
     @GET

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
@@ -43,6 +43,7 @@ public class GeneratedAnnotationTest extends AbstractGeneratedAnnotationTest {
                                     ManagedReferenceParent.class,
                                     ManagedReferenceChild.class,
                                     DateFormatBean.class,
+                                    DateStringShapeWithPatternBean.class,
                                     DurationFormatBean.class,
                                     NumberShapedTemporalBean.class,
                                     ZonedDateTimeFormatBean.class,

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
@@ -46,6 +46,7 @@ public class GeneratedAnnotationWithReflectionFreeSerializersTest extends Abstra
                                     ManagedReferenceParent.class,
                                     ManagedReferenceChild.class,
                                     DateFormatBean.class,
+                                    DateStringShapeWithPatternBean.class,
                                     DurationFormatBean.class,
                                     NumberShapedTemporalBean.class,
                                     ZonedDateTimeFormatBean.class,


### PR DESCRIPTION
Added `&& fieldSpecs.formatPattern() == null` guard so that `java.util.Date` fields with both `shape = STRING` and a custom pattern fall through to` writeFormattedDateValue()` instead of `writeToStringValue()`. This mirrors the existing guard for java.time types.

- Fixes: #55678 