### PR TITLE
PersistentLoginManager clock method

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PersistentLoginManager.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PersistentLoginManager.java
@@ -67,6 +67,10 @@ public class PersistentLoginManager {
         }
     }
 
+    protected long getCurrentMillis() {
+        return System.currentTimeMillis();
+    }
+
     public RestoreResult restore(RoutingContext context) {
         return restore(context, cookieName);
     }
@@ -97,7 +101,7 @@ public class PersistentLoginManager {
                 return null;
             }
             long expireIdle = Long.parseLong(result.substring(0, sep));
-            long now = System.currentTimeMillis();
+            long now = getCurrentMillis();
             log.debugf("Current time: %s, Expire idle timeout: %s, expireIdle - now is: %d - %d = %d",
                     new Date(now).toString(), new Date(expireIdle).toString(), expireIdle, now, expireIdle - now);
             // We don't attempt renewal, idle timeout already expired.
@@ -132,7 +136,7 @@ public class PersistentLoginManager {
             secureRandom.nextBytes(iv);
             cipher.init(Cipher.ENCRYPT_MODE, secretKey, new GCMParameterSpec(ENC_TAG_LENGTH, iv));
             StringBuilder contents = new StringBuilder();
-            long timeout = System.currentTimeMillis() + timeoutMillis;
+            long timeout = getCurrentMillis() + timeoutMillis;
             log.debugf("The new cookie will expire at %s", new Date(timeout).toString());
             contents.append(timeout);
             contents.append(":");
@@ -190,5 +194,4 @@ public class PersistentLoginManager {
             return principal;
         }
     }
-
 }


### PR DESCRIPTION
Adds a single protected method to provide the current system time in milliseconds. Does not address the other items discussed in #55106.

- Closes: https://github.com/quarkusio/quarkus/issues/55106
- Replaces: https://github.com/quarkusio/quarkus/pull/55276