### PR TITLE
Use most suitable constructor for deserialization in reflection-free Jackson serializers

### DIFF
--- a/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonAllowFinalFieldsAsMutatorsDisabledTest.java
+++ b/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonAllowFinalFieldsAsMutatorsDisabledTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.jackson.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import tools.jackson.databind.ObjectMapper;
+
+public class JacksonAllowFinalFieldsAsMutatorsDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest();
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Test
+    public void testFinalFieldsNotUsedAsMutatorsByDefault() {
+        BeanWithFinalField result = objectMapper.readValue("{\"name\":\"hello\"}", BeanWithFinalField.class);
+        assertThat(result.getName()).isNull();
+    }
+
+    public static class BeanWithFinalField {
+        private final String name = null;
+
+        public String getName() {
+            return name;
+        }
+    }
+}

--- a/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonAllowFinalFieldsAsMutatorsEnabledTest.java
+++ b/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonAllowFinalFieldsAsMutatorsEnabledTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.jackson.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import tools.jackson.databind.ObjectMapper;
+
+public class JacksonAllowFinalFieldsAsMutatorsEnabledTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withConfigurationResource("application-allow-final-fields-as-mutators-enabled.properties");
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Test
+    public void testFinalFieldsUsedAsMutators() {
+        BeanWithFinalField result = objectMapper.readValue("{\"name\":\"hello\"}", BeanWithFinalField.class);
+        assertThat(result.getName()).isEqualTo("hello");
+    }
+
+    public static class BeanWithFinalField {
+        private final String name = null;
+
+        public String getName() {
+            return name;
+        }
+    }
+}

--- a/extensions/jackson/deployment/src/test/resources/application-allow-final-fields-as-mutators-enabled.properties
+++ b/extensions/jackson/deployment/src/test/resources/application-allow-final-fields-as-mutators-enabled.properties
@@ -1,0 +1,1 @@
+quarkus.jackson.allow-final-fields-as-mutators=true

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ConfigurationCustomizer.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ConfigurationCustomizer.java
@@ -54,6 +54,9 @@ public class ConfigurationCustomizer implements JsonMapperBuilderCustomizer {
         if (jacksonBuildTimeConfig.useGettersAsSetters()) {
             builder.enable(MapperFeature.USE_GETTERS_AS_SETTERS);
         }
+        if (jacksonBuildTimeConfig.allowFinalFieldsAsMutators()) {
+            builder.enable(MapperFeature.ALLOW_FINAL_FIELDS_AS_MUTATORS);
+        }
         if (jacksonBuildTimeConfig.acceptCaseInsensitiveEnums()) {
             builder.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
         }

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonBuildTimeConfig.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonBuildTimeConfig.java
@@ -79,6 +79,15 @@ public interface JacksonBuildTimeConfig {
     boolean useGettersAsSetters();
 
     /**
+     * If enabled, Jackson will allow 'final' fields to be auto-detected as mutators
+     * (used to change the value of the logical property) during deserialization.
+     * This is disabled by default to match the default Jackson 3 behavior.
+     * Note that Jackson 2 defaulted to {@code true}.
+     */
+    @WithDefault("false")
+    boolean allowFinalFieldsAsMutators();
+
+    /**
      * If enabled, Jackson will ignore case during Enum deserialization.
      */
     @WithDefault("false")

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -383,7 +383,7 @@ public abstract class JacksonCodeGenerator {
         return methodName;
     }
 
-    private MethodInfo getterMethodInfo(ClassInfo classInfo, FieldInfo fieldInfo) {
+    protected MethodInfo getterMethodInfo(ClassInfo classInfo, FieldInfo fieldInfo) {
         MethodInfo namedAccessor = findMethod(classInfo, fieldInfo.name());
         if (namedAccessor != null
                 && (classInfo.isRecord() || namedAccessor.hasAnnotation(JsonProperty.class)

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
@@ -983,6 +983,50 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
     }
 
     @Override
+    protected Optional<MethodInfo> findConstructor(ClassInfo classInfo) {
+        Optional<MethodInfo> ctorOpt = super.findConstructor(classInfo);
+        if (ctorOpt.isPresent() && ctorOpt.get().parametersCount() == 0 && !classInfo.isRecord()) {
+            Set<String> unsettableFields = findUnsettableFields(classInfo);
+            if (!unsettableFields.isEmpty()) {
+                return classInfo.constructors().stream()
+                        .filter(ctor -> Modifier.isPublic(ctor.flags()) && ctorCoversFields(ctor, unsettableFields))
+                        .findFirst();
+            }
+        }
+        return ctorOpt;
+    }
+
+    private static boolean ctorCoversFields(MethodInfo ctor, Set<String> fieldNames) {
+        Set<String> paramNames = new HashSet<>();
+        for (MethodParameterInfo param : ctor.parameters()) {
+            paramNames.add(param.name());
+        }
+        return paramNames.containsAll(fieldNames);
+    }
+
+    private Set<String> findUnsettableFields(ClassInfo classInfo) {
+        Set<String> unsettable = new HashSet<>();
+        for (FieldInfo field : classFields(classInfo)) {
+            if (Modifier.isStatic(field.flags()) || Modifier.isPublic(field.flags())) {
+                continue;
+            }
+            if (getterMethodInfo(classInfo, field) == null) {
+                continue;
+            }
+            if (findMethod(classInfo, "set" + ucFirst(field.name()), field.type()) != null
+                    || findMethod(classInfo, field.name(), field.type()) != null) {
+                continue;
+            }
+            String typeName = field.type().name().toString();
+            if (isAssignableTo(typeName, COLLECTION_NAME) || isAssignableTo(typeName, MAP_NAME)) {
+                continue;
+            }
+            unsettable.add(field.name());
+        }
+        return unsettable;
+    }
+
+    @Override
     protected boolean shouldGenerateCodeFor(ClassInfo classInfo) {
         return super.shouldGenerateCodeFor(classInfo) && classInfo.hasNoArgsConstructor();
     }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
@@ -821,6 +821,48 @@ public abstract class AbstractSimpleJsonTest {
     }
 
     @Test
+    public void testPojoWithNoArgConstructorEcho() {
+        RestAssured
+                .with()
+                .body("{\"name\":\"hello\",\"description\":\"world\"}")
+                .contentType("application/json; charset=utf-8")
+                .post("/simple/no-arg-ctor-pojo-echo")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("hello"))
+                .body("description", Matchers.is("world"));
+    }
+
+    @Test
+    public void testPojoWithNoMatchingConstructorEcho() {
+        RestAssured
+                .with()
+                .body("{\"name\":\"hello\",\"description\":\"world\"}")
+                .contentType("application/json; charset=utf-8")
+                .post("/simple/no-matching-ctor-pojo-echo")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("hello"))
+                .body("description", Matchers.is("world"));
+    }
+
+    @Test
+    public void testPojoWithMultipleConstructorsEcho() {
+        RestAssured
+                .with()
+                .body("{\"name\":\"hello\",\"description\":\"world\"}")
+                .contentType("application/json; charset=utf-8")
+                .post("/simple/multi-ctor-pojo-echo")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("hello"))
+                .body("description", Matchers.is("world"));
+    }
+
+    @Test
     public void testKotlinDataEcho() {
         RestAssured
                 .with()

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/MultiConstructorPojo.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/MultiConstructorPojo.java
@@ -1,0 +1,46 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import java.util.Objects;
+
+public class MultiConstructorPojo {
+
+    private String name;
+    private String description;
+
+    public MultiConstructorPojo() {
+        this.name = null;
+    }
+
+    public MultiConstructorPojo(String name) {
+        this.name = name;
+    }
+
+    public MultiConstructorPojo(long x, long y) {
+        this.name = String.valueOf(x + y);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        MultiConstructorPojo that = (MultiConstructorPojo) o;
+        return Objects.equals(name, that.name) && Objects.equals(description, that.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description);
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/NoArgConstructorPojo.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/NoArgConstructorPojo.java
@@ -1,0 +1,42 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import java.util.Objects;
+
+public class NoArgConstructorPojo {
+
+    private String name;
+    private String description;
+
+    public NoArgConstructorPojo(String name) {
+        this.name = name;
+    }
+
+    public NoArgConstructorPojo() {
+        this.name = null;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        NoArgConstructorPojo that = (NoArgConstructorPojo) o;
+        return Objects.equals(name, that.name) && Objects.equals(description, that.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description);
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/NoMatchingCtorPojo.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/NoMatchingCtorPojo.java
@@ -1,0 +1,38 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import java.util.Objects;
+
+public class NoMatchingCtorPojo {
+
+    private String name;
+    private String description;
+
+    public NoMatchingCtorPojo() {
+        this.name = null;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        NoMatchingCtorPojo that = (NoMatchingCtorPojo) o;
+        return Objects.equals(name, that.name) && Objects.equals(description, that.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description);
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
@@ -760,6 +760,30 @@ public class SimpleJsonResource extends SuperClass<Person> {
     }
 
     @POST
+    @Path("/no-arg-ctor-pojo-echo")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public NoArgConstructorPojo echoNoArgConstructorPojo(NoArgConstructorPojo obj) {
+        return obj;
+    }
+
+    @POST
+    @Path("/multi-ctor-pojo-echo")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public MultiConstructorPojo echoMultiConstructorPojo(MultiConstructorPojo obj) {
+        return obj;
+    }
+
+    @POST
+    @Path("/no-matching-ctor-pojo-echo")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public NoMatchingCtorPojo echoNoMatchingCtorPojo(NoMatchingCtorPojo obj) {
+        return obj;
+    }
+
+    @POST
     @Path("/required-creator-property")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
@@ -39,7 +39,8 @@ public class SimpleJsonTest extends AbstractSimpleJsonTest {
                                     PolymorphicItemResponse.class, PolymorphicItem.class,
                                     SensorMetadata.class, SensorMetadata.ComponentMetadata.class, SensorUnit.class,
                                     FinalCollectionHolder.class, RequiredCreatorProperty.class,
-                                    PolymorphicCreatorProperty.class)
+                                    PolymorphicCreatorProperty.class, NoArgConstructorPojo.class,
+                                    MultiConstructorPojo.class, NoMatchingCtorPojo.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +
                                     "birth-date-roles=alice,bob\n" +

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
@@ -42,7 +42,8 @@ public class SimpleJsonWithReflectionFreeSerializersTest extends AbstractSimpleJ
                                     PolymorphicItemResponse.class, PolymorphicItem.class,
                                     SensorMetadata.class, SensorMetadata.ComponentMetadata.class, SensorUnit.class,
                                     FinalCollectionHolder.class, RequiredCreatorProperty.class,
-                                    PolymorphicCreatorProperty.class)
+                                    PolymorphicCreatorProperty.class, NoArgConstructorPojo.class,
+                                    MultiConstructorPojo.class, NoMatchingCtorPojo.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +
                                     "birth-date-roles=alice,bob\n" +


### PR DESCRIPTION
Note that the original reproducer doesn't work anymore with Jackson 3 also using the default reflection-based Jackson serializers.
This is caused by a change in `MapperFeature.ALLOW_FINAL_FIELDS_AS_MUTATORS`

  - Jackson 2: default true — final fields could be used as mutators (set via reflection during deserialization)
  - Jackson 3: default false — final fields are not used as mutators unless explicitly annotated

The Jackson 3 javadoc says it explicitly: "Feature is disabled by default in Jackson 3.x, in 2.x it was enabled by default.", see https://javadoc.io/doc/tools.jackson.core/jackson-databind/3.0.0/tools.jackson.databind/tools/jackson/databind/MapperFeature.html#ALLOW_FINAL_FIELDS_AS_MUTATORS

This fix is still useful, but now it only works for non-final fields, so I had to remove the `final` keywords from the tests POJOs.

- Fixes: #55675
