### PR TITLE
Enforce that only a single OIDC authentication mechanism is configured

### DIFF
--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientTooManyJwtCredentialKeyPropsTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientTooManyJwtCredentialKeyPropsTestCase.java
@@ -37,8 +37,8 @@ public class OidcClientTooManyJwtCredentialKeyPropsTestCase {
                 }
                 assertNotNull(te, "Expected ConfigurationException, but got: " + t);
                 assertEquals(
-                        "Only a single OIDC JWT credential key property can be configured, but you have configured:"
-                                + " quarkus.oidc-client.credentials.jwt.key,quarkus.oidc-client.credentials.jwt.secret",
+                        "Only one of JWT secret or JWT private key authentication methods can be configured,"
+                                + " but 'quarkus.oidc-client.credentials.jwt' has both a JWT secret and a JWT key property set",
                         te.getMessage(),
                         "Too many JWT credential key properties are configured");
             });

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -503,7 +503,7 @@ public class OidcClientImpl implements OidcClient {
                         OidcCommonUtils.initClientSecretBasicAuth(oidcClientConfig, clientSecret),
                         jwtAssertionProvided, assertionProvider))
                 .onItem().ifNull()
-                .switchTo(() -> OidcCommonUtils.initClientJwtKey(oidcClientConfig, false)
+                .switchTo(() -> OidcCommonUtils.initClientJwtKey(oidcClientConfig)
                         .map(key -> new ClientCredentials(key, null, null, jwtAssertionProvided, assertionProvider)))
                 .<OidcClient> flatMap(clientCredentials -> metadataResolver.apply(clientCredentials)
                         .map(metadata -> {

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -100,7 +100,6 @@ public class OidcClientRecorder {
                         "Either 'quarkus.oidc-client.auth-server-url' or absolute 'quarkus.oidc-client.token-path' URL must be set");
             }
             OidcCommonUtils.verifyEndpointUrl(getEndpointUrl(oidcConfig));
-            OidcCommonUtils.verifyCommonConfiguration(oidcConfig, false, false);
         } catch (Throwable t) {
             LOG.debug(t.getMessage());
             String message = String.format("'%s' client configuration is not initialized", oidcClientId);
@@ -108,6 +107,7 @@ public class OidcClientRecorder {
         }
 
         try {
+            OidcCommonUtils.verifyCommonConfiguration(oidcConfig, false, false);
             OidcCommonUtils.validateCredentialsForAllEndpoints(oidcConfig.credentials());
         } catch (ConfigurationException e) {
             return Uni.createFrom().failure(e);

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -19,12 +19,10 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.EnumMap;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
@@ -182,12 +180,69 @@ public class OidcCommonUtils {
                             "'%1$scredentials.secret' and '%1$scredentials.client-secret' properties are mutually exclusive",
                             configPrefix));
         }
-        if ((creds.secret().isPresent() || creds.clientSecret().value().isPresent()) && creds.jwt().secret().isPresent()) {
+        boolean clientSecretConfigured = creds.secret().isPresent()
+                || creds.clientSecret().value().isPresent()
+                || creds.clientSecret().provider().key().isPresent();
+        boolean jwtSecretConfigured = creds.jwt().secret().isPresent()
+                || creds.jwt().secretProvider().key().isPresent();
+
+        if (clientSecretConfigured && jwtSecretConfigured) {
             throw new ConfigurationException(
                     String.format(
-                            "Use only '%1$scredentials.secret' or '%1$scredentials.client-secret' or '%1$scredentials.jwt.secret' property",
+                            "Only one of client secret or JWT secret authentication methods can be configured,"
+                                    + " but '%1$scredentials' has both a client secret and a JWT secret property set",
                             configPrefix));
         }
+        int jwtKeyPropsCount = (creds.jwt().key().isPresent() ? 1 : 0)
+                + (creds.jwt().keyFile().isPresent() ? 1 : 0)
+                + (creds.jwt().keyStoreFile().isPresent() ? 1 : 0);
+        if (jwtKeyPropsCount > 1) {
+            throw new ConfigurationException(
+                    String.format(
+                            "Only one of '%1$scredentials.jwt.key', '%1$scredentials.jwt.key-file'"
+                                    + " or '%1$scredentials.jwt.key-store-file' can be configured",
+                            configPrefix));
+        }
+        boolean jwtKeyConfigured = jwtKeyPropsCount == 1;
+        boolean jwtBearerOrSpiffe = creds.jwt().source() == Source.BEARER
+                || creds.jwt().source() == Source.SPIFFE_JWT;
+
+        if (jwtSecretConfigured && jwtKeyConfigured) {
+            throw new ConfigurationException(
+                    String.format(
+                            "Only one of JWT secret or JWT private key authentication methods can be configured,"
+                                    + " but '%1$scredentials.jwt' has both a JWT secret and a JWT key property set",
+                            configPrefix));
+        }
+        if (clientSecretConfigured && jwtKeyConfigured) {
+            throw new ConfigurationException(
+                    String.format(
+                            "Only one of client secret or JWT private key authentication methods can be configured,"
+                                    + " but '%1$scredentials' has both a client secret and a JWT key property set",
+                            configPrefix));
+        }
+        if (clientSecretConfigured && jwtBearerOrSpiffe) {
+            throw new ConfigurationException(
+                    String.format(
+                            "Only one of client secret or JWT bearer/SPIFFE authentication methods can be configured,"
+                                    + " but '%1$scredentials' has both a client secret and '%1$scredentials.jwt.source=%2$s' set",
+                            configPrefix, creds.jwt().source().toString().toLowerCase()));
+        }
+        if (jwtKeyConfigured && jwtBearerOrSpiffe) {
+            throw new ConfigurationException(
+                    String.format(
+                            "Only one of JWT private key or JWT bearer/SPIFFE authentication methods can be configured,"
+                                    + " but '%1$scredentials' has both a JWT key property and '%1$scredentials.jwt.source=%2$s' set",
+                            configPrefix, creds.jwt().source().toString().toLowerCase()));
+        }
+        if (jwtSecretConfigured && jwtBearerOrSpiffe) {
+            throw new ConfigurationException(
+                    String.format(
+                            "Only one of JWT secret or JWT bearer/SPIFFE authentication methods can be configured,"
+                                    + " but '%1$scredentials' has both a JWT secret and '%1$scredentials.jwt.source=%2$s' set",
+                            configPrefix, creds.jwt().source().toString().toLowerCase()));
+        }
+
         Credentials.Jwt jwt = creds.jwt();
         if (jwt.source() == Source.BEARER) {
             if (isServerConfig && jwt.tokenPath().isEmpty()) {
@@ -437,30 +492,12 @@ public class OidcCommonUtils {
                         && clientSecretMethod(creds) == Secret.Method.BASIC);
     }
 
-    public static boolean isClientJwtAuthRequired(Credentials creds, boolean server) {
-        Set<String> props = new HashSet<>();
-        if (creds.jwt().secret().isPresent()) {
-            props.add(".credentials.jwt.secret");
-        }
-        if (creds.jwt().secretProvider().key().isPresent()) {
-            props.add(".credentials.jwt.secret-provider.key");
-        }
-        if (creds.jwt().key().isPresent()) {
-            props.add(".credentials.jwt.key");
-        }
-        if (creds.jwt().keyFile().isPresent()) {
-            props.add(".credentials.jwt.key-file");
-        }
-        if (creds.jwt().keyStoreFile().isPresent()) {
-            props.add(".credentials.jwt.key-store-file");
-        }
-        if (props.size() > 1) {
-            final String prefix = server ? "quarkus.oidc" : "quarkus.oidc-client";
-            throw new ConfigurationException("""
-                    Only a single OIDC JWT credential key property can be configured, but you have configured: %s"""
-                    .formatted(props.stream().map(p -> (prefix + p)).collect(Collectors.joining(","))));
-        }
-        return props.size() == 1;
+    public static boolean isClientJwtAuthRequired(Credentials creds) {
+        return creds.jwt().secret().isPresent()
+                || creds.jwt().secretProvider().key().isPresent()
+                || creds.jwt().key().isPresent()
+                || creds.jwt().keyFile().isPresent()
+                || creds.jwt().keyStoreFile().isPresent();
     }
 
     public static boolean isClientSecretPostAuthRequired(Credentials creds) {
@@ -635,8 +672,8 @@ public class OidcCommonUtils {
 
     }
 
-    public static Uni<Key> initClientJwtKey(OidcClientCommonConfig oidcConfig, boolean server) {
-        if (isClientJwtAuthRequired(oidcConfig.credentials(), server)) {
+    public static Uni<Key> initClientJwtKey(OidcClientCommonConfig oidcConfig) {
+        if (isClientJwtAuthRequired(oidcConfig.credentials())) {
             return clientJwtKey(oidcConfig.credentials());
         }
         return Uni.createFrom().nullItem();

--- a/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/OidcCommonUtilsTest.java
+++ b/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/OidcCommonUtilsTest.java
@@ -1,6 +1,8 @@
 package io.quarkus.oidc.common.runtime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -12,6 +14,7 @@ import java.util.StringTokenizer;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.runtime.configuration.ConfigurationException;
 import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.ProxyOptions;
@@ -208,6 +211,354 @@ public class OidcCommonUtilsTest {
         String jwt = OidcCommonUtils.signJwtWithKey(cfg, "http://localhost", key);
         JsonObject json = decodeJwtContent(jwt);
         assertEquals("https://server.example.com/", json.getString("aud"));
+    }
+
+    @Test
+    public void testSecretAndClientSecretAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.secret = Optional.of("secret1");
+        cfg.credentials.clientSecret.value = Optional.of("secret2");
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("mutually exclusive"));
+    }
+
+    @Test
+    public void testClientSecretValueAndJwtSecretAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.clientSecret.value = Optional.of("secret");
+        cfg.credentials.jwt.secret = Optional.of("jwt-secret");
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("client secret"));
+        assertTrue(ex.getMessage().contains("JWT secret"));
+    }
+
+    @Test
+    public void testSecretAndJwtSecretProviderAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.secret = Optional.of("secret");
+        cfg.credentials.jwt.secretProvider.key = Optional.of("vault-jwt-secret");
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("client secret"));
+        assertTrue(ex.getMessage().contains("JWT secret"));
+    }
+
+    @Test
+    public void testClientSecretValueAndJwtSecretProviderAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.clientSecret.value = Optional.of("secret");
+        cfg.credentials.jwt.secretProvider.key = Optional.of("vault-jwt-secret");
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("client secret"));
+        assertTrue(ex.getMessage().contains("JWT secret"));
+    }
+
+    @Test
+    public void testClientSecretProviderAndJwtSecretAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.clientSecret.provider.key = Optional.of("vault-key");
+        cfg.credentials.jwt.secret = Optional.of("jwt-secret");
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("client secret"));
+        assertTrue(ex.getMessage().contains("JWT secret"));
+    }
+
+    @Test
+    public void testClientSecretProviderAndJwtSecretProviderAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.clientSecret.provider.key = Optional.of("vault-key");
+        cfg.credentials.jwt.secretProvider.key = Optional.of("vault-jwt-secret");
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("client secret"));
+        assertTrue(ex.getMessage().contains("JWT secret"));
+    }
+
+    @Test
+    public void testClientSecretAndJwtKeyFileAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.clientSecret.value = Optional.of("secret");
+        cfg.credentials.jwt.keyFile = Optional.of("privateKey.pem");
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("client secret"));
+        assertTrue(ex.getMessage().contains("JWT key"));
+    }
+
+    @Test
+    public void testClientSecretAndJwtKeyAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.secret = Optional.of("secret");
+        cfg.credentials.jwt.key = Optional.of("pem-key-content");
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("client secret"));
+        assertTrue(ex.getMessage().contains("JWT key"));
+    }
+
+    @Test
+    public void testClientSecretAndJwtKeyStoreAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.clientSecret.value = Optional.of("secret");
+        cfg.credentials.jwt.keyStoreFile = Optional.of("keystore.jks");
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("client secret"));
+        assertTrue(ex.getMessage().contains("JWT key"));
+    }
+
+    @Test
+    public void testClientSecretProviderAndJwtKeyFileAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.clientSecret.provider.key = Optional.of("vault-key");
+        cfg.credentials.jwt.keyFile = Optional.of("privateKey.pem");
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("client secret"));
+        assertTrue(ex.getMessage().contains("JWT key"));
+    }
+
+    @Test
+    public void testJwtKeyAndKeyFileAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.jwt.key = Optional.of("pem-key-content");
+        cfg.credentials.jwt.keyFile = Optional.of("privateKey.pem");
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("credentials.jwt.key"));
+        assertTrue(ex.getMessage().contains("credentials.jwt.key-file"));
+    }
+
+    @Test
+    public void testJwtKeyAndKeyStoreAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.jwt.key = Optional.of("pem-key-content");
+        cfg.credentials.jwt.keyStoreFile = Optional.of("keystore.jks");
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("credentials.jwt.key"));
+        assertTrue(ex.getMessage().contains("credentials.jwt.key-store-file"));
+    }
+
+    @Test
+    public void testJwtKeyFileAndKeyStoreAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.jwt.keyFile = Optional.of("privateKey.pem");
+        cfg.credentials.jwt.keyStoreFile = Optional.of("keystore.jks");
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("credentials.jwt.key-file"));
+        assertTrue(ex.getMessage().contains("credentials.jwt.key-store-file"));
+    }
+
+    @Test
+    public void testAllThreeJwtKeyPropertiesAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.jwt.key = Optional.of("pem-key-content");
+        cfg.credentials.jwt.keyFile = Optional.of("privateKey.pem");
+        cfg.credentials.jwt.keyStoreFile = Optional.of("keystore.jks");
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("credentials.jwt.key"));
+    }
+
+    @Test
+    public void testJwtSecretAndJwtKeyAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.jwt.secret = Optional.of("jwt-secret");
+        cfg.credentials.jwt.key = Optional.of("pem-key-content");
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("JWT secret"));
+        assertTrue(ex.getMessage().contains("JWT private key"));
+    }
+
+    @Test
+    public void testJwtSecretAndJwtKeyFileAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.jwt.secret = Optional.of("jwt-secret");
+        cfg.credentials.jwt.keyFile = Optional.of("privateKey.pem");
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("JWT secret"));
+        assertTrue(ex.getMessage().contains("JWT private key"));
+    }
+
+    @Test
+    public void testJwtSecretProviderAndJwtKeyStoreAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.jwt.secretProvider.key = Optional.of("vault-jwt-secret");
+        cfg.credentials.jwt.keyStoreFile = Optional.of("keystore.jks");
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("JWT secret"));
+        assertTrue(ex.getMessage().contains("JWT private key"));
+    }
+
+    @Test
+    public void testClientSecretAndJwtBearerAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.clientSecret.value = Optional.of("secret");
+        cfg.credentials.jwt.source = OidcClientCommonConfig.Credentials.Jwt.Source.BEARER;
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("client secret"));
+        assertTrue(ex.getMessage().contains("jwt.source=bearer"));
+    }
+
+    @Test
+    public void testClientSecretAndJwtSpiffeAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.secret = Optional.of("secret");
+        cfg.credentials.jwt.source = OidcClientCommonConfig.Credentials.Jwt.Source.SPIFFE_JWT;
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("client secret"));
+        assertTrue(ex.getMessage().contains("jwt.source=spiffe_jwt"));
+    }
+
+    @Test
+    public void testJwtKeyFileAndJwtBearerAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.jwt.keyFile = Optional.of("privateKey.pem");
+        cfg.credentials.jwt.source = OidcClientCommonConfig.Credentials.Jwt.Source.BEARER;
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("JWT private key"));
+        assertTrue(ex.getMessage().contains("jwt.source=bearer"));
+    }
+
+    @Test
+    public void testJwtKeyStoreAndJwtSpiffeAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.jwt.keyStoreFile = Optional.of("keystore.jks");
+        cfg.credentials.jwt.source = OidcClientCommonConfig.Credentials.Jwt.Source.SPIFFE_JWT;
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("JWT private key"));
+        assertTrue(ex.getMessage().contains("jwt.source=spiffe_jwt"));
+    }
+
+    @Test
+    public void testJwtSecretAndJwtBearerAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.jwt.secret = Optional.of("jwt-secret");
+        cfg.credentials.jwt.source = OidcClientCommonConfig.Credentials.Jwt.Source.BEARER;
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("JWT secret"));
+        assertTrue(ex.getMessage().contains("jwt.source=bearer"));
+    }
+
+    @Test
+    public void testJwtSecretProviderAndJwtSpiffeAreMutuallyExclusive() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.jwt.secretProvider.key = Optional.of("vault-jwt-secret");
+        cfg.credentials.jwt.source = OidcClientCommonConfig.Credentials.Jwt.Source.SPIFFE_JWT;
+
+        ConfigurationException ex = assertThrows(ConfigurationException.class,
+                () -> OidcCommonUtils.verifyCommonConfiguration(cfg, false, false));
+        assertTrue(ex.getMessage().contains("JWT secret"));
+        assertTrue(ex.getMessage().contains("jwt.source=spiffe_jwt"));
+    }
+
+    @Test
+    public void testSingleClientSecretIsValid() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.clientSecret.value = Optional.of("secret");
+        OidcCommonUtils.verifyCommonConfiguration(cfg, false, false);
+    }
+
+    @Test
+    public void testSingleJwtKeyFileIsValid() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.jwt.keyFile = Optional.of("privateKey.pem");
+        OidcCommonUtils.verifyCommonConfiguration(cfg, false, false);
+    }
+
+    @Test
+    public void testSingleJwtSecretIsValid() {
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
+        cfg.setClientId("client");
+        cfg.credentials.jwt.secret = Optional.of("jwt-secret");
+        OidcCommonUtils.verifyCommonConfiguration(cfg, false, false);
     }
 
     public static JsonObject decodeJwtContent(String jwt) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
@@ -769,7 +769,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
                 .transform(clientSecret -> new ClientCredentials(null, clientSecret, null,
                         OidcCommonUtils.initClientSecretBasicAuth(oidcConfig, clientSecret),
                         jwtAssertionProvided, assertionProvider, queryAuth))
-                .onItem().ifNull().switchTo(() -> OidcCommonUtils.initClientJwtKey(oidcConfig, true)
+                .onItem().ifNull().switchTo(() -> OidcCommonUtils.initClientJwtKey(oidcConfig)
                         .onItem().ifNotNull()
                         .transform(key -> new ClientCredentials(key, null, null, null,
                                 jwtAssertionProvided, assertionProvider, queryAuth))


### PR DESCRIPTION
`quarkus-oidc` and `quarkus-oidc-client` have many OIDC client authentication methods supported, this PR attempts to make sure that only a single method is supported at a time.

That may require more polishing but we should start from somewhere