### PR TITLE
Fix flaky DrainTest OOM by streaming response bodies instead of buffering

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stress/DrainTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stress/DrainTest.java
@@ -30,18 +30,18 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusExtensionTest;
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.PoolOptions;
 
 public class DrainTest {
 
-    private static final long RUN_TIMEOUT = System.getenv("CI") != null ? 120 : 30;
+    private static final long RUN_TIMEOUT = System.getenv("CI") != null ? 120 : 60;
 
     @RegisterExtension
     static QuarkusExtensionTest test = new QuarkusExtensionTest()
@@ -91,9 +91,16 @@ public class DrainTest {
             for (int i = 0; i < num; i++) {
                 client.request(HttpMethod.GET, path)
                         .compose(HttpClientRequest::send)
-                        .compose(HttpClientResponse::body)
-                        .onSuccess(body -> {
-                            sum.addAndGet(body.length());
+                        .compose(resp -> {
+                            Promise<Long> promise = Promise.promise();
+                            AtomicLong bodyLength = new AtomicLong();
+                            resp.handler(buffer -> bodyLength.addAndGet(buffer.length()));
+                            resp.endHandler(v -> promise.complete(bodyLength.get()));
+                            resp.exceptionHandler(promise::fail);
+                            return promise.future();
+                        })
+                        .onSuccess(length -> {
+                            sum.addAndGet(length);
                             latch.countDown();
                         })
                         .onFailure(err -> {


### PR DESCRIPTION
This is flaky all the time. Apparently it used to run in 30s in CI until @jponge bumped the timeout for CI to 120s in eb34d18f41486fc1258380f2b9bc17ebdbf27a78, perhaps due to the Vert.x 5 changes in 32a26bc10105cf0a7d2c258766a8432bdf66fe14 ?

The test fires 10,000 requests of 100KB each. The client was buffering every response body via HttpClientResponse::body, accumulating ~1GB of direct memory. Since client and server share the same JVM, this combined with server-side buffers to exceed the ~1.5GB direct memory limit under CI load.

Replace body buffering with a streaming handler that counts bytes and releases each chunk immediately. Also increase the non-CI timeout from 30s to 60s, as HTTP/2 tests need more than 30s to complete.

