### PR TITLE
Enable Netty's FFM malloc/free path and set ignoreExpensiveClean

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -504,7 +504,7 @@
                         <!-- the add-opens java.base/java.lang=ALL-UNNAMED is here for
                              org.jboss.JDKSpecific.ThreadAccess.clearThreadLocals() -->
                         <!-- set -XX:+HeapDumpOnOutOfMemoryError to provide some useful debugging info, should this happen -->
-                        <argLine>${jacoco.agent.argLine} -Xmx1500m -XX:+HeapDumpOnOutOfMemoryError -XX:MaxMetaspaceSize=1500m -Djava.io.tmpdir="${project.build.directory}" ${surefire.argLine.additional} --add-opens java.naming/com.sun.naming.internal=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED</argLine>
+                        <argLine>${jacoco.agent.argLine} -Xmx1500m -XX:+HeapDumpOnOutOfMemoryError -XX:MaxMetaspaceSize=1500m -Djava.io.tmpdir="${project.build.directory}" ${surefire.argLine.additional} --enable-native-access=ALL-UNNAMED --add-opens java.naming/com.sun.naming.internal=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED</argLine>
                         <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                     </configuration>
                 </plugin>

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -119,6 +119,17 @@ class NettyProcessor {
     }
 
     @BuildStep
+    public SystemPropertyBuildItem ignoreExpensiveClean() {
+        // On JDK 25+ without --enable-native-access, Netty's CleanerJava25 (shared arenas) has
+        // hasExpensiveClean()=true. Without this flag, unpooled direct buffers fall back to the NOOP
+        // cleaner (GC-only deallocation), which causes unbounded native memory growth and OOM kills
+        // on containers. This flag forces unpooled buffers to use the shared arena path instead —
+        // expensive but deterministic.
+        // See https://github.com/quarkusio/quarkus/issues/54011
+        return new SystemPropertyBuildItem("io.netty.ignoreExpensiveClean", "true");
+    }
+
+    @BuildStep
     public PreInitRunnableBuildItem preInitPlatformDependent() {
         // initialize PlatformDependent as a pre-init task as it's quite slow
         return PreInitRunnableBuildItem.initializeClass(PlatformDependent.class.getName(),
@@ -802,7 +813,13 @@ class NettyProcessor {
     }
 
     @BuildStep
-    void nativeTransportsEnableNativeAccess(BuildProducer<ModuleEnableNativeAccessBuildItem> nativeAccess) {
+    void enableNativeAccess(BuildProducer<ModuleEnableNativeAccessBuildItem> nativeAccess) {
+        // Netty 4.2 on JDK 24+ uses CleanerJava24Linker (FFM malloc/free) for direct buffer
+        // allocation when native access is granted to io.netty.common. Without this, JDK 25+
+        // falls back to CleanerJava25 (shared arenas with expensive thread-local handshakes)
+        // or NOOP (GC-only deallocation for unpooled buffers, causing container OOM).
+        // See https://github.com/quarkusio/quarkus/issues/54011
+        nativeAccess.produce(new ModuleEnableNativeAccessBuildItem("io.netty.common"));
         if (QuarkusClassLoader.isClassPresentAtRuntime("io.netty.channel.epoll.EpollMode")) {
             nativeAccess.produce(new ModuleEnableNativeAccessBuildItem("io.netty.transport.classes.epoll"));
         }


### PR DESCRIPTION
Adds `Enable-Native-Access: ALL-UNNAMED` to the JAR manifest (via `ModuleEnableNativeAccessBuildItem` for `io.netty.common`) and sets `-Dio.netty.ignoreExpensiveClean=true`.

On JDK 25+, Netty 4.2 auto-disables Unsafe and without native access falls to `CleanerJava25` (shared arenas), where unpooled buffers get routed to the NOOP cleaner (GC-only deallocation → prone to OOM on scarce CPU envs). With native access granted, Netty uses `CleanerJava24Linker` (FFM malloc/free) — fast and deterministic for all buffer types. The `ignoreExpensiveClean` flag is the safety net for when native access isn't available.

### Related

- The `CleanerJava9` bytecode rewrite was removed in 37f2fb7eb70 as part of the Vert.x 5 migration (incompatible with Netty 4.2 internals). Re-implementing it is tracked in #53309.
- Native image behavior is not yet verified — it already passes `--enable-native-access=ALL-UNNAMED` unconditionally and runtime-initializes `PlatformDependent`, so these changes should be harmless, but we haven't tested it.

----

- Closes: #54011