### PR TITLE
Change the default http.(client|server).request.duration to s…

### DIFF
--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/compatibility/HttpCompatibilityTest.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/compatibility/HttpCompatibilityTest.java
@@ -144,7 +144,7 @@ public class HttpCompatibilityTest {
                     assertThat(clientMetricData)
                             .hasName("http.client.requests") // in OTel it should be "http.server.request.duration"
                             .hasDescription("") // in OTel it should be "Duration of HTTP client requests."
-                            .hasUnit("ms") // OTel has seconds
+                            .hasUnit("s") // OTel has seconds
                             .hasHistogramSatisfying(histogram -> histogram.isCumulative()
                                     .hasPointsSatisfying(
                                             // valid entries
@@ -174,7 +174,7 @@ public class HttpCompatibilityTest {
         assertThat(metricData)
                 .hasName("http.server.requests") // in OTel it should be "http.server.request.duration"
                 .hasDescription("HTTP server request processing time") // in OTel it should be "Duration of HTTP server requests."
-                .hasUnit("ms") // OTel has seconds
+                .hasUnit("s") // OTel has seconds
                 .hasHistogramSatisfying(histogram -> histogram.isCumulative()
                         .hasPointsSatisfying(
                                 // valid entries

--- a/extensions/micrometer-opentelemetry/runtime/src/main/java/io/quarkus/micrometer/opentelemetry/runtime/MicrometerOtelBridgeRecorder.java
+++ b/extensions/micrometer-opentelemetry/runtime/src/main/java/io/quarkus/micrometer/opentelemetry/runtime/MicrometerOtelBridgeRecorder.java
@@ -31,7 +31,8 @@ public class MicrometerOtelBridgeRecorder {
                 MeterRegistry meterRegistry = OpenTelemetryMeterRegistry.builder(openTelemetry.get())
                         .setPrometheusMode(false)
                         .setMicrometerHistogramGaugesEnabled(true)
-                        .setBaseTimeUnit(TimeUnit.MILLISECONDS)
+                        // The time unit should be seconds according to the OpenTelemetry documentation
+                        .setBaseTimeUnit(TimeUnit.SECONDS)
                         .setClock(Clock.SYSTEM)
                         .build();
                 Metrics.addRegistry(meterRegistry);


### PR DESCRIPTION
…econds instead of milliseconds. Per the OpenTelemtry documentation, this metric is supposed to be in seconds not milliseconds.

Fixes #52649

