### PR TITLE
Fix OpenTelemetry Logs swapping timestamp and observedTimestamp values

### DIFF
--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingTest.java
@@ -112,6 +112,18 @@ public class OtelLoggingTest {
     }
 
     @Test
+    public void testEventTimestampPrecedesObservedTimestamp() {
+        assertEquals("hello", jBossLoggingBean.hello("Logging message to test the timestamps"));
+
+        List<LogRecordData> finishedLogRecordItems = logRecordExporter.getFinishedLogRecordItemsAtLeast(1);
+        LogRecordData last = finishedLogRecordItems.get(finishedLogRecordItems.size() - 1);
+
+        assertThat(last.getTimestampEpochNanos())
+                .isPositive()
+                .isLessThanOrEqualTo(last.getObservedTimestampEpochNanos());
+    }
+
+    @Test
     public void testTrace() {
         final String message = "Logging with tracing";
         assertEquals("hello", jBossLoggingBean.helloTraced(message));

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/OpenTelemetryLogHandler.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/OpenTelemetryLogHandler.java
@@ -58,8 +58,8 @@ public class OpenTelemetryLogHandler extends ExtHandler {
         final LogRecordBuilder logRecordBuilder = openTelemetry.getLogsBridge()
                 .loggerBuilder(INSTRUMENTATION_NAME)
                 .build().logRecordBuilder()
-                .setTimestamp(Instant.now())
-                .setObservedTimestamp(record.getInstant());
+                .setTimestamp(record.getInstant())
+                .setObservedTimestamp(Instant.now());
 
         if (record.getLevel() != null) {
             logRecordBuilder.setSeverity(mapSeverity(record.getLevel()))


### PR DESCRIPTION
Ensure the timestamp is used as the time when the event occurred, and observedTimestamp as the time when the event was observed, according to the OpenTelemetry Logs API specification.

- Fixes: #55710

