### PR TITLE
Add reproducibility check for integration tests

### DIFF
--- a/.github/check-it-reproducibility.sh
+++ b/.github/check-it-reproducibility.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Build the whole integration-tests reactor NUM_RUNS times and check every produced
+# target/quarkus-app is byte-identical across builds (diffoscope). CI only; needs diffoscope.
+
+set -u -o pipefail
+
+NUM_RUNS="${NUM_RUNS:-5}"
+OUTPUT_DIR="${OUTPUT_DIR:-reproducibility-checks/$(date -u +%Y-%m-%dT%H-%M-%SZ)}"
+EXTRA_MAVEN_ARGS="${EXTRA_MAVEN_ARGS:-}"
+# Allows to use a custom diffoscope command for testing
+DIFFOSCOPE="${DIFFOSCOPE:-diffoscope}"
+
+command -v "${DIFFOSCOPE%% *}" >/dev/null || { echo "ERROR: '${DIFFOSCOPE%% *}' not found on PATH" >&2; exit 2; }
+
+REF_DIR="$OUTPUT_DIR/reference"
+DIFF_DIR="$OUTPUT_DIR/diffs"
+REPORT="$OUTPUT_DIR/report.md"
+MODULES="$OUTPUT_DIR/modules.txt"
+FAILED="$OUTPUT_DIR/not-reproducible.txt"
+mkdir -p "$REF_DIR" "$DIFF_DIR"
+: > "$FAILED"
+
+build() {
+  ./mvnw -e -B --fail-at-end -T2C -f integration-tests/pom.xml \
+    -DskipTests -Dquarkus.build.skip=false -Dno-build-cache \
+    -Dproject.build.outputTimestamp=2024-01-01T00:00:00Z \
+    $EXTRA_MAVEN_ARGS clean package
+}
+
+for ((run = 1; run <= NUM_RUNS; run++)); do
+  echo "::group::Reactor build $run/$NUM_RUNS"
+  build || echo "!! build $run reported failures (continuing)"
+  echo "::endgroup::"
+
+  if [[ "$run" -eq 1 ]]; then
+    : > "$MODULES"
+    while IFS= read -r app; do
+      module="${app%/target/quarkus-app}"
+      cp -a "$app" "$REF_DIR/${module//\//__}"
+      echo "$module" >> "$MODULES"
+    done < <(find integration-tests -type d -name quarkus-app | sort)
+    echo ">> reference: $(wc -l < "$MODULES") modules"
+    continue
+  fi
+
+  # Diff each reference module against this build. A vanished quarkus-app (build failed
+  # this run) makes diffoscope error, which also counts as not reproducible.
+  while IFS= read -r module; do
+    grep -qxF "$module" "$FAILED" && continue
+    safe="${module//\//__}"
+    if ! $DIFFOSCOPE --exclude-directory-metadata=recursive --html "$DIFF_DIR/$safe.html" \
+        "$REF_DIR/$safe" "$module/target/quarkus-app"; then
+      echo "!! [$module] not reproducible"
+      echo "$module" >> "$FAILED"
+    fi
+  done < "$MODULES"
+done
+
+n_failed=$(wc -l < "$FAILED" | tr -d ' ')
+{
+  echo "# Integration test reproducibility report"
+  echo
+  echo "- Reactor builds: \`$NUM_RUNS\`"
+  echo "- Modules checked: \`$(wc -l < "$MODULES" | tr -d ' ')\`"
+  echo "- Not reproducible: \`$n_failed\`"
+  if [[ "$n_failed" -gt 0 ]]; then
+    echo
+    echo "## Not reproducible"
+    echo
+    while IFS= read -r m; do echo "- \`$m\`"; done < "$FAILED"
+  fi
+} > "$REPORT"
+
+echo "Report written to $REPORT"
+[[ "$n_failed" -eq 0 ]]

--- a/.github/workflows/it-reproducibility-check.yml
+++ b/.github/workflows/it-reproducibility-check.yml
@@ -1,0 +1,71 @@
+name: Quarkus Integration Test Reproducibility Check
+
+permissions:
+  contents: read
+  packages: read
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}"
+  cancel-in-progress: ${{ github.repository != 'quarkusio/quarkus' }}
+
+env:
+  LANG: en_US.UTF-8
+  MAVEN_OPTS: -Xmx4g -XX:MaxMetaspaceSize=1g
+  COMMON_MAVEN_ARGS: "-e -B --settings .github/mvn-settings.xml --fail-at-end"
+  QUICK_INSTALL_MAVEN_ARGS: "-Dscalpel.enabled=false -DskipTests -DskipITs -DskipDocs -Dinvoker.skip -Dskip.gradle.tests -Djbang.skip -Dtruststore.skip -Dno-format -Dno-build-cache -Dno-test-modules -Prelocations"
+  NUM_RUNS: "5"
+
+jobs:
+  it-reproducibility-check:
+    name: Integration Test Reproducibility Check
+    runs-on: ubuntu-latest
+    if: github.repository == 'quarkusio/quarkus' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up JDK 21
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Reclaim Disk Space
+        run: .github/ci-prerequisites.sh
+      - name: Install diffoscope
+        # procyon-decompiler lets diffoscope render .class files as readable
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y diffoscope procyon-decompiler
+      - name: Print disk usage before build
+        run: .github/ci-disk-usage.sh
+      - name: Build Quarkus
+        run: ./mvnw $COMMON_MAVEN_ARGS $QUICK_INSTALL_MAVEN_ARGS -pl '!docs' clean install
+      - name: Run integration test reproducibility check
+        env:
+          EXTRA_MAVEN_ARGS: "--settings .github/mvn-settings.xml"
+        run: .github/check-it-reproducibility.sh
+      - name: Append report to job summary
+        if: always()
+        run: |
+          report=$(ls -td reproducibility-checks/*/report.md 2>/dev/null | head -1 || true)
+          if [[ -n "$report" ]]; then
+            cat "$report" >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Print disk usage after build
+        if: always()
+        run: .github/ci-disk-usage.sh
+      - name: Upload reproducibility results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: it-reproducibility-results
+          path: |
+            reproducibility-checks/*/report.md
+            reproducibility-checks/*/*.txt
+            reproducibility-checks/*/diffs
+          retention-days: 7
+          if-no-files-found: warn


### PR DESCRIPTION
This job builds all of the integration tests in a single reactor build and saved the outputs (namely, `quarkus-app` folder) as a reference. After that, it does 4 additional builds and compares the built artifacts with reference ones.

Current limitations:

- Does not run reproducibility check on Gradle related integration tests.
- Only checks artifacts in `target/quarkus-app`, so works for `fast-jar`, `aot-jar` and `mutable-jar` build types.