### PR TITLE
Remove unnecessary static init in `QuarkusJacksonJsonCodec`

### DIFF
--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/jackson/QuarkusJacksonJsonCodec.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/jackson/QuarkusJacksonJsonCodec.java
@@ -36,10 +36,6 @@ public class QuarkusJacksonJsonCodec implements JsonCodec {
     // we don't want to create this unless it's absolutely necessary (and it rarely is)
     private static volatile ObjectMapper prettyMapper;
 
-    static {
-        populateMapper();
-    }
-
     public static void reset() {
         mapper = null;
         prettyMapper = null;


### PR DESCRIPTION
This should fix the CI failures seen in various PRs
 in `integration-tests/resteasy-reactive-kotlin/standard`