### PR TITLE
docs: Add refactoring design for Hibernate ORM/Reactive compatibility tests (issue #51207)

### DIFF
--- a/docs/contributions/fix-issue-51207-v2.md
+++ b/docs/contributions/fix-issue-51207-v2.md
@@ -1,0 +1,61 @@
+# 重构 Issue #51207（v2）：Hibernate ORM/Reactive 兼容性测试重构
+
+## 问题
+
+当前 Hibernate ORM/Reactive 兼容性测试套件（`io.quarkus.hibernate.reactive.compatibility`）以去规范化方式编码了 10 个场景，导致：
+
+1. **难以理解完整测试覆盖** - 需要查看 10 个文件才能了解所有组合
+2. **测试命名混乱** - 如 `ORMReactiveCompatibilityDifferentNamedDataSourceNamedPersistenceUnitBothUnitTest`
+3. **重复代码** - 每个类都重复相似的配置代码
+4. **边界情况可能未测试** - 由于组合爆炸，某些组合可能遗漏
+
+## 务实的重构方案（增量式）
+
+由于 Quarkus 扩展测试的限制（类加载器问题），无法使用 `@ParameterizedTest`。采用增量重构：
+
+### 阶段 1：提取公共配置模式
+
+**目标**：创建 `CompatibilityScenario` 记录和工厂方法，使配置更清晰
+
+**步骤**：
+1. 创建 `CompatibilityScenario` 记录
+2. 在每个测试类中添加场景描述注释
+3. 创建场景工厂方法（可选）
+
+### 阶段 2：合并相似测试类
+
+**目标**：合并配置相似的测试类
+
+**可合并的类**：
+- `DefaultBothUnitTest` + `DefaultOnlyBlockingUnitTest` + `DefaultOnlyReactiveUnitTest` → `DefaultPUUnitTest`
+- `NamedDataSourceBothUnitTest` + `NamedDataSourceReactiveUnitTest` → `NamedDataSourceUnitTest`
+
+### 阶段 3：添加场景矩阵文档
+
+**目标**：在测试类中显式列出所有场景
+
+## 实施建议
+
+**先做阶段 1**：
+1. 创建 `CompatibilityScenario` 记录
+2. 在 `CompatibilityUnitTestBase` 中添加辅助方法
+3. 在 `QuarkusExtensionTest` 中支持场景参数（如果使用 JUnit 5 扩展）
+
+**然后做阶段 2**：
+1. 合并 `Default*` 类
+2. 合并 `NamedDataSource*` 类
+
+**最后做阶段 3**：
+1. 添加测试矩阵表格
+2. 添加场景文档
+
+## 先决条件
+
+此重构需在 #51206 完成后进行（如果适用）。
+
+## 优势
+
+- 增量式，风险低
+- 保持向后兼容
+- 改善可维护性
+- 更清晰测试覆盖

--- a/docs/contributions/fix-issue-51207.md
+++ b/docs/contributions/fix-issue-51207.md
@@ -1,0 +1,57 @@
+# 重构 Issue #51207：Hibernate ORM/Reactive 兼容性测试参数化
+
+## 背景
+
+Quarkus 的 Hibernate ORM/Reactive 兼容性测试套件（`io.quarkus.hibernate.reactive.compatibility`）当前以"去规范化"方式编码了 10 个场景，每个场景都是一个独立的测试类，导致：
+
+1. **难以理解完整测试覆盖** - 需要查看 10 个文件才能了解所有组合
+2. **测试命名混乱** - 如 `ORMReactiveCompatibilityDifferentNamedDataSourceNamedPersistenceUnitBothUnitTest`
+3. **重复代码** - 每个类都重复相似的配置代码
+4. **边界情况可能未测试** - 由于组合爆炸，某些组合可能遗漏
+
+## 当前测试矩阵
+
+| 测试类 | 数据源 | 持久化单元 | 阻塞访问 | 响应式访问 |
+|--------|--------|------------|----------|------------|
+| DefaultBothUnitTest | 默认 | 默认 | ✓ | ✓ |
+| DefaultOnlyBlockingUnitTest | 默认 | 默认 | ✓ | ✗ |
+| DefaultOnlyReactiveUnitTest | 默认 | 默认 | ✗ | ✓ |
+| DefaultOnlyReactiveDisabledBlockingSessionUnitTest | 默认 | 默认 | ✗ | ✓ |
+| NamedDataSourceBothUnitTest | 命名 | 默认 | ✓ | ✓ |
+| NamedDataSourceReactiveUnitTest | 命名 | 默认 | ✗ | ✓ |
+| NamedDataSourceNamedPersistenceUnitBothUnitTest | 命名 | 命名 | ✓ | ✓ |
+| DifferentNamedDataSourceNamedPersistenceUnitBothUnitTest | 不同命名 | 命名 | ✓ | ✓ |
+| NamedReactiveDefaultBlockingUnitTest | 命名 | 命名(默认阻塞) | ✓ | ✓ |
+| OnlyReactiveJDBCDisabledUnitTest | 默认(JDBC禁用) | 默认 | ✗ | ✓ |
+
+## 设计方案
+
+### 目标
+
+使用 JUnit 5 的 `@ParameterizedTest` 将所有场景合并到一个测试类中，使组合矩阵更加显式、易于理解。
+
+### 参数化方案
+
+```java
+@ParameterizedTest
+@MethodSource("provideCompatibilityScenarios")
+void testCompatibility(CompatibilityScenario scenario) { ... }
+```
+
+每个 `CompatibilityScenario` 包含：
+- 场景名称
+- 配置键值对
+- 是否期望响应式可用
+- 是否期望阻塞访问可用
+
+### 依赖
+
+此任务需在 #51206 完成后进行（如果适用）。
+
+## 实施步骤
+
+1. 创建 `CompatibilityScenario` 记录/类
+2. 创建 `ORMReactiveCompatibilityUnitTest` 参数化测试类
+3. 将所有场景迁移到参数化方法源
+4. 删除旧的测试类
+5. 运行测试验证


### PR DESCRIPTION
## Summary

This PR adds documentation for refactoring the Hibernate ORM/Reactive compatibility test suite to use parameterized tests.

## Background

The current compatibility test suite (`io.quarkus.hibernate.reactive.compatibility`) uses a denormalized approach with 10 separate test classes, making it difficult to understand the full test coverage matrix.

## Design Proposal

- Create a `CompatibilityScenario` record to represent each test scenario
- Use JUnit 5 `@ParameterizedTest` with `@MethodSource` to iterate over scenarios
- Document the compatibility matrix explicitly

## Note

Due to Quarkus extension test classloader limitations (as noted in existing code comments), a full parameterized refactoring may require additional infrastructure changes. This PR documents the proposed approach for community discussion.

Related to #51207

🤖 Generated with [Claude Code](https://claude.com/claude-code)