### PR TITLE
[3.x] Fix REST Client hang when a 3xx response has no Location header

### DIFF
--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/redirect/NotModifiedWithRequestCustomizerTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/redirect/NotModifiedWithRequestCustomizerTest.java
@@ -1,0 +1,86 @@
+package io.quarkus.rest.client.reactive.redirect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.smallrye.mutiny.Uni;
+
+public class NotModifiedWithRequestCustomizerTest {
+
+    /**
+     * Bounds the wait, so a response that never arrives fails the test instead of blocking it forever.
+     */
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Client.class, RedirectingResource.class));
+
+    @TestHTTPResource
+    URI uri;
+
+    private Client clientWithCustomizer(AtomicInteger customizerInvocations) {
+        return QuarkusRestClientBuilder.newBuilder()
+                .baseUri(uri)
+                .followRedirects(true)
+                .httpClientRequestCustomizer(request -> customizerInvocations.incrementAndGet())
+                .build(Client.class);
+    }
+
+    /**
+     * A 304 has no Location header, so there is no redirect to follow even though the status is within the range
+     * that Vert.x hands to the redirect handler.
+     */
+    @Test
+    void shouldReturnNotModifiedWhenThereIsNoRedirectToFollow() {
+        AtomicInteger customizerInvocations = new AtomicInteger();
+
+        Response response = clientWithCustomizer(customizerInvocations)
+                .notModified(RedirectingResource.ETAG)
+                .await().atMost(TIMEOUT);
+
+        assertThat(response.getStatus()).isEqualTo(304);
+        assertThat(customizerInvocations).hasValue(1);
+    }
+
+    @Test
+    void shouldApplyCustomizerToRedirectRequest() {
+        AtomicInteger customizerInvocations = new AtomicInteger();
+
+        Response response = clientWithCustomizer(customizerInvocations)
+                .redirected(1)
+                .await().atMost(TIMEOUT);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(customizerInvocations).hasValue(2);
+    }
+
+    @Path("/redirect")
+    public interface Client {
+
+        @GET
+        @Path("304")
+        Uni<Response> notModified(@HeaderParam(HttpHeaders.IF_NONE_MATCH) String ifNoneMatch);
+
+        @GET
+        @Path("302")
+        Uni<Response> redirected(@QueryParam("redirects") Integer redirects);
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/redirect/RedirectingResource.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/redirect/RedirectingResource.java
@@ -12,6 +12,8 @@ import jakarta.ws.rs.core.Response;
 @Path("/redirect")
 public class RedirectingResource {
 
+    static final String ETAG = "\"etag\"";
+
     @GET
     @Path("302")
     public Response redirectedResponse(@QueryParam("redirects") Integer number, HttpHeaders httpHeaders) {
@@ -26,6 +28,16 @@ public class RedirectingResource {
             return Response.status(Response.Status.FOUND).location(URI.create("/redirect/302?redirects=" + (number - 1)))
                     .build();
         }
+    }
+
+    @GET
+    @Path("304")
+    public Response notModifiedResponse(HttpHeaders httpHeaders) {
+        // a 304 has no Location header although its status is within the 300..399 range
+        if (ETAG.equals(httpHeaders.getHeaderString(HttpHeaders.IF_NONE_MATCH))) {
+            return Response.notModified(ETAG).build();
+        }
+        return Response.ok().header(HttpHeaders.ETAG, ETAG).build();
     }
 
     @POST

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
@@ -273,15 +273,16 @@ public class ClientSendRequestHandler implements ClientRestHandler {
         }
         httpClientRequest.redirectHandler(response -> {
             /*
-             * The docs for `redirectHandler()` make no statement about whether the returned result is nullable.
-             * We'll guard against null here and assume there's no redirect taking place.
+             * A redirect handler signals "no redirect" by returning null: `HttpClientRequestImpl#handleResponse`
+             * only checks the returned Future for nullness, so a Future completing with null would end up being
+             * dereferenced and the response would never be delivered.
              */
             Function<HttpClientResponse, Future<RequestOptions>> redirectHandler = requestContext.getHttpClient()
                     // For Vert.x 5 we'll have to cast the `HttpClient` to `HttpClientInternal` in order to access
                     // this method
                     .redirectHandler();
             if (redirectHandler == null) {
-                return Future.succeededFuture(null);
+                return null;
             }
 
             /*
@@ -290,20 +291,24 @@ public class ClientSendRequestHandler implements ClientRestHandler {
              *
              * But it doesn't return `HttpClientRequest`, it returns a `Future<RequestOptions>`.
              * Vert.x 3 exposed redirect handling in terms of HttpClientRequest, while Vert.x 4
-             * changed the client-level redirect handler to Future<RequestOptions>. The current
-             * docs still describe the old null semantics, so they are likely stale.
+             * changed the client-level redirect handler to Future<RequestOptions>.
              *
-             * In practice, we defensively accept both interpretations of "no redirect":
-             * - the handler returns a null Future<RequestOptions>
-             * - the handler returns a Future completing with null RequestOptions
+             * The null result is what a 3xx response without a Location header produces, and
+             * `HttpClientRequestImpl#handleResponse` routes all of 300..399 through here, so 304 Not Modified
+             * ends up here as well.
              */
             Future<RequestOptions> redirectOptions = redirectHandler.apply(response);
             if (redirectOptions == null) {
-                return Future.succeededFuture(null);
+                return null;
             }
             return redirectOptions.compose(options -> {
                 if (options == null) {
-                    return Future.succeededFuture(null);
+                    /*
+                     * "No redirect" cannot be expressed once we have handed back a Future, so fail instead of
+                     * leaving the caller waiting for a response that is never delivered.
+                     */
+                    return Future.failedFuture(new IllegalStateException(
+                            "The client redirect handler completed with null RequestOptions. Return null instead to indicate that no redirect should be followed."));
                 }
                 /*
                  * If there is a redirect taking place install the original request's customizers to the redirect


### PR DESCRIPTION
Since 3.36.0, a REST Client with `followRedirects` enabled never completes its response when the server replies with a 3xx status that carries no `Location` header, 304 Not Modified being the common case. `installRedirectRequestCustomizer` signals "no redirect" as `Future.succeededFuture(null)`, but `HttpClientRequestImpl#handleResponse` only null-checks the returned `Future` and then dereferences its null result in `handleNextRequest`. The resulting NPE escapes to the Vert.x exception handler and the response promise is never completed, so an application that forwards conditional requests upstream hangs on every 304 until its read timeout.

The handler now returns `null` for the two synchronous "no redirect" cases, which is what Vert.x expects and what `WrapperVertxRedirectHandlerImpl` in the same package already does. Once a `Future` has been handed back, "no redirect" can no longer be expressed at all, so a `Future` that completes with `null` options now fails the request rather than leaving it hanging.

- Fixes: #55714
