### PR TITLE
Remove nonsensical configuration from Hibernate Search AI skill

### DIFF
--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -7,8 +7,6 @@ Requires `hibernate-search-orm-elasticsearch` + `hibernate-orm` (or `hibernate-o
 
 ```properties
 quarkus.hibernate-search-orm.elasticsearch.version=9
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
-%prod.quarkus.hibernate-orm.schema-management.strategy=update
 ```
 
 Dev Services starts Elasticsearch automatically. The version property must match — check the Dev Services log for the actual version started.


### PR DESCRIPTION
We certainly shouldn't recommend HBM2DDL 'update' in prod
