### PR TITLE
Use dev services and implicit schema-management more broadly in h2-based tests

### DIFF
--- a/extensions/hibernate-envers/deployment/src/test/resources/application-emptysuffixtable.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-emptysuffixtable.properties
@@ -1,7 +1,6 @@
 quarkus.datasource.db-kind=h2
 
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-envers.audit-table-suffix=
 quarkus.hibernate-envers.audit-table-prefix=P_
 quarkus.hibernate-envers.revision-field-name=GEN

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-multiple-pu.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-multiple-pu.properties
@@ -1,7 +1,6 @@
 quarkus.datasource.db-kind=h2
 
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.packages=io.quarkus.hibernate.orm.envers
 quarkus.hibernate-envers.audit-table-suffix=
 quarkus.hibernate-envers.audit-table-prefix=P_
@@ -9,7 +8,6 @@ quarkus.hibernate-envers.revision-field-name=GEN
 quarkus.hibernate-envers.revision-type-field-name=GEN_TYPE
 
 quarkus.datasource."db1".db-kind=h2
-quarkus.hibernate-orm."db1".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."db1".datasource=db1
 quarkus.hibernate-orm."db1".packages=io.quarkus.hibernate.orm.envers
 quarkus.hibernate-envers."db1".audit-table-suffix=
@@ -18,7 +16,6 @@ quarkus.hibernate-envers."db1".revision-field-name=REVISION
 quarkus.hibernate-envers."db1".revision-type-field-name=REV_TYPE
 
 quarkus.datasource."db2".db-kind=h2
-quarkus.hibernate-orm."db2".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."db2".datasource=db2
 quarkus.hibernate-orm."db2".packages=io.quarkus.hibernate.orm.envers
 quarkus.hibernate-envers."db2".audit-table-suffix=

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-allow-identifier-reuse.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-allow-identifier-reuse.properties
@@ -1,5 +1,4 @@
 quarkus.datasource.db-kind=h2
 
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-envers.audit-strategy=org.hibernate.envers.strategy.ValidityAuditStrategy
 quarkus.hibernate-envers.allow-identifier-reuse=true

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-audit-strategy.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-audit-strategy.properties
@@ -1,4 +1,3 @@
 quarkus.datasource.db-kind=h2
 
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-envers.audit-strategy=org.hibernate.envers.strategy.ValidityAuditStrategy

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-default-schema-catalog.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-default-schema-catalog.properties
@@ -1,5 +1,4 @@
 quarkus.datasource.db-kind=h2
 
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-envers.default-schema=public
 quarkus.hibernate-envers.default-catalog=

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-do-not-audit-optimistic-locking-field.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-do-not-audit-optimistic-locking-field.properties
@@ -1,4 +1,3 @@
 quarkus.datasource.db-kind=h2
 
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-envers.do-not-audit-optimistic-locking-field=false

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-embeddable-set-ordinal-field-name.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-embeddable-set-ordinal-field-name.properties
@@ -1,4 +1,3 @@
 quarkus.datasource.db-kind=h2
 
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-envers.embeddable-set-ordinal-field-name=ORD

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-modified-column-naming-strategy.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-modified-column-naming-strategy.properties
@@ -1,4 +1,3 @@
 quarkus.datasource.db-kind=h2
 
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-envers.modified-column-naming-strategy=org.hibernate.envers.boot.internal.ImprovedModifiedColumnNamingStrategy

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-modified-flags.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-modified-flags.properties
@@ -1,5 +1,4 @@
 quarkus.datasource.db-kind=h2
 
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-envers.global-with-modified-flag=true
 quarkus.hibernate-envers.modified-flag-suffix=_changed

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-original-id-prop-name.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-original-id-prop-name.properties
@@ -1,4 +1,3 @@
 quarkus.datasource.db-kind=h2
 
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-envers.original-id-prop-name=oid

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-revision-listener.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-revision-listener.properties
@@ -1,4 +1,3 @@
 quarkus.datasource.db-kind=h2
 
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-envers.revision-listener=io.quarkus.hibernate.orm.envers.MyListenerlessRevisionListener

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-revision-on-collection-change.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-revision-on-collection-change.properties
@@ -1,4 +1,3 @@
 quarkus.datasource.db-kind=h2
 
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-envers.revision-on-collection-change=false

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-store-data-at-delete.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-store-data-at-delete.properties
@@ -1,5 +1,4 @@
 quarkus.datasource.db-kind=h2
 
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-envers.store-data-at-delete=true
 quarkus.hibernate-envers.audit-table-suffix=_SUFFIX

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-track-entities-changed-in-revision.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-track-entities-changed-in-revision.properties
@@ -1,4 +1,3 @@
 quarkus.datasource.db-kind=h2
 
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-envers.track-entities-changed-in-revision=true

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-use-revision-entity-with-native-id.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-use-revision-entity-with-native-id.properties
@@ -1,4 +1,3 @@
 quarkus.datasource.db-kind=h2
 
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-envers.use-revision-entity-with-native-id=false

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-validity-strategy-field-name-overrides.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-validity-strategy-field-name-overrides.properties
@@ -1,6 +1,5 @@
 quarkus.datasource.db-kind=h2
 
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-envers.audit-strategy=org.hibernate.envers.strategy.ValidityAuditStrategy
 quarkus.hibernate-envers.audit-strategy-validity-store-revend-timestamp=true
 quarkus.hibernate-envers.audit-strategy-validity-end-rev-field-name=REV_END

--- a/extensions/hibernate-envers/deployment/src/test/resources/application.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application.properties
@@ -1,4 +1,3 @@
 quarkus.datasource.db-kind=h2
 
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/MultiplePUAsAlternativesWithBeanProducerTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/MultiplePUAsAlternativesWithBeanProducerTest.java
@@ -52,20 +52,17 @@ public abstract class MultiplePUAsAlternativesWithBeanProducerTest {
                         .addClass(MyProducer.class))
                 .overrideConfigKey("quarkus.hibernate-orm.pu-1.packages", MyEntity.class.getPackageName())
                 .overrideConfigKey("quarkus.hibernate-orm.pu-1.datasource", "ds-1")
-                .overrideConfigKey("quarkus.hibernate-orm.pu-1.schema-management.strategy", "drop-and-create")
                 .overrideConfigKey("quarkus.hibernate-orm.pu-1.active", "false")
                 .overrideConfigKey("quarkus.datasource.ds-1.db-kind", "h2")
                 .overrideConfigKey("quarkus.datasource.ds-1.active", "false")
                 .overrideConfigKey("quarkus.hibernate-orm.pu-2.packages", MyEntity.class.getPackageName())
                 .overrideConfigKey("quarkus.hibernate-orm.pu-2.datasource", "ds-2")
-                .overrideConfigKey("quarkus.hibernate-orm.pu-2.schema-management.strategy", "drop-and-create")
                 .overrideConfigKey("quarkus.hibernate-orm.pu-2.active", "false")
                 .overrideConfigKey("quarkus.datasource.ds-2.db-kind", "h2")
                 .overrideConfigKey("quarkus.datasource.ds-2.active", "false")
                 // This is where we select the active PU / datasource
                 .overrideRuntimeConfigKey("quarkus.hibernate-orm." + activePuName + ".active", "true")
-                .overrideRuntimeConfigKey("quarkus.datasource." + activeDsName + ".active", "true")
-                .overrideRuntimeConfigKey("quarkus.datasource." + activeDsName + ".jdbc.url", "jdbc:h2:mem:testds1");
+                .overrideRuntimeConfigKey("quarkus.datasource." + activeDsName + ".active", "true");
     }
 
     private final String activePuName;

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DbVersionDefaultsCompatibleTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DbVersionDefaultsCompatibleTest.java
@@ -40,6 +40,7 @@ public class DbVersionDefaultsCompatibleTest {
             // Explicitly select "compatible" defaults
             .overrideConfigKey("quarkus.datasource.db-version-defaults", "compatible")
             // Starting offline for faster testing -- shouldn't affect test results
+            .overrideConfigKey("quarkus.datasource.jdbc.url", "jdbc:postgresql://localhost:5432/some-non-existing-database")
             .overrideConfigKey("quarkus.hibernate-orm.database.start-offline", "true")
             .overrideConfigKey("quarkus.hibernate-orm.schema-management.strategy", "none")
             .overrideConfigKey("quarkus.devservices.enabled", "false");

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DbVersionDefaultsCompatibleWithQuarkusOverrideTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DbVersionDefaultsCompatibleWithQuarkusOverrideTest.java
@@ -40,6 +40,7 @@ public class DbVersionDefaultsCompatibleWithQuarkusOverrideTest {
             // Explicitly select "compatible" defaults
             .overrideConfigKey("quarkus.datasource.db-version-defaults", "compatible")
             // Starting offline for faster testing -- shouldn't affect test results
+            .overrideConfigKey("quarkus.datasource.jdbc.url", "jdbc:postgresql://localhost:5432/some-non-existing-database")
             .overrideConfigKey("quarkus.hibernate-orm.database.start-offline", "true")
             .overrideConfigKey("quarkus.hibernate-orm.schema-management.strategy", "none")
             .overrideConfigKey("quarkus.devservices.enabled", "false");

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DbVersionDefaultsDefaultTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DbVersionDefaultsDefaultTest.java
@@ -34,6 +34,7 @@ public class DbVersionDefaultsDefaultTest {
             .overrideConfigKey("quarkus.datasource.db-kind", "postgresql")
             // Do not select defaults -- they should default to "recent"
             // Starting offline for faster testing -- shouldn't affect test results
+            .overrideConfigKey("quarkus.datasource.jdbc.url", "jdbc:postgresql://localhost:5432/some-non-existing-database")
             .overrideConfigKey("quarkus.hibernate-orm.database.start-offline", "true")
             .overrideConfigKey("quarkus.hibernate-orm.schema-management.strategy", "none")
             .overrideConfigKey("quarkus.devservices.enabled", "false");

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DbVersionDefaultsRecentTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DbVersionDefaultsRecentTest.java
@@ -35,6 +35,7 @@ public class DbVersionDefaultsRecentTest {
             // Explicitly select "recent" defaults (which is... the default)
             .overrideConfigKey("quarkus.datasource.db-version-defaults", "recent")
             // Starting offline for faster testing -- shouldn't affect test results
+            .overrideConfigKey("quarkus.datasource.jdbc.url", "jdbc:postgresql://localhost:5432/some-non-existing-database")
             .overrideConfigKey("quarkus.hibernate-orm.database.start-offline", "true")
             .overrideConfigKey("quarkus.hibernate-orm.schema-management.strategy", "none")
             .overrideConfigKey("quarkus.devservices.enabled", "false");

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/offline/StartOfflineEmbeddedDbTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/offline/StartOfflineEmbeddedDbTest.java
@@ -19,7 +19,6 @@ public class StartOfflineEmbeddedDbTest {
                     .addClass(MyEntity.class))
             .withConfigurationResource("application.properties")
             .overrideConfigKey("quarkus.datasource.db-kind", "h2")
-            .overrideConfigKey("quarkus.datasource.jdbc.url", "jdbc:h2:mem:test")
             // Do NOT set db-version explicitly - let it default
             // H2 is embedded, so no warning should be issued
             .overrideConfigKey("quarkus.hibernate-orm.database.start-offline", "true")

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-config-named-pu.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-config-named-pu.properties
@@ -1,9 +1,6 @@
 # This is necessary for the named datasource to be considered "configured" at build time.
 quarkus.datasource."mydatasource".db-kind=h2
 
-quarkus.datasource."mydatasource".jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm."mypu".datasource=mydatasource
 quarkus.hibernate-orm."mypu".packages=io.quarkus.hibernate.orm.config
-quarkus.hibernate-orm."mypu".schema-management.strategy=drop-and-create

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-datasource-only.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-datasource-only.properties
@@ -1,2 +1,1 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-discriminator-ignore-explicit-for-joined-default-value.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-discriminator-ignore-explicit-for-joined-default-value.properties
@@ -1,2 +1,1 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-discriminator-ignore-explicit-for-joined-true-value.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-discriminator-ignore-explicit-for-joined-true-value.properties
@@ -1,4 +1,2 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 quarkus.hibernate-orm.discriminator.ignore-explicit-for-joined=true

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-fetch-max-depth-zero.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-fetch-max-depth-zero.properties
@@ -1,7 +1,4 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.hibernate-orm.fetch.max-depth=0

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-generate-script.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-generate-script.properties
@@ -1,8 +1,5 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.hibernate-orm.scripts.generation=drop-and-create
 quarkus.hibernate-orm.scripts.generation.create-target=target/test-classes/create.sql

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-generation-none-customh2.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-generation-none-customh2.properties
@@ -1,6 +1,4 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.schema-management.strategy=none
 #We need the custom dialect to force the failure to happen exclusively during DDL generation

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-implicit-naming-strategy.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-implicit-naming-strategy.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.implicit-naming-strategy=io.quarkus.hibernate.orm.naming.CustomImplicitNamingStrategy

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-import-load-script-test.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-import-load-script-test.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-import-multiple-load-scripts-test.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-import-multiple-load-scripts-test.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import-1.sql,import-2.sql

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-invalid-multiline-test.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-invalid-multiline-test.properties
@@ -1,7 +1,4 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.schema-management.halt-on-error=true
 quarkus.hibernate-orm.sql-load-script=invalid-multiline.sql

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-load-script-as-zip-file-test.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-load-script-as-zip-file-test.properties
@@ -1,5 +1,2 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
-quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=load-script-test.zip

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-load-scripts-as-multiple-zip-files-and-sql-file-test.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-load-scripts-as-multiple-zip-files-and-sql-file-test.properties
@@ -1,5 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=load-script-test.sql, import-multiple-load-scripts-1.zip, import-multiple-load-scripts-2.zip

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-load-scripts-as-multiple-zip-files-test.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-load-scripts-as-multiple-zip-files-test.properties
@@ -1,5 +1,2 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
-quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import-multiple-load-scripts-1.zip, import-multiple-load-scripts-2.zip

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-log-sql-format-sql-default.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-log-sql-format-sql-default.properties
@@ -1,4 +1,2 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 quarkus.hibernate-orm.log.sql=true

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-log-sql-format-sql-false.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-log-sql-format-sql-false.properties
@@ -1,5 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.log.format-sql=false

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-mapping-files-my-hbm-xml.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-mapping-files-my-hbm-xml.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.mapping-files=my-hbm.xml

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-mapping-files-my-orm-xml.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-mapping-files-my-orm-xml.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.mapping-files=my-orm.xml

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-mapping-files-no-file.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-mapping-files-no-file.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.mapping-files=no-file

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-metadata-builder-contributor.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-metadata-builder-contributor.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.metadata-builder-contributor=io.quarkus.hibernate.orm.metadatabuildercontributor.CustomMetadataBuilderContributor

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-metrics-enabled.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-metrics-enabled.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.metrics.enabled=true

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-load-script-files-as-zip-file-test.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-load-script-files-as-zip-file-test.properties
@@ -1,5 +1,2 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
-quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=multiple-load-script-files.zip

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-annotations.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-annotations.properties
@@ -6,11 +6,8 @@ quarkus.datasource.users.jdbc.min-size=2
 
 quarkus.datasource.inventory.db-kind=h2
 
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.datasource=<default>
 
-quarkus.hibernate-orm."users".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."users".datasource=users
 
-quarkus.hibernate-orm."inventory".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."inventory".datasource=inventory

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-default-disabled.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-default-disabled.properties
@@ -1,13 +1,7 @@
 quarkus.datasource.users.db-kind=h2
-quarkus.datasource.users.jdbc.url=jdbc:h2:mem:users
-
 quarkus.datasource.inventory.db-kind=h2
-quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory
-
-quarkus.hibernate-orm."users".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."users".datasource=users
 quarkus.hibernate-orm."users".packages=io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.user
 
-quarkus.hibernate-orm."inventory".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."inventory".datasource=inventory
 quarkus.hibernate-orm."inventory".packages=io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.inventory

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-unaffected-entities.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-unaffected-entities.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.inventory.db-kind=h2
-quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory
-
-quarkus.hibernate-orm."inventory".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."inventory".datasource=inventory
 quarkus.hibernate-orm."inventory".packages=io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.inventory

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-undefined-packages.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-undefined-packages.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.users.db-kind=h2
-quarkus.datasource.users.jdbc.url=jdbc:h2:mem:users
-
 quarkus.hibernate-orm."users".log.sql=true
-quarkus.hibernate-orm."users".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."users".datasource=users

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units.properties
@@ -1,19 +1,10 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default
-
 quarkus.datasource.users.db-kind=h2
-quarkus.datasource.users.jdbc.url=jdbc:h2:mem:users
-
 quarkus.datasource.inventory.db-kind=h2
-quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory
-
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.packages=io.quarkus.hibernate.orm.multiplepersistenceunits.model.config
 
-quarkus.hibernate-orm."users".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."users".datasource=users
 quarkus.hibernate-orm."users".packages=io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.user
 
-quarkus.hibernate-orm."inventory".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."inventory".datasource=inventory
 quarkus.hibernate-orm."inventory".packages=io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.inventory

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-pu-discriminator-ignore-explicit-for-joined-default-value.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-pu-discriminator-ignore-explicit-for-joined-default-value.properties
@@ -1,13 +1,7 @@
 quarkus.datasource.users.db-kind=h2
-quarkus.datasource.users.jdbc.url=jdbc:h2:mem:users
-
 quarkus.datasource.inventory.db-kind=h2
-quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory
-
-quarkus.hibernate-orm."users".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."users".datasource=users
 quarkus.hibernate-orm."users".packages=io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.user
 
-quarkus.hibernate-orm."inventory".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."inventory".datasource=inventory
 quarkus.hibernate-orm."inventory".packages=io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.inventory

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-pu-discriminator-ignore-explicit-for-joined-true-value.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-pu-discriminator-ignore-explicit-for-joined-true-value.properties
@@ -1,15 +1,9 @@
 quarkus.datasource.users.db-kind=h2
-quarkus.datasource.users.jdbc.url=jdbc:h2:mem:users
-
 quarkus.datasource.inventory.db-kind=h2
-quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory
-
-quarkus.hibernate-orm."users".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."users".datasource=users
 quarkus.hibernate-orm."users".packages=io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.user
 quarkus.hibernate-orm."users".discriminator.ignore-explicit-for-joined=true
 
-quarkus.hibernate-orm."inventory".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."inventory".datasource=inventory
 quarkus.hibernate-orm."inventory".packages=io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.inventory
 quarkus.hibernate-orm."inventory".discriminator.ignore-explicit-for-joined=true

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-named-datasource.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-named-datasource.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.users.db-kind=h2
-quarkus.datasource.users.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.datasource=users

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-no-file-option-test.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-no-file-option-test.properties
@@ -1,7 +1,4 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 #quarkus.hibernate-orm.sql-load-script=load-script-test.sql
 quarkus.hibernate-orm.sql-load-script=no-file

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-ormxml-annotationoverride-disabled.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-ormxml-annotationoverride-disabled.properties
@@ -1,5 +1,2 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-ormxml-annotationoverride-enabled.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-ormxml-annotationoverride-enabled.properties
@@ -1,5 +1,2 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-other-load-script-test.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-other-load-script-test.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.sql-load-script=load-script-test.sql

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-physical-naming-strategy.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-physical-naming-strategy.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.physical-naming-strategy=io.quarkus.hibernate.orm.naming.PrefixPhysicalNamingStrategy

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-quoted-identifiers.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-quoted-identifiers.properties
@@ -1,7 +1,4 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.hibernate-orm.quote-identifiers.strategy=all-except-column-definitions

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-quoted-keywords.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-quoted-keywords.properties
@@ -1,7 +1,4 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.hibernate-orm.quote-identifiers.strategy=only-keywords

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-tsr.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-tsr.properties
@@ -1,5 +1,2 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.conn.packages=io.quarkus.narayana.quarkus

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-validation-disabled.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-validation-disabled.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.validation.enabled=false
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-validation-mode-auto.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-validation-mode-auto.properties
@@ -1,7 +1,4 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
 # we don't set it explicitly as it is a default:
 #quarkus.hibernate-orm.validation.mode=AUTO
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-validation-mode-multiple.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-validation-mode-multiple.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.validation.mode=callback,ddl
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-validation-mode-none.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-validation-mode-none.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.validation.mode=none
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/extensions/hibernate-orm/deployment/src/test/resources/application.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application.properties
@@ -1,5 +1,2 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false-and-named-pu-active-true.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false-and-named-pu-active-true.properties
@@ -1,19 +1,12 @@
 # We already start Elasticsearch with Maven
-quarkus.devservices.enabled=false
-
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
-
 quarkus.datasource."nameddatasource".db-kind=h2
-quarkus.datasource."nameddatasource".jdbc.url=jdbc:h2:mem:nameddatasource;DB_CLOSE_DELAY=-1
 
 quarkus.hibernate-orm.datasource=<default>
 quarkus.hibernate-orm.packages=io.quarkus.hibernate.search.orm.elasticsearch.test.devui
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.hibernate-orm."namedpu".datasource=nameddatasource
 quarkus.hibernate-orm."namedpu".packages=io.quarkus.hibernate.search.orm.elasticsearch.test.devui.namedpu
-quarkus.hibernate-orm."namedpu".schema-management.strategy=drop-and-create
 
 # Hibernate Search is inactive for the default PU
 quarkus.hibernate-search-orm.active=false

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false.properties
@@ -1,10 +1,5 @@
 # We already start Elasticsearch with Maven
-quarkus.devservices.enabled=false
-
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
-
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.hibernate-search-orm.active=false
 quarkus.hibernate-search-orm.elasticsearch.version=9.4

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui.properties
@@ -1,10 +1,4 @@
-# We already start Elasticsearch with Maven
-quarkus.devservices.enabled=false
-
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
-
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.hibernate-search-orm.elasticsearch.version=9.4
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-multiple-persistence-units.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-multiple-persistence-units.properties
@@ -1,17 +1,8 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
-
 quarkus.datasource.data1.db-kind=h2
-quarkus.datasource.data1.jdbc.url=jdbc:h2:mem:data1;DB_CLOSE_DELAY=-1
-
 quarkus.datasource.data2.db-kind=h2
-quarkus.datasource.data2.jdbc.url=jdbc:h2:mem:data2;DB_CLOSE_DELAY=-1
-
 quarkus.datasource.data3.db-kind=h2
-quarkus.datasource.data3.jdbc.url=jdbc:h2:mem:data3;DB_CLOSE_DELAY=-1
-
 quarkus.hibernate-orm.datasource=<default>
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.hibernate-search-orm.elasticsearch.version=9
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
@@ -19,7 +10,6 @@ quarkus.hibernate-search-orm.elasticsearch.protocol=${elasticsearch.protocol:htt
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop
 quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy=sync
 
-quarkus.hibernate-orm."pu1".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."pu1".datasource=data1
 
 quarkus.hibernate-search-orm."pu1".elasticsearch.version=9
@@ -28,7 +18,6 @@ quarkus.hibernate-search-orm."pu1".elasticsearch.protocol=${elasticsearch.protoc
 quarkus.hibernate-search-orm."pu1".schema-management.strategy=drop-and-create-and-drop
 quarkus.hibernate-search-orm."pu1".indexing.plan.synchronization.strategy=sync
 
-quarkus.hibernate-orm."pu2".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."pu2".datasource=data2
 
 quarkus.hibernate-search-orm."pu2".elasticsearch.version=9
@@ -37,7 +26,6 @@ quarkus.hibernate-search-orm."pu2".elasticsearch.protocol=${elasticsearch.protoc
 quarkus.hibernate-search-orm."pu2".schema-management.strategy=drop-and-create-and-drop
 quarkus.hibernate-search-orm."pu2".indexing.plan.synchronization.strategy=sync
 
-quarkus.hibernate-orm."pu3".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."pu3".datasource=data3
 
 # No indexed entity in PU3

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-nohsearchconfig-named-pu.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-nohsearchconfig-named-pu.properties
@@ -1,6 +1,3 @@
 quarkus.datasource."data1".db-kind=h2
-quarkus.datasource."data1".jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
-
-quarkus.hibernate-orm."PU1".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."PU1".packages=io.quarkus.hibernate.search.orm.elasticsearch.test.configuration
 quarkus.hibernate-orm."PU1".datasource=data1

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-nohsearchconfig.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-nohsearchconfig.properties
@@ -1,4 +1,1 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
-
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-start-offline.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-start-offline.properties
@@ -1,8 +1,4 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
-
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
-
 quarkus.hibernate-search-orm.elasticsearch.version=9.4
 # Simulate an offline Elasticsearch instance by pointing to a non-existing cluster
 quarkus.hibernate-search-orm.elasticsearch.hosts=localhost:14800

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application.properties
@@ -1,8 +1,4 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
-
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
-
 quarkus.hibernate-search-orm.elasticsearch.version=9
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm.elasticsearch.protocol=${elasticsearch.protocol:http}

--- a/extensions/hibernate-search-orm-outbox-polling/deployment/src/test/java/io/quarkus/hibernate/search/orm/outboxpolling/test/configuration/devmode/HibernateSearchDevModeFailingOrmTest.java
+++ b/extensions/hibernate-search-orm-outbox-polling/deployment/src/test/java/io/quarkus/hibernate/search/orm/outboxpolling/test/configuration/devmode/HibernateSearchDevModeFailingOrmTest.java
@@ -44,7 +44,7 @@ public class HibernateSearchDevModeFailingOrmTest {
         config.modifyResourceFile(
                 "application.properties",
                 s -> APPLICATION_PROPERTIES + """
-                        quarkus.datasource.jdbc.min-size=20
+                        quarkus.datasource.jdbc.url=INCORRECT
                         """);
         RestAssured.when().put("/test/hibernate-search-outbox-polling/check-agents-running").then()
                 .statusCode(500);

--- a/extensions/hibernate-search-orm-outbox-polling/deployment/src/test/resources/application-dev-mode.properties
+++ b/extensions/hibernate-search-orm-outbox-polling/deployment/src/test/resources/application-dev-mode.properties
@@ -1,10 +1,5 @@
 quarkus.ssl.native = false
-
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
-quarkus.datasource.jdbc.max-size=8
-
-quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.hibernate-search-orm.elasticsearch.version=9
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}

--- a/extensions/hibernate-search-orm-outbox-polling/deployment/src/test/resources/application-multiple-persistence-units.properties
+++ b/extensions/hibernate-search-orm-outbox-polling/deployment/src/test/resources/application-multiple-persistence-units.properties
@@ -1,10 +1,5 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
-
 quarkus.datasource.data1.db-kind=h2
-quarkus.datasource.data1.jdbc.url=jdbc:h2:mem:data1;DB_CLOSE_DELAY=-1
-
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.datasource=<default>
 
 quarkus.hibernate-search-orm.elasticsearch.version=9
@@ -13,7 +8,6 @@ quarkus.hibernate-search-orm.elasticsearch.protocol=${elasticsearch.protocol:htt
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop
 quarkus.hibernate-search-orm.coordination.strategy=outbox-polling
 
-quarkus.hibernate-orm."pu1".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."pu1".datasource=data1
 
 quarkus.hibernate-search-orm."pu1".elasticsearch.version=9

--- a/extensions/hibernate-search-orm-outbox-polling/deployment/src/test/resources/application.properties
+++ b/extensions/hibernate-search-orm-outbox-polling/deployment/src/test/resources/application.properties
@@ -1,8 +1,4 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
-
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
-
 quarkus.hibernate-search-orm.elasticsearch.version=9
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm.elasticsearch.protocol=${elasticsearch.protocol:http}

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/AgroalMetricsOnlyTestCase.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/AgroalMetricsOnlyTestCase.java
@@ -19,8 +19,7 @@ public class AgroalMetricsOnlyTestCase {
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .overrideConfigKey("quarkus.datasource.db-kind", "h2")
             .overrideConfigKey("quarkus.datasource.metrics.enabled", "true")
-            .overrideRuntimeConfigKey("quarkus.datasource.username", "username-named")
-            .overrideRuntimeConfigKey("quarkus.datasource.jdbc.url", "jdbc:h2:tcp://localhost/mem:testing");
+            .overrideRuntimeConfigKey("quarkus.datasource.username", "username-named");
 
     @Inject
     MeterRegistry registry;

--- a/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/test/kotlin/io/quarkus/hibernate/orm/panache/kotlin/deployment/test/multiple_pu/DefaultPersistenceUnitFileTest.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/test/kotlin/io/quarkus/hibernate/orm/panache/kotlin/deployment/test/multiple_pu/DefaultPersistenceUnitFileTest.kt
@@ -37,7 +37,6 @@ class DefaultPersistenceUnitFileTest {
                             .addAsResource(StringAsset(
                                     """
                     quarkus.datasource.db-kind=h2
-                    quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
                     """.trimIndent()),
                                     "application.properties")
                 }

--- a/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/test/resources/application-erroneous-multiple-persistence-units.properties
+++ b/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/test/resources/application-erroneous-multiple-persistence-units.properties
@@ -1,12 +1,6 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
-
 quarkus.datasource.second.db-kind=h2
-quarkus.datasource.second.jdbc.url=jdbc:h2:mem:second;DB_CLOSE_DELAY=-1
-
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.packages=io.quarkus.hibernate.orm.panache.kotlin.deployment.test.multiple_pu.first
 
-quarkus.hibernate-orm."second".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."second".datasource=second
 quarkus.hibernate-orm."second".packages=io.quarkus.hibernate.orm.panache.kotlin.deployment.test.multiple_pu.first

--- a/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/test/resources/application-multiple-persistence-units.properties
+++ b/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/test/resources/application-multiple-persistence-units.properties
@@ -1,12 +1,6 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
-
 quarkus.datasource.second.db-kind=h2
-quarkus.datasource.second.jdbc.url=jdbc:h2:mem:second;DB_CLOSE_DELAY=-1
-
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.packages=io.quarkus.hibernate.orm.panache.kotlin.deployment.test.multiple_pu.first
 
-quarkus.hibernate-orm."second".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."second".datasource=second
 quarkus.hibernate-orm."second".packages=io.quarkus.hibernate.orm.panache.kotlin.deployment.test.multiple_pu.second

--- a/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/test/resources/application-test.properties
+++ b/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/test/resources/application-test.properties
@@ -1,5 +1,2 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/multiple_pu/DefaultPersistenceUnitFileTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/multiple_pu/DefaultPersistenceUnitFileTest.java
@@ -20,8 +20,7 @@ public class DefaultPersistenceUnitFileTest {
                     .addClasses(FirstEntity.class, SecondEntity.class, PanacheTestResource.class)
                     .addAsManifestResource("META-INF/some-persistence.xml", "persistence.xml")
                     .addAsResource(new StringAsset(
-                            "quarkus.datasource.db-kind=h2\n" +
-                                    "quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1"),
+                            "quarkus.datasource.db-kind=h2"),
                             "application.properties"));
 
     @Test

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/resources/application-erroneous-multiple-persistence-units.properties
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/resources/application-erroneous-multiple-persistence-units.properties
@@ -1,13 +1,7 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:first;DB_CLOSE_DELAY=-1
-
 quarkus.datasource.second.db-kind=h2
-quarkus.datasource.second.jdbc.url=jdbc:h2:mem:second;DB_CLOSE_DELAY=-1
-
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.packages=io.quarkus.hibernate.orm.panache.deployment.test.multiple_pu.first
 
-quarkus.hibernate-orm."second".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."second".datasource=second
 quarkus.hibernate-orm."second".packages=io.quarkus.hibernate.orm.panache.deployment.test.multiple_pu.first
         

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/resources/application-multiple-persistence-units-for-repository.properties
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/resources/application-multiple-persistence-units-for-repository.properties
@@ -1,12 +1,6 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:first;DB_CLOSE_DELAY=-1
-
 quarkus.datasource.repository.db-kind=h2
-quarkus.datasource.repository.jdbc.url=jdbc:h2:mem:repository;DB_CLOSE_DELAY=-1
-
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.packages=io.quarkus.hibernate.orm.panache.deployment.test.multiple_pu.first
 
-quarkus.hibernate-orm."repository".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."repository".datasource=repository
 quarkus.hibernate-orm."repository".packages=io.quarkus.hibernate.orm.panache.deployment.test.multiple_pu.repository

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/resources/application-multiple-persistence-units.properties
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/resources/application-multiple-persistence-units.properties
@@ -1,12 +1,6 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:first;DB_CLOSE_DELAY=-1
-
 quarkus.datasource.second.db-kind=h2
-quarkus.datasource.second.jdbc.url=jdbc:h2:mem:second;DB_CLOSE_DELAY=-1
-
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.packages=io.quarkus.hibernate.orm.panache.deployment.test.multiple_pu.first
 
-quarkus.hibernate-orm."second".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."second".datasource=second
 quarkus.hibernate-orm."second".packages=io.quarkus.hibernate.orm.panache.deployment.test.multiple_pu.second

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/resources/application-test.properties
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/resources/application-test.properties
@@ -1,5 +1,2 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
@@ -32,6 +32,9 @@ class OpenApiIntegrationTest {
                     Dependency.of("io.quarkus", "quarkus-jdbc-h2-deployment", Version.getVersion()),
                     Dependency.of("io.quarkus", "quarkus-resteasy-jsonb-deployment", Version.getVersion()),
                     Dependency.of("io.quarkus", "quarkus-security-deployment", Version.getVersion())))
+            // QuarkusProdModeTest => we lose dev services
+            .overrideConfigKey("quarkus.datasource.jdbc.url", "jdbc:h2:mem:test")
+            .overrideConfigKey("quarkus.hibernate-orm.schema-management.strategy", "drop-and-create")
             .setRun(true);
 
     @Test

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/security/AbstractSecurityAnnotationTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/security/AbstractSecurityAnnotationTest.java
@@ -36,9 +36,7 @@ abstract class AbstractSecurityAnnotationTest {
             .overrideConfigKey("quarkus.security.users.embedded.users.foo", "foo")
             .overrideConfigKey("quarkus.security.users.embedded.roles.foo", "user")
             .overrideConfigKey("quarkus.security.users.embedded.users.bar", "bar")
-            .overrideConfigKey("quarkus.security.users.embedded.roles.bar", "admin")
-            .overrideRuntimeConfigKey("quarkus.datasource.jdbc.url", "jdbc:h2:mem:test")
-            .overrideRuntimeConfigKey("quarkus.hibernate-orm.schema-management.strategy", "drop-and-create");
+            .overrideConfigKey("quarkus.security.users.embedded.roles.bar", "admin");
 
     @Entity
     @Table(name = "item")

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/resources/application.properties
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/resources/application.properties
@@ -1,7 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
-
 # Scopes will not populate in the OpenAPI document unless the security scheme is Oauth2 or OIDC
 quarkus.smallrye-openapi.security-scheme=oauth2-implicit

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/FormAuthJpaTestCase.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/FormAuthJpaTestCase.java
@@ -20,11 +20,7 @@ public class FormAuthJpaTestCase {
 
     private static final String APP_PROPS = "" +
             "quarkus.datasource.db-kind=h2\n" +
-            "quarkus.datasource.username=sa\n" +
-            "quarkus.datasource.password=sa\n" +
-            "quarkus.datasource.jdbc.url=jdbc:h2:mem:minimal-config'\n" +
             "quarkus.hibernate-orm.sql-load-script=import.sql\n" +
-            "quarkus.hibernate-orm.schema-management.strategy=drop-and-create\n" +
             "#quarkus.hibernate-orm.log.sql=true\n" +
             "quarkus.http.auth.form.enabled=true\n" +
             "quarkus.http.auth.form.login-page=login\n" +

--- a/extensions/security-jpa/deployment/src/test/resources/bcrypt-password-mapper/application.properties
+++ b/extensions/security-jpa/deployment/src/test/resources/bcrypt-password-mapper/application.properties
@@ -1,8 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.username=sa
-quarkus.datasource.password=sa
-quarkus.datasource.jdbc.url=jdbc:h2:mem:bcrypt-password-mapper'
-
 quarkus.hibernate-orm.sql-load-script=import.sql
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 #quarkus.hibernate-orm.log.sql=true

--- a/extensions/security-jpa/deployment/src/test/resources/custom-password-mapper/application.properties
+++ b/extensions/security-jpa/deployment/src/test/resources/custom-password-mapper/application.properties
@@ -1,8 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.username=sa
-quarkus.datasource.password=sa
-quarkus.datasource.jdbc.url=jdbc:h2:mem:custom-password-mapper'
-
 quarkus.hibernate-orm.sql-load-script=import.sql
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 #quarkus.hibernate-orm.log.sql=true

--- a/extensions/security-jpa/deployment/src/test/resources/minimal-config/application.properties
+++ b/extensions/security-jpa/deployment/src/test/resources/minimal-config/application.properties
@@ -1,8 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.username=sa
-quarkus.datasource.password=sa
-quarkus.datasource.jdbc.url=jdbc:h2:mem:minimal-config'
-
 quarkus.hibernate-orm.sql-load-script=import.sql
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 #quarkus.hibernate-orm.log.sql=true

--- a/extensions/security-jpa/deployment/src/test/resources/multiple-entities/application.properties
+++ b/extensions/security-jpa/deployment/src/test/resources/multiple-entities/application.properties
@@ -1,9 +1,4 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.username=sa
-quarkus.datasource.password=sa
-quarkus.datasource.jdbc.url=jdbc:h2:mem:multiple-queries'
-
 quarkus.hibernate-orm.sql-load-script=import.sql
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 #quarkus.hibernate-orm.log.sql=true
 

--- a/extensions/security-jpa/deployment/src/test/resources/multiple-roles-in-collection/application.properties
+++ b/extensions/security-jpa/deployment/src/test/resources/multiple-roles-in-collection/application.properties
@@ -1,9 +1,4 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.username=sa
-quarkus.datasource.password=sa
-quarkus.datasource.jdbc.url=jdbc:h2:mem:multiple-queries'
-
 quarkus.hibernate-orm.sql-load-script=import.sql
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 #quarkus.hibernate-orm.log.sql=true
 

--- a/extensions/security-jpa/deployment/src/test/resources/multiple-roles/application.properties
+++ b/extensions/security-jpa/deployment/src/test/resources/multiple-roles/application.properties
@@ -1,8 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.username=sa
-quarkus.datasource.password=sa
-quarkus.datasource.jdbc.url=jdbc:h2:mem:custom-role-decoder'
-
 quarkus.hibernate-orm.sql-load-script=import.sql
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 #quarkus.hibernate-orm.log.sql=true

--- a/extensions/security-jpa/deployment/src/test/resources/multitenant-persistence-unit/application.properties
+++ b/extensions/security-jpa/deployment/src/test/resources/multitenant-persistence-unit/application.properties
@@ -1,19 +1,13 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.username=sa
-quarkus.datasource.password=sa
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default
 
 quarkus.datasource.one.db-kind=h2
-quarkus.datasource.one.username=sa
-quarkus.datasource.one.password=sa
+# We want to use the same underlying DB as 'two'
 quarkus.datasource.one.jdbc.url=jdbc:h2:mem:shared
 
 quarkus.datasource.two.db-kind=h2
-quarkus.datasource.two.username=sa
-quarkus.datasource.two.password=sa
+# We want to use the same underlying DB as 'one'
 quarkus.datasource.two.jdbc.url=jdbc:h2:mem:shared
 
 quarkus.hibernate-orm.multitenant=DATABASE
 quarkus.hibernate-orm.sql-load-script=import.sql
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.packages=io.quarkus.security.jpa

--- a/extensions/security-jpa/deployment/src/test/resources/named-persistence-unit/application.properties
+++ b/extensions/security-jpa/deployment/src/test/resources/named-persistence-unit/application.properties
@@ -1,11 +1,6 @@
 quarkus.datasource.heureka.db-kind=h2
-quarkus.datasource.heureka.username=sa
-quarkus.datasource.heureka.password=sa
-quarkus.datasource.heureka.jdbc.url=jdbc:h2:mem:named-pu'
-
 quarkus.hibernate-orm.heureka.datasource=heureka
 quarkus.hibernate-orm.heureka.sql-load-script=import.sql
-quarkus.hibernate-orm.heureka.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.heureka.packages=io.quarkus.security.jpa
 
 quarkus.security-jpa.persistence-unit-name=heureka

--- a/extensions/spring-data-jpa/deployment/src/test/resources/application-erroneous-multiple-persistence-units.properties
+++ b/extensions/spring-data-jpa/deployment/src/test/resources/application-erroneous-multiple-persistence-units.properties
@@ -1,12 +1,6 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:first;DB_CLOSE_DELAY=-1
-
 quarkus.datasource.second.db-kind=h2
-quarkus.datasource.second.jdbc.url=jdbc:h2:mem:second;DB_CLOSE_DELAY=-1
-
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.packages=io.quarkus.spring.data.deployment.multiple_pu.first
 
-quarkus.hibernate-orm."second".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."second".datasource=second
 quarkus.hibernate-orm."second".packages=io.quarkus.spring.data.deployment.multiple_pu.first

--- a/extensions/spring-data-jpa/deployment/src/test/resources/application-multiple-persistence-units.properties
+++ b/extensions/spring-data-jpa/deployment/src/test/resources/application-multiple-persistence-units.properties
@@ -1,12 +1,6 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:first;DB_CLOSE_DELAY=-1
-
 quarkus.datasource.second.db-kind=h2
-quarkus.datasource.second.jdbc.url=jdbc:h2:mem:second;DB_CLOSE_DELAY=-1
-
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.packages=io.quarkus.spring.data.deployment.multiple_pu.first
 
-quarkus.hibernate-orm."second".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."second".datasource=second
 quarkus.hibernate-orm."second".packages=io.quarkus.spring.data.deployment.multiple_pu.second

--- a/extensions/spring-data-jpa/deployment/src/test/resources/application-test.properties
+++ b/extensions/spring-data-jpa/deployment/src/test/resources/application-test.properties
@@ -1,5 +1,2 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/extensions/spring-data-jpa/deployment/src/test/resources/application.properties
+++ b/extensions/spring-data-jpa/deployment/src/test/resources/application.properties
@@ -1,5 +1,2 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
 #quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/extensions/spring-data-rest/deployment/src/test/resources/application.properties
+++ b/extensions/spring-data-rest/deployment/src/test/resources/application.properties
@@ -1,4 +1,1 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/integration-tests/aesh/src/test/resources/application.properties
+++ b/integration-tests/aesh/src/test/resources/application.properties
@@ -1,7 +1,3 @@
 # Enable the exit command for REPL test shutdown
 quarkus.aesh.add-exit-command=true
-
-# H2 datasource for Hibernate tests
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:aesh-test;DB_CLOSE_DELAY=-1
-quarkus.hibernate-orm.database.generation=drop-and-create

--- a/integration-tests/gradle/src/main/resources/quarkus-dev-dependency/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/quarkus-dev-dependency/src/main/resources/application.properties
@@ -1,5 +1,2 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
-quarkus.datasource.jdbc.driver=org.h2.Driver
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql

--- a/integration-tests/gradle/src/main/resources/quarkus-run-mode-panache-liquibase/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/quarkus-run-mode-panache-liquibase/src/main/resources/application.properties
@@ -1,4 +1,3 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test
 quarkus.hibernate-orm.database.generation=none
 quarkus.liquibase.migrate-at-start=false

--- a/integration-tests/jpa-postgresql/src/test/resources-filtered/projects/devservices-postgresql-fixed-port/src/main/resources/application.properties
+++ b/integration-tests/jpa-postgresql/src/test/resources-filtered/projects/devservices-postgresql-fixed-port/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.devservices.port=55434
-quarkus.hibernate-orm.database.generation=drop-and-create
 # Fresh port to avoid conflicts with other tests
 quarkus.http.port=8084
 quarkus.http.test-port=8085

--- a/integration-tests/jpa-postgresql/src/test/resources-filtered/projects/devservices-postgresql-no-reuse/src/main/resources/application.properties
+++ b/integration-tests/jpa-postgresql/src/test/resources-filtered/projects/devservices-postgresql-no-reuse/src/main/resources/application.properties
@@ -2,6 +2,5 @@ quarkus.datasource.db-kind=postgresql
 # Fixed port so the second run fails with a port conflict if the container isn't stopped.
 # The specific value is arbitrary.
 quarkus.datasource.devservices.port=55433
-quarkus.hibernate-orm.database.generation=drop-and-create
 # Fresh port to avoid conflicts with other tests
 quarkus.http.test-port=8088

--- a/integration-tests/jpa-postgresql/src/test/resources-filtered/projects/devservices-postgresql-reuse/src/main/resources/application.properties
+++ b/integration-tests/jpa-postgresql/src/test/resources-filtered/projects/devservices-postgresql-reuse/src/main/resources/application.properties
@@ -2,6 +2,5 @@ quarkus.datasource.db-kind=postgresql
 # Fixed port so the second run fails with a port conflict if the container isn't reused.
 # The specific value is arbitrary.
 quarkus.datasource.devservices.port=55432
-quarkus.hibernate-orm.database.generation=drop-and-create
 # Fresh port to avoid conflicts with other tests
 quarkus.http.test-port=8086

--- a/integration-tests/rest-data-hibernate-json-types/src/main/resources/application.properties
+++ b/integration-tests/rest-data-hibernate-json-types/src/main/resources/application.properties
@@ -1,6 +1,4 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
-quarkus.hibernate-orm.database.generation=drop-and-create
 # unclutter the logs
 quarkus.log.category."org.jboss.resteasy.reactive.server.handlers.ParameterHandler".level=OFF
 


### PR DESCRIPTION
Most of the time we don't have specific needs for the DB, so we can just let dev services create it.
Things like DB_CLOSE_DELAY=-1 should be unnecessary with dev services these days -- either they add it, or it's irrelevant.

And then when we do that, Hibernate ORM's schema management will automatically be set to 'drop-and-create'.
