### PR TITLE
[3.27] Bump org.postgresql:postgresql from 42.7.11 to 42.7.13

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -120,7 +120,7 @@
         <quartz.version>2.5.0</quartz.version>
         <h2.version>2.3.230</h2.version> <!-- When updating, needs to be matched in io.quarkus.hibernate.orm.runtime.config.DialectVersions
                                               and the dependency jts-core needs to be updated in extensions/jdbc/jdbc-h2/runtime/pom.xml -->
-        <postgresql-jdbc.version>42.7.11</postgresql-jdbc.version>
+        <postgresql-jdbc.version>42.7.13</postgresql-jdbc.version>
         <mariadb-jdbc.version>3.5.6</mariadb-jdbc.version>
         <mysql-jdbc.version>8.3.0</mysql-jdbc.version>
         <mssql-jdbc.version>13.2.1.jre11</mssql-jdbc.version>


### PR DESCRIPTION
Forgotten backport that should've gone into 3.27.5