### PR TITLE
Fix `VertxOutputStream` thundering herd on HTTP/2 by using per-stream lock

### DIFF
--- a/independent-projects/vertx-utils/src/main/java/io/quarkus/vertx/utils/VertxOutputStream.java
+++ b/independent-projects/vertx-utils/src/main/java/io/quarkus/vertx/utils/VertxOutputStream.java
@@ -29,6 +29,9 @@ public class VertxOutputStream extends OutputStream {
     private final HttpServerRequest request;
     private final AppendBuffer appendBuffer;
     private final HttpServerResponse response;
+    // Per-stream lock for drain wait/notify. Using request.connection() would cause a thundering
+    // herd on HTTP/2 where all streams share one connection and one notifyAll() wakes every thread.
+    private final Object lock = new Object();
 
     private boolean committed;
     private boolean closed;
@@ -48,9 +51,9 @@ public class VertxOutputStream extends OutputStream {
                 throwable = event;
                 log.debugf(event, "IO Exception ");
                 request.connection().close();
-                synchronized (request.connection()) {
+                synchronized (lock) {
                     if (waitingForDrain) {
-                        request.connection().notifyAll();
+                        lock.notifyAll();
                     }
                 }
             }
@@ -62,9 +65,9 @@ public class VertxOutputStream extends OutputStream {
         context.getRoutingContext().addEndHandler(new Handler<>() {
             @Override
             public void handle(AsyncResult<Void> event) {
-                synchronized (request.connection()) {
+                synchronized (lock) {
                     if (waitingForDrain) {
-                        request.connection().notifyAll();
+                        lock.notifyAll();
                     }
                 }
             }
@@ -80,8 +83,7 @@ public class VertxOutputStream extends OutputStream {
             response.end();
             return;
         }
-        //do all this in the same lock
-        synchronized (request.connection()) {
+        synchronized (lock) {
             try {
                 awaitWriteable();
                 if (last) {
@@ -106,7 +108,7 @@ public class VertxOutputStream extends OutputStream {
             // NEVER block the event loop!
             return;
         }
-        assert Thread.holdsLock(request.connection());
+        assert Thread.holdsLock(lock);
         while (response.writeQueueFull()) {
             if (throwable != null) {
                 throw new IOException(throwable);
@@ -117,7 +119,7 @@ public class VertxOutputStream extends OutputStream {
             try {
                 waitingForDrain = true;
                 // To make sure we don't get stuck waiting, we time out periodically
-                request.connection().wait(1000); // Verify every second
+                lock.wait(1000);
                 // Check for timeout / closed connection
                 if (request.response().ended() || request.response().closed()) {
                     if (throwable != null) {
@@ -240,9 +242,9 @@ public class VertxOutputStream extends OutputStream {
 
         @Override
         public void handle(Void event) {
-            synchronized (out.request.connection()) {
+            synchronized (out.lock) {
                 if (out.waitingForDrain) {
-                    out.request.connection().notifyAll();
+                    out.lock.notifyAll();
                 }
             }
         }


### PR DESCRIPTION
VertxOutputStream synchronized on request.connection() for drain wait/notify. With HTTP/2, all streams share one connection, so a single drain event called notifyAll() and woke every blocked worker thread across all streams. Most threads found their queue still full and went back to sleep, wasting CPU on lock contention and causing timeouts under load (e.g. DrainTest.testSyncHttp2).

Replace the connection-level lock with a per-stream Object lock so each stream's drain handler only wakes its own writer thread.

Apparently, if this is true, then the behaviour of what happens when using the connection as a lock changed in Vert.x 5 and has consequences. Again, if true, we should review existing uses of this as a lock in our code base.

