### PR TITLE
Unable to import in IDEA: fix unresolvable ${aesh.version} property

### DIFF
--- a/integration-tests/aesh-native/pom.xml
+++ b/integration-tests/aesh-native/pom.xml
@@ -62,11 +62,11 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.aesh</groupId>
                             <artifactId>aesh-processor</artifactId>
-                            <version>${aesh.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/integration-tests/aesh-ssh-native/pom.xml
+++ b/integration-tests/aesh-ssh-native/pom.xml
@@ -63,11 +63,11 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.aesh</groupId>
                             <artifactId>aesh-processor</artifactId>
-                            <version>${aesh.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/integration-tests/aesh-websocket-native/pom.xml
+++ b/integration-tests/aesh-websocket-native/pom.xml
@@ -63,11 +63,11 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.aesh</groupId>
                             <artifactId>aesh-processor</artifactId>
-                            <version>${aesh.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/integration-tests/aesh/pom.xml
+++ b/integration-tests/aesh/pom.xml
@@ -95,11 +95,11 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.aesh</groupId>
                             <artifactId>aesh-processor</artifactId>
-                            <version>${aesh.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>


### PR DESCRIPTION
I was unable to import in IDEA because of it failing to resolve the aesh version. This change fixes it.

Explanation from Claude:

```
Fix unresolvable ${aesh.version} in the aesh integration tests

    The aesh integration tests reference ${aesh.version} for the
    aesh-processor annotation processor path, but that property is only
    defined in bom/application/pom.xml. That pom is consumed as an imported
    BOM, and BOM imports only propagate dependencyManagement, not
    properties, so the expression is never resolved in these modules.

    The Maven CLI build hides the problem: maven-compiler-plugin discards
    the uninterpolated version and falls back to the managed version from
    the quarkus-bom (3.16.4). IntelliJ IDEA's importer does not, and instead
    tries to resolve org.aesh:aesh-processor:${aesh.version} literally,
    which fails and gets cached in the local repository, breaking the
    project import.

    Drop the <version> element so the version always comes from
    dependencyManagement, consistent with the other annotation processor
    paths declared under integration-tests/.
```