### PR TITLE
Use `orderKey` in `VertxBootstrapConsumerBuildItem` for reproducibility

### DIFF
--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/binder/VertxBinderProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/binder/VertxBinderProcessor.java
@@ -56,7 +56,8 @@ public class VertxBinderProcessor {
     void buildStatic(VertxMeterBinderRecorder recorder,
             BuildProducer<VertxBootstrapConsumerBuildItem> boostrap,
             BuildProducer<VertxOptionsConsumerBuildItem> options) {
-        boostrap.produce(new VertxBootstrapConsumerBuildItem(recorder.configureMetricFactory(), LIBRARY_AFTER - 1));
+        boostrap.produce(new VertxBootstrapConsumerBuildItem(recorder.configureMetricFactory(), LIBRARY_AFTER - 1,
+                "micrometer.vertx.metric-factory"));
         options.produce(
                 new VertxOptionsConsumerBuildItem(recorder.configureMetricsOptions(), Interceptor.Priority.LIBRARY_AFTER,
                         "micrometer.vertx.metrics"));

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/tracing/instrumentation/InstrumentationProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/tracing/instrumentation/InstrumentationProcessor.java
@@ -113,20 +113,23 @@ public class InstrumentationProcessor {
     @BuildStep(onlyIfNot = MetricsExtensionAvailable.class, onlyIf = VertxHttpAvailable.class)
     @Record(ExecutionTime.STATIC_INIT)
     VertxBootstrapConsumerBuildItem vertxHttpMetrics(InstrumentationRecorder recorder) {
-        return new VertxBootstrapConsumerBuildItem(recorder.getVertxHttpMetrics(), LIBRARY_AFTER + 1);
+        return new VertxBootstrapConsumerBuildItem(recorder.getVertxHttpMetrics(), LIBRARY_AFTER + 1,
+                "opentelemetry.vertx.http-metrics");
     }
 
     @BuildStep(onlyIfNot = { MetricsExtensionAvailable.class, VertxHttpAvailable.class })
     @Record(ExecutionTime.STATIC_INIT)
     VertxBootstrapConsumerBuildItem vertxMetricsOptions(InstrumentationRecorder recorder) {
-        return new VertxBootstrapConsumerBuildItem(recorder.getVertxMetricsOptions(), LIBRARY_AFTER + 1);
+        return new VertxBootstrapConsumerBuildItem(recorder.getVertxMetricsOptions(), LIBRARY_AFTER + 2,
+                "opentelemetry.vertx.metrics");
     }
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     VertxBootstrapConsumerBuildItem vertxTracingOptions(
             InstrumentationRecorder recorder) {
-        return new VertxBootstrapConsumerBuildItem(recorder.processVertxBootstrap(), LIBRARY_AFTER);
+        return new VertxBootstrapConsumerBuildItem(recorder.processVertxBootstrap(), LIBRARY_AFTER,
+                "opentelemetry.vertx.tracing");
     }
 
     // RESTEasy and Vert.x web

--- a/extensions/vertx/deployment-spi/src/main/java/io/quarkus/vertx/deployment/spi/VertxBootstrapConsumerBuildItem.java
+++ b/extensions/vertx/deployment-spi/src/main/java/io/quarkus/vertx/deployment/spi/VertxBootstrapConsumerBuildItem.java
@@ -11,11 +11,8 @@ import io.vertx.core.internal.VertxBootstrap;
  * Provide a consumer of VertxBootstrap to allow customization of
  * Vert.x bootstrap behavior, e.g. setting tracer factory or metrics.
  * <p>
- * Consumers will be called in priority order (lowest to highest)
+ * Consumers will be called in priority order (lowest to highest), then by order key,
  * after VertxOptions customizers have been applied.
- * <p>
- * When multiple build items have the same priority, the order of execution
- * is not guaranteed.
  * <p>
  * Unlike {@link VertxOptionsConsumerBuildItem}, there is no runtime alternative. {@link VertxBootstrap} being an
  * internal API, only extensions can customize it, and they must do so at build time.
@@ -24,10 +21,20 @@ public final class VertxBootstrapConsumerBuildItem extends MultiBuildItem
         implements Comparable<VertxBootstrapConsumerBuildItem> {
     private final Consumer<VertxBootstrap> consumer;
     private final int priority;
+    private final String orderKey;
 
-    public VertxBootstrapConsumerBuildItem(Consumer<VertxBootstrap> consumer, int priority) {
+    /**
+     * @param consumer the consumer to apply to VertxBootstrap
+     * @param priority consumers are called from lowest to highest priority
+     * @param orderKey a stable key used to order consumers with the same priority
+     */
+    public VertxBootstrapConsumerBuildItem(Consumer<VertxBootstrap> consumer, int priority, String orderKey) {
+        if (orderKey == null || orderKey.isEmpty()) {
+            throw new IllegalArgumentException("orderKey must be present and not empty");
+        }
         this.consumer = consumer;
         this.priority = priority;
+        this.orderKey = orderKey;
     }
 
     public Consumer<VertxBootstrap> getConsumer() {
@@ -36,14 +43,24 @@ public final class VertxBootstrapConsumerBuildItem extends MultiBuildItem
 
     @Override
     public int compareTo(VertxBootstrapConsumerBuildItem o) {
-        int priorityComparison = Integer.compare(this.priority, o.priority);
-        if (priorityComparison != 0) {
-            return priorityComparison;
+        if (this == o) {
+            return 0;
+        }
+        int result = Integer.compare(this.priority, o.priority);
+        if (result != 0) {
+            return result;
         }
         Logger.getLogger(VertxBootstrapConsumerBuildItem.class).warnf(
                 "Two VertxBootstrapConsumerBuildItem have the same priority (%d). The order of execution is not guaranteed. " +
                         "Consider using different priorities to ensure a deterministic order.",
                 this.priority);
-        return priorityComparison;
+        result = this.orderKey.compareTo(o.orderKey);
+        if (result == 0) {
+            throw new IllegalStateException(
+                    "Two VertxBootstrapConsumerBuildItem instances have the same priority and orderKey, which is not allowed. "
+                            + "First instance: [priority: " + this.priority + ", orderKey: " + this.orderKey + "], "
+                            + "second instance: [priority: " + o.priority + ", orderKey: " + o.orderKey + "]");
+        }
+        return result;
     }
 }

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/BuildTimeVertxBootstrapCustomizerOrderTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/BuildTimeVertxBootstrapCustomizerOrderTest.java
@@ -23,11 +23,11 @@ public class BuildTimeVertxBootstrapCustomizerOrderTest {
                     .create(JavaArchive.class))
             .addBuildChainCustomizer(builder -> {
                 builder.addBuildStep(context -> {
-                    context.produce(new VertxBootstrapConsumerBuildItem(CustomizerWithPriority1000.INSTANCE, 1000));
+                    context.produce(new VertxBootstrapConsumerBuildItem(CustomizerWithPriority1000.INSTANCE, 1000, "foo"));
                 }).produces(VertxBootstrapConsumerBuildItem.class).build();
 
                 builder.addBuildStep(context -> {
-                    context.produce(new VertxBootstrapConsumerBuildItem(CustomizerWithPriority2000.INSTANCE, 2000));
+                    context.produce(new VertxBootstrapConsumerBuildItem(CustomizerWithPriority2000.INSTANCE, 2000, "foo"));
                 }).produces(VertxBootstrapConsumerBuildItem.class).build();
 
             });

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/BuildTimeVertxBootstrapCustomizerSamePriorityTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/BuildTimeVertxBootstrapCustomizerSamePriorityTest.java
@@ -24,12 +24,12 @@ public class BuildTimeVertxBootstrapCustomizerSamePriorityTest {
                     .create(JavaArchive.class))
             .addBuildChainCustomizer(builder -> {
                 builder.addBuildStep(context -> {
-                    context.produce(new VertxBootstrapConsumerBuildItem(CustomizerWithPriority1000.INSTANCE, 1000));
+                    context.produce(new VertxBootstrapConsumerBuildItem(CustomizerWithPriority1000.INSTANCE, 1000, "foo"));
                 }).produces(VertxBootstrapConsumerBuildItem.class).build();
 
                 builder.addBuildStep(context -> {
                     context.produce(
-                            new VertxBootstrapConsumerBuildItem(AnotherCustomizerWithPriority1000.INSTANCE, 1000));
+                            new VertxBootstrapConsumerBuildItem(AnotherCustomizerWithPriority1000.INSTANCE, 1000, "bar"));
                 }).produces(VertxBootstrapConsumerBuildItem.class).build();
 
             })
@@ -41,7 +41,7 @@ public class BuildTimeVertxBootstrapCustomizerSamePriorityTest {
 
     @Test
     public void testThatTheCustomizersAreCalledInOrder() {
-        assertThat(calls).containsExactly("1000", "1000");
+        assertThat(calls).containsExactly("bar", "foo");
     }
 
     public static final List<String> calls = new ArrayList<>();
@@ -53,7 +53,7 @@ public class BuildTimeVertxBootstrapCustomizerSamePriorityTest {
         @Override
         public void accept(VertxBootstrap bootstrap) {
             assertThat(bootstrap).isNotNull();
-            calls.add("1000");
+            calls.add("foo");
         }
     }
 
@@ -64,7 +64,7 @@ public class BuildTimeVertxBootstrapCustomizerSamePriorityTest {
         @Override
         public void accept(VertxBootstrap bootstrap) {
             assertThat(bootstrap).isNotNull();
-            calls.add("1000");
+            calls.add("bar");
         }
     }
 }

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/BuildTimeVertxBootstrapCustomizerTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/BuildTimeVertxBootstrapCustomizerTest.java
@@ -24,7 +24,7 @@ public class BuildTimeVertxBootstrapCustomizerTest {
                     .create(JavaArchive.class))
             .addBuildChainCustomizer(builder -> {
                 builder.addBuildStep(context -> {
-                    context.produce(new VertxBootstrapConsumerBuildItem(MyVertxBootstrapCustomizer.INSTANCE, 3000));
+                    context.produce(new VertxBootstrapConsumerBuildItem(MyVertxBootstrapCustomizer.INSTANCE, 3000, "foo"));
                 }).produces(VertxBootstrapConsumerBuildItem.class).build();
             });
 


### PR DESCRIPTION
Without an additional key, items with the same priority have an unstable order in the bytecode.