### PR TITLE
Restore HTTP/2 MAX_CONCURRENT_STREAMS default to 100

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
@@ -44,6 +44,7 @@ import io.vertx.core.http.Http1ServerConfig;
 import io.vertx.core.http.Http2ServerConfig;
 import io.vertx.core.http.Http2Settings;
 import io.vertx.core.http.HttpServerConfig;
+import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.QueryParamDecoderConfig;
 import io.vertx.core.http.WebSocketServerConfig;
@@ -369,7 +370,8 @@ public class HttpServerOptionsUtils {
         // HTTP/2 config
         if (httpConfig.http2()) {
             Http2ServerConfig http2 = new Http2ServerConfig();
-            var settings = new Http2Settings();
+            var settings = new Http2Settings()
+                    .setMaxConcurrentStreams(HttpServerOptions.DEFAULT_INITIAL_SETTINGS_MAX_CONCURRENT_STREAMS);
             if (httpConfig.limits().headerTableSize().isPresent()) {
                 settings.setHeaderTableSize(httpConfig.limits().headerTableSize().getAsLong());
             }


### PR DESCRIPTION
Still checking exactly IF is the right fix as we changed to unlimited stream on purpose - it seems!

Vert.x 5.1.x sets maxConcurrentStreams=100 in its constructor while we leave it unbounded, which TBH is a match with the RFC.
I'm now investigating if we should restore it OR something due to Netty has made the unlimited case to fail due to OOM

The whole story so far seems to be:
  - Before 1a0bdae0763 (June 2023): no setInitialSettings() → Vert.x default of 100 was in effect
  - After 1a0bdae0763: new Http2Settings() replaces it → unlimited. Side effect of fixing #33692 (HTTP 431), unintentional
  - DrainTest added Jan 2024: after the unlimited default was already in place
  - The config doc quotes the RFC ("no limit") but Vert.x's Http2ServerConfig constructor intentionally sets 100
