### PR TITLE
Whitelist all built-in types from Smallrye Config to skip reflection registration

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -136,6 +136,56 @@ import io.smallrye.config.SmallRyeConfigProviderResolver;
 public class ConfigGenerationBuildStep {
     private static final String SERVICES_PREFIX = "META-INF/services/";
 
+    // Types for which SmallRye Config itself always has a built-in, non-reflective converter
+    // (see Converters.ALL_CONVERTERS) and which Quarkus core does *not* also register a converter for
+    // via the Converter SPI. These need no reflection at all: SmallRye never needs to resolve an
+    // implicit converter for them reflectively, and there is no Quarkus-registered converter for them
+    // whose target type needs to be resolved via Class.forName either.
+    // Note some types with a SmallRye built-in converter (e.g. java.net.InetAddress) are deliberately
+    // NOT in this set, because Quarkus core also registers its own converter for them - see
+    // QUARKUS_CONVERTER_SPI_TYPES below.
+    // (Copied as a constant to avoid the processing overhead of computing the list, as it rarely changes -
+    // we ensure it stays in sync via ConfigGenerationBuildStepTest)
+    private static final Set<String> SMALLRYE_BUILT_IN_CONVERTER_TYPES = Set.of(
+            "java.lang.String",
+            "java.lang.Boolean",
+            "java.lang.Double",
+            "java.lang.Float",
+            "java.lang.Long",
+            "java.lang.Integer",
+            "java.lang.Short",
+            "java.lang.Byte",
+            "java.lang.Character",
+            "java.lang.Class",
+            "java.util.UUID",
+            "java.util.Currency",
+            "java.util.BitSet",
+            "java.io.File",
+            "java.net.URI",
+            "java.time.format.DateTimeFormatter",
+            "java.lang.CharSequence",
+            "java.util.OptionalInt",
+            "java.util.OptionalLong",
+            "java.util.OptionalDouble");
+
+    // Types for which Quarkus core registers a converter via the Converter SPI.
+    // In this case (see AbstractConfigBuilder#withConverter) a Class.forName(String)
+    // operation needs to be available at runtime, but no other reflective operations are necessary.
+    // (Copied as a constant to avoid the processing overhead of computing the list, as it rarely changes -
+    // we ensure it stays in sync via ConfigGenerationBuildStepTest)
+    private static final Set<String> QUARKUS_CONVERTER_SPI_TYPES = Set.of(
+            "java.net.InetSocketAddress",
+            "java.nio.charset.Charset",
+            "io.smallrye.common.net.CidrAddress",
+            "java.net.InetAddress",
+            "java.util.regex.Pattern",
+            "java.nio.file.Path",
+            "java.time.Duration",
+            "java.util.Locale",
+            "java.time.ZoneId",
+            "java.util.logging.Level",
+            "io.quarkus.runtime.logging.InheritableLevel");
+
     @BuildStep
     void nativeSupport(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClassProducer) {
         runtimeInitializedClassProducer.produce(new RuntimeInitializedClassBuildItem(InetRunTime.class.getName()));
@@ -348,10 +398,7 @@ public class ConfigGenerationBuildStep {
                             .reason("Required by Config Converter " + mapProperty.getKeyConvertWith().getName())
                             .build());
                 } else {
-                    reflectiveClasses.produce(ReflectiveClassBuildItem.builder(mapProperty.getKeyRawType())
-                            .reason("Required by Config Converter " + mapProperty.getKeyRawType().getName())
-                            .methods()
-                            .build());
+                    registerConverterReflection(mapProperty.getKeyRawType(), reflectiveClasses);
                 }
 
                 registerImplicitConverter(mapProperty.getValueProperty(), reflectiveClasses);
@@ -370,16 +417,52 @@ public class ConfigGenerationBuildStep {
                         .reason("Required by Config Converter " + leafProperty.getConvertWith().getName())
                         .build());
             } else {
-                reflectiveClasses.produce(ReflectiveClassBuildItem.builder(leafProperty.getValueRawType())
-                        .reason("Required by Config Converter " + leafProperty.getValueRawType().getName())
-                        .methods()
-                        .build());
+                registerConverterReflection(leafProperty.getValueRawType(), reflectiveClasses);
             }
         } else if (property.isOptional()) {
             registerImplicitConverter(property.asOptional().getNestedProperty(), reflectiveClasses);
         } else if (property.isCollection()) {
             registerImplicitConverter(property.asCollection().getElement(), reflectiveClasses);
         }
+    }
+
+    /**
+     * Registers a config property's raw type for reflection.
+     * <p>
+     * Types with a SmallRye Config built-in converter need no reflection at all - SmallRye never needs to
+     * resolve an implicit converter for them reflectively, and Quarkus never wires a converter for them
+     * either.
+     * <p>
+     * Types with a Quarkus-registered Converter SPI converter need the class itself registered for
+     * reflection - with no members - purely so that the generated config builder bytecode can resolve
+     * the converter's target type via {@code Class.forName(String)} at runtime (see
+     * {@code AbstractConfigBuilder#withConverter}); no implicit converter is ever resolved for these
+     * types either, so no method or constructor reflection is needed.
+     * <p>
+     * Every other type may need an implicit converter resolved reflectively (SmallRye probes
+     * {@code valueOf}, {@code parse}, {@code of}, ...), so it needs full method reflection.
+     */
+    private static void registerConverterReflection(
+            Class<?> rawType,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
+
+        String rawTypeName = rawType.getName();
+        if (SMALLRYE_BUILT_IN_CONVERTER_TYPES.contains(rawTypeName)) {
+            return;
+        }
+
+        if (QUARKUS_CONVERTER_SPI_TYPES.contains(rawTypeName)) {
+            reflectiveClasses.produce(ReflectiveClassBuildItem.builder(rawType)
+                    .reason("Required by Config Converter " + rawTypeName + " (Class.forName resolution only)")
+                    .constructors(false)
+                    .build());
+            return;
+        }
+
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(rawType)
+                .reason("Required by Config Converter " + rawTypeName + " (All methods potentially needed)")
+                .methods()
+                .build());
     }
 
     @BuildStep(onlyIf = SystemOnlySources.class)

--- a/core/deployment/src/test/java/io/quarkus/deployment/steps/ConfigGenerationBuildStepTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/steps/ConfigGenerationBuildStepTest.java
@@ -1,0 +1,99 @@
+package io.quarkus.deployment.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.config.spi.Converter;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.deployment.util.ServiceUtil;
+import io.smallrye.config.Converters;
+
+/**
+ * This test exists to verify that the constant fields
+ * ConfigGenerationBuildStep#SMALLRYE_BUILT_IN_CONVERTER_TYPES and
+ * ConfigGenerationBuildStep#QUARKUS_CONVERTER_SPI_TYPES
+ * are aligned with the content of the Smallrye Config version we depend on and the converters
+ * Quarkus core itself registers, namely:
+ * - QUARKUS_CONVERTER_SPI_TYPES must match the target types of all converters provided by Quarkus by
+ * default (listed in
+ * quarkus/core/runtime/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter)
+ * - SMALLRYE_BUILT_IN_CONVERTER_TYPES must match all converters included by default in Smallrye Config
+ * (field ALL_CONVERTERS in class io.smallrye.config.Converters), minus the types already covered by
+ * QUARKUS_CONVERTER_SPI_TYPES
+ * If this test fails, it implies the hardcoded lists need to be updated.
+ */
+class ConfigGenerationBuildStepTest {
+
+    private static final String CONVERTER_SERVICES = "META-INF/services/" + Converter.class.getName();
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void converterTypeSetsMatchSmallRyeConfigAndQuarkusCore() throws Exception {
+        Set<String> smallRyeTypes = smallRyeBuiltInConverterTypes();
+        Set<String> quarkusTypes = quarkusServiceLoadedConverterTypes();
+
+        Field quarkusSpiField = ConfigGenerationBuildStep.class.getDeclaredField("QUARKUS_CONVERTER_SPI_TYPES");
+        quarkusSpiField.setAccessible(true);
+        Set<String> hardcodedQuarkusSpiTypes = (Set<String>) quarkusSpiField.get(null);
+
+        assertThat(new TreeSet<>(hardcodedQuarkusSpiTypes))
+                .as("QUARKUS_CONVERTER_SPI_TYPES must match the target types of the converters provided by "
+                        + "Quarkus core - update the hardcoded set if this fails")
+                .isEqualTo(new TreeSet<>(quarkusTypes));
+
+        Field smallRyeBuiltInField = ConfigGenerationBuildStep.class.getDeclaredField("SMALLRYE_BUILT_IN_CONVERTER_TYPES");
+        smallRyeBuiltInField.setAccessible(true);
+        Set<String> hardcodedSmallRyeTypes = (Set<String>) smallRyeBuiltInField.get(null);
+
+        Set<String> expectedSmallRyeOnlyTypes = new TreeSet<>(smallRyeTypes);
+        expectedSmallRyeOnlyTypes.removeAll(quarkusTypes);
+
+        assertThat(new TreeSet<>(hardcodedSmallRyeTypes))
+                .as("SMALLRYE_BUILT_IN_CONVERTER_TYPES must match SmallRye Converters.ALL_CONVERTERS types "
+                        + "that are not also registered by Quarkus core via the Converter SPI - update the "
+                        + "hardcoded set if this fails")
+                .isEqualTo(expectedSmallRyeOnlyTypes);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Set<String> smallRyeBuiltInConverterTypes() throws Exception {
+        Field smallryeField = Converters.class.getDeclaredField("ALL_CONVERTERS");
+        smallryeField.setAccessible(true);
+        Map<Type, ?> allConverters = (Map<Type, ?>) smallryeField.get(null);
+        return allConverters.keySet().stream()
+                .filter(t -> t instanceof Class<?>)
+                .map(t -> ((Class<?>) t).getName())
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * The converter target types Quarkus core registers via the {@link Converter} SPI. Only the Quarkus core
+     * runtime declares such a service file on this module's test classpath, so this resolves to the
+     * contents of {@code core/runtime/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter}.
+     */
+    private static Set<String> quarkusServiceLoadedConverterTypes() throws Exception {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        Set<String> converterNames = ServiceUtil.classNamesNamedIn(classLoader, CONVERTER_SERVICES);
+        assertThat(converterNames)
+                .as("The Quarkus core Converter service file should be on the test classpath")
+                .isNotEmpty();
+
+        Set<String> types = new TreeSet<>();
+        for (String converterName : converterNames) {
+            Class<?> converterClass = Class.forName(converterName, false, classLoader);
+            Type converterType = Converters.getConverterType(converterClass);
+            assertThat(converterType)
+                    .as("Unable to resolve the converted type of " + converterName)
+                    .isInstanceOf(Class.class);
+            types.add(((Class<?>) converterType).getName());
+        }
+        return types;
+    }
+}


### PR DESCRIPTION
Previously all configuration converters were being registered for reflection, only because external ones might need this.

This was drastically increasing the amount of code the native-image compiler needs to pull in, not least as these converters support serialization this was making the entire serialization mechanism mandatory for any Quarkus application.

For context:
I'm testing our ability and impact to skip having to include the serialization mechanism into a native image, and this was one of the cases making it impossible. There's only another case which is even simpler to solve.

Registering `java.net.URI` also was found to be unnecessary apparently - I guess that had been improved since the comment was introduced.
