### PR TITLE
Fix reproducibility checks for `quarkus-rest-deployment`

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -1819,9 +1819,9 @@ public class ResteasyReactiveProcessor {
             return;
         }
 
-        Map<Class<?>, Supplier<?>> runtimeConfigMap = new HashMap<>();
+        Map<String, Supplier<?>> runtimeConfigMap = new HashMap<>();
         for (HandlerConfigurationProviderBuildItem item : items) {
-            runtimeConfigMap.put(item.getConfigClass(), item.getValueSupplier());
+            runtimeConfigMap.put(item.getConfigClass().getName(), item.getValueSupplier());
         }
 
         recorder.configureHandlers(deployment.get().getDeployment(), runtimeConfigMap);

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRuntimeRecorder.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRuntimeRecorder.java
@@ -56,12 +56,12 @@ public class ResteasyReactiveRuntimeRecorder {
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes", "ForLoopReplaceableByForEach" })
-    public void configureHandlers(RuntimeValue<Deployment> deployment, Map<Class<?>, Supplier<?>> runtimeConfigMap) {
+    public void configureHandlers(RuntimeValue<Deployment> deployment, Map<String, Supplier<?>> runtimeConfigMap) {
         List<GenericRuntimeConfigurableServerRestHandler<?>> runtimeConfigurableServerRestHandlers = deployment.getValue()
                 .getRuntimeConfigurableServerRestHandlers();
         for (int i = 0; i < runtimeConfigurableServerRestHandlers.size(); i++) {
             GenericRuntimeConfigurableServerRestHandler handler = runtimeConfigurableServerRestHandlers.get(i);
-            Supplier<?> supplier = runtimeConfigMap.get(handler.getConfigurationClass());
+            Supplier<?> supplier = runtimeConfigMap.get(handler.getConfigurationClass().getName());
             if (supplier == null) {
                 throw new IllegalStateException(
                         "Handler '" + handler.getClass().getName() + "' has not been properly configured.");


### PR DESCRIPTION
Use `Map<String,T>` instead of `Map<Class,T>` in `ResteasyReactiveProcessor` to make maps iteration order stable.