### PR TITLE
Make sure `MicrometerRegistryProviderBuildItem` has a stable collection order

### DIFF
--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.micrometer.deployment;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
@@ -216,7 +217,7 @@ public class MicrometerProcessor {
             List<MetricsFactoryConsumerBuildItem> metricsFactoryConsumerBuildItems,
             ShutdownContextBuildItem shutdownContextBuildItem) {
 
-        Set<Class<? extends MeterRegistry>> typeClasses = new HashSet<>();
+        Set<Class<? extends MeterRegistry>> typeClasses = new LinkedHashSet<>();
         for (MicrometerRegistryProviderBuildItem item : providerClassItems) {
             typeClasses.add(item.getRegistryClass());
         }

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerRegistryProviderBuildItem.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerRegistryProviderBuildItem.java
@@ -5,7 +5,8 @@ import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.micrometer.runtime.MicrometerRecorder;
 
 @SuppressWarnings("unchecked")
-public final class MicrometerRegistryProviderBuildItem extends MultiBuildItem {
+public final class MicrometerRegistryProviderBuildItem extends MultiBuildItem
+        implements Comparable<MicrometerRegistryProviderBuildItem> {
 
     final Class<? extends MeterRegistry> clazz;
 
@@ -26,5 +27,10 @@ public final class MicrometerRegistryProviderBuildItem extends MultiBuildItem {
         return "MicrometerRegistryProviderBuildItem{"
                 + clazz
                 + '}';
+    }
+
+    @Override
+    public int compareTo(MicrometerRegistryProviderBuildItem o) {
+        return this.clazz.getName().compareTo(o.clazz.getName());
     }
 }


### PR DESCRIPTION
This ensures that the generated bytecode is stable and reproducible.