### PR TITLE
Fix db-version used for Oracle in native tests on Test Pilot

### DIFF
--- a/.github/oracle-test-pilot-native-tests.json
+++ b/.github/oracle-test-pilot-native-tests.json
@@ -17,7 +17,7 @@
         {
             "category": "26ai",
             "oci-service": "base-database-service-26ai",
-            "db-version": "26",
+            "db-version": "23.26",
             "timeout": 25,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle"
         }


### PR DESCRIPTION
I'm very surprised we didn't see a failure in the original PR, but we do see it in https://github.com/quarkusio/quarkus/pull/55723/ , and that PR makes PU/datasource configuration more reliable, so if I squint I guess I kinda can see it...
