### PR TITLE
Ignore `UnsatisfiedLinkError` in `isOpenSsl35Available`

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/AbstractHybridKeyExchangeTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/AbstractHybridKeyExchangeTest.java
@@ -11,7 +11,11 @@ public abstract class AbstractHybridKeyExchangeTest {
     Vertx vertx;
 
     static boolean isOpenSsl35Available() {
-        return OpenSsl.isAvailable() && OpenSsl.version() >= 0x30500000L;
+        try {
+            return OpenSsl.isAvailable() && OpenSsl.version() >= 0x30500000L;
+        } catch (UnsatisfiedLinkError e) {
+            return false;
+        }
     }
 
     static boolean isJdk27OrLater() {


### PR DESCRIPTION
For some reason in CI we are getting

```posh
java.lang.UnsatisfiedLinkError: 'int io.netty.internal.tcnative.SSL.version()'
	at io.netty.internal.tcnative.SSL.version(Native Method)
	at io.netty.handler.ssl.OpenSsl.version(OpenSsl.java:640)
	at io.quarkus.vertx.http.tls.AbstractHybridKeyExchangeTest.isOpenSsl35Available(AbstractHybridKeyExchangeTest.java:14)
```

The easiest solution for now is just to ignore that
