### PR TITLE
cache openSsl35Available to avoid UnsatisfiedLinkError

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/AbstractHybridKeyExchangeTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/AbstractHybridKeyExchangeTest.java
@@ -7,11 +7,21 @@ import io.vertx.core.Vertx;
 
 public abstract class AbstractHybridKeyExchangeTest {
 
+    // Evaluated once at class-load time, before any QuarkusClassLoader is created.
+    // Repeated calls during @EnabledIf are unsafe: after a Quarkus instance shuts down
+    // its classloader may be GC'd, triggering JNI_OnUnload which deregisters SSL native
+    // methods globally while UNAVAILABILITY_CAUSE stays null (isAvailable() still true).
+    private static final boolean OPENSSL_35_AVAILABLE = checkOpenSsl35();
+
+    private static boolean checkOpenSsl35() {
+        return OpenSsl.isAvailable() && OpenSsl.version() >= 0x30500000L;
+    }
+
     @Inject
     Vertx vertx;
 
     static boolean isOpenSsl35Available() {
-        return OpenSsl.isAvailable() && OpenSsl.version() >= 0x30500000L;
+        return OPENSSL_35_AVAILABLE;
     }
 
     static boolean isJdk27OrLater() {


### PR DESCRIPTION
replaces #55745. Instead of silently ignoring errors we compute `isOpenSsl35Available` once and cache it. It should resolve the `UnsatisfiedLinkError` that were likely due to classes unloading and loading between tests.