### PR TITLE
Deprecate quarkus.hibernate-orm.blocking in favor of per-PU jdbc.enabled/reactive.enabled

### DIFF
--- a/docs/src/main/asciidoc/hibernate-reactive.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive.adoc
@@ -304,7 +304,7 @@ NOTE: Hibernate ORM and Hibernate Reactive won't share the same persistence cont
 +
 [source,properties]
 ----
-quarkus.hibernate-orm.blocking=false
+quarkus.hibernate-orm.jdbc.enabled=false
 ----
 
 Quarkus will set many Hibernate Reactive configuration settings automatically, and will often use more modern defaults.

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
@@ -49,7 +49,7 @@ public interface HibernateOrmConfig {
      * @asciidoclet
      */
     @WithDefault("true")
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "3.39")
     boolean blocking();
 
     /**

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
@@ -43,9 +43,13 @@ public interface HibernateOrmConfig {
      * You can set this property to `false` if you want to disable them
      * despite having a JDBC datasource.
      *
+     * @deprecated Use {@code quarkus.hibernate-orm.jdbc.enabled} for the default persistence unit,
+     *             and {@code quarkus.hibernate-orm."<persistence-unit-name>".jdbc.enabled} for named persistence
+     *             units, to configure this on a per-persistence-unit basis instead.
      * @asciidoclet
      */
     @WithDefault("true")
+    @Deprecated
     boolean blocking();
 
     /**

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
@@ -689,10 +689,10 @@ public interface HibernateOrmConfigPersistenceUnit {
          * <p>
          * Use {@code quarkus.hibernate-orm.jdbc.enabled} for the default persistence unit
          * and {@code quarkus.hibernate-orm."<persistence-unit-name>".jdbc.enabled} for named persistence units.
-         * This does not deprecate or replace {@code quarkus.hibernate-orm.blocking}.
+         * This is the per-persistence-unit replacement for the deprecated {@code quarkus.hibernate-orm.blocking}.
          * <p>
          * If not set, this is inferred from whether a JDBC datasource is available for this persistence unit,
-         * as well as the global `quarkus.hibernate-orm.blocking` setting.
+         * as well as the global (deprecated) `quarkus.hibernate-orm.blocking` setting.
          *
          * @asciidoclet
          */

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -1170,8 +1170,10 @@ public final class HibernateOrmProcessor {
             BuildProducer<UnremovableBeanBuildItem> unremovableBeans,
             List<DatabaseKindDialectBuildItem> dbKindMetadataBuildItems) {
         if (!hibernateOrmConfig.blocking()) {
-            LOG.infof(
-                    "Hibernate ORM was disabled explicitly by quarkus.hibernate-orm.blocking=false");
+            LOG.warnf(
+                    "Hibernate ORM was disabled explicitly by quarkus.hibernate-orm.blocking=false."
+                            + " This property is deprecated: use 'quarkus.hibernate-orm.jdbc.enabled=false' instead"
+                            + " (or the per-persistence-unit equivalent).");
             return;
         }
 


### PR DESCRIPTION
## Summary

Follow-up to #55382, addressing the final review discussion there
([comment thread](https://github.com/quarkusio/quarkus/pull/55382#discussion_r3628277883)).

Now that blocking (JDBC) / reactive bootstrap can be enabled or disabled per persistence unit
via `quarkus.hibernate-orm.jdbc.enabled` / `quarkus.hibernate-orm.reactive.enabled` (and their
named-persistence-unit equivalents), the global `quarkus.hibernate-orm.blocking` flag is
superseded. Per the consensus in the linked discussion (@gsmet, @lucamolteni, @FroMage), we
keep the global flag for backward compatibility but deprecate it, since the per-PU properties
are now the recommended way to configure this.

## Changes

- `HibernateOrmConfig#blocking()`: marked `@Deprecated`, with javadoc pointing to the new
  per-PU `jdbc.enabled` properties.
- `HibernateOrmConfigPersistenceUnit`'s `jdbc().enabled()` javadoc: updated wording now that
  it *is* the replacement for the deprecated global flag.
- `HibernateOrmProcessor`: the log message emitted when `quarkus.hibernate-orm.blocking=false`
  is set was bumped from `info` to `warn` (matching the existing pattern used elsewhere in this
  processor for other deprecated properties) and now points users at the replacement property.
- `hibernate-reactive.adoc`: updated the one documentation example that used
  `quarkus.hibernate-orm.blocking=false` to use `quarkus.hibernate-orm.jdbc.enabled=false` instead.

No behavioral change: the deprecated flag still works exactly as before, it just now warns.

## Testing

- `MultiplePersistenceUnitsJdbcEnabledFalseTest` and `MultiplePersistenceUnitsDefaultDisabledTest`
  pass (verifying the per-PU and global disabling paths both still work as expected).