### PR TITLE
Set default HTTP/2 MAX_CONCURRENT_STREAMS to 128

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
@@ -77,13 +77,15 @@ public interface ServerLimitsConfig {
     OptionalLong headerTableSize();
 
     /**
-     * Set SETTINGS_MAX_CONCURRENT_STREAMS HTTP/2 setting.
+     * Set the SETTINGS_MAX_CONCURRENT_STREAMS HTTP/2 setting.
      * <p>
      * Indicates the maximum number of concurrent streams that the sender will allow. This limit is directional: it
-     * applies to the number of streams that the sender permits the receiver to create. Initially, there is no limit to
-     * this value. It is recommended that this value be no smaller than 100, to not unnecessarily limit parallelism.
+     * applies to the number of streams that the sender permits the receiver to create.
+     * Per <a href="https://www.rfc-editor.org/rfc/rfc9113#section-6.5.2">RFC 9113, Section 6.5.2</a>,
+     * it is recommended that this value be no smaller than 100, so as to not unnecessarily limit parallelism.
      */
-    OptionalLong maxConcurrentStreams();
+    @WithDefault("128")
+    long maxConcurrentStreams();
 
     /**
      * Set the SETTINGS_MAX_FRAME_SIZE HTTP/2 setting.

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
@@ -374,9 +374,7 @@ public class HttpServerOptionsUtils {
                 settings.setHeaderTableSize(httpConfig.limits().headerTableSize().getAsLong());
             }
             settings.setPushEnabled(httpConfig.http2PushEnabled());
-            if (httpConfig.limits().maxConcurrentStreams().isPresent()) {
-                settings.setMaxConcurrentStreams(httpConfig.limits().maxConcurrentStreams().getAsLong());
-            }
+            settings.setMaxConcurrentStreams(httpConfig.limits().maxConcurrentStreams());
             if (httpConfig.initialWindowSize().isPresent()) {
                 settings.setInitialWindowSize(httpConfig.initialWindowSize().getAsInt());
             }

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtilsTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtilsTest.java
@@ -304,7 +304,7 @@ class HttpServerOptionsUtilsTest {
         when(limits.maxFormBufferedBytes()).thenReturn(MemorySize.of("1k"));
         when(limits.maxInitialLineLength()).thenReturn(4096);
         when(limits.headerTableSize()).thenReturn(OptionalLong.empty());
-        when(limits.maxConcurrentStreams()).thenReturn(OptionalLong.empty());
+        when(limits.maxConcurrentStreams()).thenReturn(128L);
         when(limits.maxFrameSize()).thenReturn(OptionalInt.empty());
         when(limits.maxHeaderListSize()).thenReturn(OptionalLong.empty());
         when(limits.rstFloodMaxRstFramePerWindow()).thenReturn(OptionalInt.empty());


### PR DESCRIPTION
This aligns Quarkus with other project defaults, such as:
- Apache HTTPD (100)
- Apache Tomcat (100)
- nginx (128)
- Go net/http2 (250)

This also fixes issues with `DrainTest::testSyncHttp2` which timed out or ended in OOM.
