### PR TITLE
Send `@MatrixParam` and `@RestMatrix` from the REST Client

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -330,6 +330,36 @@ public interface ExtensionsService {
 }
 ----
 
+=== Matrix Parameters
+
+Matrix parameters can be specified with `@MatrixParam` or `@RestMatrix`. The `@RestMatrix` annotation is equivalent to
+`@MatrixParam`, but the name is optional — when omitted, the parameter name is used.
+
+[source, java]
+----
+package org.acme.rest.client;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.jboss.resteasy.reactive.RestMatrix;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.Path;
+
+@Path("/greet")
+@RegisterRestClient
+public interface GreetingService {
+
+    @GET
+    String greet(@MatrixParam("name") String name);
+
+    @GET
+    String greetRest(@RestMatrix String name);
+}
+----
+
+Calling `greet("world")` sends a request to `/greet;name=world`.
+
 === Dynamic base URLs
 
 The REST client allows for a per invocation override of the base URL using the `io.quarkus.rest.client.reactive.Url` annotation.

--- a/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -108,6 +108,7 @@ import org.jboss.resteasy.reactive.client.processor.beanparam.CookieParamItem;
 import org.jboss.resteasy.reactive.client.processor.beanparam.FormParamItem;
 import org.jboss.resteasy.reactive.client.processor.beanparam.HeaderParamItem;
 import org.jboss.resteasy.reactive.client.processor.beanparam.Item;
+import org.jboss.resteasy.reactive.client.processor.beanparam.MatrixParamItem;
 import org.jboss.resteasy.reactive.client.processor.beanparam.PathParamItem;
 import org.jboss.resteasy.reactive.client.processor.beanparam.QueryParamItem;
 import org.jboss.resteasy.reactive.client.processor.scanning.ClientEndpointIndexer;
@@ -1107,6 +1108,14 @@ public class JaxrsClientReactiveProcessor {
                                             jandexMethod.parameterType(paramIdx), index, methodCreator.getThis(),
                                             getGenericTypeFromArray(methodCreator, methodGenericParametersField, paramIdx),
                                             getAnnotationsFromArray(methodCreator, methodParamAnnotationsField, paramIdx)));
+                        } else if (param.parameterType == ParameterType.MATRIX) {
+                            // matrix params have to be set on a method-level web target (they vary between invocations)
+                            methodCreator.assign(methodTarget,
+                                    addMatrixParam(jandexMethod, methodCreator, methodTarget, param.name,
+                                            methodCreator.getMethodParam(paramIdx),
+                                            jandexMethod.parameterType(paramIdx), index, methodCreator.getThis(),
+                                            getGenericTypeFromArray(methodCreator, methodGenericParametersField, paramIdx),
+                                            getAnnotationsFromArray(methodCreator, methodParamAnnotationsField, paramIdx)));
                         } else if (param.parameterType == ParameterType.BEAN
                                 || param.parameterType == ParameterType.MULTI_PART_FORM) {
                             // bean params require both, web-target and Invocation.Builder, modifications
@@ -1762,6 +1771,16 @@ public class JaxrsClientReactiveProcessor {
                                                     subParamField.paramIndex),
                                             getAnnotationsFromArray(subMethodCreator, subParamField.paramAnnotationsField,
                                                     subParamField.paramIndex)));
+                        } else if (param.parameterType == ParameterType.MATRIX) {
+                            // matrix params have to be set on a method-level web target (they vary between invocations)
+                            subMethodCreator.assign(methodTarget,
+                                    addMatrixParam(jandexMethod, subMethodCreator, methodTarget, param.name,
+                                            paramValue, subParamField.type, index,
+                                            subMethodCreator.readInstanceField(clientField, subMethodCreator.getThis()),
+                                            getGenericTypeFromArray(subMethodCreator, subParamField.genericsParametersField,
+                                                    subParamField.paramIndex),
+                                            getAnnotationsFromArray(subMethodCreator, subParamField.paramAnnotationsField,
+                                                    subParamField.paramIndex)));
                         } else if (param.parameterType == ParameterType.BEAN
                                 || param.parameterType == ParameterType.MULTI_PART_FORM) {
                             // bean params require both, web-target and Invocation.Builder, modifications
@@ -1903,6 +1922,17 @@ public class JaxrsClientReactiveProcessor {
                             // query params have to be set on a method-level web target (they vary between invocations)
                             subMethodCreator.assign(methodTarget,
                                     addQueryParam(jandexMethod, subMethodCreator, methodTarget, param.name,
+                                            subMethodCreator.getMethodParam(paramIdx),
+                                            jandexSubMethod.parameterType(paramIdx), index,
+                                            subMethodCreator.readInstanceField(clientField, subMethodCreator.getThis()),
+                                            getGenericTypeFromArray(subMethodCreator, subMethodGenericParametersField,
+                                                    paramIdx),
+                                            getAnnotationsFromArray(subMethodCreator, subMethodParamAnnotationsField,
+                                                    paramIdx)));
+                        } else if (param.parameterType == ParameterType.MATRIX) {
+                            // matrix params have to be set on a method-level web target (they vary between invocations)
+                            subMethodCreator.assign(methodTarget,
+                                    addMatrixParam(jandexMethod, subMethodCreator, methodTarget, param.name,
                                             subMethodCreator.getMethodParam(paramIdx),
                                             jandexSubMethod.parameterType(paramIdx), index,
                                             subMethodCreator.readInstanceField(clientField, subMethodCreator.getThis()),
@@ -3020,6 +3050,16 @@ public class JaxrsClientReactiveProcessor {
                                     getGenericTypeFromParameter(creator, beanParamDescriptorField, item.fieldName()),
                                     getAnnotationsFromParameter(creator, beanParamDescriptorField, item.fieldName())));
                     break;
+                case MATRIX_PARAM:
+                    MatrixParamItem matrixParam = (MatrixParamItem) item;
+                    creator.assign(target,
+                            addMatrixParam(jandexMethod, creator, target, matrixParam.name(),
+                                    matrixParam.extract(creator, param),
+                                    matrixParam.getValueType(),
+                                    index, client,
+                                    getGenericTypeFromParameter(creator, beanParamDescriptorField, item.fieldName()),
+                                    getAnnotationsFromParameter(creator, beanParamDescriptorField, item.fieldName())));
+                    break;
                 case COOKIE:
                     CookieParamItem cookieParam = (CookieParamItem) item;
                     addCookieParam(invoEnricher, invocationBuilder,
@@ -3149,9 +3189,40 @@ public class JaxrsClientReactiveProcessor {
             ResultHandle client,
             ResultHandle genericType,
             ResultHandle paramAnnotations) {
+        return addWebTargetParam(jandexMethod, methodCreator, webTarget, paramName, queryParamHandle, type, index, client,
+                genericType, paramAnnotations, "queryParam");
+    }
+
+    // takes a result handle to target as one of the parameters, returns a result handle to a modified target
+    private ResultHandle addMatrixParam(MethodInfo jandexMethod, BytecodeCreator methodCreator,
+            ResultHandle webTarget,
+            String paramName,
+            ResultHandle matrixParamHandle,
+            Type type,
+            IndexView index,
+            // this client or containing client if we're in a subresource
+            ResultHandle client,
+            ResultHandle genericType,
+            ResultHandle paramAnnotations) {
+        return addWebTargetParam(jandexMethod, methodCreator, webTarget, paramName, matrixParamHandle, type, index, client,
+                genericType, paramAnnotations, "matrixParam");
+    }
+
+    // takes a result handle to target as one of the parameters, returns a result handle to a modified target
+    private ResultHandle addWebTargetParam(MethodInfo jandexMethod, BytecodeCreator methodCreator,
+            ResultHandle webTarget,
+            String paramName,
+            ResultHandle paramHandle,
+            Type type,
+            IndexView index,
+            // this client or containing client if we're in a subresource
+            ResultHandle client,
+            ResultHandle genericType,
+            ResultHandle paramAnnotations,
+            String webTargetParamMethod) {
 
         AssignableResultHandle result = methodCreator.createVariable(WebTarget.class);
-        BranchResult isParamNull = methodCreator.ifNull(queryParamHandle);
+        BranchResult isParamNull = methodCreator.ifNull(paramHandle);
         BytecodeCreator notNullParam = isParamNull.falseBranch();
         if (isMap(type, index)) {
             var resolvesTypes = resolveMapTypes(type, jandexMethod);
@@ -3163,7 +3234,7 @@ public class JaxrsClientReactiveProcessor {
             notNullParam.assign(result, webTarget);
             // Loop through the keys
             ResultHandle keySet = notNullParam.invokeInterfaceMethod(ofMethod(Map.class, "keySet", Set.class),
-                    queryParamHandle);
+                    paramHandle);
             ResultHandle keysIterator = notNullParam.invokeInterfaceMethod(
                     ofMethod(Set.class, "iterator", Iterator.class), keySet);
             BytecodeCreator loopCreator = notNullParam.whileLoop(c -> iteratorHasNext(c, keysIterator)).block();
@@ -3171,7 +3242,7 @@ public class JaxrsClientReactiveProcessor {
                     ofMethod(Iterator.class, "next", Object.class), keysIterator);
             // get the value and convert
             ResultHandle value = loopCreator.invokeInterfaceMethod(ofMethod(Map.class, "get", Object.class, Object.class),
-                    queryParamHandle, key);
+                    paramHandle, key);
             var valueType = resolvesTypes.getValue();
             String componentType = valueType.name().toString();
             ResultHandle paramArray;
@@ -3194,8 +3265,8 @@ public class JaxrsClientReactiveProcessor {
                                 value);
             }
             // get the new WebTarget
-            addQueryParamToWebTarget(loopCreator, key, result, client, genericType, paramAnnotations,
-                    paramArray, componentType, result);
+            addWebTargetParamToWebTarget(loopCreator, key, result, client, genericType, paramAnnotations,
+                    paramArray, componentType, result, webTargetParamMethod);
         } else {
             ResultHandle paramArray;
             String componentType = null;
@@ -3207,51 +3278,51 @@ public class JaxrsClientReactiveProcessor {
                         componentType = DotNames.BYTE.toString();
                         paramArray = notNullParam.invokeStaticMethod(
                                 MethodDescriptor.ofMethod(ToObjectArray.class, "primitiveArray", Byte[].class, byte[].class),
-                                queryParamHandle);
+                                paramHandle);
                     } else if (primitiveType == PrimitiveType.CHAR) {
                         componentType = DotNames.CHARACTER.toString();
                         paramArray = notNullParam.invokeStaticMethod(
                                 MethodDescriptor.ofMethod(ToObjectArray.class, "primitiveArray", Character[].class,
                                         char[].class),
-                                queryParamHandle);
+                                paramHandle);
                     } else if (primitiveType == PrimitiveType.DOUBLE) {
                         componentType = DotNames.DOUBLE.toString();
                         paramArray = notNullParam.invokeStaticMethod(
                                 MethodDescriptor.ofMethod(ToObjectArray.class, "primitiveArray", Double[].class,
                                         double[].class),
-                                queryParamHandle);
+                                paramHandle);
                     } else if (primitiveType == PrimitiveType.FLOAT) {
                         componentType = DotNames.FLOAT.toString();
                         paramArray = notNullParam.invokeStaticMethod(
                                 MethodDescriptor.ofMethod(ToObjectArray.class, "primitiveArray", Float[].class, float[].class),
-                                queryParamHandle);
+                                paramHandle);
                     } else if (primitiveType == PrimitiveType.INT) {
                         componentType = DotNames.INTEGER.toString();
                         paramArray = notNullParam.invokeStaticMethod(
                                 MethodDescriptor.ofMethod(ToObjectArray.class, "primitiveArray", Integer[].class, int[].class),
-                                queryParamHandle);
+                                paramHandle);
                     } else if (primitiveType == PrimitiveType.LONG) {
                         componentType = DotNames.LONG.toString();
                         paramArray = notNullParam.invokeStaticMethod(
                                 MethodDescriptor.ofMethod(ToObjectArray.class, "primitiveArray", Long[].class, long[].class),
-                                queryParamHandle);
+                                paramHandle);
                     } else if (primitiveType == PrimitiveType.SHORT) {
                         componentType = DotNames.SHORT.toString();
                         paramArray = notNullParam.invokeStaticMethod(
                                 MethodDescriptor.ofMethod(ToObjectArray.class, "primitiveArray", Short[].class, short[].class),
-                                queryParamHandle);
+                                paramHandle);
                     } else if (primitiveType == PrimitiveType.BOOLEAN) {
                         componentType = DotNames.BOOLEAN.toString();
                         paramArray = notNullParam.invokeStaticMethod(
                                 MethodDescriptor.ofMethod(ToObjectArray.class, "primitiveArray", Boolean[].class,
                                         boolean[].class),
-                                queryParamHandle);
+                                paramHandle);
                     } else {
                         throw new IllegalArgumentException("not supported yet");
                     }
                 } else {
                     componentType = constituentType.name().toString();
-                    paramArray = notNullParam.checkCast(queryParamHandle, Object[].class);
+                    paramArray = notNullParam.checkCast(paramHandle, Object[].class);
                 }
             } else if (isCollection(type, index)) {
                 if (type.kind() == PARAMETERIZED_TYPE) {
@@ -3265,7 +3336,7 @@ public class JaxrsClientReactiveProcessor {
                 }
                 paramArray = notNullParam.invokeStaticMethod(
                         MethodDescriptor.ofMethod(ToObjectArray.class, "collection", Object[].class, Collection.class),
-                        queryParamHandle);
+                        paramHandle);
             } else if (isOptional(type, index)) {
                 if (type.kind() == PARAMETERIZED_TYPE) {
                     Type paramType = type.asParameterizedType().arguments().get(0);
@@ -3278,16 +3349,16 @@ public class JaxrsClientReactiveProcessor {
                 }
                 paramArray = notNullParam.invokeStaticMethod(
                         MethodDescriptor.ofMethod(ToObjectArray.class, "optional", Object[].class, Optional.class),
-                        queryParamHandle);
+                        paramHandle);
             } else {
                 componentType = type.name().toString();
                 paramArray = notNullParam.invokeStaticMethod(
                         MethodDescriptor.ofMethod(ToObjectArray.class, "value", Object[].class, Object.class),
-                        queryParamHandle);
+                        paramHandle);
             }
 
-            addQueryParamToWebTarget(notNullParam, notNullParam.load(paramName), webTarget, client, genericType,
-                    paramAnnotations, paramArray, componentType, result);
+            addWebTargetParamToWebTarget(notNullParam, notNullParam.load(paramName), webTarget, client, genericType,
+                    paramAnnotations, paramArray, componentType, result, webTargetParamMethod);
         }
 
         isParamNull.trueBranch().assign(result, webTarget);
@@ -3323,19 +3394,20 @@ public class JaxrsClientReactiveProcessor {
                 creator.invokeInterfaceMethod(ofMethod(Iterator.class, "hasNext", boolean.class), iterator));
     }
 
-    private void addQueryParamToWebTarget(BytecodeCreator creator, ResultHandle paramName,
+    private void addWebTargetParamToWebTarget(BytecodeCreator creator, ResultHandle paramName,
             ResultHandle webTarget,
             ResultHandle client, ResultHandle genericType,
             ResultHandle paramAnnotations, ResultHandle paramArray,
             String componentType,
-            AssignableResultHandle resultVariable) {
+            AssignableResultHandle resultVariable,
+            String webTargetParamMethod) {
         ResultHandle convertedParamArray = creator.invokeVirtualMethod(
                 MethodDescriptor.ofMethod(RestClientBase.class, "convertParamArray", Object[].class, Object[].class,
                         Class.class, java.lang.reflect.Type.class, Annotation[].class),
                 client, paramArray, creator.loadClassFromTCCL(componentType), genericType, paramAnnotations);
 
         creator.assign(resultVariable, creator.invokeInterfaceMethod(
-                MethodDescriptor.ofMethod(WebTarget.class, "queryParam", WebTarget.class,
+                MethodDescriptor.ofMethod(WebTarget.class, webTargetParamMethod, WebTarget.class,
                         String.class, Object[].class),
                 webTarget, paramName, convertedParamArray));
     }

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/MatrixParamTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/MatrixParamTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.rest.client.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.Path;
+
+import org.jboss.resteasy.reactive.RestMatrix;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class MatrixParamTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClasses(Resource.class, Client.class));
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @Test
+    void clientSendsMatrixParam() {
+        Client client = QuarkusRestClientBuilder.newBuilder().baseUri(baseUri).build(Client.class);
+        assertThat(client.greet("world")).isEqualTo("hello world");
+        assertThat(client.greetRest("world")).isEqualTo("hello world");
+    }
+
+    @Test
+    void clientOmitsNullMatrixParam() {
+        Client client = QuarkusRestClientBuilder.newBuilder().baseUri(baseUri).build(Client.class);
+        assertThat(client.greet(null)).isEqualTo("hello null");
+    }
+
+    @Path("/greet")
+    public static class Resource {
+
+        @GET
+        public String greet(@MatrixParam("name") String name) {
+            return "hello " + name;
+        }
+    }
+
+    @Path("/greet")
+    public interface Client {
+
+        @GET
+        String greet(@MatrixParam("name") String name);
+
+        @GET
+        String greetRest(@RestMatrix("name") String name);
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/MatrixParamWithPathParamTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/MatrixParamWithPathParamTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.rest.client.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.List;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+import org.jboss.resteasy.reactive.RestMatrix;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class MatrixParamWithPathParamTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClasses(Resource.class, Client.class));
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @Test
+    void clientSendsMatrixParamWithPathParam() {
+        Client client = QuarkusRestClientBuilder.newBuilder().baseUri(baseUri).build(Client.class);
+        assertThat(client.get("42", "full")).isEqualTo("42/full");
+        assertThat(client.getMulti("42", List.of("a", "b"))).isEqualTo("42/a,b");
+    }
+
+    @Path("/items/{id}")
+    public static class Resource {
+
+        @GET
+        public String get(@PathParam("id") String id, @MatrixParam("view") String view) {
+            return id + "/" + view;
+        }
+
+        @GET
+        @Path("multi")
+        public String getMulti(@PathParam("id") String id, @MatrixParam("tag") List<String> tags) {
+            return id + "/" + String.join(",", tags);
+        }
+    }
+
+    @Path("/items/{id}")
+    public interface Client {
+
+        @GET
+        String get(@PathParam("id") String id, @RestMatrix("view") String view);
+
+        @GET
+        @Path("multi")
+        String getMulti(@PathParam("id") String id, @MatrixParam("tag") List<String> tags);
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/beanparam/BeanMatrixParamTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/beanparam/BeanMatrixParamTest.java
@@ -1,0 +1,63 @@
+package io.quarkus.rest.client.reactive.beanparam;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.Path;
+
+import org.jboss.resteasy.reactive.RestMatrix;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class BeanMatrixParamTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClasses(Resource.class, Client.class, MatrixBean.class));
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @Test
+    void clientSendsMatrixParamsFromBeanParam() {
+        Client client = QuarkusRestClientBuilder.newBuilder().baseUri(baseUri).build(Client.class);
+        assertThat(client.greet(new MatrixBean("world", "en"))).isEqualTo("hello world/en");
+    }
+
+    @Path("/greet")
+    public static class Resource {
+
+        @GET
+        public String greet(@MatrixParam("name") String name, @MatrixParam("lang") String lang) {
+            return "hello " + name + "/" + lang;
+        }
+    }
+
+    @Path("/greet")
+    public interface Client {
+
+        @GET
+        String greet(@BeanParam MatrixBean bean);
+    }
+
+    public static class MatrixBean {
+        @MatrixParam("name")
+        public String name;
+
+        @RestMatrix
+        public String lang;
+
+        public MatrixBean(String name, String lang) {
+            this.name = name;
+            this.lang = lang;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/beanparam/BeanParamTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/beanparam/BeanParamTest.java
@@ -128,8 +128,6 @@ public class BeanParamTest {
         private String restQueryOverridden = "restQueryOverridden";
         @QueryParam("queryParam")
         private String queryParam = "queryParam";
-
-        // FIXME: Matrix not supported
     }
 
     public static class MyBeanParamWithProperties {
@@ -198,8 +196,6 @@ public class BeanParamTest {
         public String getQueryParam() {
             return "queryParam";
         }
-
-        // FIXME: Matrix not supported
     }
 
     @Path("/")

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/encoded/ClientWithMatrixParamAndEncodedTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/encoded/ClientWithMatrixParamAndEncodedTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.rest.client.reactive.encoded;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import jakarta.ws.rs.Encoded;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.ext.web.RoutingContext;
+
+public class ClientWithMatrixParamAndEncodedTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClasses(Resource.class, ClientWithoutEncoded.class,
+                    ClientWithEncoded.class));
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @Test
+    void encodesMatrixParamByDefault() {
+        ClientWithoutEncoded client = RestClientBuilder.newBuilder().baseUri(baseUri).build(ClientWithoutEncoded.class);
+        // '=' must be percent-encoded in matrix values
+        assertThat(client.call("a=b")).isEqualTo(";name=a%3Db");
+    }
+
+    @Test
+    void respectsEncodedMatrixParam() {
+        ClientWithEncoded client = RestClientBuilder.newBuilder().baseUri(baseUri).build(ClientWithEncoded.class);
+        // With @Encoded, '=' is left unencoded
+        assertThat(client.call("a=b")).isEqualTo(";name=a=b");
+    }
+
+    @Path("/matrix-encoded")
+    public static class Resource {
+        @GET
+        public String call(RoutingContext context) {
+            String path = context.request().path();
+            int idx = path.indexOf(";name=");
+            return idx < 0 ? path : path.substring(idx);
+        }
+    }
+
+    @Path("/matrix-encoded")
+    public interface ClientWithoutEncoded {
+        @GET
+        String call(@MatrixParam("name") String name);
+    }
+
+    @Path("/matrix-encoded")
+    public interface ClientWithEncoded {
+        @GET
+        String call(@Encoded @MatrixParam("name") String name);
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/subresource/SubResourceMatrixParamTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/subresource/SubResourceMatrixParamTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.rest.client.reactive.subresource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class SubResourceMatrixParamTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClasses(Resource.class, RootClient.class, SubClient.class));
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @Test
+    void clientSendsMatrixParamOnSubResource() {
+        RootClient client = QuarkusRestClientBuilder.newBuilder().baseUri(baseUri).build(RootClient.class);
+        assertThat(client.sub("users").greet("world")).isEqualTo("users/hello world");
+    }
+
+    @Path("/")
+    public static class Resource {
+
+        @Path("{root}")
+        public SubResource sub(@PathParam("root") String root) {
+            return new SubResource(root);
+        }
+
+        public static class SubResource {
+            private final String root;
+
+            public SubResource(String root) {
+                this.root = root;
+            }
+
+            @GET
+            @Path("greet")
+            public String greet(@MatrixParam("name") String name) {
+                return root + "/hello " + name;
+            }
+        }
+    }
+
+    public interface RootClient {
+        @Path("{root}")
+        SubClient sub(@PathParam("root") String root);
+    }
+
+    public interface SubClient {
+        @GET
+        @Path("greet")
+        String greet(@MatrixParam("name") String name);
+    }
+}

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/BeanParamParser.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/BeanParamParser.java
@@ -5,11 +5,13 @@ import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNa
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.ENCODED;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.FORM_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.HEADER_PARAM;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.MATRIX_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.PATH_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.QUERY_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_COOKIE_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_FORM_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_HEADER_PARAM;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_MATRIX_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_PATH_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_QUERY_PARAM;
 
@@ -78,6 +80,28 @@ public class BeanParamParser {
                             new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString()),
                             fieldInfo.type()),
                     (annotationValue, getterMethod) -> new QueryParamItem(getterMethod.name(),
+                            annotationValue != null ? annotationValue : getterName(getterMethod),
+                            getterMethod.hasDeclaredAnnotation(ENCODED),
+                            new GetterExtractor(getterMethod),
+                            getterMethod.returnType())));
+
+            resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, MATRIX_PARAM,
+                    (annotationValue, fieldInfo) -> new MatrixParamItem(fieldInfo.name(), annotationValue,
+                            fieldInfo.hasDeclaredAnnotation(ENCODED),
+                            new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString()),
+                            fieldInfo.type()),
+                    (annotationValue, getterMethod) -> new MatrixParamItem(getterMethod.name(), annotationValue,
+                            getterMethod.hasDeclaredAnnotation(ENCODED),
+                            new GetterExtractor(getterMethod),
+                            getterMethod.returnType())));
+
+            resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, REST_MATRIX_PARAM,
+                    (annotationValue, fieldInfo) -> new MatrixParamItem(fieldInfo.name(),
+                            annotationValue != null ? annotationValue : fieldInfo.name(),
+                            fieldInfo.hasDeclaredAnnotation(ENCODED),
+                            new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString()),
+                            fieldInfo.type()),
+                    (annotationValue, getterMethod) -> new MatrixParamItem(getterMethod.name(),
                             annotationValue != null ? annotationValue : getterName(getterMethod),
                             getterMethod.hasDeclaredAnnotation(ENCODED),
                             new GetterExtractor(getterMethod),

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/ItemType.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/ItemType.java
@@ -7,5 +7,5 @@ public enum ItemType {
     HEADER_PARAM,
     PATH_PARAM,
     FORM_PARAM,
-    // TODO: more
+    MATRIX_PARAM,
 }

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/MatrixParamItem.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/MatrixParamItem.java
@@ -1,0 +1,23 @@
+package org.jboss.resteasy.reactive.client.processor.beanparam;
+
+import org.jboss.jandex.Type;
+
+public class MatrixParamItem extends Item {
+
+    private final String name;
+    private final Type valueType;
+
+    public MatrixParamItem(String fieldName, String name, boolean encoded, ValueExtractor extractor, Type valueType) {
+        super(fieldName, ItemType.MATRIX_PARAM, encoded, extractor);
+        this.name = name;
+        this.valueType = valueType;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public Type getValueType() {
+        return valueType;
+    }
+}

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/UriBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/UriBuilderImpl.java
@@ -764,7 +764,9 @@ public class UriBuilderImpl extends UriBuilder {
         for (Object val : values) {
             if (val == null)
                 throw new IllegalArgumentException("Value is null");
-            path += ";" + Encode.encodeMatrixParam(name) + "=" + Encode.encodeMatrixParam(val.toString());
+            String matrixName = encode ? Encode.encodeMatrixParam(name) : name;
+            String matrixValue = encode ? Encode.encodeMatrixParam(val.toString()) : val.toString();
+            path += ";" + matrixName + "=" + matrixValue;
         }
         return this;
     }


### PR DESCRIPTION
REST Client interfaces silently dropped `@MatrixParam` / `@RestMatrix` parameters (including on `@BeanParam` types). The server already supported matrix params; only client bytecode generation was missing a `ParameterType.MATRIX` branch, so values never reached `WebTarget.matrixParam`.

This wires matrix params through the same conversion path as query params for root methods, subresources, and bean params, makes `UriBuilder.matrixParam` respect the encode flag so `@Encoded` works, and documents the annotations in the REST Client guide.

* Fixes #55746