### PR TITLE
Fix invocation of the Arquillian lifecycle callbacks

### DIFF
--- a/test-framework/arquillian/pom.xml
+++ b/test-framework/arquillian/pom.xml
@@ -107,6 +107,11 @@
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testng</groupId>
+            <artifactId>arquillian-testng-container</artifactId>
+            <scope>test</scope> <!-- Only to cover the TestNG callbacks, consumers such as the TCKs bring their own. -->
+        </dependency>
     </dependencies>
 
 </project>

--- a/test-framework/arquillian/src/main/java/io/quarkus/arquillian/QuarkusBeforeAfterLifecycle.java
+++ b/test-framework/arquillian/src/main/java/io/quarkus/arquillian/QuarkusBeforeAfterLifecycle.java
@@ -3,11 +3,17 @@ package io.quarkus.arquillian;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import org.jboss.arquillian.container.spi.client.deployment.Deployment;
+import org.jboss.arquillian.container.spi.client.deployment.DeploymentScenario;
 import org.jboss.arquillian.container.spi.context.annotation.DeploymentScoped;
 import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.impl.RunModeUtils;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.arquillian.test.spi.annotation.ClassScoped;
+import org.jboss.arquillian.test.spi.event.suite.TestLifecycleEvent;
 
 public class QuarkusBeforeAfterLifecycle {
 
@@ -16,6 +22,8 @@ public class QuarkusBeforeAfterLifecycle {
     private static final String TESTNG_CALLBACKS = "io.quarkus.arquillian.QuarkusTestNgCallbacks";
     private static final String JUNIT_INVOKE_BEFORES = "invokeJunitBefores";
     private static final String JUNIT_INVOKE_AFTERS = "invokeJunitAfters";
+    private static final String JUNIT_INVOKE_BEFORE_ALLS = "invokeJunitBeforeAlls";
+    private static final String JUNIT_INVOKE_AFTER_ALLS = "invokeJunitAfterAlls";
     private static final String TESTNG_INVOKE_BEFORE_CLASS = "invokeTestNgBeforeClasses";
     private static final String TESTNG_INVOKE_AFTER_CLASS = "invokeTestNgAfterClasses";
     private static final String TESTNG_INVOKE_BEFORE_METHOD = "invokeTestNgBeforeMethods";
@@ -23,13 +31,26 @@ public class QuarkusBeforeAfterLifecycle {
 
     private static final int DEFAULT_PRECEDENCE = -100;
 
+    /**
+     * The managed deployment is undeployed by an {@code AfterClass} observer of default precedence, and undeploying
+     * discards the in container test instance, so the class level callbacks have to be invoked before that happens.
+     */
+    private static final int AFTER_CLASS_PRECEDENCE = 100;
+
     @Inject
     @DeploymentScoped
-    private Instance<QuarkusDeployment> deployment;
+    private Instance<QuarkusDeployment> quarkusDeployment;
+
+    @Inject
+    private Instance<Deployment> deployment;
+
+    @Inject
+    @ClassScoped
+    private Instance<DeploymentScenario> deploymentScenario;
 
     public void on(@Observes(precedence = DEFAULT_PRECEDENCE) org.jboss.arquillian.test.spi.event.suite.Before event)
             throws Throwable {
-        if (!event.getTestClass().isAnnotationPresent(RunAsClient.class)) {
+        if (!isRunAsClient(event)) {
             if (isJunit5Available()) {
                 invokeCallbacks(JUNIT_INVOKE_BEFORES, JUNIT5_CALLBACKS);
             } else if (isJunit4Available()) {
@@ -43,7 +64,7 @@ public class QuarkusBeforeAfterLifecycle {
 
     public void on(@Observes(precedence = DEFAULT_PRECEDENCE) org.jboss.arquillian.test.spi.event.suite.After event)
             throws Throwable {
-        if (!event.getTestClass().isAnnotationPresent(RunAsClient.class)) {
+        if (!isRunAsClient(event)) {
             if (isJunit5Available()) {
                 invokeCallbacks(JUNIT_INVOKE_AFTERS, JUNIT5_CALLBACKS);
             } else if (isJunit4Available()) {
@@ -58,17 +79,48 @@ public class QuarkusBeforeAfterLifecycle {
     public void beforeClass(
             @Observes(precedence = DEFAULT_PRECEDENCE) org.jboss.arquillian.test.spi.event.suite.BeforeClass event)
             throws Throwable {
-        if (isTestNGAvailable()) {
-            invokeCallbacks(TESTNG_INVOKE_BEFORE_CLASS, TESTNG_CALLBACKS);
+        if (!isRunAsClient(event.getTestClass())) {
+            if (isJunit5Available()) {
+                invokeCallbacks(JUNIT_INVOKE_BEFORE_ALLS, JUNIT5_CALLBACKS);
+            }
+            if (isTestNGAvailable()) {
+                invokeCallbacks(TESTNG_INVOKE_BEFORE_CLASS, TESTNG_CALLBACKS);
+            }
         }
     }
 
     public void afterClass(
-            @Observes(precedence = DEFAULT_PRECEDENCE) org.jboss.arquillian.test.spi.event.suite.AfterClass event)
+            @Observes(precedence = AFTER_CLASS_PRECEDENCE) org.jboss.arquillian.test.spi.event.suite.AfterClass event)
             throws Throwable {
-        if (isTestNGAvailable()) {
-            invokeCallbacks(TESTNG_INVOKE_AFTER_CLASS, TESTNG_CALLBACKS);
+        if (!isRunAsClient(event.getTestClass())) {
+            if (isJunit5Available()) {
+                invokeCallbacks(JUNIT_INVOKE_AFTER_ALLS, JUNIT5_CALLBACKS);
+            }
+            if (isTestNGAvailable()) {
+                invokeCallbacks(TESTNG_INVOKE_AFTER_CLASS, TESTNG_CALLBACKS);
+            }
         }
+    }
+
+    /**
+     * A test which runs as client is executed on the test instance created by the test framework itself, so its
+     * callbacks are already invoked by the test framework and must not be invoked on the in container test instance
+     * again. Next to {@link RunAsClient}, this is also the case for a deployment declared as not testable.
+     */
+    private boolean isRunAsClient(TestLifecycleEvent event) {
+        return RunModeUtils.isRunAsClient(deployment.get(), event.getTestClass(), event.getTestMethod());
+    }
+
+    /**
+     * The deployment context is not active during the class level events, so the run mode can there only be determined
+     * from the deployment scenario of the class.
+     */
+    private boolean isRunAsClient(TestClass testClass) {
+        if (testClass.isAnnotationPresent(RunAsClient.class)) {
+            return true;
+        }
+        DeploymentScenario scenario = deploymentScenario.get();
+        return scenario == null || scenario.deployments().stream().noneMatch(d -> d.getDescription().testable());
     }
 
     private boolean isJunit5Available() {
@@ -97,8 +149,8 @@ public class QuarkusBeforeAfterLifecycle {
             throws IllegalAccessException, IllegalArgumentException, InvocationTargetException,
             NoSuchMethodException, SecurityException, ClassNotFoundException {
         ClassLoader old = Thread.currentThread().getContextClassLoader();
-        ClassLoader cl = deployment.get() != null && deployment.get().hasAppClassLoader()
-                ? deployment.get().getAppClassLoader()
+        ClassLoader cl = quarkusDeployment.get() != null && quarkusDeployment.get().hasAppClassLoader()
+                ? quarkusDeployment.get().getAppClassLoader()
                 : old;
 
         try {

--- a/test-framework/arquillian/src/main/java/io/quarkus/arquillian/QuarkusJunit5Callbacks.java
+++ b/test-framework/arquillian/src/main/java/io/quarkus/arquillian/QuarkusJunit5Callbacks.java
@@ -12,6 +12,8 @@ class QuarkusJunit5Callbacks extends QuarkusJunitCallbacks {
 
     private static final String BEFORE_EACH_CLASS_NAME_JUNIT5 = "org.junit.jupiter.api.BeforeEach";
     private static final String AFTER_EACH_CLASS_NAME_JUNIT5 = "org.junit.jupiter.api.AfterEach";
+    private static final String BEFORE_ALL_CLASS_NAME_JUNIT5 = "org.junit.jupiter.api.BeforeAll";
+    private static final String AFTER_ALL_CLASS_NAME_JUNIT5 = "org.junit.jupiter.api.AfterAll";
 
     static void invokeJunitBefores(Object testInstance)
             throws IllegalAccessException, IllegalArgumentException, InvocationTargetException, ClassNotFoundException {
@@ -21,5 +23,15 @@ class QuarkusJunit5Callbacks extends QuarkusJunitCallbacks {
     static void invokeJunitAfters(Object testInstance)
             throws IllegalAccessException, IllegalArgumentException, InvocationTargetException, ClassNotFoundException {
         invokeJunitAfters(AFTER_EACH_CLASS_NAME_JUNIT5, testInstance);
+    }
+
+    static void invokeJunitBeforeAlls(Object testInstance)
+            throws IllegalAccessException, IllegalArgumentException, InvocationTargetException, ClassNotFoundException {
+        invokeJunitBefores(BEFORE_ALL_CLASS_NAME_JUNIT5, testInstance);
+    }
+
+    static void invokeJunitAfterAlls(Object testInstance)
+            throws IllegalAccessException, IllegalArgumentException, InvocationTargetException, ClassNotFoundException {
+        invokeJunitAfters(AFTER_ALL_CLASS_NAME_JUNIT5, testInstance);
     }
 }

--- a/test-framework/arquillian/src/main/java/io/quarkus/arquillian/QuarkusJunitCallbacks.java
+++ b/test-framework/arquillian/src/main/java/io/quarkus/arquillian/QuarkusJunitCallbacks.java
@@ -3,6 +3,7 @@ package io.quarkus.arquillian;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -23,9 +24,7 @@ abstract class QuarkusJunitCallbacks {
             collectCallbacks(testInstance.getClass(), befores, (Class<? extends Annotation>) testInstance.getClass()
                     .getClassLoader().loadClass(className));
             for (Method before : befores) {
-                if (before.canAccess(testInstance) && before.getParameters().length == 0) {
-                    before.invoke(testInstance);
-                }
+                invokeCallback(before, testInstance);
             }
         }
     }
@@ -37,10 +36,20 @@ abstract class QuarkusJunitCallbacks {
             collectCallbacks(testInstance.getClass(), afters, (Class<? extends Annotation>) testInstance.getClass()
                     .getClassLoader().loadClass(className));
             for (Method after : afters) {
-                if (after.canAccess(testInstance) && after.getParameters().length == 0) {
-                    after.invoke(testInstance);
-                }
+                invokeCallback(after, testInstance);
             }
+        }
+    }
+
+    /**
+     * A class level callback is static unless the test declares the per class test instance lifecycle, and
+     * {@link Method#canAccess(Object)} rejects a non-null object for a static method.
+     */
+    private static void invokeCallback(Method callback, Object testInstance)
+            throws IllegalAccessException, InvocationTargetException {
+        Object target = Modifier.isStatic(callback.getModifiers()) ? null : testInstance;
+        if (callback.canAccess(target) && callback.getParameters().length == 0) {
+            callback.invoke(target);
         }
     }
 

--- a/test-framework/arquillian/src/test/java/io/quarkus/arquillian/test/BeforeAllInContainerTest.java
+++ b/test-framework/arquillian/src/test/java/io/quarkus/arquillian/test/BeforeAllInContainerTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.arquillian.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Verifies that {@code @BeforeAll} is invoked on the in container test instance, exactly once for the class. The counter
+ * is static, so the value which the test method observes is the one of this class as loaded by the application class
+ * loader, which is only incremented when the callback is invoked on the in container test instance.
+ */
+@ExtendWith(ArquillianExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class BeforeAllInContainerTest {
+
+    static final AtomicInteger BEFORE_ALL = new AtomicInteger();
+
+    @Deployment
+    public static JavaArchive createTestArchive() {
+        return ShrinkWrap.create(JavaArchive.class)
+                .addClass(Foo.class);
+    }
+
+    @Inject
+    Foo foo;
+
+    @BeforeAll
+    public static void beforeAll() {
+        BEFORE_ALL.incrementAndGet();
+    }
+
+    @Test
+    @Order(1)
+    public void testBeforeAllWasInvokedInContainer() {
+        assertNotNull(foo);
+        assertEquals(1, BEFORE_ALL.get());
+    }
+
+    @Test
+    @Order(2)
+    public void testBeforeAllWasNotInvokedAgain() {
+        assertEquals(1, BEFORE_ALL.get());
+    }
+}

--- a/test-framework/arquillian/src/test/java/io/quarkus/arquillian/test/ClassCallbacksTestNg.java
+++ b/test-framework/arquillian/src/test/java/io/quarkus/arquillian/test/ClassCallbacksTestNg.java
@@ -1,0 +1,57 @@
+package io.quarkus.arquillian.test;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * The TestNG counterpart of {@link BeforeAllInContainerTest}, run by {@link TestNgCallbacksTest} rather than by the build
+ * itself, because the build runs the JUnit provider only.
+ * <p>
+ * The {@code @BeforeClass} counter is static, so the value which the test method observes is the one of this class as
+ * loaded by the application class loader, which is only incremented when the callback is invoked on the in container test
+ * instance. The {@code @AfterClass} invocation can only be observed once the class has finished, by which time the
+ * application class loader is gone, so it records the class loader which invoked it in a system property instead. TestNG
+ * itself invokes the callback on the test instance which it created, so the mere fact that it was invoked proves nothing.
+ */
+public class ClassCallbacksTestNg extends Arquillian {
+
+    static final String AFTER_CLASS_CLASS_LOADERS = ClassCallbacksTestNg.class.getName() + ".afterClassClassLoaders";
+
+    static final AtomicInteger BEFORE_CLASS = new AtomicInteger();
+
+    @Deployment
+    public static JavaArchive createTestArchive() {
+        return ShrinkWrap.create(JavaArchive.class)
+                .addClass(Foo.class);
+    }
+
+    @Inject
+    Foo foo;
+
+    @BeforeClass
+    public void beforeClass() {
+        BEFORE_CLASS.incrementAndGet();
+    }
+
+    @AfterClass
+    public void afterClass() {
+        System.setProperty(AFTER_CLASS_CLASS_LOADERS,
+                System.getProperty(AFTER_CLASS_CLASS_LOADERS, "") + getClass().getClassLoader().getClass().getName() + " ");
+    }
+
+    @Test
+    public void testBeforeClassWasInvokedInContainer() {
+        assertEquals(BEFORE_CLASS.get(), 1);
+    }
+}

--- a/test-framework/arquillian/src/test/java/io/quarkus/arquillian/test/MethodCallbacksRunAsClientTestNg.java
+++ b/test-framework/arquillian/src/test/java/io/quarkus/arquillian/test/MethodCallbacksRunAsClientTestNg.java
@@ -1,0 +1,38 @@
+package io.quarkus.arquillian.test;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * The TestNG counterpart of {@link RunAsClientCallbacksTest}, run by {@link TestNgCallbacksTest} rather than by the build
+ * itself, because the build runs the JUnit provider only. The counter is kept in a system property rather than in a
+ * static field, because the two test instances are loaded by different class loaders and would therefore each have their
+ * own copy of a static field, which would hide the second invocation.
+ */
+public class MethodCallbacksRunAsClientTestNg extends Arquillian {
+
+    static final String BEFORE_METHOD_COUNT = MethodCallbacksRunAsClientTestNg.class.getName() + ".beforeMethodCount";
+
+    @Deployment(testable = false)
+    public static JavaArchive createTestArchive() {
+        return ShrinkWrap.create(JavaArchive.class)
+                .addClass(Foo.class);
+    }
+
+    @BeforeMethod
+    public void beforeMethod() {
+        System.setProperty(BEFORE_METHOD_COUNT, String.valueOf(count() + 1));
+    }
+
+    static int count() {
+        return Integer.parseInt(System.getProperty(BEFORE_METHOD_COUNT, "0"));
+    }
+
+    @Test
+    public void testRunsAsClient() {
+    }
+}

--- a/test-framework/arquillian/src/test/java/io/quarkus/arquillian/test/RunAsClientCallbacksTest.java
+++ b/test-framework/arquillian/src/test/java/io/quarkus/arquillian/test/RunAsClientCallbacksTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.arquillian.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Verifies that the callbacks of a test which runs as client, here because the deployment is declared as not testable,
+ * are invoked exactly once. The test framework already invokes them on the test instance which it created itself, so
+ * invoking them on the in container test instance as well would run them twice.
+ * <p>
+ * The counter is kept in a system property rather than in a static field, because the two test instances are loaded by
+ * different class loaders and would therefore each have their own copy of a static field, which would hide the second
+ * invocation from this test.
+ */
+@ExtendWith(ArquillianExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class RunAsClientCallbacksTest {
+
+    private static final String BEFORE_EACH_COUNT = RunAsClientCallbacksTest.class.getName() + ".beforeEachCount";
+
+    @Deployment(testable = false)
+    public static JavaArchive createTestArchive() {
+        return ShrinkWrap.create(JavaArchive.class)
+                .addClass(Foo.class);
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        System.setProperty(BEFORE_EACH_COUNT, String.valueOf(count() + 1));
+    }
+
+    @Test
+    @Order(1)
+    public void testBeforeEachWasInvokedOnce() {
+        assertEquals(1, count());
+    }
+
+    @Test
+    @Order(2)
+    public void testBeforeEachWasInvokedOnceMore() {
+        assertEquals(2, count());
+    }
+
+    private static int count() {
+        return Integer.parseInt(System.getProperty(BEFORE_EACH_COUNT, "0"));
+    }
+}

--- a/test-framework/arquillian/src/test/java/io/quarkus/arquillian/test/TestNgCallbacksTest.java
+++ b/test-framework/arquillian/src/test/java/io/quarkus/arquillian/test/TestNgCallbacksTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.arquillian.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
+
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+
+/**
+ * Verifies that the TestNG class level callbacks are invoked on the in container test instance, by running
+ * {@link ClassCallbacksTestNg} through TestNG itself. The build runs the JUnit provider only, so a TestNG test which is
+ * named as one would be silently skipped instead.
+ */
+public class TestNgCallbacksTest {
+
+    @Test
+    public void testClassLevelCallbacksAreInvokedInContainer() {
+        System.clearProperty(ClassCallbacksTestNg.AFTER_CLASS_CLASS_LOADERS);
+
+        run(ClassCallbacksTestNg.class);
+
+        String classLoaders = System.getProperty(ClassCallbacksTestNg.AFTER_CLASS_CLASS_LOADERS, "");
+        assertTrue(classLoaders.contains(QuarkusClassLoader.class.getSimpleName()),
+                "@AfterClass was not invoked on the in container test instance, but only by " + classLoaders);
+    }
+
+    @Test
+    public void testMethodLevelCallbacksAreNotInvokedTwiceWhenRunningAsClient() {
+        System.clearProperty(MethodCallbacksRunAsClientTestNg.BEFORE_METHOD_COUNT);
+
+        run(MethodCallbacksRunAsClientTestNg.class);
+
+        assertEquals(1, MethodCallbacksRunAsClientTestNg.count());
+    }
+
+    private static void run(Class<?> testClass) {
+        TestListenerAdapter listener = new TestListenerAdapter();
+        TestNG testng = new TestNG();
+        testng.setTestClasses(new Class[] { testClass });
+        testng.addListener(listener);
+        testng.setUseDefaultListeners(false);
+        testng.run();
+
+        assertEquals(List.of(), listener.getConfigurationFailures().stream().map(r -> r.getThrowable().toString()).toList());
+        assertEquals(List.of(), listener.getFailedTests().stream().map(r -> r.getThrowable().toString()).toList());
+        assertEquals(1, listener.getPassedTests().size());
+    }
+}


### PR DESCRIPTION
`QuarkusBeforeAfterLifecycle` re-invokes the test framework callbacks on the in container test instance, because the test framework invokes them on the instance which it created itself, and that is not the one which runs an in container test. This fixes two problems with that, plus two defects which surfaced while fixing the second one.

### Callbacks are invoked twice for a test which runs as client

A test which runs as client is executed on the instance of the test framework, so its callbacks are already invoked by the test framework and must not be invoked on the in container test instance again. The check for this only looked at `@RunAsClient`:

```java
if (!event.getTestClass().isAnnotationPresent(RunAsClient.class)) {
```

Arquillian's own rule is broader, see `RunModeUtils#isRunAsClient`, which also treats a deployment declared as not testable as running as client:

```java
runAsClient = deployment.getDescription().testable() ? false : true;
```

So every `@BeforeEach` and `@AfterEach` of a `@Deployment(testable = false)` (E2E) test was invoked twice, once by the test framework on its own instance and once here on the in container instance. It now delegates to `RunModeUtils`, the same way `ClientBeforeAfterLifecycleEventExecuter` does. The deployment context is not active during the class level events, so the run mode is there derived from the deployment scenario instead.

### JUnit 5 @BeforeAll and @AfterAll are never invoked

`beforeClass` and `afterClass` wired the per class callbacks for TestNG only, so a JUnit 5 test could not prepare any class level state on the instance which actually runs in container, even though `@BeforeEach` and `@AfterEach` were wired. Two further defects had to be fixed before this could work:

- The class level callbacks were invoked from an `AfterClass` observer of precedence `-100`. `ContainerEventController` observes `AfterClass` at default precedence and fires the undeploy, which sets `QuarkusDeployableContainer.testInstance` to null, so by the time the observer ran there was nothing left to invoke them on. Arquillian documents the convention for this: *"BeforeX event execution has a low precedence to execute as late in the Before Phase as possible. AfterX event execution has a high precedence to execute as early in the After Phase as possible."* **Note this means the TestNG `@AfterClass` callbacks were never invoked either, and they start being invoked as of this PR.** That is the one behaviour change here which is worth a careful look, given this module is what the TCKs run on.
- A class level callback is static unless the test declares `@TestInstance(Lifecycle.PER_CLASS)`, and `Method#canAccess` throws `IllegalArgumentException: non-null object for public static void ...` when a non-null object is passed for a static member. This never showed up before because `@BeforeEach` and `@AfterEach` are never static.

### How this was found

This was discovered in the integration tests of [OmniFaces](https://github.com/omnifaces/omnifaces), which are Arquillian tests with `@Deployment(testable = false)` driving a browser through Selenium. `OmniFacesIT` creates the browser in `@BeforeAll` and navigates in `@BeforeEach`, and had to be worked around like this:

```java
private WebDriver browser;

@BeforeAll
public void setup() {
    browser = createBrowser();
    PageFactory.initElements(browser, this);
}

@BeforeEach
public void init() {
    if (browser == null) {
        setup(); // Because quarkus-arquillian doesn't recognize the different lifecycle of @BeforeAll on a
                 // @TestInstance(Lifecycle.PER_CLASS) and forgets to invoke it on each instantiation.
    }
    ...
}
```

Both defects combined there: `@BeforeEach` was invoked a second time on the in container instance, and because `@BeforeAll` had never been invoked on that instance its browser field was still null, so the null check created a second browser. Every test class therefore ended up with two browsers, both of which loaded the page, and only one of which was ever quit. For those tests, which count the connections which a page opens, this consistently reported one connection too many. Making the field static and null checking it was the workaround; with this PR the original code works unchanged, and the run goes back to exactly one browser per test class which is properly quit. Every other container the same tests run on was unaffected.

### Tests

Each of the changed paths gets a test which fails without the corresponding fix:

- `RunAsClientCallbacksTest` asserts that `@BeforeEach` of a not testable deployment is invoked once. Without the fix it counts `2` and then `4`. The counter is a system property rather than a static field, because the two test instances are loaded by different class loaders and would each have their own copy of a static field, which is precisely why this went unnoticed for so long.
- `BeforeAllInContainerTest` asserts that `@BeforeAll` is invoked once on the in container instance, observed through a static field of the class as loaded by the application class loader. Without the fix it counts `0`, and without the static handling it errors.
- `TestNgCallbacksTest` covers the TestNG side, asserting that `@AfterClass` is invoked on the in container instance and that `@BeforeMethod` of a not testable deployment is invoked once. Without the fix the former reports that it was invoked only by the application class loader, and the latter counts `2`. It drives TestNG programmatically, because surefire auto detects the JUnit provider only for this module and a TestNG test named as one is silently skipped instead. This is also why `arquillian-testng-container` is added in test scope, the module itself ships only `testng` and leaves the container to consumers such as the TCKs.

`mvn test` on the module: 13 tests, all green with the fix, 6 assertions failing without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 5)
