### PR TITLE
Upgrade Yasson from 3.0.4 to 3.0.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,6 @@ updates:
       - dependency-name: org.apache.james:apache-mime4j
       - dependency-name: org.quartz-scheduler:quartz
       - dependency-name: com.cronutils:cron-utils
-      - dependency-name: org.eclipse:yasson
       - dependency-name: org.yaml:snakeyaml
       - dependency-name: com.google.guava:guava
       - dependency-name: org.jboss.logging:*
@@ -111,7 +110,7 @@ updates:
       - dependency-name: com.fasterxml.jackson:jackson-bom
       - dependency-name: com.fasterxml:classmate
       # Yasson
-      - dependency-name: org.eclipse:yasson
+      - dependency-name: org.eclipse.yasson:yasson
       # AWS
       - dependency-name: com.amazonaws:*
       # Azure

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -165,7 +165,7 @@
         <awaitility.version>4.3.0</awaitility.version>
         <jboss-logmanager.version>3.2.2.Final</jboss-logmanager.version>
         <flyway.version>12.0.0</flyway.version>
-        <yasson.version>3.0.4</yasson.version>
+        <yasson.version>3.0.5</yasson.version>
         <!-- liquibase-mongodb is not released everytime with liquibase anymore, but the two versions need to be compatible -->
         <liquibase.version>4.33.0</liquibase.version>
         <liquibase-mongodb.version>4.33.0.1</liquibase-mongodb.version>
@@ -4972,7 +4972,7 @@
                 <version>${parsson.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.eclipse</groupId>
+                <groupId>org.eclipse.yasson</groupId>
                 <artifactId>yasson</artifactId>
                 <version>${yasson.version}</version>
             </dependency>
@@ -5240,6 +5240,15 @@
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-json-binding-provider</artifactId>
                 <version>${resteasy.version}</version>
+                <exclusions>
+                    <!-- This is needed until RESTEasy upgrades to Yasson 3.0.5 requiring the groupId change to
+                         org.eclipse.yasson.
+                    -->
+                    <exclusion>
+                        <groupId>org.eclipse</groupId>
+                        <artifactId>yasson</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>

--- a/extensions/jsonb/runtime/pom.xml
+++ b/extensions/jsonb/runtime/pom.xml
@@ -14,7 +14,7 @@
     <description>JSON Binding support</description>
     <dependencies>
         <dependency>
-            <groupId>org.eclipse</groupId>
+            <groupId>org.eclipse.yasson</groupId>
             <artifactId>yasson</artifactId>
         </dependency>
         <dependency>

--- a/independent-projects/enforcer-rules/src/main/resources/enforcer-rules/quarkus-banned-dependencies.xml
+++ b/independent-projects/enforcer-rules/src/main/resources/enforcer-rules/quarkus-banned-dependencies.xml
@@ -53,6 +53,8 @@
                 <exclude>org.jboss.marshalling:jboss-marshalling-osgi</exclude>
                 <exclude>org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec</exclude>
                 <exclude>org.glassfish:jakarta.json</exclude>
+                <!-- The groupId for Yasson changed from org.eclipse to org.eclipse.yasson in version 3.0.5 -->
+                <exclude>org.eclipse:yasson</exclude>
                 <exclude>org.eclipse.parsson:jakarta.json</exclude>
                 <!-- Ensure none of the deps use netty-all. This forces deps to use more fine grained netty artifacts -->
                 <exclude>io.netty:netty-all</exclude>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -64,7 +64,7 @@
         <jackson-bom.version>3.1.4</jackson-bom.version>
         <smallrye-stork.version>3.0.0</smallrye-stork.version>
         <jakarta.validation-api.version>3.1.1</jakarta.validation-api.version>
-        <yasson.version>3.0.4</yasson.version>
+        <yasson.version>3.0.5</yasson.version>
         <jakarta.json.bind-api.version>3.0.2</jakarta.json.bind-api.version>
         <awaitility.version>4.3.0</awaitility.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
@@ -199,7 +199,7 @@
                 <version>${gizmo.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.eclipse</groupId>
+                <groupId>org.eclipse.yasson</groupId>
                 <artifactId>yasson</artifactId>
                 <version>${yasson.version}</version>
             </dependency>

--- a/independent-projects/resteasy-reactive/server/jsonb/pom.xml
+++ b/independent-projects/resteasy-reactive/server/jsonb/pom.xml
@@ -20,7 +20,7 @@
             <artifactId>resteasy-reactive</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse</groupId>
+            <groupId>org.eclipse.yasson</groupId>
             <artifactId>yasson</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
This requires a change to the groupId from org.eclipse to org.eclipse.yasson.

Note the change of the groupId which came in via https://github.com/eclipse-ee4j/yasson/pull/729. This was required to be able to deploy to Maven Central.

