### PR TITLE
Compatibility validation for extensions based on Quarkus core version

### DIFF
--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -63,6 +63,10 @@
             <artifactId>smallrye-common-process</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-version</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
         </dependency>

--- a/core/deployment/src/main/java/io/quarkus/deployment/BootstrapConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/BootstrapConfig.java
@@ -67,4 +67,19 @@ public interface BootstrapConfig {
         WARN,
         IGNORE;
     }
+
+    /**
+     * Whether to throw an error, warn or silently ignore extensions whose {@code requires-quarkus-core}
+     * metadata declares a version range that does not include the Quarkus core version used by the
+     * application. The check is skipped when the Quarkus core version is {@code 999-SNAPSHOT} or when an
+     * extension does not declare a {@code requires-quarkus-core} version range.
+     */
+    @WithDefault("error")
+    IncompatibleExtensions incompatibleExtensions();
+
+    enum IncompatibleExtensions {
+        ERROR,
+        WARN,
+        IGNORE;
+    }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/BootstrapConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/BootstrapConfig.java
@@ -67,4 +67,19 @@ public interface BootstrapConfig {
         WARN,
         IGNORE;
     }
+
+    /**
+     * Whether to throw an error, warn or silently ignore extensions whose metadata declares a supported
+     * Quarkus version range ({@code requires-quarkus-version} in {@code META-INF/quarkus-extension.properties})
+     * that does not include the Quarkus core version used by the application. The check is skipped when the
+     * Quarkus core version is {@code 999-SNAPSHOT} or when an extension does not declare a version range.
+     */
+    @WithDefault("error")
+    IncompatibleExtensions incompatibleExtensions();
+
+    enum IncompatibleExtensions {
+        ERROR,
+        WARN,
+        IGNORE;
+    }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/AppModelProviderBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/AppModelProviderBuildItem.java
@@ -1,5 +1,7 @@
 package io.quarkus.deployment.builditem;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -8,8 +10,12 @@ import org.jboss.logging.Logger;
 import io.quarkus.bootstrap.app.DependencyInfoProvider;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.model.PlatformImports;
+import io.quarkus.builder.Version;
 import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.deployment.BootstrapConfig;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.smallrye.common.version.VersionScheme;
 
 /**
  * A build item used to provide a application dependency model.
@@ -19,6 +25,12 @@ import io.quarkus.deployment.BootstrapConfig;
 public final class AppModelProviderBuildItem extends SimpleBuildItem {
 
     private static final Logger log = Logger.getLogger(AppModelProviderBuildItem.class);
+
+    /**
+     * The version used by the main branch of Quarkus and of extensions built against it. It never satisfies
+     * upper-bounded {@code requires-quarkus-core} ranges, so the compatibility check is skipped for it.
+     */
+    private static final String MAIN_BRANCH_VERSION = "999-SNAPSHOT";
 
     private final ApplicationModel appModel;
 
@@ -41,6 +53,12 @@ public final class AppModelProviderBuildItem extends SimpleBuildItem {
      * <li><b>WARN</b>: Logs a warning.</li>
      * <li><b>IGNORE</b>: Skips validation entirely.</li>
      * </ul>
+     * <p>
+     * Additionally validates that the Quarkus core version used by the application satisfies the
+     * {@code requires-quarkus-version} range declared in the {@code META-INF/quarkus-extension.properties}
+     * descriptor of each extension present in the application model.
+     * The behavior in case of an incompatible extension depends on the provided
+     * {@link BootstrapConfig#incompatibleExtensions()} in the same way as described above.
      *
      * @param config the bootstrap configuration
      * @return the validated application model
@@ -62,7 +80,73 @@ public final class AppModelProviderBuildItem extends SimpleBuildItem {
                             + config.misalignedPlatformImports());
             }
         }
+        validateExtensionCompatibility(config.incompatibleExtensions(), Version.getVersion());
         return appModel;
+    }
+
+    void validateExtensionCompatibility(BootstrapConfig.IncompatibleExtensions action, String quarkusCoreVersion) {
+        if (BootstrapConfig.IncompatibleExtensions.IGNORE.equals(action)) {
+            return;
+        }
+        if (MAIN_BRANCH_VERSION.equals(quarkusCoreVersion)) {
+            log.debugf("Quarkus core version is %s; skipping the extension compatibility check", quarkusCoreVersion);
+            return;
+        }
+        final Map<ArtifactKey, String> requiredQuarkusVersions = appModel.getRequiredQuarkusVersions();
+        if (requiredQuarkusVersions.isEmpty()) {
+            return;
+        }
+        final StringBuilder incompatible = new StringBuilder();
+        /* Many extensions declare the same range, so each distinct range is evaluated only once */
+        final Map<String, Boolean> evaluatedRanges = new HashMap<>();
+        for (ResolvedDependency dep : appModel.getDependencies()) {
+            if (!dep.isRuntimeExtensionArtifact()) {
+                continue;
+            }
+            final String requiresQuarkusVersion = requiredQuarkusVersions.get(dep.getKey());
+            if (requiresQuarkusVersion == null
+                    || (!requiresQuarkusVersion.startsWith("[") && !requiresQuarkusVersion.startsWith("("))) {
+                /* No explicit version range declared by the extension */
+                continue;
+            }
+            if (evaluatedRanges.computeIfAbsent(requiresQuarkusVersion, range -> satisfies(range, quarkusCoreVersion))) {
+                continue;
+            }
+            incompatible.append(System.lineSeparator())
+                    .append("- ").append(dep.toCompactCoords())
+                    .append(" (requires Quarkus ").append(requiresQuarkusVersion).append(")");
+        }
+        if (incompatible.length() == 0) {
+            return;
+        }
+        final String report = "The following extensions declare in their metadata a supported Quarkus version range"
+                + " that does not include the Quarkus core version used by the application (" + quarkusCoreVersion + "):"
+                + incompatible
+                + System.lineSeparator()
+                + "This may lead to obscure build time or runtime failures."
+                + " Please align the versions in your dependency management, e.g. by importing a matching Quarkus"
+                + " platform BOM stream. This check can be configured via"
+                + " quarkus.bootstrap.incompatible-extensions (error, warn, ignore).";
+        switch (action) {
+            case ERROR:
+                throw new RuntimeException(report);
+            case WARN:
+                log.warn(report);
+                break;
+            default:
+                throw new RuntimeException("Unrecognized option for quarkus.bootstrap.incompatible-extensions: "
+                        + action);
+        }
+    }
+
+    private static boolean satisfies(String range, String version) {
+        try {
+            return VersionScheme.MAVEN.fromRangeString(range).test(version);
+        } catch (RuntimeException e) {
+            log.debugf(e, "Could not evaluate the required Quarkus version range %s;"
+                    + " skipping the compatibility check for it", range);
+            return true;
+        }
     }
 
     public Supplier<DependencyInfoProvider> getDependencyInfoProvider() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/AppModelProviderBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/AppModelProviderBuildItem.java
@@ -1,15 +1,24 @@
 package io.quarkus.deployment.builditem;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.util.Objects;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.app.DependencyInfoProvider;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.model.PlatformImports;
+import io.quarkus.builder.Version;
 import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.deployment.BootstrapConfig;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.smallrye.common.version.VersionScheme;
 
 /**
  * A build item used to provide a application dependency model.
@@ -19,6 +28,15 @@ import io.quarkus.deployment.BootstrapConfig;
 public final class AppModelProviderBuildItem extends SimpleBuildItem {
 
     private static final Logger log = Logger.getLogger(AppModelProviderBuildItem.class);
+
+    private static final Pattern REQUIRES_QUARKUS_CORE_PATTERN = Pattern
+            .compile("requires-quarkus-core:\\s*\"?([^\"\\s]+)\"?");
+
+    /**
+     * The version used by the main branch of Quarkus and of extensions built against it. It never satisfies
+     * upper-bounded {@code requires-quarkus-core} ranges, so the compatibility check is skipped for it.
+     */
+    private static final String MAIN_BRANCH_VERSION = "999-SNAPSHOT";
 
     private final ApplicationModel appModel;
 
@@ -41,6 +59,11 @@ public final class AppModelProviderBuildItem extends SimpleBuildItem {
      * <li><b>WARN</b>: Logs a warning.</li>
      * <li><b>IGNORE</b>: Skips validation entirely.</li>
      * </ul>
+     * <p>
+     * Additionally validates that the Quarkus core version used by the application satisfies the
+     * {@code requires-quarkus-core} version range declared by each extension present in the application model.
+     * The behavior in case of an incompatible extension depends on the provided
+     * {@link BootstrapConfig#incompatibleExtensions()} in the same way as described above.
      *
      * @param config the bootstrap configuration
      * @return the validated application model
@@ -62,7 +85,88 @@ public final class AppModelProviderBuildItem extends SimpleBuildItem {
                             + config.misalignedPlatformImports());
             }
         }
+        validateExtensionCompatibility(config.incompatibleExtensions(), Version.getVersion());
         return appModel;
+    }
+
+    void validateExtensionCompatibility(BootstrapConfig.IncompatibleExtensions action, String quarkusCoreVersion) {
+        if (BootstrapConfig.IncompatibleExtensions.IGNORE.equals(action)) {
+            return;
+        }
+        if (MAIN_BRANCH_VERSION.equals(quarkusCoreVersion)) {
+            log.debugf("Quarkus core version is %s; skipping the extension compatibility check", quarkusCoreVersion);
+            return;
+        }
+        final StringBuilder incompatible = new StringBuilder();
+        for (ResolvedDependency dep : appModel.getDependencies()) {
+            if (!dep.isRuntimeExtensionArtifact()) {
+                continue;
+            }
+            final String requiresQuarkusCore = readRequiresQuarkusCore(dep);
+            if (requiresQuarkusCore == null
+                    || (!requiresQuarkusCore.startsWith("[") && !requiresQuarkusCore.startsWith("("))) {
+                /* No explicit version range declared by the extension */
+                continue;
+            }
+            try {
+                if (VersionScheme.MAVEN.fromRangeString(requiresQuarkusCore).test(quarkusCoreVersion)) {
+                    continue;
+                }
+            } catch (RuntimeException e) {
+                log.debugf(e, "Could not evaluate requires-quarkus-core range %s of %s;"
+                        + " skipping the compatibility check for this extension", requiresQuarkusCore,
+                        dep.toCompactCoords());
+                continue;
+            }
+            incompatible.append(System.lineSeparator())
+                    .append("- ").append(dep.toCompactCoords())
+                    .append(" (requires Quarkus core ").append(requiresQuarkusCore).append(")");
+        }
+        if (incompatible.length() == 0) {
+            return;
+        }
+        final String report = "The following extensions declare via the requires-quarkus-core metadata that they are"
+                + " incompatible with the Quarkus core version used by the application (" + quarkusCoreVersion + "):"
+                + incompatible
+                + System.lineSeparator()
+                + "This may lead to obscure build time or runtime failures."
+                + " Please align the versions in your dependency management, e.g. by importing a matching Quarkus"
+                + " platform BOM stream. This check can be configured via"
+                + " quarkus.bootstrap.incompatible-extensions (error, warn, ignore).";
+        switch (action) {
+            case ERROR:
+                throw new RuntimeException(report);
+            case WARN:
+                log.warn(report);
+                break;
+            default:
+                throw new RuntimeException("Unrecognized option for quarkus.bootstrap.incompatible-extensions: "
+                        + action);
+        }
+    }
+
+    private static String readRequiresQuarkusCore(ResolvedDependency dep) {
+        final String descriptor = dep.getContentTree().apply(BootstrapConstants.EXTENSION_METADATA_PATH, visit -> {
+            if (visit == null) {
+                return null;
+            }
+            try {
+                return Files.readString(visit.getPath());
+            } catch (IOException e) {
+                throw new UncheckedIOException(
+                        "Could not read " + BootstrapConstants.EXTENSION_METADATA_PATH + " from " + visit.getUrl(), e);
+            }
+        });
+        return descriptor == null ? null : parseRequiresQuarkusCore(descriptor);
+    }
+
+    /**
+     * @param extensionYaml the content of a {@code META-INF/quarkus-extension.yaml} file
+     * @return the value of the {@code requires-quarkus-core} attribute or {@code null} if it could not be found
+     */
+    static String parseRequiresQuarkusCore(String extensionYaml) {
+        final Matcher m = REQUIRES_QUARKUS_CORE_PATTERN.matcher(extensionYaml);
+        return m.find() ? m.group(1) : null;
     }
 
     public Supplier<DependencyInfoProvider> getDependencyInfoProvider() {

--- a/core/deployment/src/test/java/io/quarkus/deployment/builditem/AppModelProviderBuildItemTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/builditem/AppModelProviderBuildItemTest.java
@@ -1,0 +1,92 @@
+package io.quarkus.deployment.builditem;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.bootstrap.BootstrapConstants;
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.model.ApplicationModelBuilder;
+import io.quarkus.deployment.BootstrapConfig.IncompatibleExtensions;
+import io.quarkus.maven.dependency.DependencyFlags;
+import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
+
+public class AppModelProviderBuildItemTest {
+
+    @Test
+    public void testIncompatibleExtension() {
+        final AppModelProviderBuildItem item = new AppModelProviderBuildItem(model("[3.38,3.40)"));
+
+        /* Quarkus core version below the declared range */
+        final RuntimeException error = assertThrows(RuntimeException.class,
+                () -> item.validateExtensionCompatibility(IncompatibleExtensions.ERROR, "3.36.1"));
+        assertTrue(error.getMessage().contains("org.acme:acme-extension:1.0"), error.getMessage());
+        assertTrue(error.getMessage().contains("requires Quarkus [3.38,3.40)"), error.getMessage());
+
+        /* Quarkus core version above the declared range */
+        assertThrows(RuntimeException.class,
+                () -> item.validateExtensionCompatibility(IncompatibleExtensions.ERROR, "3.40.0"));
+
+        /* WARN and IGNORE do not throw */
+        assertDoesNotThrow(() -> item.validateExtensionCompatibility(IncompatibleExtensions.WARN, "3.36.1"));
+        assertDoesNotThrow(() -> item.validateExtensionCompatibility(IncompatibleExtensions.IGNORE, "3.36.1"));
+    }
+
+    @Test
+    public void testCompatibleExtension() {
+        final AppModelProviderBuildItem item = new AppModelProviderBuildItem(model("[3.38,3.40)"));
+        assertDoesNotThrow(() -> item.validateExtensionCompatibility(IncompatibleExtensions.ERROR, "3.38.1"));
+        assertDoesNotThrow(() -> item.validateExtensionCompatibility(IncompatibleExtensions.ERROR, "3.39.5"));
+
+        final AppModelProviderBuildItem openEnded = new AppModelProviderBuildItem(model("[3.38,)"));
+        assertDoesNotThrow(() -> openEnded.validateExtensionCompatibility(IncompatibleExtensions.ERROR, "4.0.0"));
+    }
+
+    @Test
+    public void testMainBranchVersionSkipsCheck() {
+        final AppModelProviderBuildItem item = new AppModelProviderBuildItem(model("[3.38,3.40)"));
+        assertDoesNotThrow(() -> item.validateExtensionCompatibility(IncompatibleExtensions.ERROR, "999-SNAPSHOT"));
+    }
+
+    @Test
+    public void testNoRangeSkipsCheck() {
+        /* A plain version instead of a range is not enforced */
+        final AppModelProviderBuildItem plainVersion = new AppModelProviderBuildItem(model("3.38.0"));
+        assertDoesNotThrow(() -> plainVersion.validateExtensionCompatibility(IncompatibleExtensions.ERROR, "3.36.1"));
+
+        /* No requires-quarkus-version property at all */
+        final AppModelProviderBuildItem noProperty = new AppModelProviderBuildItem(model(null));
+        assertDoesNotThrow(() -> noProperty.validateExtensionCompatibility(IncompatibleExtensions.ERROR, "3.36.1"));
+    }
+
+    private ApplicationModel model(String requiresQuarkusVersion) {
+        final ResolvedDependencyBuilder extension = ResolvedDependencyBuilder.newInstance()
+                .setGroupId("org.acme")
+                .setArtifactId("acme-extension")
+                .setVersion("1.0")
+                .setFlags(DependencyFlags.RUNTIME_CP | DependencyFlags.DEPLOYMENT_CP
+                        | DependencyFlags.RUNTIME_EXTENSION_ARTIFACT);
+        final ApplicationModelBuilder builder = new ApplicationModelBuilder()
+                .setAppArtifact(ResolvedDependencyBuilder.newInstance()
+                        .setGroupId("org.acme")
+                        .setArtifactId("acme-app")
+                        .setVersion("1.0"))
+                .addDependency(extension)
+                .addDependency(ResolvedDependencyBuilder.newInstance()
+                        .setGroupId("org.acme")
+                        .setArtifactId("plain-jar")
+                        .setVersion("1.0")
+                        .setFlags(DependencyFlags.RUNTIME_CP | DependencyFlags.DEPLOYMENT_CP));
+        final Properties props = new Properties();
+        props.setProperty(BootstrapConstants.PROP_DEPLOYMENT_ARTIFACT, "org.acme:acme-extension-deployment:1.0");
+        if (requiresQuarkusVersion != null) {
+            props.setProperty(BootstrapConstants.PROP_REQUIRES_QUARKUS_VERSION, requiresQuarkusVersion);
+        }
+        builder.handleExtensionProperties(props, extension.getKey());
+        return builder.build();
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/builditem/AppModelProviderBuildItemTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/builditem/AppModelProviderBuildItemTest.java
@@ -1,0 +1,108 @@
+package io.quarkus.deployment.builditem;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.model.ApplicationModelBuilder;
+import io.quarkus.deployment.BootstrapConfig.IncompatibleExtensions;
+import io.quarkus.maven.dependency.DependencyFlags;
+import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
+
+public class AppModelProviderBuildItemTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void testParseRequiresQuarkusCore() {
+        assertEquals("[3.38,3.40)", AppModelProviderBuildItem.parseRequiresQuarkusCore("---\n"
+                + "artifact: \"org.acme:acme-extension:1.0\"\n"
+                + "metadata:\n"
+                + "  built-with-quarkus-core: \"3.38.0\"\n"
+                + "  requires-quarkus-core: \"[3.38,3.40)\"\n"));
+        assertEquals("[3.38,)", AppModelProviderBuildItem.parseRequiresQuarkusCore("requires-quarkus-core: [3.38,)\n"));
+        assertNull(AppModelProviderBuildItem.parseRequiresQuarkusCore("built-with-quarkus-core: \"3.38.0\"\n"));
+    }
+
+    @Test
+    public void testIncompatibleExtension() throws IOException {
+        final AppModelProviderBuildItem item = new AppModelProviderBuildItem(model("[3.38,3.40)"));
+
+        /* Quarkus core version below the declared range */
+        final RuntimeException error = assertThrows(RuntimeException.class,
+                () -> item.validateExtensionCompatibility(IncompatibleExtensions.ERROR, "3.36.1"));
+        assertTrue(error.getMessage().contains("org.acme:acme-extension:1.0"), error.getMessage());
+        assertTrue(error.getMessage().contains("requires Quarkus core [3.38,3.40)"), error.getMessage());
+
+        /* Quarkus core version above the declared range */
+        assertThrows(RuntimeException.class,
+                () -> item.validateExtensionCompatibility(IncompatibleExtensions.ERROR, "3.40.0"));
+
+        /* WARN and IGNORE do not throw */
+        assertDoesNotThrow(() -> item.validateExtensionCompatibility(IncompatibleExtensions.WARN, "3.36.1"));
+        assertDoesNotThrow(() -> item.validateExtensionCompatibility(IncompatibleExtensions.IGNORE, "3.36.1"));
+    }
+
+    @Test
+    public void testCompatibleExtension() throws IOException {
+        final AppModelProviderBuildItem item = new AppModelProviderBuildItem(model("[3.38,3.40)"));
+        assertDoesNotThrow(() -> item.validateExtensionCompatibility(IncompatibleExtensions.ERROR, "3.38.1"));
+        assertDoesNotThrow(() -> item.validateExtensionCompatibility(IncompatibleExtensions.ERROR, "3.39.5"));
+
+        final AppModelProviderBuildItem openEnded = new AppModelProviderBuildItem(model("[3.38,)"));
+        assertDoesNotThrow(() -> openEnded.validateExtensionCompatibility(IncompatibleExtensions.ERROR, "4.0.0"));
+    }
+
+    @Test
+    public void testMainBranchVersionSkipsCheck() throws IOException {
+        final AppModelProviderBuildItem item = new AppModelProviderBuildItem(model("[3.38,3.40)"));
+        assertDoesNotThrow(() -> item.validateExtensionCompatibility(IncompatibleExtensions.ERROR, "999-SNAPSHOT"));
+    }
+
+    @Test
+    public void testNoRangeSkipsCheck() throws IOException {
+        /* A plain version instead of a range is not enforced */
+        final AppModelProviderBuildItem item = new AppModelProviderBuildItem(model("3.38.0"));
+        assertDoesNotThrow(() -> item.validateExtensionCompatibility(IncompatibleExtensions.ERROR, "3.36.1"));
+    }
+
+    private ApplicationModel model(String requiresQuarkusCore) throws IOException {
+        final Path extensionDir = Files.createDirectories(tempDir.resolve("acme-extension/META-INF")).getParent();
+        Files.writeString(extensionDir.resolve("META-INF/quarkus-extension.yaml"), "---\n"
+                + "artifact: \"org.acme:acme-extension:1.0\"\n"
+                + "metadata:\n"
+                + "  requires-quarkus-core: \"" + requiresQuarkusCore + "\"\n");
+        final Path plainJarDir = Files.createDirectories(tempDir.resolve("plain-jar"));
+        return new ApplicationModelBuilder()
+                .setAppArtifact(ResolvedDependencyBuilder.newInstance()
+                        .setGroupId("org.acme")
+                        .setArtifactId("acme-app")
+                        .setVersion("1.0")
+                        .setResolvedPath(tempDir.resolve("acme-app")))
+                .addDependency(ResolvedDependencyBuilder.newInstance()
+                        .setGroupId("org.acme")
+                        .setArtifactId("acme-extension")
+                        .setVersion("1.0")
+                        .setResolvedPath(extensionDir)
+                        .setFlags(DependencyFlags.RUNTIME_CP | DependencyFlags.DEPLOYMENT_CP
+                                | DependencyFlags.RUNTIME_EXTENSION_ARTIFACT))
+                .addDependency(ResolvedDependencyBuilder.newInstance()
+                        .setGroupId("org.acme")
+                        .setArtifactId("plain-jar")
+                        .setVersion("1.0")
+                        .setResolvedPath(plainJarDir)
+                        .setFlags(DependencyFlags.RUNTIME_CP | DependencyFlags.DEPLOYMENT_CP))
+                .build();
+    }
+}

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
@@ -17,6 +17,7 @@ public class QuarkusExtensionConfiguration {
     private Property<Boolean> disableValidation;
     private Property<String> deploymentArtifact;
     private Property<String> deploymentModule;
+    private Property<String> requiresQuarkusCore;
     private ListProperty<String> excludedArtifacts;
     private ListProperty<String> parentFirstArtifacts;
     private ListProperty<String> runnerParentFirstArtifacts;
@@ -36,6 +37,7 @@ public class QuarkusExtensionConfiguration {
         deploymentArtifact = project.getObjects().property(String.class);
         deploymentModule = project.getObjects().property(String.class);
         deploymentModule.convention("deployment");
+        requiresQuarkusCore = project.getObjects().property(String.class);
 
         excludedArtifacts = project.getObjects().listProperty(String.class);
         parentFirstArtifacts = project.getObjects().listProperty(String.class);
@@ -68,6 +70,18 @@ public class QuarkusExtensionConfiguration {
 
     public void setDeploymentModule(String deploymentModule) {
         this.deploymentModule.set(deploymentModule);
+    }
+
+    /**
+     * The Quarkus version range this extension requires, e.g. {@code [3.38,3.40)}. If not set, an open-ended
+     * range derived from the Quarkus core version found on the classpath is used.
+     */
+    public Property<String> getRequiresQuarkusCore() {
+        return requiresQuarkusCore;
+    }
+
+    public void setRequiresQuarkusCore(String requiresQuarkusCore) {
+        this.requiresQuarkusCore.set(requiresQuarkusCore);
     }
 
     public ListProperty<String> getExcludedArtifacts() {

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTask.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTask.java
@@ -27,6 +27,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -133,6 +134,12 @@ public class ExtensionDescriptorTask extends DefaultTask {
     @Input
     public Map<String, String> getProjectInfo() {
         return projectInfo;
+    }
+
+    @Input
+    @Optional
+    public String getRequiresQuarkusCore() {
+        return quarkusExtensionConfiguration.getRequiresQuarkusCore().getOrNull();
     }
 
     @Input
@@ -304,6 +311,11 @@ public class ExtensionDescriptorTask extends DefaultTask {
             }
         }
 
+        final String requiresQuarkusVersion = getRequiresQuarkusVersionRange();
+        if (requiresQuarkusVersion != null) {
+            props.setProperty(BootstrapConstants.PROP_REQUIRES_QUARKUS_VERSION, requiresQuarkusVersion);
+        }
+
         try {
             Files.createDirectories(metaInfDir);
             try (BufferedWriter writer = Files
@@ -465,6 +477,27 @@ public class ExtensionDescriptorTask extends DefaultTask {
             ObjectNode metadata = getMetadataNode(extObject);
             metadata.put("built-with-quarkus-core", coreVersion);
         }
+        String versionRange = getRequiresQuarkusVersionRange();
+        if (versionRange != null) {
+            ObjectNode metadata = getMetadataNode(extObject);
+            if (!metadata.has("requires-quarkus-core")) {
+                metadata.put("requires-quarkus-core", versionRange);
+            }
+        }
+    }
+
+    private String getRequiresQuarkusVersionRange() {
+        final String explicitRange = getRequiresQuarkusCore();
+        return explicitRange != null ? explicitRange : toVersionRange(getQuarkusCoreVersionOrNull());
+    }
+
+    private static String toVersionRange(String version) {
+        if (version == null) {
+            return null;
+        }
+        String[] versionItems = version.split("-");
+        versionItems = versionItems[0].split("\\.");
+        return "[" + versionItems[0] + "." + (versionItems.length > 1 ? versionItems[1] : "0") + ",)";
     }
 
     private static void appendCapability(Capability capability, StringBuilder buf) {

--- a/docs/src/main/asciidoc/extension-metadata.adoc
+++ b/docs/src/main/asciidoc/extension-metadata.adoc
@@ -118,7 +118,7 @@ sponsor: A Sponsoring Organisation <8>
 ----
 <1> Description that can be displayed to users. In this case, the description was copied from the `pom.xml` of the extension module but it could also be provided in the template file.
 <2> Quarkus version the extension was built with
-<3> The Quarkus version range this extension requires. Optional, and will be set automatically by using the `built-with-quarkus-core` as the minimum range.
+<3> The Quarkus version range this extension requires. Optional, and will be set automatically by using the `built-with-quarkus-core` as the minimum range. The range is enforced at application build time: if the Quarkus core version used by the application does not satisfy the ranges declared by the extensions present in the application, the build fails by default. This behavior can be configured via the `quarkus.bootstrap.incompatible-extensions` property (`error`, `warn` or `ignore`).
 <4> The minimum Java version required for this extension to run. Will be generated based on the `maven.compiler.release` used in the build.
 <5> https://quarkus.io/guides/capabilities[Capabilities] this extension provides
 <6> Direct dependencies on other extensions

--- a/docs/src/main/asciidoc/extension-metadata.adoc
+++ b/docs/src/main/asciidoc/extension-metadata.adoc
@@ -160,7 +160,7 @@ sponsor: A Sponsoring Organisation <8>
 ----
 <1> Description that can be displayed to users. In this case, the description was copied from the `pom.xml` of the extension module but it could also be provided in the template file.
 <2> Quarkus version the extension was built with
-<3> The Quarkus version range this extension requires. Optional, and will be set automatically by using the `built-with-quarkus-core` as the minimum range.
+<3> The Quarkus version range this extension requires. Optional, and will be set automatically by using the `built-with-quarkus-core` as the minimum range. The range is enforced at application build time: if the Quarkus core version used by the application does not satisfy the ranges declared by the extensions present in the application, the build fails by default. This behavior can be configured via the `quarkus.bootstrap.incompatible-extensions` property (`error`, `warn` or `ignore`).
 <4> The minimum Java version required for this extension to run. Will be generated based on the `maven.compiler.release` used in the build.
 <5> https://quarkus.io/guides/capabilities[Capabilities] this extension provides
 <6> Direct dependencies on other extensions

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
@@ -34,6 +34,7 @@ public interface BootstrapConstants {
     String PROP_DEPLOYMENT_ARTIFACT = "deployment-artifact";
     String PROP_PROVIDES_CAPABILITIES = "provides-capabilities";
     String PROP_REQUIRES_CAPABILITIES = "requires-capabilities";
+    String PROP_REQUIRES_QUARKUS_VERSION = "requires-quarkus-version";
     String PARENT_FIRST_ARTIFACTS = "parent-first-artifacts";
     String EXCLUDED_ARTIFACTS = "excluded-artifacts";
     String LESSER_PRIORITY_ARTIFACTS = "lesser-priority-artifacts";
@@ -71,6 +72,7 @@ public interface BootstrapConstants {
     String MAPPABLE_LOCAL_PROJECTS = "local-projects";
     String MAPPABLE_EXCLUDED_RESOURCES = "excluded-resources";
     String MAPPABLE_EXTENSION_DEV_CONFIG = "extension-dev-config";
+    String MAPPABLE_REQUIRED_QUARKUS_VERSIONS = "required-quarkus-versions";
     // ArtifactDependency Mappable keys
     String MAPPABLE_MAVEN_ARTIFACT = "maven-artifact";
     String MAPPABLE_SCOPE = "scope";

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ApplicationModel.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ApplicationModel.java
@@ -180,6 +180,18 @@ public interface ApplicationModel extends Mappable {
      */
     Collection<ExtensionDevModeConfig> getExtensionDevModeConfig();
 
+    /**
+     * Quarkus version ranges required by the extensions present in the application model, as declared via the
+     * {@code requires-quarkus-version} property in their {@code META-INF/quarkus-extension.properties}
+     * descriptors, keyed by the extension runtime artifact key. Extensions that do not declare the property
+     * are not present in the map.
+     *
+     * @return required Quarkus version ranges per extension, never null
+     */
+    default Map<ArtifactKey, String> getRequiredQuarkusVersions() {
+        return Map.of();
+    }
+
     @Override
     default Map<String, Object> asMap(MappableCollectionFactory factory) {
         final Map<String, Object> map = factory.newMap();
@@ -214,6 +226,15 @@ public interface ApplicationModel extends Mappable {
         }
         if (!getExtensionDevModeConfig().isEmpty()) {
             map.put(BootstrapConstants.MAPPABLE_EXTENSION_DEV_CONFIG, Mappable.asMaps(getExtensionDevModeConfig(), factory));
+        }
+        if (!getRequiredQuarkusVersions().isEmpty()) {
+            final Map<ArtifactKey, String> requiredQuarkusVersions = getRequiredQuarkusVersions();
+            final Map<String, Object> mappedRequiredQuarkusVersions = factory.newMap(requiredQuarkusVersions.size());
+            // Sort by key to keep the serialized form deterministic across JVMs (see #55619).
+            requiredQuarkusVersions.entrySet().stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .forEach(entry -> mappedRequiredQuarkusVersions.put(entry.getKey().toString(), entry.getValue()));
+            map.put(BootstrapConstants.MAPPABLE_REQUIRED_QUARKUS_VERSIONS, mappedRequiredQuarkusVersions);
         }
         return map;
     }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ApplicationModelBuilder.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ApplicationModelBuilder.java
@@ -97,6 +97,15 @@ public class ApplicationModelBuilder {
             }
         }
 
+        final Map<String, Object> requiredQuarkusVersionsMap = (Map<String, Object>) map
+                .get(BootstrapConstants.MAPPABLE_REQUIRED_QUARKUS_VERSIONS);
+        if (requiredQuarkusVersionsMap != null) {
+            for (Map.Entry<String, Object> requiredQuarkusVersion : requiredQuarkusVersionsMap.entrySet()) {
+                builder.addRequiredQuarkusVersion(ArtifactKey.fromString(requiredQuarkusVersion.getKey()),
+                        requiredQuarkusVersion.getValue().toString());
+            }
+        }
+
         return builder.build();
     }
 
@@ -113,6 +122,7 @@ public class ApplicationModelBuilder {
     PlatformImports platformImports;
     final Map<WorkspaceModuleId, WorkspaceModule.Mutable> projectModules = new HashMap<>();
     final Collection<ExtensionDevModeConfig> extensionDevConfig = new ConcurrentLinkedDeque<>();
+    final Map<ArtifactKey, String> requiredQuarkusVersions = new ConcurrentHashMap<>();
 
     public ApplicationModelBuilder() {
         // we never include the ide launcher in the final app model
@@ -285,6 +295,9 @@ public class ApplicationModelBuilder {
                 case BootstrapConstants.EXT_DEV_MODE_LOCK_JVM_OPTIONS:
                     lockJvmOptions = splitByCommaAndAddAll(value, lockJvmOptions);
                     break;
+                case BootstrapConstants.PROP_REQUIRES_QUARKUS_VERSION:
+                    addRequiredQuarkusVersion(extensionKey, value);
+                    break;
                 default:
                     if (name.startsWith(REMOVED_RESOURCES_DOT)) {
                         addRemovedResources(extensionKey, name, value);
@@ -296,6 +309,19 @@ public class ApplicationModelBuilder {
                     jvmOptionsBuilder == null ? JvmOptions.builder().build() : jvmOptionsBuilder.build(),
                     lockJvmOptions));
         }
+    }
+
+    /**
+     * Records the Quarkus version range required by the given extension, as declared via the
+     * {@code requires-quarkus-version} property of its {@code META-INF/quarkus-extension.properties} descriptor.
+     *
+     * @param extensionKey extension runtime artifact key
+     * @param versionRange the required Quarkus version range
+     * @return this builder instance
+     */
+    public ApplicationModelBuilder addRequiredQuarkusVersion(ArtifactKey extensionKey, String versionRange) {
+        requiredQuarkusVersions.put(extensionKey, versionRange);
+        return this;
     }
 
     private static Set<String> splitByCommaAndAddAll(String commaList, Set<String> set) {

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/DefaultApplicationModel.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/DefaultApplicationModel.java
@@ -25,6 +25,7 @@ public class DefaultApplicationModel implements ApplicationModel, Serializable {
     private final Set<ArtifactKey> localProjectArtifacts;
     private final Map<ArtifactKey, Set<String>> excludedResources;
     private final List<ExtensionDevModeConfig> extensionDevConfig;
+    private final Map<ArtifactKey, String> requiredQuarkusVersions;
 
     public DefaultApplicationModel(ApplicationModelBuilder builder) {
         this.appArtifact = builder.appArtifact.build();
@@ -34,6 +35,7 @@ public class DefaultApplicationModel implements ApplicationModel, Serializable {
         this.localProjectArtifacts = Set.copyOf(builder.reloadableWorkspaceModules);
         this.excludedResources = Map.copyOf(builder.excludedResources);
         this.extensionDevConfig = List.copyOf(builder.extensionDevConfig);
+        this.requiredQuarkusVersions = Map.copyOf(builder.requiredQuarkusVersions);
     }
 
     @Override
@@ -99,6 +101,11 @@ public class DefaultApplicationModel implements ApplicationModel, Serializable {
     @Override
     public Collection<ExtensionDevModeConfig> getExtensionDevModeConfig() {
         return extensionDevConfig;
+    }
+
+    @Override
+    public Map<ArtifactKey, String> getRequiredQuarkusVersions() {
+        return requiredQuarkusVersions;
     }
 
     private Collection<ResolvedDependency> collectDependencies(int flags) {

--- a/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -288,7 +288,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         final String quarkusCoreVersionRange = requiresQuarkusCore == null ? toVersionRange(quarkusCoreVersion)
                 : requiresQuarkusCore;
         if (quarkusCoreVersionRange != null) {
-            props.put("requires-quarkus-version", quarkusCoreVersionRange);
+            props.put(BootstrapConstants.PROP_REQUIRES_QUARKUS_VERSION, quarkusCoreVersionRange);
         }
         final Path output = outputDirectory.toPath().resolve(BootstrapConstants.META_INF);
         try {


### PR DESCRIPTION
- Introduced `incompatibleExtensions` configuration in `BootstrapConfig` to manage extension compatibility checks.
- Enhanced `AppModelProviderBuildItem` to validate extensions against the Quarkus core version.


---

- Closes: #55761 


