### PR TITLE
Fix flaky HibernateOrmNoWarningsTest on Oracle 19/21

### DIFF
--- a/integration-tests/jpa-oracle/src/test/java/io/quarkus/it/jpa/oracle/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-oracle/src/test/java/io/quarkus/it/jpa/oracle/HibernateOrmNoWarningsTest.java
@@ -24,8 +24,21 @@ import io.quarkus.test.junit.QuarkusTest;
         @ResourceArg(name = LogCollectingTestResource.INCLUDE, value = "org\\.hibernate\\..*")
 })
 public class HibernateOrmNoWarningsTest {
+
+    private static int getOracleMajorVersion() {
+        String version = System.getProperty("oracle.db-version");
+        if (version == null || version.isEmpty()) {
+            version = System.getProperty("oracle.default.version");
+        }
+        if (version == null || version.isEmpty()) {
+            return Integer.MAX_VALUE;
+        }
+        return Integer.parseInt(version.split("\\.")[0]);
+    }
+
     @Test
     public void testNoWarningsOnStartup() {
+        int oracleMajorVersion = getOracleMajorVersion();
         assertThat(LogCollectingTestResource.current().getRecords()
                 // Ignore logs about JDBC fetch size: Oracle's default is very wrong.
                 // See:
@@ -34,7 +47,15 @@ public class HibernateOrmNoWarningsTest {
                 // https://in.relation.to/2025/01/24/jdbc-fetch-size/
                 // https://github.com/hibernate/hibernate-orm/pull/10636
                 // Also, the Hibernate team is in talks with Oracle to get this fixed, so hopefully this will disappear soon.
-                .stream().filter(r -> !r.getMessage().contains("Low default JDBC fetch size")))
+                .stream().filter(r -> !r.getMessage().contains("Low default JDBC fetch size"))
+                // Ignore warnings about dropping non-existent tables on Oracle < 23.
+                // Oracle 23c added "DROP TABLE IF EXISTS", but older versions (19, 21) don't support it,
+                // so Hibernate's drop-and-create schema generation logs a warning (ORA-00942)
+                // when the table doesn't exist yet on the first run.
+                .filter(r -> oracleMajorVersion >= 23
+                        || !LogCollectingTestResource.format(r).contains("ORA-00942"))
+                .filter(r -> oracleMajorVersion >= 23
+                        || !LogCollectingTestResource.format(r).contains("ORA-02289")))
                 // There shouldn't be any warning or error
                 .as("Startup logs (warning or higher)")
                 .extracting(LogCollectingTestResource::format)


### PR DESCRIPTION
Oracle < 23 does not support "DROP TABLE IF EXISTS", so Hibernate's drop-and-create schema generation logs an ORA-00942 warning when the table doesn't exist yet on first run, causing a test failure and a rerun. On following runs the table exists (was created in the first run) so the warning is avoided and the test passes. Hence the flakiness.

=> Ignore that specific warning on Oracle versions below 23.

cc @gsmet @geoand since you'll probably notice this flaky test on other PRs -- this is the solution.