### PR TITLE
Jakarta REST 4 EntityPart support for server and client

### DIFF
--- a/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -66,6 +66,7 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.client.RxInvoker;
 import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.EntityPart;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedHashMap;
@@ -92,6 +93,7 @@ import org.jboss.jandex.TypeVariable;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.client.api.ClientMultipartForm;
 import org.jboss.resteasy.reactive.client.handlers.ClientObservabilityHandler;
+import org.jboss.resteasy.reactive.client.handlers.ClientSendRequestHandler;
 import org.jboss.resteasy.reactive.client.impl.AsyncInvokerImpl;
 import org.jboss.resteasy.reactive.client.impl.ClientBuilderImpl;
 import org.jboss.resteasy.reactive.client.impl.ClientImpl;
@@ -206,6 +208,7 @@ public class JaxrsClientReactiveProcessor {
     private static final String BUFFER_SIGNATURE = "L" + Buffer.class.getName().replace('.', '/') + ";";
     private static final String BYTE_ARRAY_SIGNATURE = "[B";
     private static final String FILE_UPLOAD_SIGNATURE = "L" + FileUpload.class.getName().replace('.', '/') + ";";
+    private static final String ENTITY_PART_SIGNATURE = "L" + EntityPart.class.getName().replace('.', '/') + ";";
 
     private static final Logger log = Logger.getLogger(JaxrsClientReactiveProcessor.class);
 
@@ -1392,6 +1395,7 @@ public class JaxrsClientReactiveProcessor {
                 || signature.equals(BYTE_ARRAY_SIGNATURE)
                 || signature.equals(MULTI_BYTE_SIGNATURE)
                 || signature.equals(FILE_UPLOAD_SIGNATURE)
+                || signature.equals(ENTITY_PART_SIGNATURE)
                 || partType != null);
     }
 
@@ -2329,6 +2333,11 @@ public class JaxrsClientReactiveProcessor {
         } else if (MULTI_BYTE_SIGNATURE.equals(parameterSignature)) {
             addMultiAsFile(bytecodeCreator, multipartForm, formParamName, mimeType, partFilename, fieldValue,
                     errorLocation);
+        } else if (typeStr.equals(EntityPart.class.getName())) {
+            bytecodeCreator.invokeStaticMethod(
+                    MethodDescriptor.ofMethod(ClientSendRequestHandler.class, "addEntityPartToForm",
+                            void.class, QuarkusMultipartForm.class, EntityPart.class),
+                    multipartForm, fieldValue);
         } else if (mimeType != null) {
             if (partFilename != null) {
                 log.warnf("Using the @PartFilename annotation is unsupported on the type '%s'. Problematic field is: '%s'",

--- a/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -66,6 +66,7 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.client.RxInvoker;
 import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.EntityPart;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedHashMap;
@@ -92,6 +93,7 @@ import org.jboss.jandex.TypeVariable;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.client.api.ClientMultipartForm;
 import org.jboss.resteasy.reactive.client.handlers.ClientObservabilityHandler;
+import org.jboss.resteasy.reactive.client.handlers.ClientSendRequestHandler;
 import org.jboss.resteasy.reactive.client.impl.AsyncInvokerImpl;
 import org.jboss.resteasy.reactive.client.impl.ClientBuilderImpl;
 import org.jboss.resteasy.reactive.client.impl.ClientImpl;
@@ -206,6 +208,7 @@ public class JaxrsClientReactiveProcessor {
     private static final String BUFFER_SIGNATURE = "L" + Buffer.class.getName().replace('.', '/') + ";";
     private static final String BYTE_ARRAY_SIGNATURE = "[B";
     private static final String FILE_UPLOAD_SIGNATURE = "L" + FileUpload.class.getName().replace('.', '/') + ";";
+    private static final String ENTITY_PART_SIGNATURE = "L" + EntityPart.class.getName().replace('.', '/') + ";";
 
     private static final Logger log = Logger.getLogger(JaxrsClientReactiveProcessor.class);
 
@@ -1403,6 +1406,7 @@ public class JaxrsClientReactiveProcessor {
                 || signature.equals(BYTE_ARRAY_SIGNATURE)
                 || signature.equals(MULTI_BYTE_SIGNATURE)
                 || signature.equals(FILE_UPLOAD_SIGNATURE)
+                || signature.equals(ENTITY_PART_SIGNATURE)
                 || partType != null);
     }
 
@@ -2340,6 +2344,11 @@ public class JaxrsClientReactiveProcessor {
         } else if (MULTI_BYTE_SIGNATURE.equals(parameterSignature)) {
             addMultiAsFile(bytecodeCreator, multipartForm, formParamName, mimeType, partFilename, fieldValue,
                     errorLocation);
+        } else if (typeStr.equals(EntityPart.class.getName())) {
+            bytecodeCreator.invokeStaticMethod(
+                    MethodDescriptor.ofMethod(ClientSendRequestHandler.class, "addEntityPartToForm",
+                            void.class, QuarkusMultipartForm.class, EntityPart.class),
+                    multipartForm, fieldValue);
         } else if (mimeType != null) {
             if (partFilename != null) {
                 log.warnf("Using the @PartFilename annotation is unsupported on the type '%s'. Problematic field is: '%s'",

--- a/extensions/resteasy-reactive/rest-client-jaxrs/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/ClientResponseBuilderFactory.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/ClientResponseBuilderFactory.java
@@ -5,7 +5,9 @@ import jakarta.ws.rs.core.Response;
 import org.jboss.resteasy.reactive.RestResponse.ResponseBuilder;
 import org.jboss.resteasy.reactive.client.impl.ClientResponseBuilderImpl;
 import org.jboss.resteasy.reactive.client.impl.ClientRestResponseBuilderImpl;
+import org.jboss.resteasy.reactive.client.spi.ClientContextResolver;
 import org.jboss.resteasy.reactive.common.core.ResponseBuilderFactory;
+import org.jboss.resteasy.reactive.common.core.Serialisers;
 
 /**
  * ResponseBuilderFactory used only when the server response builder factory is not available
@@ -24,5 +26,10 @@ public class ClientResponseBuilderFactory implements ResponseBuilderFactory {
     @Override
     public <T> ResponseBuilder<T> createRestResponse() {
         return new ClientRestResponseBuilderImpl<>();
+    }
+
+    @Override
+    public Serialisers getSerialisers() {
+        return ClientContextResolver.getInstance().resolve(Thread.currentThread().getContextClassLoader()).getSerialisers();
     }
 }

--- a/extensions/resteasy-reactive/rest-client-jaxrs/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/JaxrsClientReactiveRecorder.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/JaxrsClientReactiveRecorder.java
@@ -15,6 +15,7 @@ import org.jboss.resteasy.reactive.client.impl.ClientSerialisers;
 import org.jboss.resteasy.reactive.client.spi.MultipartResponseData;
 import org.jboss.resteasy.reactive.common.core.GenericTypeMapping;
 import org.jboss.resteasy.reactive.common.core.Serialisers;
+import org.jboss.resteasy.reactive.common.jaxrs.EntityPartBuilderImpl;
 
 import io.quarkus.resteasy.reactive.common.runtime.ResteasyReactiveCommonRecorder;
 import io.quarkus.runtime.RuntimeValue;
@@ -64,6 +65,7 @@ public class JaxrsClientReactiveRecorder extends ResteasyReactiveCommonRecorder 
         ClientSerialisers s = new ClientSerialisers();
         s.registerBuiltins(RuntimeType.CLIENT);
         serialisers = s;
+        EntityPartBuilderImpl.setSerialisersSupplier(() -> serialisers);
         return s;
     }
 

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/multipart/EntityPartClientTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/multipart/EntityPartClientTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -20,6 +21,9 @@ import jakarta.ws.rs.core.EntityPart;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.jboss.resteasy.reactive.MultipartForm;
+import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
@@ -36,7 +40,10 @@ public class EntityPartClientTest {
                 @Override
                 public JavaArchive get() {
                     return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(EchoResource.class);
+                            .addClasses(EchoResource.class, EntityPartWriterResource.class,
+                                    EchoFormResource.class,
+                                    EntityPartContainerClient.class, ClientFormWithEntityPart.class,
+                                    Greeting.class);
                 }
             });
 
@@ -70,6 +77,38 @@ public class EntityPartClientTest {
         }
     }
 
+    @Test
+    void entityPartBuilderUsesMessageBodyWriter() throws IOException {
+        Client client = ClientBuilder.newClient();
+        try {
+            Response response = client.target(baseUri).path("/entity-part-writer")
+                    .request(MediaType.TEXT_PLAIN)
+                    .get();
+
+            assertThat(response.getStatus()).isEqualTo(200);
+            assertThat(response.readEntity(String.class)).isEqualTo("{\"message\":\"hello\"}");
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void entityPartInClientContainer() throws IOException {
+        EntityPartContainerClient restClient = RestClientBuilder.newBuilder()
+                .baseUri(baseUri).build(EntityPartContainerClient.class);
+
+        ClientFormWithEntityPart form = new ClientFormWithEntityPart();
+        form.dataPart = EntityPart.withName("dataPart")
+                .content("some data")
+                .mediaType(MediaType.TEXT_PLAIN_TYPE)
+                .build();
+        form.name = "testName";
+
+        String result = restClient.send(form);
+        assertThat(result).contains("dataPart=some data");
+        assertThat(result).contains("name=testName");
+    }
+
     @Path("/echo-parts")
     public static class EchoResource {
 
@@ -84,5 +123,53 @@ public class EntityPartClientTest {
             }
             return String.join(",", results);
         }
+    }
+
+    @Path("/entity-part-writer")
+    public static class EntityPartWriterResource {
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String buildEntityPart() throws IOException {
+            Greeting g = new Greeting();
+            g.message = "hello";
+            EntityPart part = EntityPart.withName("data")
+                    .mediaType(MediaType.APPLICATION_JSON_TYPE)
+                    .content(g, Greeting.class)
+                    .build();
+            return new String(part.getContent().readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    @Path("/echo-form")
+    public static class EchoFormResource {
+
+        @POST
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        @Produces(MediaType.TEXT_PLAIN)
+        public String echo(@RestForm EntityPart dataPart, @RestForm String name) throws IOException {
+            String content = new String(dataPart.getContent().readAllBytes(), StandardCharsets.UTF_8);
+            return "dataPart=" + content + ",name=" + name;
+        }
+    }
+
+    @Path("/echo-form")
+    public interface EntityPartContainerClient {
+        @POST
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        @Produces(MediaType.TEXT_PLAIN)
+        String send(@MultipartForm ClientFormWithEntityPart form);
+    }
+
+    public static class ClientFormWithEntityPart {
+        @RestForm
+        public EntityPart dataPart;
+
+        @RestForm
+        public String name;
+    }
+
+    public static class Greeting {
+        public String message;
     }
 }

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/multipart/EntityPartClientTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/multipart/EntityPartClientTest.java
@@ -2,6 +2,7 @@ package io.quarkus.rest.client.reactive.multipart;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -20,6 +21,9 @@ import jakarta.ws.rs.core.EntityPart;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.jboss.resteasy.reactive.MultipartForm;
+import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
@@ -36,7 +40,8 @@ public class EntityPartClientTest {
                 @Override
                 public JavaArchive get() {
                     return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(EchoResource.class);
+                            .addClasses(EchoResource.class, EchoFormResource.class,
+                                    EntityPartContainerClient.class, ClientFormWithEntityPart.class);
                 }
             });
 
@@ -70,6 +75,46 @@ public class EntityPartClientTest {
         }
     }
 
+    @Test
+    void jsonEntityPartRoundTrip() throws IOException {
+        String json = "{\"message\":\"hello\"}";
+        List<EntityPart> parts = List.of(
+                EntityPart.withName("data")
+                        .content(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)))
+                        .mediaType(MediaType.APPLICATION_JSON_TYPE)
+                        .build());
+
+        Client client = ClientBuilder.newClient();
+        try {
+            Response response = client.target(baseUri).path("/echo-parts")
+                    .request(MediaType.TEXT_PLAIN)
+                    .post(Entity.entity(parts, MediaType.MULTIPART_FORM_DATA_TYPE));
+
+            assertThat(response.getStatus()).isEqualTo(200);
+            String body = response.readEntity(String.class);
+            assertThat(body).contains("data={\"message\":\"hello\"}");
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void entityPartInClientContainer() throws IOException {
+        EntityPartContainerClient restClient = RestClientBuilder.newBuilder()
+                .baseUri(baseUri).build(EntityPartContainerClient.class);
+
+        ClientFormWithEntityPart form = new ClientFormWithEntityPart();
+        form.dataPart = EntityPart.withName("dataPart")
+                .content("some data")
+                .mediaType(MediaType.TEXT_PLAIN_TYPE)
+                .build();
+        form.name = "testName";
+
+        String result = restClient.send(form);
+        assertThat(result).contains("dataPart=some data");
+        assertThat(result).contains("name=testName");
+    }
+
     @Path("/echo-parts")
     public static class EchoResource {
 
@@ -84,5 +129,33 @@ public class EntityPartClientTest {
             }
             return String.join(",", results);
         }
+    }
+
+    @Path("/echo-form")
+    public static class EchoFormResource {
+
+        @POST
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        @Produces(MediaType.TEXT_PLAIN)
+        public String echo(@RestForm EntityPart dataPart, @RestForm String name) throws IOException {
+            String content = new String(dataPart.getContent().readAllBytes(), StandardCharsets.UTF_8);
+            return "dataPart=" + content + ",name=" + name;
+        }
+    }
+
+    @Path("/echo-form")
+    public interface EntityPartContainerClient {
+        @POST
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        @Produces(MediaType.TEXT_PLAIN)
+        String send(@MultipartForm ClientFormWithEntityPart form);
+    }
+
+    public static class ClientFormWithEntityPart {
+        @RestForm
+        public EntityPart dataPart;
+
+        @RestForm
+        public String name;
     }
 }

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -137,6 +137,7 @@ import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.processor.KotlinUtils;
 import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
@@ -1271,15 +1272,16 @@ public class ResteasyReactiveProcessor {
     }
 
     private void discoverServiceProviders(String serviceFile, Consumer<String> producer) {
-        try {
-            Set<String> classNames = new HashSet<>(ServiceUtil.classNamesNamedIn(
-                    Thread.currentThread().getContextClassLoader(), serviceFile));
-            for (String className : classNames) {
-                producer.accept(className);
+        QuarkusClassLoader.visitRuntimeResources(serviceFile, visit -> {
+            try {
+                Set<String> classNames = ServiceUtil.classNamesNamedIn(visit.getPath());
+                for (String className : classNames) {
+                    producer.accept(className);
+                }
+            } catch (IOException e) {
+                log.warn("Unable to properly detect and parse the contents of '" + serviceFile + "'", e);
             }
-        } catch (IOException e) {
-            log.warn("Unable to properly detect and parse the contents of '" + serviceFile + "'", e);
-        }
+        });
     }
 
     private static String determineHandledGenericTypeOfProviderInterface(Class<?> providerClass,

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -137,6 +137,7 @@ import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.processor.KotlinUtils;
 import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
@@ -1271,14 +1272,27 @@ public class ResteasyReactiveProcessor {
     }
 
     private void discoverServiceProviders(String serviceFile, Consumer<String> producer) {
-        try {
-            Set<String> classNames = new HashSet<>(ServiceUtil.classNamesNamedIn(
-                    Thread.currentThread().getContextClassLoader(), serviceFile));
-            for (String className : classNames) {
-                producer.accept(className);
+        if (Thread.currentThread().getContextClassLoader() instanceof QuarkusClassLoader) {
+            QuarkusClassLoader.visitRuntimeResources(serviceFile, visit -> {
+                try {
+                    Set<String> classNames = ServiceUtil.classNamesNamedIn(visit.getPath());
+                    for (String className : classNames) {
+                        producer.accept(className);
+                    }
+                } catch (IOException e) {
+                    log.warn("Unable to properly detect and parse the contents of '" + serviceFile + "'", e);
+                }
+            });
+        } else {
+            try {
+                Set<String> classNames = new HashSet<>(ServiceUtil.classNamesNamedIn(
+                        Thread.currentThread().getContextClassLoader(), serviceFile));
+                for (String className : classNames) {
+                    producer.accept(className);
+                }
+            } catch (IOException e) {
+                log.warn("Unable to properly detect and parse the contents of '" + serviceFile + "'", e);
             }
-        } catch (IOException e) {
-            log.warn("Unable to properly detect and parse the contents of '" + serviceFile + "'", e);
         }
     }
 

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/EntityPartFormParamTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/EntityPartFormParamTest.java
@@ -31,7 +31,7 @@ public class EntityPartFormParamTest {
                 @Override
                 public JavaArchive get() {
                     return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(Resource.class);
+                            .addClasses(Resource.class, FormDataWithEntityPart.class);
                 }
             });
 
@@ -78,6 +78,43 @@ public class EntityPartFormParamTest {
         assertThat(response).isEqualTo("name=Charlie,age=25");
     }
 
+    @Test
+    public void entityPartReaderWriterRoundTrip() {
+        String response = given()
+                .multiPart("value", "42")
+                .accept("text/plain")
+                .when()
+                .post("/entity-part-form/provider-roundtrip")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        assertThat(response).isEqualTo("42");
+    }
+
+    @Test
+    public void entityPartInContainer() {
+        String response = given()
+                .multiPart("file", "test.txt", "file content".getBytes(), "application/octet-stream")
+                .multiPart("name", "Alice")
+                .accept("text/plain")
+                .when()
+                .post("/entity-part-form/container")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        assertThat(response).isEqualTo("file=file content,name=Alice");
+    }
+
+    public static class FormDataWithEntityPart {
+        @RestForm
+        public EntityPart file;
+
+        @RestForm
+        public String name;
+    }
+
     @Path("/entity-part-form")
     public static class Resource {
 
@@ -106,6 +143,31 @@ public class EntityPartFormParamTest {
         public String mixed(@FormParam("name") EntityPart namePart, @FormParam("age") String age) throws IOException {
             String content = new String(namePart.getContent().readAllBytes(), StandardCharsets.UTF_8);
             return namePart.getName() + "=" + content + ",age=" + age;
+        }
+
+        @POST
+        @Path("provider-roundtrip")
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        @Produces(MediaType.TEXT_PLAIN)
+        public String providerRoundTrip(@RestForm EntityPart value) throws IOException {
+            // Reader path: deserialize text/plain content as Integer via MessageBodyReader
+            Integer num = value.getContent(Integer.class);
+            // Writer path: serialize Integer via MessageBodyWriter in EntityPart.Builder
+            EntityPart built = EntityPart.withName("result")
+                    .content(num, Integer.class)
+                    .mediaType(MediaType.TEXT_PLAIN_TYPE)
+                    .build();
+            // Read back the writer's output to verify it serialized correctly
+            return built.getContent(String.class);
+        }
+
+        @POST
+        @Path("container")
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        @Produces(MediaType.TEXT_PLAIN)
+        public String container(FormDataWithEntityPart form) throws IOException {
+            String fileContent = new String(form.file.getContent().readAllBytes(), StandardCharsets.UTF_8);
+            return "file=" + fileContent + ",name=" + form.name;
         }
     }
 }

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
@@ -27,6 +27,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.resteasy.reactive.common.core.BlockingOperationSupport;
 import org.jboss.resteasy.reactive.common.core.SingletonBeanFactory;
+import org.jboss.resteasy.reactive.common.jaxrs.EntityPartBuilderImpl;
 import org.jboss.resteasy.reactive.common.util.ServerMediaType;
 import org.jboss.resteasy.reactive.server.core.CurrentRequestManager;
 import org.jboss.resteasy.reactive.server.core.Deployment;
@@ -158,6 +159,7 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
         DisabledRestEndpoints.set(deployment.getDisabledEndpoints());
         initClassFactory.createInstance().getInstance().init(deployment);
         currentDeployment = deployment;
+        EntityPartBuilderImpl.setSerialisersSupplier(deployment::getSerialisers);
 
         if (LaunchMode.current() == LaunchMode.DEVELOPMENT) {
             // For Not Found Screen

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientResponseCompleteRestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientResponseCompleteRestHandler.java
@@ -4,7 +4,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.ParameterizedType;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -25,6 +24,7 @@ import org.jboss.resteasy.reactive.client.impl.multipart.FileDownloadImpl;
 import org.jboss.resteasy.reactive.client.spi.ClientRestHandler;
 import org.jboss.resteasy.reactive.client.spi.FieldFiller;
 import org.jboss.resteasy.reactive.client.spi.MultipartResponseData;
+import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.common.jaxrs.EntityPartImpl;
 import org.jboss.resteasy.reactive.common.jaxrs.ResponseImpl;
 import org.jboss.resteasy.reactive.common.jaxrs.StatusTypeImpl;
@@ -67,10 +67,11 @@ public class ClientResponseCompleteRestHandler implements ClientRestHandler {
             if (context.getResponseMultipartParts() != null) {
                 GenericType<?> responseType = context.getResponseType();
 
-                if (isEntityPartList(responseType)) {
+                if (EntityPartImpl.isEntityPartList(responseType.getType())) {
+                    Serialisers serialisers = context.getRestClient().getClientContext().getSerialisers();
                     List<EntityPart> entityParts = new ArrayList<>();
                     for (InterfaceHttpData httpData : context.getResponseMultipartParts()) {
-                        entityParts.add(nettyPartToEntityPart(httpData));
+                        entityParts.add(nettyPartToEntityPart(httpData, serialisers));
                     }
                     builder.entity(entityParts);
                 } else {
@@ -158,18 +159,7 @@ public class ClientResponseCompleteRestHandler implements ClientRestHandler {
         return builder.build();
     }
 
-    private static boolean isEntityPartList(GenericType<?> responseType) {
-        if (responseType.getRawType() != List.class) {
-            return false;
-        }
-        if (responseType.getType() instanceof ParameterizedType pt) {
-            java.lang.reflect.Type[] args = pt.getActualTypeArguments();
-            return args.length == 1 && args[0] == EntityPart.class;
-        }
-        return false;
-    }
-
-    private static EntityPart nettyPartToEntityPart(InterfaceHttpData httpData) throws IOException {
+    private static EntityPart nettyPartToEntityPart(InterfaceHttpData httpData, Serialisers serialisers) throws IOException {
         String name = httpData.getName();
         String fileName = null;
         InputStream content;
@@ -190,13 +180,9 @@ public class ClientResponseCompleteRestHandler implements ClientRestHandler {
         }
 
         headers.putSingle("Content-Type", mediaType.toString());
-        StringBuilder cd = new StringBuilder("form-data; name=\"").append(name).append("\"");
-        if (fileName != null) {
-            cd.append("; filename=\"").append(fileName).append("\"");
-        }
-        headers.putSingle("Content-Disposition", cd.toString());
+        headers.putSingle("Content-Disposition", EntityPartImpl.buildContentDisposition(name, fileName));
 
-        return new EntityPartImpl(name, fileName, headers, mediaType, content);
+        return new EntityPartImpl(name, fileName, headers, mediaType, content, serialisers);
     }
 
 }

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
@@ -8,6 +8,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -17,6 +18,8 @@ import java.util.function.Function;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.EntityPart;
+import jakarta.ws.rs.core.GenericEntity;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -39,6 +42,7 @@ import org.jboss.resteasy.reactive.client.impl.multipart.QuarkusMultipartRespons
 import org.jboss.resteasy.reactive.client.spi.ClientRestHandler;
 import org.jboss.resteasy.reactive.client.spi.MultipartResponseData;
 import org.jboss.resteasy.reactive.common.core.Serialisers;
+import org.jboss.resteasy.reactive.common.jaxrs.EntityPartImpl;
 import org.jboss.resteasy.reactive.common.util.MultivaluedTreeMap;
 
 import io.netty.buffer.ByteBufInputStream;
@@ -344,7 +348,9 @@ public class ClientSendRequestHandler implements ClientRestHandler {
                         QuarkusMultipartResponseDecoder multipartDecoder = new QuarkusMultipartResponseDecoder(
                                 clientResponse);
 
-                        java.util.List<io.vertx.core.buffer.Buffer> rawBuffers = new java.util.ArrayList<>();
+                        // Collect raw buffers so we can reconstruct an entity stream for MessageBodyReader usage
+                        // (e.g. Response.readEntity with a custom reader), since the Netty decoder consumes the data
+                        List<Buffer> rawBuffers = new ArrayList<>();
                         clientResponse.handler(buffer -> {
                             rawBuffers.add(buffer.copy());
                             multipartDecoder.offer(buffer);
@@ -358,8 +364,8 @@ public class ClientSendRequestHandler implements ClientRestHandler {
                                 List<InterfaceHttpData> datas = multipartDecoder.getBodyHttpDatas();
                                 requestContext.setResponseMultipartParts(datas);
 
-                                io.vertx.core.buffer.Buffer combined = io.vertx.core.buffer.Buffer.buffer();
-                                for (io.vertx.core.buffer.Buffer b : rawBuffers) {
+                                Buffer combined = Buffer.buffer();
+                                for (Buffer b : rawBuffers) {
                                     combined.appendBuffer(b);
                                 }
                                 if (combined.length() > 0) {
@@ -585,14 +591,16 @@ public class ClientSendRequestHandler implements ClientRestHandler {
             RestClientRequestContext state) throws Exception {
         QuarkusMultipartForm multipartForm;
         Object entityObj = state.getEntity().getEntity();
-        if (entityObj instanceof jakarta.ws.rs.core.GenericEntity<?> ge) {
+        boolean entityPartList = false;
+        if (entityObj instanceof GenericEntity<?> ge) {
+            entityPartList = EntityPartImpl.isEntityPartList(ge.getType());
             entityObj = ge.getEntity();
         }
         if (entityObj instanceof QuarkusMultipartForm) {
             multipartForm = (QuarkusMultipartForm) entityObj;
-        } else if (entityObj instanceof List<?> list && !list.isEmpty()
-                && list.get(0) instanceof jakarta.ws.rs.core.EntityPart) {
-            multipartForm = entityPartsToMultipartForm((List<jakarta.ws.rs.core.EntityPart>) list);
+        } else if (entityObj instanceof List<?> list
+                && (entityPartList || (!list.isEmpty() && list.get(0) instanceof EntityPart))) {
+            multipartForm = entityPartsToMultipartForm((List<EntityPart>) list);
         } else {
             throw new IllegalArgumentException(
                     "Multipart form upload expects an entity of type MultipartForm or List<EntityPart>, got: " + entityObj);
@@ -703,33 +711,38 @@ public class ClientSendRequestHandler implements ClientRestHandler {
         }
     }
 
-    private QuarkusMultipartForm entityPartsToMultipartForm(List<jakarta.ws.rs.core.EntityPart> parts) throws IOException {
+    private QuarkusMultipartForm entityPartsToMultipartForm(List<EntityPart> parts) throws IOException {
         QuarkusMultipartForm form = new QuarkusMultipartForm();
-        for (jakarta.ws.rs.core.EntityPart part : parts) {
-            String name = part.getName();
-            String fileName = part.getFileName().orElse(null);
-            MediaType mediaType = part.getMediaType();
-            String mediaTypeStr = mediaType != null ? mediaType.toString() : MediaType.APPLICATION_OCTET_STREAM;
-            Buffer content = Buffer.buffer(part.getContent().readAllBytes());
-
-            if (fileName != null) {
-                boolean isText = mediaType != null && mediaType.getType().equals("text");
-                if (isText) {
-                    form.textFileUpload(name, fileName, content, mediaTypeStr);
-                } else {
-                    form.binaryFileUpload(name, fileName, content, mediaTypeStr);
-                }
-            } else {
-                boolean isText = mediaType == null || mediaType.equals(MediaType.TEXT_PLAIN_TYPE)
-                        || mediaType.getType().equals("text");
-                if (isText) {
-                    form.attribute(name, content.toString(), null);
-                } else {
-                    form.binaryFileUpload(name, name, content, mediaTypeStr);
-                }
-            }
+        for (EntityPart part : parts) {
+            addEntityPartToForm(form, part);
         }
         return form;
+    }
+
+    public static void addEntityPartToForm(QuarkusMultipartForm form, EntityPart part) throws IOException {
+        String name = part.getName();
+        String fileName = part.getFileName().orElse(null);
+        MediaType mediaType = part.getMediaType();
+        String mediaTypeStr = mediaType != null ? mediaType.toString() : MediaType.APPLICATION_OCTET_STREAM;
+        Buffer content = Buffer.buffer(part.getContent().readAllBytes());
+
+        if (fileName != null) {
+            boolean isText = mediaType != null && mediaType.getType().equals("text");
+            if (isText) {
+                form.textFileUpload(name, fileName, content, mediaTypeStr);
+            } else {
+                form.binaryFileUpload(name, fileName, content, mediaTypeStr);
+            }
+        } else {
+            boolean isText = mediaType == null || mediaType.equals(MediaType.TEXT_PLAIN_TYPE)
+                    || mediaType.getType().equals("text");
+            if (isText) {
+                form.attribute(name, content.toString(), null);
+            } else {
+                // empty fileName tells PausableHttpPostRequestEncoder to omit filename= from Content-Disposition
+                form.binaryFileUpload(name, "", content, mediaTypeStr);
+            }
+        }
     }
 
     private void setEntityRelatedHeaders(MultivaluedMap<String, String> headerMap, Entity<?> entity) {

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
@@ -8,6 +8,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -17,6 +18,8 @@ import java.util.function.Function;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.EntityPart;
+import jakarta.ws.rs.core.GenericEntity;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -39,6 +42,7 @@ import org.jboss.resteasy.reactive.client.impl.multipart.QuarkusMultipartRespons
 import org.jboss.resteasy.reactive.client.spi.ClientRestHandler;
 import org.jboss.resteasy.reactive.client.spi.MultipartResponseData;
 import org.jboss.resteasy.reactive.common.core.Serialisers;
+import org.jboss.resteasy.reactive.common.jaxrs.EntityPartImpl;
 import org.jboss.resteasy.reactive.common.util.MultivaluedTreeMap;
 
 import io.netty.buffer.ByteBufInputStream;
@@ -344,7 +348,9 @@ public class ClientSendRequestHandler implements ClientRestHandler {
                         QuarkusMultipartResponseDecoder multipartDecoder = new QuarkusMultipartResponseDecoder(
                                 clientResponse);
 
-                        java.util.List<io.vertx.core.buffer.Buffer> rawBuffers = new java.util.ArrayList<>();
+                        // Collect raw buffers so we can reconstruct an entity stream for MessageBodyReader usage
+                        // (e.g. Response.readEntity with a custom reader), since the Netty decoder consumes the data
+                        List<Buffer> rawBuffers = new ArrayList<>();
                         clientResponse.handler(buffer -> {
                             rawBuffers.add(buffer.copy());
                             multipartDecoder.offer(buffer);
@@ -358,8 +364,8 @@ public class ClientSendRequestHandler implements ClientRestHandler {
                                 List<InterfaceHttpData> datas = multipartDecoder.getBodyHttpDatas();
                                 requestContext.setResponseMultipartParts(datas);
 
-                                io.vertx.core.buffer.Buffer combined = io.vertx.core.buffer.Buffer.buffer();
-                                for (io.vertx.core.buffer.Buffer b : rawBuffers) {
+                                Buffer combined = Buffer.buffer();
+                                for (Buffer b : rawBuffers) {
                                     combined.appendBuffer(b);
                                 }
                                 if (combined.length() > 0) {
@@ -585,14 +591,16 @@ public class ClientSendRequestHandler implements ClientRestHandler {
             RestClientRequestContext state) throws Exception {
         QuarkusMultipartForm multipartForm;
         Object entityObj = state.getEntity().getEntity();
-        if (entityObj instanceof jakarta.ws.rs.core.GenericEntity<?> ge) {
+        boolean entityPartList = false;
+        if (entityObj instanceof GenericEntity<?> ge) {
+            entityPartList = EntityPartImpl.isEntityPartList(ge.getType());
             entityObj = ge.getEntity();
         }
         if (entityObj instanceof QuarkusMultipartForm) {
             multipartForm = (QuarkusMultipartForm) entityObj;
-        } else if (entityObj instanceof List<?> list && !list.isEmpty()
-                && list.get(0) instanceof jakarta.ws.rs.core.EntityPart) {
-            multipartForm = entityPartsToMultipartForm((List<jakarta.ws.rs.core.EntityPart>) list);
+        } else if (entityObj instanceof List<?> list
+                && (entityPartList || (!list.isEmpty() && list.get(0) instanceof EntityPart))) {
+            multipartForm = entityPartsToMultipartForm((List<EntityPart>) list);
         } else {
             throw new IllegalArgumentException(
                     "Multipart form upload expects an entity of type MultipartForm or List<EntityPart>, got: " + entityObj);
@@ -703,9 +711,16 @@ public class ClientSendRequestHandler implements ClientRestHandler {
         }
     }
 
-    private QuarkusMultipartForm entityPartsToMultipartForm(List<jakarta.ws.rs.core.EntityPart> parts) throws IOException {
+    private QuarkusMultipartForm entityPartsToMultipartForm(List<EntityPart> parts) throws IOException {
         QuarkusMultipartForm form = new QuarkusMultipartForm();
-        for (jakarta.ws.rs.core.EntityPart part : parts) {
+        for (EntityPart part : parts) {
+            addEntityPartToForm(form, part);
+        }
+        return form;
+    }
+
+    public static void addEntityPartToForm(QuarkusMultipartForm form, EntityPart part) {
+        try {
             String name = part.getName();
             String fileName = part.getFileName().orElse(null);
             MediaType mediaType = part.getMediaType();
@@ -725,11 +740,13 @@ public class ClientSendRequestHandler implements ClientRestHandler {
                 if (isText) {
                     form.attribute(name, content.toString(), null);
                 } else {
-                    form.binaryFileUpload(name, name, content, mediaTypeStr);
+                    // empty fileName tells PausableHttpPostRequestEncoder to omit filename= from Content-Disposition
+                    form.binaryFileUpload(name, "", content, mediaTypeStr);
                 }
             }
+        } catch (IOException e) {
+            throw new java.io.UncheckedIOException(e);
         }
-        return form;
     }
 
     private void setEntityRelatedHeaders(MultivaluedMap<String, String> headerMap, Entity<?> entity) {

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import jakarta.ws.rs.RuntimeType;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.EntityPart;
 import jakarta.ws.rs.core.GenericEntity;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.MediaType;
@@ -40,6 +41,7 @@ import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestConte
 import org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext;
 import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.common.jaxrs.ConfigurationImpl;
+import org.jboss.resteasy.reactive.common.jaxrs.EntityPartImpl;
 import org.jboss.resteasy.reactive.common.jaxrs.ResponseImpl;
 import org.jboss.resteasy.reactive.common.util.CaseInsensitiveMap;
 import org.jboss.resteasy.reactive.spi.ThreadSetupAction;
@@ -564,14 +566,16 @@ public class RestClientRequestContext extends AbstractResteasyReactiveContext<Re
             return false;
         }
         Object entityObj = entity.getEntity();
+        boolean entityPartList = false;
         if (entityObj instanceof GenericEntity<?> ge) {
+            entityPartList = EntityPartImpl.isEntityPartList(ge.getType());
             entityObj = ge.getEntity();
         }
         if (entityObj instanceof QuarkusMultipartForm) {
             return true;
         }
-        if (entityObj instanceof java.util.List<?> list && !list.isEmpty()
-                && list.get(0) instanceof jakarta.ws.rs.core.EntityPart) {
+        if (entityObj instanceof List<?> list
+                && (entityPartList || (!list.isEmpty() && list.get(0) instanceof EntityPart))) {
             return true;
         }
         return false;

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
@@ -64,6 +64,7 @@ import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Configuration;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.EntityPart;
 import jakarta.ws.rs.core.Feature;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -295,7 +296,7 @@ public final class ResteasyReactiveDotNames {
 
     public static final DotName MULTI_PART_DATA_INPUT = DotName
             .createSimple("org.jboss.resteasy.reactive.server.multipart.MultipartFormDataInput");
-    public static final DotName ENTITY_PART = DotName.createSimple("jakarta.ws.rs.core.EntityPart");
+    public static final DotName ENTITY_PART = DotName.createSimple(EntityPart.class);
     public static final DotName OBJECT_NAME = DotName.createSimple(Object.class.getName());
     // Types ignored for reflection used by the RESTEasy and SmallRye REST client extensions.
     private static final Set<DotName> TYPES_IGNORED_FOR_REFLECTION = new HashSet<>(Arrays.asList(

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/ResponseBuilderFactory.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/ResponseBuilderFactory.java
@@ -12,4 +12,5 @@ public interface ResponseBuilderFactory {
 
     <T> RestResponse.ResponseBuilder<T> createRestResponse();
 
+    Serialisers getSerialisers();
 }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/EntityPartBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/EntityPartBuilderImpl.java
@@ -1,31 +1,44 @@
 package org.jboss.resteasy.reactive.common.jaxrs;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.EntityPart;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyWriter;
 
+import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.common.util.QuarkusMultivaluedHashMap;
 
 public class EntityPartBuilderImpl implements EntityPart.Builder {
+
+    private static final Annotation[] EMPTY_ANNOTATIONS = new Annotation[0];
 
     private final String name;
     private String fileName;
     private MediaType mediaType;
     private MultivaluedMap<String, String> headers;
-    private InputStream content;
+    private Serialisers serialisers;
 
-    public EntityPartBuilderImpl(String name) {
+    private Object content;
+    private Class<?> contentType;
+    private Type contentGenericType;
+
+    public EntityPartBuilderImpl(String name, Serialisers serialisers) {
         if (name == null) {
             throw new IllegalArgumentException("name must not be null");
         }
         this.name = name;
+        this.serialisers = serialisers;
         this.mediaType = MediaType.APPLICATION_OCTET_STREAM_TYPE;
         this.headers = new QuarkusMultivaluedHashMap<>();
     }
@@ -84,6 +97,8 @@ public class EntityPartBuilderImpl implements EntityPart.Builder {
             throw new IllegalArgumentException("content must not be null");
         }
         this.content = content;
+        this.contentType = null;
+        this.contentGenericType = null;
         return this;
     }
 
@@ -95,18 +110,9 @@ public class EntityPartBuilderImpl implements EntityPart.Builder {
         if (type == null) {
             throw new IllegalArgumentException("type must not be null");
         }
-        if (content instanceof InputStream) {
-            this.content = (InputStream) content;
-        } else if (content instanceof String) {
-            if (mediaType == MediaType.APPLICATION_OCTET_STREAM_TYPE) {
-                mediaType = MediaType.TEXT_PLAIN_TYPE;
-            }
-            this.content = new ByteArrayInputStream(((String) content).getBytes(StandardCharsets.UTF_8));
-        } else if (content instanceof byte[]) {
-            this.content = new ByteArrayInputStream((byte[]) content);
-        } else {
-            this.content = new ByteArrayInputStream(content.toString().getBytes(StandardCharsets.UTF_8));
-        }
+        this.content = content;
+        this.contentType = type;
+        this.contentGenericType = type;
         return this;
     }
 
@@ -118,7 +124,49 @@ public class EntityPartBuilderImpl implements EntityPart.Builder {
         if (type == null) {
             throw new IllegalArgumentException("type must not be null");
         }
-        return content(content, (Class<T>) type.getRawType());
+        this.content = content;
+        this.contentType = type.getRawType();
+        this.contentGenericType = type.getType();
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> InputStream serialiseContent() {
+        T content = (T) this.content;
+        Class<T> rawType = (Class<T>) contentType;
+        Type genericType = contentGenericType;
+
+        if (content instanceof String) {
+            if (mediaType == MediaType.APPLICATION_OCTET_STREAM_TYPE) {
+                mediaType = MediaType.TEXT_PLAIN_TYPE;
+            }
+            return new ByteArrayInputStream(((String) content).getBytes(StandardCharsets.UTF_8));
+        } else if (content instanceof byte[]) {
+            return new ByteArrayInputStream((byte[]) content);
+        } else if (serialisers != null) {
+            MessageBodyWriter<T> writer = null;
+            List<MessageBodyWriter<?>> writers = serialisers.findWriters(null, rawType, mediaType);
+            for (MessageBodyWriter<?> w : writers) {
+                if (w.isWriteable(rawType, genericType, EMPTY_ANNOTATIONS, mediaType)) {
+                    writer = (MessageBodyWriter<T>) w;
+                    break;
+                }
+            }
+            if (writer != null) {
+                try {
+                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                    writer.writeTo(content, rawType, genericType, EMPTY_ANNOTATIONS, mediaType,
+                            new QuarkusMultivaluedHashMap<>(), baos);
+                    return new ByteArrayInputStream(baos.toByteArray());
+                } catch (IOException e) {
+                    throw new IllegalArgumentException("Failed to serialize content of type " + rawType.getName(), e);
+                }
+            } else {
+                return new ByteArrayInputStream(content.toString().getBytes(StandardCharsets.UTF_8));
+            }
+        } else {
+            return new ByteArrayInputStream(content.toString().getBytes(StandardCharsets.UTF_8));
+        }
     }
 
     @Override
@@ -127,17 +175,19 @@ public class EntityPartBuilderImpl implements EntityPart.Builder {
             throw new IllegalStateException("No content has been set");
         }
 
+        InputStream resolvedContent;
+        if (content instanceof InputStream) {
+            resolvedContent = (InputStream) content;
+        } else {
+            resolvedContent = serialiseContent();
+        }
+
         MultivaluedMap<String, String> builtHeaders = new QuarkusMultivaluedHashMap<>();
         builtHeaders.putAll(headers);
 
         builtHeaders.putSingle("Content-Type", mediaType.toString());
+        builtHeaders.putSingle("Content-Disposition", EntityPartImpl.buildContentDisposition(name, fileName));
 
-        StringBuilder cd = new StringBuilder("form-data; name=\"").append(name).append("\"");
-        if (fileName != null) {
-            cd.append("; filename=\"").append(fileName).append("\"");
-        }
-        builtHeaders.putSingle("Content-Disposition", cd.toString());
-
-        return new EntityPartImpl(name, fileName, builtHeaders, mediaType, content);
+        return new EntityPartImpl(name, fileName, builtHeaders, mediaType, resolvedContent, serialisers);
     }
 }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/EntityPartBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/EntityPartBuilderImpl.java
@@ -1,31 +1,52 @@
 package org.jboss.resteasy.reactive.common.jaxrs;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.function.Supplier;
 
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.EntityPart;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyWriter;
 
+import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.common.util.QuarkusMultivaluedHashMap;
 
 public class EntityPartBuilderImpl implements EntityPart.Builder {
+
+    private static final Annotation[] EMPTY_ANNOTATIONS = new Annotation[0];
+
+    private static volatile Supplier<Serialisers> serialisersSupplier;
+
+    public static void setSerialisersSupplier(Supplier<Serialisers> supplier) {
+        serialisersSupplier = supplier;
+    }
 
     private final String name;
     private String fileName;
     private MediaType mediaType;
     private MultivaluedMap<String, String> headers;
     private InputStream content;
+    private Serialisers serialisers;
 
     public EntityPartBuilderImpl(String name) {
+        this(name, serialisersSupplier != null ? serialisersSupplier.get() : null);
+    }
+
+    public EntityPartBuilderImpl(String name, Serialisers serialisers) {
         if (name == null) {
             throw new IllegalArgumentException("name must not be null");
         }
         this.name = name;
+        this.serialisers = serialisers;
         this.mediaType = MediaType.APPLICATION_OCTET_STREAM_TYPE;
         this.headers = new QuarkusMultivaluedHashMap<>();
     }
@@ -87,6 +108,7 @@ public class EntityPartBuilderImpl implements EntityPart.Builder {
         return this;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <T> EntityPart.Builder content(T content, Class<? extends T> type) throws IllegalArgumentException {
         if (content == null) {
@@ -95,6 +117,23 @@ public class EntityPartBuilderImpl implements EntityPart.Builder {
         if (type == null) {
             throw new IllegalArgumentException("type must not be null");
         }
+        return writeContent(content, (Class<T>) type, type);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> EntityPart.Builder content(T content, GenericType<T> type) throws IllegalArgumentException {
+        if (content == null) {
+            throw new IllegalArgumentException("content must not be null");
+        }
+        if (type == null) {
+            throw new IllegalArgumentException("type must not be null");
+        }
+        return writeContent(content, (Class<T>) type.getRawType(), type.getType());
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> EntityPart.Builder writeContent(T content, Class<T> rawType, Type genericType) {
         if (content instanceof InputStream) {
             this.content = (InputStream) content;
         } else if (content instanceof String) {
@@ -104,21 +143,31 @@ public class EntityPartBuilderImpl implements EntityPart.Builder {
             this.content = new ByteArrayInputStream(((String) content).getBytes(StandardCharsets.UTF_8));
         } else if (content instanceof byte[]) {
             this.content = new ByteArrayInputStream((byte[]) content);
+        } else if (serialisers != null) {
+            MessageBodyWriter<T> writer = null;
+            List<MessageBodyWriter<?>> writers = serialisers.findWriters(null, rawType, mediaType);
+            for (MessageBodyWriter<?> w : writers) {
+                if (w.isWriteable(rawType, genericType, EMPTY_ANNOTATIONS, mediaType)) {
+                    writer = (MessageBodyWriter<T>) w;
+                    break;
+                }
+            }
+            if (writer != null) {
+                try {
+                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                    writer.writeTo(content, rawType, genericType, EMPTY_ANNOTATIONS, mediaType,
+                            new QuarkusMultivaluedHashMap<>(), baos);
+                    this.content = new ByteArrayInputStream(baos.toByteArray());
+                } catch (IOException e) {
+                    throw new IllegalArgumentException("Failed to serialize content of type " + rawType.getName(), e);
+                }
+            } else {
+                this.content = new ByteArrayInputStream(content.toString().getBytes(StandardCharsets.UTF_8));
+            }
         } else {
             this.content = new ByteArrayInputStream(content.toString().getBytes(StandardCharsets.UTF_8));
         }
         return this;
-    }
-
-    @Override
-    public <T> EntityPart.Builder content(T content, GenericType<T> type) throws IllegalArgumentException {
-        if (content == null) {
-            throw new IllegalArgumentException("content must not be null");
-        }
-        if (type == null) {
-            throw new IllegalArgumentException("type must not be null");
-        }
-        return content(content, (Class<T>) type.getRawType());
     }
 
     @Override
@@ -131,12 +180,7 @@ public class EntityPartBuilderImpl implements EntityPart.Builder {
         builtHeaders.putAll(headers);
 
         builtHeaders.putSingle("Content-Type", mediaType.toString());
-
-        StringBuilder cd = new StringBuilder("form-data; name=\"").append(name).append("\"");
-        if (fileName != null) {
-            cd.append("; filename=\"").append(fileName).append("\"");
-        }
-        builtHeaders.putSingle("Content-Disposition", cd.toString());
+        builtHeaders.putSingle("Content-Disposition", EntityPartImpl.buildContentDisposition(name, fileName));
 
         return new EntityPartImpl(name, fileName, builtHeaders, mediaType, content);
     }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/EntityPartImpl.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/EntityPartImpl.java
@@ -2,6 +2,10 @@ package org.jboss.resteasy.reactive.common.jaxrs;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -10,23 +14,30 @@ import jakarta.ws.rs.core.EntityPart;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+
+import org.jboss.resteasy.reactive.common.core.Serialisers;
 
 public class EntityPartImpl implements EntityPart {
+
+    private static final Annotation[] EMPTY_ANNOTATIONS = new Annotation[0];
 
     private final String name;
     private final String fileName;
     private final MultivaluedMap<String, String> headers;
     private final MediaType mediaType;
     private final InputStream content;
+    private final Serialisers serialisers;
     private final AtomicBoolean contentConsumed = new AtomicBoolean(false);
 
     public EntityPartImpl(String name, String fileName, MultivaluedMap<String, String> headers,
-            MediaType mediaType, InputStream content) {
+            MediaType mediaType, InputStream content, Serialisers serialisers) {
         this.name = name;
         this.fileName = fileName;
         this.headers = headers;
         this.mediaType = mediaType;
         this.content = content;
+        this.serialisers = serialisers;
     }
 
     @Override
@@ -53,23 +64,41 @@ public class EntityPartImpl implements EntityPart {
         if (!contentConsumed.compareAndSet(false, true)) {
             throw new IllegalStateException("getContent() has already been invoked");
         }
-        if (type == InputStream.class) {
-            return type.cast(content);
-        }
-        if (type == String.class) {
-            return type.cast(new String(content.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8));
-        }
-        if (type == byte[].class) {
-            return type.cast(content.readAllBytes());
-        }
-        throw new IllegalArgumentException(
-                "Unsupported type: " + type.getName() + ". Use InputStream, String, or byte[].");
+        return readContent(type, type);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <T> T getContent(GenericType<T> type)
             throws IllegalArgumentException, IllegalStateException, IOException, WebApplicationException {
-        return getContent((Class<T>) type.getRawType());
+        if (!contentConsumed.compareAndSet(false, true)) {
+            throw new IllegalStateException("getContent() has already been invoked");
+        }
+        return readContent((Class<T>) type.getRawType(), type.getType());
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T readContent(Class<T> rawType, Type genericType) throws IOException, WebApplicationException {
+        if (rawType == InputStream.class) {
+            return rawType.cast(content);
+        }
+        if (rawType == String.class) {
+            return rawType.cast(new String(content.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8));
+        }
+        if (rawType == byte[].class) {
+            return rawType.cast(content.readAllBytes());
+        }
+        if (serialisers != null) {
+            List<MessageBodyReader<?>> readers = serialisers.findReaders(null, rawType, mediaType);
+            for (MessageBodyReader<?> r : readers) {
+                if (r.isReadable(rawType, genericType, EMPTY_ANNOTATIONS, mediaType)) {
+                    MessageBodyReader<T> reader = (MessageBodyReader<T>) r;
+                    return reader.readFrom(rawType, genericType, EMPTY_ANNOTATIONS, mediaType, headers, content);
+                }
+            }
+        }
+        throw new IllegalArgumentException(
+                "Unsupported type: " + rawType.getName() + ". Use InputStream, String, or byte[].");
     }
 
     @Override
@@ -80,5 +109,27 @@ public class EntityPartImpl implements EntityPart {
     @Override
     public MediaType getMediaType() {
         return mediaType;
+    }
+
+    public static boolean isEntityPartList(Type type) {
+        if (type instanceof ParameterizedType pt) {
+            if (pt.getRawType() == List.class) {
+                Type[] args = pt.getActualTypeArguments();
+                return args.length == 1 && args[0] == EntityPart.class;
+            }
+        }
+        return false;
+    }
+
+    public static String buildContentDisposition(String name, String fileName) {
+        StringBuilder cd = new StringBuilder("form-data; name=\"").append(escapeQuotes(name)).append("\"");
+        if (fileName != null) {
+            cd.append("; filename=\"").append(escapeQuotes(fileName)).append("\"");
+        }
+        return cd.toString();
+    }
+
+    private static String escapeQuotes(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/EntityPartImpl.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/EntityPartImpl.java
@@ -2,6 +2,10 @@ package org.jboss.resteasy.reactive.common.jaxrs;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -10,23 +14,35 @@ import jakarta.ws.rs.core.EntityPart;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+
+import org.jboss.resteasy.reactive.common.core.Serialisers;
 
 public class EntityPartImpl implements EntityPart {
+
+    private static final Annotation[] EMPTY_ANNOTATIONS = new Annotation[0];
 
     private final String name;
     private final String fileName;
     private final MultivaluedMap<String, String> headers;
     private final MediaType mediaType;
     private final InputStream content;
+    private final Serialisers serialisers;
     private final AtomicBoolean contentConsumed = new AtomicBoolean(false);
 
     public EntityPartImpl(String name, String fileName, MultivaluedMap<String, String> headers,
             MediaType mediaType, InputStream content) {
+        this(name, fileName, headers, mediaType, content, null);
+    }
+
+    public EntityPartImpl(String name, String fileName, MultivaluedMap<String, String> headers,
+            MediaType mediaType, InputStream content, Serialisers serialisers) {
         this.name = name;
         this.fileName = fileName;
         this.headers = headers;
         this.mediaType = mediaType;
         this.content = content;
+        this.serialisers = serialisers;
     }
 
     @Override
@@ -53,23 +69,41 @@ public class EntityPartImpl implements EntityPart {
         if (!contentConsumed.compareAndSet(false, true)) {
             throw new IllegalStateException("getContent() has already been invoked");
         }
-        if (type == InputStream.class) {
-            return type.cast(content);
-        }
-        if (type == String.class) {
-            return type.cast(new String(content.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8));
-        }
-        if (type == byte[].class) {
-            return type.cast(content.readAllBytes());
-        }
-        throw new IllegalArgumentException(
-                "Unsupported type: " + type.getName() + ". Use InputStream, String, or byte[].");
+        return readContent(type, type);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <T> T getContent(GenericType<T> type)
             throws IllegalArgumentException, IllegalStateException, IOException, WebApplicationException {
-        return getContent((Class<T>) type.getRawType());
+        if (!contentConsumed.compareAndSet(false, true)) {
+            throw new IllegalStateException("getContent() has already been invoked");
+        }
+        return readContent((Class<T>) type.getRawType(), type.getType());
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T readContent(Class<T> rawType, Type genericType) throws IOException, WebApplicationException {
+        if (rawType == InputStream.class) {
+            return rawType.cast(content);
+        }
+        if (rawType == String.class) {
+            return rawType.cast(new String(content.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8));
+        }
+        if (rawType == byte[].class) {
+            return rawType.cast(content.readAllBytes());
+        }
+        if (serialisers != null) {
+            List<MessageBodyReader<?>> readers = serialisers.findReaders(null, rawType, mediaType);
+            for (MessageBodyReader<?> r : readers) {
+                if (r.isReadable(rawType, genericType, EMPTY_ANNOTATIONS, mediaType)) {
+                    MessageBodyReader<T> reader = (MessageBodyReader<T>) r;
+                    return reader.readFrom(rawType, genericType, EMPTY_ANNOTATIONS, mediaType, headers, content);
+                }
+            }
+        }
+        throw new IllegalArgumentException(
+                "Unsupported type: " + rawType.getName() + ". Use InputStream, String, or byte[].");
     }
 
     @Override
@@ -80,5 +114,27 @@ public class EntityPartImpl implements EntityPart {
     @Override
     public MediaType getMediaType() {
         return mediaType;
+    }
+
+    public static boolean isEntityPartList(Type type) {
+        if (type instanceof ParameterizedType pt) {
+            if (pt.getRawType() == List.class) {
+                Type[] args = pt.getActualTypeArguments();
+                return args.length == 1 && args[0] == EntityPart.class;
+            }
+        }
+        return false;
+    }
+
+    public static String buildContentDisposition(String name, String fileName) {
+        StringBuilder cd = new StringBuilder("form-data; name=\"").append(escapeQuotes(name)).append("\"");
+        if (fileName != null) {
+            cd.append("; filename=\"").append(escapeQuotes(fileName)).append("\"");
+        }
+        return cd.toString();
+    }
+
+    private static String escapeQuotes(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/RuntimeDelegateImpl.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/RuntimeDelegateImpl.java
@@ -22,6 +22,7 @@ import jakarta.ws.rs.ext.RuntimeDelegate;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.RestResponse.ResponseBuilder;
 import org.jboss.resteasy.reactive.common.core.ResponseBuilderFactory;
+import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.common.headers.CacheControlDelegate;
 import org.jboss.resteasy.reactive.common.headers.CookieHeaderDelegate;
 import org.jboss.resteasy.reactive.common.headers.DateDelegate;
@@ -50,6 +51,11 @@ public class RuntimeDelegateImpl extends RuntimeDelegate {
 
             @Override
             public <T> ResponseBuilder<T> createRestResponse() {
+                throw new RuntimeException("Quarkus REST server side components are not installed.");
+            }
+
+            @Override
+            public Serialisers getSerialisers() {
                 throw new RuntimeException("Quarkus REST server side components are not installed.");
             }
         };
@@ -144,6 +150,10 @@ public class RuntimeDelegateImpl extends RuntimeDelegate {
 
     @Override
     public EntityPart.Builder createEntityPartBuilder(String s) throws IllegalArgumentException {
-        return new EntityPartBuilderImpl(s);
+        return new EntityPartBuilderImpl(s, factory.getSerialisers());
+    }
+
+    public Serialisers getSerialisers() {
+        return factory.getSerialisers();
     }
 }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/providers/serialisers/EntityPartReader.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/providers/serialisers/EntityPartReader.java
@@ -1,11 +1,13 @@
 package org.jboss.resteasy.reactive.common.providers.serialisers;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,8 +18,13 @@ import jakarta.ws.rs.core.EntityPart;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.RuntimeDelegate;
 
+import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.common.jaxrs.EntityPartImpl;
+import org.jboss.resteasy.reactive.common.jaxrs.RuntimeDelegateImpl;
+import org.jboss.resteasy.reactive.common.util.CaseInsensitiveMap;
+import org.jboss.resteasy.reactive.common.util.MultipartParser;
 import org.jboss.resteasy.reactive.common.util.QuarkusMultivaluedHashMap;
 
 @Consumes("multipart/form-data")
@@ -48,127 +55,81 @@ public class EntityPartReader implements MessageBodyReader<List<EntityPart>> {
             throw new WebApplicationException("Missing boundary parameter in Content-Type");
         }
         byte[] body = entityStream.readAllBytes();
-        return parseMultipart(body, boundary);
-    }
 
-    private List<EntityPart> parseMultipart(byte[] body, String boundary) throws IOException {
         List<EntityPart> parts = new ArrayList<>();
-        byte[] delimiterBytes = ("--" + boundary).getBytes(StandardCharsets.US_ASCII);
-        byte[] closeBytes = ("--" + boundary + "--").getBytes(StandardCharsets.US_ASCII);
-        byte[] crlf = "\r\n".getBytes(StandardCharsets.US_ASCII);
-
-        int pos = indexOf(body, delimiterBytes, 0);
-        if (pos < 0) {
-            return parts;
-        }
-        pos += delimiterBytes.length;
-        if (pos + 1 < body.length && body[pos] == '\r' && body[pos + 1] == '\n') {
-            pos += 2;
-        }
-
-        while (pos < body.length) {
-            int nextDelimiter = indexOf(body, delimiterBytes, pos);
-            if (nextDelimiter < 0) {
-                break;
-            }
-
-            int partEnd = nextDelimiter;
-            if (partEnd >= 2 && body[partEnd - 2] == '\r' && body[partEnd - 1] == '\n') {
-                partEnd -= 2;
-            }
-
-            EntityPart part = parsePart(body, pos, partEnd);
-            if (part != null) {
-                parts.add(part);
-            }
-
-            pos = nextDelimiter + delimiterBytes.length;
-            if (pos + 1 < body.length && body[pos] == '-' && body[pos + 1] == '-') {
-                break;
-            }
-            if (pos + 1 < body.length && body[pos] == '\r' && body[pos + 1] == '\n') {
-                pos += 2;
-            }
-        }
-
+        EntityPartCollector collector = new EntityPartCollector(parts);
+        MultipartParser.ParseState parser = MultipartParser.beginParse(
+                collector, boundary.getBytes(StandardCharsets.US_ASCII), "UTF-8");
+        parser.parse(ByteBuffer.wrap(body));
         return parts;
     }
 
-    private EntityPart parsePart(byte[] body, int start, int end) {
-        int headerEnd = indexOfDoubleCrlf(body, start, end);
-        if (headerEnd < 0) {
-            return null;
+    private static class EntityPartCollector implements MultipartParser.PartHandler {
+        private final List<EntityPart> parts;
+        private CaseInsensitiveMap<String> currentHeaders;
+        private ByteArrayOutputStream currentData;
+
+        EntityPartCollector(List<EntityPart> parts) {
+            this.parts = parts;
         }
 
-        String headerSection = new String(body, start, headerEnd - start, StandardCharsets.UTF_8);
-        int contentStart = headerEnd + 4;
+        @Override
+        public void beginPart(CaseInsensitiveMap<String> headers) {
+            this.currentHeaders = headers;
+            this.currentData = new ByteArrayOutputStream();
+        }
 
-        MultivaluedMap<String, String> headers = new QuarkusMultivaluedHashMap<>();
-        String[] headerLines = headerSection.split("\r\n");
-        for (String line : headerLines) {
-            int colon = line.indexOf(':');
-            if (colon > 0) {
-                String headerName = line.substring(0, colon).trim();
-                String headerValue = line.substring(colon + 1).trim();
-                headers.add(headerName, headerValue);
+        @Override
+        public void data(ByteBuffer buffer) throws IOException {
+            if (buffer.hasArray()) {
+                currentData.write(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
+            } else {
+                byte[] bytes = new byte[buffer.remaining()];
+                buffer.get(bytes);
+                currentData.write(bytes);
             }
         }
 
-        String name = null;
-        String fileName = null;
-        String contentDisposition = headers.getFirst("Content-Disposition");
-        if (contentDisposition != null) {
-            name = extractParam(contentDisposition, "name");
-            fileName = extractParam(contentDisposition, "filename");
-        }
-        if (name == null) {
-            return null;
-        }
-
-        MediaType partMediaType = MediaType.APPLICATION_OCTET_STREAM_TYPE;
-        String contentType = headers.getFirst("Content-Type");
-        if (contentType != null) {
-            partMediaType = MediaType.valueOf(contentType);
-        }
-
-        byte[] contentBytes = new byte[end - contentStart];
-        System.arraycopy(body, contentStart, contentBytes, 0, contentBytes.length);
-
-        return new EntityPartImpl(name, fileName, headers, partMediaType, new ByteArrayInputStream(contentBytes));
-    }
-
-    private String extractParam(String header, String paramName) {
-        String search = paramName + "=\"";
-        int idx = header.indexOf(search);
-        if (idx < 0) {
-            return null;
-        }
-        int start = idx + search.length();
-        int end = header.indexOf('"', start);
-        if (end < 0) {
-            return null;
-        }
-        return header.substring(start, end);
-    }
-
-    private int indexOfDoubleCrlf(byte[] data, int from, int to) {
-        for (int i = from; i <= to - 4; i++) {
-            if (data[i] == '\r' && data[i + 1] == '\n' && data[i + 2] == '\r' && data[i + 3] == '\n') {
-                return i;
+        @Override
+        public void endPart() {
+            String contentDisposition = currentHeaders.getFirst("Content-Disposition");
+            if (contentDisposition == null) {
+                return;
             }
-        }
-        return -1;
-    }
-
-    private int indexOf(byte[] data, byte[] pattern, int from) {
-        outer: for (int i = from; i <= data.length - pattern.length; i++) {
-            for (int j = 0; j < pattern.length; j++) {
-                if (data[i + j] != pattern[j]) {
-                    continue outer;
-                }
+            String name = extractParam(contentDisposition, "name");
+            if (name == null) {
+                return;
             }
-            return i;
+            String fileName = extractParam(contentDisposition, "filename");
+
+            MediaType partMediaType = MediaType.APPLICATION_OCTET_STREAM_TYPE;
+            String contentType = currentHeaders.getFirst("Content-Type");
+            if (contentType != null) {
+                partMediaType = MediaType.valueOf(contentType);
+            }
+
+            MultivaluedMap<String, String> headers = new QuarkusMultivaluedHashMap<>();
+            for (var entry : currentHeaders.entrySet()) {
+                headers.put(entry.getKey(), entry.getValue());
+            }
+
+            Serialisers serialisers = ((RuntimeDelegateImpl) RuntimeDelegate.getInstance()).getSerialisers();
+            parts.add(new EntityPartImpl(name, fileName, headers, partMediaType,
+                    new ByteArrayInputStream(currentData.toByteArray()), serialisers));
         }
-        return -1;
+
+        private static String extractParam(String header, String paramName) {
+            String search = paramName + "=\"";
+            int idx = header.indexOf(search);
+            if (idx < 0) {
+                return null;
+            }
+            int start = idx + search.length();
+            int end = header.indexOf('"', start);
+            if (end < 0) {
+                return null;
+            }
+            return header.substring(start, end);
+        }
     }
 }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/providers/serialisers/EntityPartReader.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/providers/serialisers/EntityPartReader.java
@@ -1,11 +1,13 @@
 package org.jboss.resteasy.reactive.common.providers.serialisers;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +20,8 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.MessageBodyReader;
 
 import org.jboss.resteasy.reactive.common.jaxrs.EntityPartImpl;
+import org.jboss.resteasy.reactive.common.util.CaseInsensitiveMap;
+import org.jboss.resteasy.reactive.common.util.MultipartParser;
 import org.jboss.resteasy.reactive.common.util.QuarkusMultivaluedHashMap;
 
 @Consumes("multipart/form-data")
@@ -48,127 +52,80 @@ public class EntityPartReader implements MessageBodyReader<List<EntityPart>> {
             throw new WebApplicationException("Missing boundary parameter in Content-Type");
         }
         byte[] body = entityStream.readAllBytes();
-        return parseMultipart(body, boundary);
-    }
 
-    private List<EntityPart> parseMultipart(byte[] body, String boundary) throws IOException {
         List<EntityPart> parts = new ArrayList<>();
-        byte[] delimiterBytes = ("--" + boundary).getBytes(StandardCharsets.US_ASCII);
-        byte[] closeBytes = ("--" + boundary + "--").getBytes(StandardCharsets.US_ASCII);
-        byte[] crlf = "\r\n".getBytes(StandardCharsets.US_ASCII);
-
-        int pos = indexOf(body, delimiterBytes, 0);
-        if (pos < 0) {
-            return parts;
-        }
-        pos += delimiterBytes.length;
-        if (pos + 1 < body.length && body[pos] == '\r' && body[pos + 1] == '\n') {
-            pos += 2;
-        }
-
-        while (pos < body.length) {
-            int nextDelimiter = indexOf(body, delimiterBytes, pos);
-            if (nextDelimiter < 0) {
-                break;
-            }
-
-            int partEnd = nextDelimiter;
-            if (partEnd >= 2 && body[partEnd - 2] == '\r' && body[partEnd - 1] == '\n') {
-                partEnd -= 2;
-            }
-
-            EntityPart part = parsePart(body, pos, partEnd);
-            if (part != null) {
-                parts.add(part);
-            }
-
-            pos = nextDelimiter + delimiterBytes.length;
-            if (pos + 1 < body.length && body[pos] == '-' && body[pos + 1] == '-') {
-                break;
-            }
-            if (pos + 1 < body.length && body[pos] == '\r' && body[pos + 1] == '\n') {
-                pos += 2;
-            }
-        }
-
+        EntityPartCollector collector = new EntityPartCollector(parts);
+        MultipartParser.ParseState parser = MultipartParser.beginParse(
+                collector, boundary.getBytes(StandardCharsets.US_ASCII), "UTF-8");
+        parser.parse(ByteBuffer.wrap(body));
         return parts;
     }
 
-    private EntityPart parsePart(byte[] body, int start, int end) {
-        int headerEnd = indexOfDoubleCrlf(body, start, end);
-        if (headerEnd < 0) {
-            return null;
+    private static class EntityPartCollector implements MultipartParser.PartHandler {
+        private final List<EntityPart> parts;
+        private CaseInsensitiveMap<String> currentHeaders;
+        private ByteArrayOutputStream currentData;
+
+        EntityPartCollector(List<EntityPart> parts) {
+            this.parts = parts;
         }
 
-        String headerSection = new String(body, start, headerEnd - start, StandardCharsets.UTF_8);
-        int contentStart = headerEnd + 4;
+        @Override
+        public void beginPart(CaseInsensitiveMap<String> headers) {
+            this.currentHeaders = headers;
+            this.currentData = new ByteArrayOutputStream();
+        }
 
-        MultivaluedMap<String, String> headers = new QuarkusMultivaluedHashMap<>();
-        String[] headerLines = headerSection.split("\r\n");
-        for (String line : headerLines) {
-            int colon = line.indexOf(':');
-            if (colon > 0) {
-                String headerName = line.substring(0, colon).trim();
-                String headerValue = line.substring(colon + 1).trim();
-                headers.add(headerName, headerValue);
+        @Override
+        public void data(ByteBuffer buffer) throws IOException {
+            if (buffer.hasArray()) {
+                currentData.write(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
+            } else {
+                byte[] bytes = new byte[buffer.remaining()];
+                buffer.get(bytes);
+                currentData.write(bytes);
             }
         }
 
-        String name = null;
-        String fileName = null;
-        String contentDisposition = headers.getFirst("Content-Disposition");
-        if (contentDisposition != null) {
-            name = extractParam(contentDisposition, "name");
-            fileName = extractParam(contentDisposition, "filename");
-        }
-        if (name == null) {
-            return null;
-        }
-
-        MediaType partMediaType = MediaType.APPLICATION_OCTET_STREAM_TYPE;
-        String contentType = headers.getFirst("Content-Type");
-        if (contentType != null) {
-            partMediaType = MediaType.valueOf(contentType);
-        }
-
-        byte[] contentBytes = new byte[end - contentStart];
-        System.arraycopy(body, contentStart, contentBytes, 0, contentBytes.length);
-
-        return new EntityPartImpl(name, fileName, headers, partMediaType, new ByteArrayInputStream(contentBytes));
-    }
-
-    private String extractParam(String header, String paramName) {
-        String search = paramName + "=\"";
-        int idx = header.indexOf(search);
-        if (idx < 0) {
-            return null;
-        }
-        int start = idx + search.length();
-        int end = header.indexOf('"', start);
-        if (end < 0) {
-            return null;
-        }
-        return header.substring(start, end);
-    }
-
-    private int indexOfDoubleCrlf(byte[] data, int from, int to) {
-        for (int i = from; i <= to - 4; i++) {
-            if (data[i] == '\r' && data[i + 1] == '\n' && data[i + 2] == '\r' && data[i + 3] == '\n') {
-                return i;
+        @Override
+        public void endPart() {
+            String contentDisposition = currentHeaders.getFirst("Content-Disposition");
+            if (contentDisposition == null) {
+                return;
             }
-        }
-        return -1;
-    }
-
-    private int indexOf(byte[] data, byte[] pattern, int from) {
-        outer: for (int i = from; i <= data.length - pattern.length; i++) {
-            for (int j = 0; j < pattern.length; j++) {
-                if (data[i + j] != pattern[j]) {
-                    continue outer;
-                }
+            String name = extractParam(contentDisposition, "name");
+            if (name == null) {
+                return;
             }
-            return i;
+            String fileName = extractParam(contentDisposition, "filename");
+
+            MediaType partMediaType = MediaType.APPLICATION_OCTET_STREAM_TYPE;
+            String contentType = currentHeaders.getFirst("Content-Type");
+            if (contentType != null) {
+                partMediaType = MediaType.valueOf(contentType);
+            }
+
+            MultivaluedMap<String, String> headers = new QuarkusMultivaluedHashMap<>();
+            for (var entry : currentHeaders.entrySet()) {
+                headers.put(entry.getKey(), entry.getValue());
+            }
+
+            parts.add(new EntityPartImpl(name, fileName, headers, partMediaType,
+                    new ByteArrayInputStream(currentData.toByteArray())));
         }
-        return -1;
+
+        private static String extractParam(String header, String paramName) {
+            String search = paramName + "=\"";
+            int idx = header.indexOf(search);
+            if (idx < 0) {
+                return null;
+            }
+            int start = idx + search.length();
+            int end = header.indexOf('"', start);
+            if (end < 0) {
+                return null;
+            }
+            return header.substring(start, end);
+        }
     }
 }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/MultipartParser.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/MultipartParser.java
@@ -1,4 +1,4 @@
-package org.jboss.resteasy.reactive.server.core.multipart;
+package org.jboss.resteasy.reactive.common.util;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -6,8 +6,6 @@ import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.util.Base64;
 import java.util.Collections;
-
-import org.jboss.resteasy.reactive.common.util.CaseInsensitiveMap;
 
 /**
  * @author Stuart Douglas

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
@@ -44,6 +44,7 @@ import java.util.function.Supplier;
 import java.util.regex.PatternSyntaxException;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
+import jakarta.ws.rs.core.EntityPart;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.PathSegment;
 
@@ -718,7 +719,7 @@ public class ServerEndpointIndexer
                 || elementType.equals(Path.class.getName())
                 || elementType.equals(File.class.getName())
                 || elementType.equals(InputStream.class.getName())
-                || elementType.equals("jakarta.ws.rs.core.EntityPart")) {
+                || elementType.equals(EntityPart.class.getName())) {
             // this is handled by MultipartFormParamExtractor
             return null;
         } else {

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/ClassInjectorTransformer.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/ClassInjectorTransformer.java
@@ -14,6 +14,7 @@ import java.util.function.BiFunction;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.EntityPart;
 import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.jandex.AnnotationInstance;
@@ -615,6 +616,10 @@ public class ClassInjectorTransformer implements BiFunction<String, ClassVisitor
             case Path:
                 value = loadMultipartPath(method, requestCtx, paramName, param.isSingle());
                 break;
+            case EntityPart:
+                value = invokeMultipartSupport(method, requestCtx, paramName, param.isSingle(),
+                        "getEntityPart", EntityPart.class);
+                break;
             case PartType:
                 value = loadMultipartPartType(method, className, fieldInfo, param, requestCtx, paramName);
                 break;
@@ -761,6 +766,8 @@ public class ClassInjectorTransformer implements BiFunction<String, ClassVisitor
             return MultipartFormParamExtractor.Type.String;
         } else if (param.getElementType().equals(InputStream.class.getName())) {
             return MultipartFormParamExtractor.Type.InputStream;
+        } else if (param.getElementType().equals(EntityPart.class.getName())) {
+            return MultipartFormParamExtractor.Type.EntityPart;
         } else if (param.getParamType().kind() == Kind.ARRAY
                 && param.getParamType().asArrayType().constituent().kind() == Kind.PRIMITIVE
                 && param.getParamType().asArrayType().constituent().asPrimitiveType().primitive() == Primitive.BYTE) {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ServerResponseBuilderFactory.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ServerResponseBuilderFactory.java
@@ -1,9 +1,11 @@
 package org.jboss.resteasy.reactive.server.core;
 
+import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.ws.rs.core.Response;
 
 import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.common.core.ResponseBuilderFactory;
+import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.server.jaxrs.ResponseBuilderImpl;
 import org.jboss.resteasy.reactive.server.jaxrs.RestResponseBuilderImpl;
 
@@ -21,5 +23,15 @@ public class ServerResponseBuilderFactory implements ResponseBuilderFactory {
     @Override
     public <T> RestResponse.ResponseBuilder<T> createRestResponse() {
         return new RestResponseBuilderImpl();
+    }
+
+    @Override
+    public Serialisers getSerialisers() {
+        try {
+            ResteasyReactiveRequestContext ctx = CurrentRequestManager.get();
+            return ctx != null ? ctx.getDeployment().getSerialisers() : null;
+        } catch (ContextNotActiveException e) {
+            return null;
+        }
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultiPartParserDefinition.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultiPartParserDefinition.java
@@ -30,6 +30,7 @@ import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.common.headers.HeaderUtil;
 import org.jboss.resteasy.reactive.common.util.CaseInsensitiveMap;
 import org.jboss.resteasy.reactive.common.util.MediaTypeHelper;
+import org.jboss.resteasy.reactive.common.util.MultipartParser;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.server.spi.ServerHttpRequest;
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartMessageBodyWriter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartMessageBodyWriter.java
@@ -25,6 +25,7 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.MessageBodyWriter;
 
 import org.jboss.resteasy.reactive.common.core.Serialisers;
+import org.jboss.resteasy.reactive.common.jaxrs.EntityPartImpl;
 import org.jboss.resteasy.reactive.common.reflection.ReflectionBeanFactoryCreator;
 import org.jboss.resteasy.reactive.common.util.QuarkusMultivaluedHashMap;
 import org.jboss.resteasy.reactive.multipart.FileDownload;
@@ -49,7 +50,7 @@ public class MultipartMessageBodyWriter implements ServerMessageBodyWriter<Objec
     @Override
     public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         if (MultipartFormDataOutput.class.isAssignableFrom(type)
-                || isEntityPartList(type, genericType)) {
+                || EntityPartImpl.isEntityPartList(genericType)) {
             return true;
         }
         if (isMultipartFormData(mediaType)) {
@@ -69,7 +70,7 @@ public class MultipartMessageBodyWriter implements ServerMessageBodyWriter<Objec
     public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target,
             MediaType mediaType) {
         if (MultipartFormDataOutput.class.isAssignableFrom(type)
-                || isEntityPartList(type, genericType)) {
+                || EntityPartImpl.isEntityPartList(genericType)) {
             return true;
         }
         if (isMultipartFormData(mediaType)) {
@@ -79,8 +80,7 @@ public class MultipartMessageBodyWriter implements ServerMessageBodyWriter<Objec
     }
 
     private static boolean isMultipartFormData(MediaType mediaType) {
-        return mediaType != null && "multipart".equals(mediaType.getType())
-                && "form-data".equals(mediaType.getSubtype());
+        return mediaType != null && MediaType.MULTIPART_FORM_DATA_TYPE.isCompatible(mediaType);
     }
 
     private static boolean methodProducesMultipart(ResteasyReactiveResourceInfo target) {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartSupport.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartSupport.java
@@ -2,7 +2,6 @@ package org.jboss.resteasy.reactive.server.core.multipart;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -28,6 +27,7 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.MessageBodyReader;
 
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.common.jaxrs.EntityPartImpl;
 import org.jboss.resteasy.reactive.common.util.Encode;
 import org.jboss.resteasy.reactive.common.util.QuarkusMultivaluedHashMap;
@@ -293,7 +293,7 @@ public final class MultipartSupport {
         }
         if (value.isFileItem()) {
             try {
-                return new FileInputStream(value.getFileItem().getFile().toFile());
+                return value.getFileItem().getInputStream();
             } catch (IOException e) {
                 throw new MultipartPartReadingException(e);
             }
@@ -311,7 +311,7 @@ public final class MultipartSupport {
         for (FormValue value : values) {
             if (value.isFileItem()) {
                 try {
-                    ret.add(new FileInputStream(value.getFileItem().getFile().toFile()));
+                    ret.add(value.getFileItem().getInputStream());
                 } catch (IOException e) {
                     throw new MultipartPartReadingException(e);
                 }
@@ -395,12 +395,13 @@ public final class MultipartSupport {
         if (formData == null) {
             return Collections.emptyList();
         }
+        Serialisers serialisers = context.getDeployment().getSerialisers();
         List<EntityPart> result = new ArrayList<>();
         for (String name : formData) {
             Deque<FormValue> values = formData.get(name);
             if (values != null) {
                 for (FormValue value : values) {
-                    result.add(formValueToEntityPart(name, value));
+                    result.add(formValueToEntityPart(name, value, serialisers));
                 }
             }
         }
@@ -412,7 +413,7 @@ public final class MultipartSupport {
         if (value == null) {
             return null;
         }
-        return formValueToEntityPart(name, value);
+        return formValueToEntityPart(name, value, context.getDeployment().getSerialisers());
     }
 
     public static List<EntityPart> getEntityParts(String name, ResteasyReactiveRequestContext context) {
@@ -420,14 +421,15 @@ public final class MultipartSupport {
         if (values == null || values.isEmpty()) {
             return Collections.emptyList();
         }
+        Serialisers serialisers = context.getDeployment().getSerialisers();
         List<EntityPart> result = new ArrayList<>();
         for (FormValue value : values) {
-            result.add(formValueToEntityPart(name, value));
+            result.add(formValueToEntityPart(name, value, serialisers));
         }
         return result;
     }
 
-    private static EntityPart formValueToEntityPart(String name, FormValue value) {
+    private static EntityPart formValueToEntityPart(String name, FormValue value, Serialisers serialisers) {
         InputStream content;
         MediaType mediaType;
         String fileName = value.getFileName();
@@ -454,13 +456,9 @@ public final class MultipartSupport {
             headers.putAll(value.getHeaders());
         }
         headers.putSingle("Content-Type", mediaType.toString());
-        StringBuilder cd = new StringBuilder("form-data; name=\"").append(name).append("\"");
-        if (fileName != null) {
-            cd.append("; filename=\"").append(fileName).append("\"");
-        }
-        headers.putSingle("Content-Disposition", cd.toString());
+        headers.putSingle("Content-Disposition", EntityPartImpl.buildContentDisposition(name, fileName));
 
-        return new EntityPartImpl(name, fileName, headers, mediaType, content);
+        return new EntityPartImpl(name, fileName, headers, mediaType, content, serialisers);
     }
 
     private static ByteArrayInputStream formAttributeValueToInputStream(String formAttributeValue) {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartSupport.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartSupport.java
@@ -28,6 +28,7 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.MessageBodyReader;
 
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.common.jaxrs.EntityPartImpl;
 import org.jboss.resteasy.reactive.common.util.Encode;
 import org.jboss.resteasy.reactive.common.util.QuarkusMultivaluedHashMap;
@@ -395,12 +396,13 @@ public final class MultipartSupport {
         if (formData == null) {
             return Collections.emptyList();
         }
+        Serialisers serialisers = context.getDeployment().getSerialisers();
         List<EntityPart> result = new ArrayList<>();
         for (String name : formData) {
             Deque<FormValue> values = formData.get(name);
             if (values != null) {
                 for (FormValue value : values) {
-                    result.add(formValueToEntityPart(name, value));
+                    result.add(formValueToEntityPart(name, value, serialisers));
                 }
             }
         }
@@ -412,7 +414,7 @@ public final class MultipartSupport {
         if (value == null) {
             return null;
         }
-        return formValueToEntityPart(name, value);
+        return formValueToEntityPart(name, value, context.getDeployment().getSerialisers());
     }
 
     public static List<EntityPart> getEntityParts(String name, ResteasyReactiveRequestContext context) {
@@ -420,14 +422,15 @@ public final class MultipartSupport {
         if (values == null || values.isEmpty()) {
             return Collections.emptyList();
         }
+        Serialisers serialisers = context.getDeployment().getSerialisers();
         List<EntityPart> result = new ArrayList<>();
         for (FormValue value : values) {
-            result.add(formValueToEntityPart(name, value));
+            result.add(formValueToEntityPart(name, value, serialisers));
         }
         return result;
     }
 
-    private static EntityPart formValueToEntityPart(String name, FormValue value) {
+    private static EntityPart formValueToEntityPart(String name, FormValue value, Serialisers serialisers) {
         InputStream content;
         MediaType mediaType;
         String fileName = value.getFileName();
@@ -454,13 +457,9 @@ public final class MultipartSupport {
             headers.putAll(value.getHeaders());
         }
         headers.putSingle("Content-Type", mediaType.toString());
-        StringBuilder cd = new StringBuilder("form-data; name=\"").append(name).append("\"");
-        if (fileName != null) {
-            cd.append("; filename=\"").append(fileName).append("\"");
-        }
-        headers.putSingle("Content-Disposition", cd.toString());
+        headers.putSingle("Content-Disposition", EntityPartImpl.buildContentDisposition(name, fileName));
 
-        return new EntityPartImpl(name, fileName, headers, mediaType, content);
+        return new EntityPartImpl(name, fileName, headers, mediaType, content, serialisers);
     }
 
     private static ByteArrayInputStream formAttributeValueToInputStream(String formAttributeValue) {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
 import jakarta.ws.rs.RuntimeType;
+import jakarta.ws.rs.core.EntityPart;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
@@ -650,7 +651,7 @@ public class RuntimeResourceDeployment {
                 MultipartFormParamExtractor.Type multiPartType = null;
                 Class<Object> typeClass = null;
                 Type genericType = null;
-                if (param.type.equals("jakarta.ws.rs.core.EntityPart")) {
+                if (param.type.equals(EntityPart.class.getName())) {
                     multiPartType = MultipartFormParamExtractor.Type.EntityPart;
                 } else if (param.type.equals(FileUpload.class.getName())) {
                     multiPartType = MultipartFormParamExtractor.Type.FileUpload;

--- a/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartParserTest.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartParserTest.java
@@ -10,7 +10,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 import org.jboss.resteasy.reactive.common.util.CaseInsensitiveMap;
-import org.jboss.resteasy.reactive.server.core.multipart.MultipartParser.PartHandler;
+import org.jboss.resteasy.reactive.common.util.MultipartParser;
+import org.jboss.resteasy.reactive.common.util.MultipartParser.PartHandler;
 import org.junit.jupiter.api.Test;
 
 public class MultipartParserTest {

--- a/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartParserTest.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartParserTest.java
@@ -9,7 +9,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 import org.jboss.resteasy.reactive.common.util.CaseInsensitiveMap;
-import org.jboss.resteasy.reactive.server.core.multipart.MultipartParser.PartHandler;
+import org.jboss.resteasy.reactive.common.util.MultipartParser;
+import org.jboss.resteasy.reactive.common.util.MultipartParser.PartHandler;
 import org.junit.jupiter.api.Test;
 
 public class MultipartParserTest {

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/framework/ResteasyReactiveUnitTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/framework/ResteasyReactiveUnitTest.java
@@ -44,7 +44,7 @@ import org.jboss.jandex.IndexView;
 import org.jboss.resteasy.reactive.common.core.BlockingOperationSupport;
 import org.jboss.resteasy.reactive.common.processor.JandexUtil;
 import org.jboss.resteasy.reactive.common.processor.scanning.ScannedSerializer;
-import org.jboss.resteasy.reactive.server.core.multipart.MultipartParser;
+import org.jboss.resteasy.reactive.common.util.MultipartParser;
 import org.jboss.resteasy.reactive.server.core.reflection.ReflectiveContextInjectedBeanFactory;
 import org.jboss.resteasy.reactive.server.processor.ResteasyReactiveDeploymentManager;
 import org.jboss.resteasy.reactive.server.processor.ScannedApplication;

--- a/tcks/jakarta-rest/README.md
+++ b/tcks/jakarta-rest/README.md
@@ -22,80 +22,18 @@ mvn verify -pl tcks/jakarta-rest -Drun-jakarta-rest-tck
   that were already excluded in the old forked TCK runner (resteasy-reactive-testsuite).
   The `DisableReason` enum mirrors the old `QuarkusRest.java` classification.
 
-## Current status (2026-07-24)
+## Current status (2026-07-31)
 
 | Metric   | Count |
 |----------|-------|
 | Total    | 2755  |
-| Pass     | 2470  |
-| Error    | 6     |
-| Failure  | 4     |
-| Skipped  | 275   |
+| Pass     | 2477  |
+| Error    | 0     |
+| Failure  | 0     |
+| Skipped  | 278   |
 
-**275 skipped** = old TCK exclusions carried forward via `ExecutionCondition` +
+**278 skipped** = old TCK exclusions carried forward via `ExecutionCondition` +
 `@Tag("se_bootstrap")`/`@Tag("servlet")` excluded via `excludedGroups` + signature test.
-
-**10 remaining failures** across 5 test classes, with 5 distinct root causes:
-
-### SSE 503 + Retry-After reconnection — missing feature (2 tests)
-
-`jaxrs21.ee.sse.sseeventsource.JAXRSClientIT`:
-- `wait2Seconds`
-- `defaultWaiting1s`
-
-These are **not** flaky timing tests. `SseEventSourceImpl.connect()` does not
-implement HTTP 503 + `Retry-After` automatic reconnection at all. When the server
-returns 503, the client treats it as a generic non-successful response, fires the
-error handler, and calls `notifyCompletion()` — it never reads `Retry-After` or
-schedules a reconnect.
-
-The tests set up a `ServiceUnavailableResource` that returns 503 with
-`Retry-After: N` on the first request and sends an SSE event on the retry.
-Since Quarkus never retries, the message is never received.
-
-**Fix location**: `SseEventSourceImpl.connect()` in
-`independent-projects/resteasy-reactive/client/runtime/…/client/impl/SseEventSourceImpl.java`
-(lines ~100-110). Needs to check for status 503, parse the `Retry-After` header,
-and schedule a one-time reconnect with that delay.
-
-### Multipart return type restriction (1 error — build-time)
-
-`jaxrs31.ee.multipart.MultipartSupportIT`:
-
-Quarkus augmentation rejects the TCK's `Response`-returning multipart endpoint:
-*"Endpoints that produce a Multipart result cannot return
-`jakarta.ws.rs.core.Response` — consider returning `RestResponse` instead."*
-The TCK uses the standard JAX-RS `Response` type, which Quarkus does not allow.
-
-### Feature/DynamicFeature registration reporting (2 failures)
-
-`jaxrs31.spec.extensions.JAXRSClientIT`:
-- `featureIsRegisteredTest`
-- `dynamicFeatureIsRegisteredTest`
-
-`Configuration.isRegistered()` returns `false` for Feature/DynamicFeature
-instances that are actually registered. The features work, but the registration
-query does not report them.
-
-### Provider visibility — no no-arg constructor (4 errors)
-
-`spec.provider.visibility.JAXRSClientIT`:
-- `bodyWriterTest`
-- `bodyReaderTest`
-- `contextResolverTest`
-- `exceptionMapperTest`
-
-TCK provider classes (`DummyWriter`, `StringReader`, `HolderResolver`,
-`VisibilityExceptionMapper`) have only `@Context`-parameter constructors.
-ArC's `BeanFactory` requires a no-arg constructor and fails with
-`NoSuchMethodException`.
-
-### Resource constructor visibility (1 error)
-
-`spec.resourceconstructor.JAXRSClientIT#visibleTest`:
-
-`GET /resource/mostAttributes` returns HTTP 406 instead of 200. Quarkus ignores
-non-public resource methods, so the expected constructor/method is not selected.
 
 ## Files
 


### PR DESCRIPTION
These are the changes from the review of #55685

Wire up EntityPart as a first-class multipart form parameter type on both server and client sides. EntityPart.Builder and EntityPartImpl use Serialisers directly (not Providers) for MessageBodyReader/Writer selection, with a static Supplier set by both server and client recorders at startup. GenericType info is preserved through reader/writer calls.

Also consolidates MultipartParser into the common module, adds Content-Disposition escaping, and resolves the 2 remaining Jakarta REST TCK failures via visitRuntimeResources-based service-loader discovery.
