### PR TITLE
Docs: document targetDirectory configuration for config doc plugin

### DIFF
--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -485,6 +485,35 @@ You will also need to configure the `maven-compiler-plugin` of the deployment mo
 </build>
 ----
 
+== Config documentation generation
+
+Older extensions generate configuration documentation into the global
+
+`target/asciidoc/generated/config/`
+
+directory located at the root of the project.
+
+=== Using quarkus-config-doc-maven-plugin
+
+Newer extensions can configure the output directory directly using the
+`quarkus-config-doc-maven-plugin`.
+
+[source,xml]
+----
+<plugin>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-config-doc-maven-plugin</artifactId>
+    <extensions>true</extensions>
+    <configuration>
+        <targetDirectory>${project.basedir}/modules/ROOT/pages/includes/</targetDirectory>
+    </configuration>
+</plugin>
+----
+
+When `targetDirectory` is configured, the generated configuration documentation
+is written to the specified directory instead of the global
+`target/asciidoc/generated/config/` location.
+
 ===== Create new Quarkus Core extension modules using Maven
 
 Quarkus provides `create-extension` Maven Mojo to initialize your extension project.


### PR DESCRIPTION
Update the Writing Extensions guide to document the targetDirectory configuration of the quarkus-config-doc-maven-plugin.

The guide previously stated that configuration documentation is generated in the global target/asciidoc/generated/config/ directory. This PR adds a new section describing the newer approach of configuring the output directory via the plugin's targetDirectory option, while retaining the existing documentation for legacy extensions that still use the global output location.

Fixes
Fixes #45257
