### PR TITLE
Preserve nested type arguments in reflection-free Jackson deserializers

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -320,6 +320,13 @@ public abstract class JacksonCodeGenerator {
     }
 
     private void registerTypeToBeGenerated(Type type) {
+        // a type argument can be parameterized itself, like the List<Foo> in a Map<String, List<Foo>>,
+        // so recurse to reach the Foo nested in it
+        if (type instanceof ParameterizedType pType) {
+            for (Type argument : pType.arguments()) {
+                registerTypeToBeGenerated(argument);
+            }
+        }
         registerTypeToBeGenerated(type.name().toString());
     }
 

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
@@ -24,7 +24,6 @@ import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.MethodParameterInfo;
-import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.TypeVariable;
 import org.jboss.jandex.VoidType;
@@ -859,41 +858,12 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
 
         FieldKind fieldKind = registerTypeToBeGenerated(fieldType, fieldTypeName);
         ResultHandle typeHandle = switch (fieldKind) {
-            case TYPE_VARIABLE -> {
-                Integer parameterIndex = typeParametersIndex.get(fieldType.asTypeVariable().identifier());
-                if (parameterIndex == null) {
-                    yield null;
-                }
-                FieldDescriptor valueTypesField = FieldDescriptor.of(classCreator.getClassName(), "valueTypes",
-                        JavaType[].class);
-                ResultHandle valueTypes = bytecode.readInstanceField(valueTypesField, bytecode.getThis());
-                yield bytecode.readArrayValue(valueTypes, parameterIndex);
-            }
-            case LIST, SET, WRAPPER -> {
-                Type contentType = ((ParameterizedType) fieldType).arguments().get(0);
+            case TYPE_VARIABLE -> readTypeVariable(classCreator, bytecode, fieldType.asTypeVariable(), typeParametersIndex);
+            case LIST, SET, WRAPPER, MAP -> {
                 MethodDescriptor getTypeFactory = ofMethod(DeserializationContext.class, "getTypeFactory",
                         TypeFactory.class);
                 ResultHandle typeFactory = bytecode.invokeVirtualMethod(getTypeFactory, deserializationContext);
-                MethodDescriptor constructParametricType = ofMethod(TypeFactory.class,
-                        "constructParametricType", JavaType.class, Class.class, Class[].class);
-                ResultHandle paramTypes = bytecode.newArray(Class.class, 1);
-                bytecode.writeArrayValue(paramTypes, 0, bytecode.loadClass(contentType.name().toString()));
-                yield bytecode.invokeVirtualMethod(constructParametricType, typeFactory,
-                        bytecode.loadClass(fieldTypeName), paramTypes);
-            }
-            case MAP -> {
-                Type keyType = ((ParameterizedType) fieldType).arguments().get(0);
-                Type valueType = ((ParameterizedType) fieldType).arguments().get(1);
-                MethodDescriptor getTypeFactory = ofMethod(DeserializationContext.class, "getTypeFactory",
-                        TypeFactory.class);
-                ResultHandle typeFactory = bytecode.invokeVirtualMethod(getTypeFactory, deserializationContext);
-                MethodDescriptor constructParametricType = ofMethod(TypeFactory.class,
-                        "constructParametricType", JavaType.class, Class.class, Class[].class);
-                ResultHandle paramTypes = bytecode.newArray(Class.class, 2);
-                bytecode.writeArrayValue(paramTypes, 0, bytecode.loadClass(keyType.name().toString()));
-                bytecode.writeArrayValue(paramTypes, 1, bytecode.loadClass(valueType.name().toString()));
-                yield bytecode.invokeVirtualMethod(constructParametricType, typeFactory,
-                        bytecode.loadClass(fieldTypeName), paramTypes);
+                yield buildJavaType(classCreator, bytecode, typeFactory, fieldType, typeParametersIndex);
             }
             default -> bytecode.loadClass(fieldTypeName);
         };
@@ -905,6 +875,64 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
         MethodDescriptor readTreeAsValue = ofMethod(DeserializationContext.class, "readTreeAsValue",
                 Object.class, JsonNode.class, fieldKind.isGeneric() ? JavaType.class : Class.class);
         return bytecode.invokeVirtualMethod(readTreeAsValue, deserializationContext, valueNode, typeHandle);
+    }
+
+    /**
+     * Reads the {@code JavaType} bound to a type variable from the {@code valueTypes} field that
+     * {@code createContextual} populates at runtime. Returns {@code null} when the variable is not
+     * a type parameter of the deserialized class.
+     */
+    private static ResultHandle readTypeVariable(ClassCreator classCreator, BytecodeCreator bytecode,
+            TypeVariable typeVariable, Map<String, Integer> typeParametersIndex) {
+        Integer parameterIndex = typeParametersIndex.get(typeVariable.identifier());
+        if (parameterIndex == null) {
+            return null;
+        }
+        FieldDescriptor valueTypesField = FieldDescriptor.of(classCreator.getClassName(), "valueTypes", JavaType[].class);
+        ResultHandle valueTypes = bytecode.readInstanceField(valueTypesField, bytecode.getThis());
+        return bytecode.readArrayValue(valueTypes, parameterIndex);
+    }
+
+    /**
+     * Emits bytecode that constructs the Jackson {@code JavaType} for the given type, recursing into
+     * type arguments so a nested type, like the {@code List<Foo>} in a {@code Map<String, List<Foo>>},
+     * keeps its generics instead of collapsing to its raw class (which would deserialize its elements
+     * as {@code LinkedHashMap}s).
+     *
+     * Returns {@code null} when the type or one of its arguments cannot be resolved at build time; the
+     * caller then abandons the generated deserializer and Jackson falls back to reflection.
+     */
+    private static ResultHandle buildJavaType(ClassCreator classCreator, BytecodeCreator bytecode,
+            ResultHandle typeFactory, Type type, Map<String, Integer> typeParametersIndex) {
+        switch (type.kind()) {
+            case CLASS:
+                return bytecode.invokeVirtualMethod(
+                        ofMethod(TypeFactory.class, "constructType", JavaType.class, java.lang.reflect.Type.class),
+                        typeFactory, bytecode.loadClass(type.name().toString()));
+            case TYPE_VARIABLE:
+                return readTypeVariable(classCreator, bytecode, type.asTypeVariable(), typeParametersIndex);
+            case WILDCARD_TYPE:
+                // resolve a wildcard to its upper bound, which Jandex defaults to Object
+                return buildJavaType(classCreator, bytecode, typeFactory, type.asWildcardType().extendsBound(),
+                        typeParametersIndex);
+            case PARAMETERIZED_TYPE:
+                List<Type> arguments = type.asParameterizedType().arguments();
+                ResultHandle argumentTypes = bytecode.newArray(JavaType.class, arguments.size());
+                for (int i = 0; i < arguments.size(); i++) {
+                    ResultHandle argumentType = buildJavaType(classCreator, bytecode, typeFactory, arguments.get(i),
+                            typeParametersIndex);
+                    if (argumentType == null) {
+                        return null;
+                    }
+                    bytecode.writeArrayValue(argumentTypes, i, argumentType);
+                }
+                return bytecode.invokeVirtualMethod(
+                        ofMethod(TypeFactory.class, "constructParametricType", JavaType.class, Class.class, JavaType[].class),
+                        typeFactory, bytecode.loadClass(type.name().toString()), argumentTypes);
+            default:
+                // arrays and primitives nested in a generic type are not supported yet
+                return null;
+        }
     }
 
     private void writeValueToObject(ClassInfo classInfo, ResultHandle objHandle, FieldSpecs fieldSpecs,

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/NestedParameterizedTypeReflectionFreeSerializerTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/NestedParameterizedTypeReflectionFreeSerializerTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import static org.hamcrest.Matchers.is;
+
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+
+public class NestedParameterizedTypeReflectionFreeSerializerTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(NestedParameterizedTypeResource.class,
+                                    NestedParameterizedTypeResource.ServiceStatus.class,
+                                    NestedParameterizedTypeResource.Request.class)
+                            .addAsResource(
+                                    new StringAsset(
+                                            "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true\n"),
+                                    "application.properties");
+                }
+            });
+
+    @Test
+    public void testMapOfLists() {
+        // Map<String, List<ServiceStatus>> must keep the inner List type argument; otherwise Jackson
+        // deserializes the elements as LinkedHashMaps and dereferencing them fails
+        post("/nested-parameterized-type/map-of-lists",
+                "{\"mapOfLists\":{\"group\":[{\"name\":\"alpha\"}]}}")
+                .body(is("alpha"));
+    }
+
+    @Test
+    public void testListOfLists() {
+        post("/nested-parameterized-type/list-of-lists",
+                "{\"listOfLists\":[[{\"name\":\"beta\"}]]}")
+                .body(is("beta"));
+    }
+
+    @Test
+    public void testListOfMaps() {
+        post("/nested-parameterized-type/list-of-maps",
+                "{\"listOfMaps\":[{\"key\":{\"name\":\"gamma\"}}]}")
+                .body(is("gamma"));
+    }
+
+    @Test
+    public void testOptionalOfList() {
+        post("/nested-parameterized-type/optional-of-list",
+                "{\"optionalOfList\":[{\"name\":\"delta\"}]}")
+                .body(is("delta"));
+    }
+
+    private static ValidatableResponse post(String path, String body) {
+        return RestAssured
+                .with()
+                .body(body)
+                .contentType("application/json; charset=utf-8")
+                .post(path)
+                .then()
+                .statusCode(200);
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/NestedParameterizedTypeResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/NestedParameterizedTypeResource.java
@@ -1,0 +1,104 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/nested-parameterized-type")
+public class NestedParameterizedTypeResource {
+
+    public static class ServiceStatus {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    /**
+     * Each field nests a parameterized type inside another parameterized type, so the generated
+     * deserializer must preserve both levels of generics. The endpoints below dereference the
+     * innermost element as a {@code ServiceStatus}, which is where a lost type argument surfaces
+     * as a {@code ClassCastException} on a {@code LinkedHashMap}.
+     */
+    public static class Request {
+        private Map<String, List<ServiceStatus>> mapOfLists;
+        private List<List<ServiceStatus>> listOfLists;
+        private List<Map<String, ServiceStatus>> listOfMaps;
+        private Optional<List<ServiceStatus>> optionalOfList;
+
+        public Map<String, List<ServiceStatus>> getMapOfLists() {
+            return mapOfLists;
+        }
+
+        public void setMapOfLists(Map<String, List<ServiceStatus>> mapOfLists) {
+            this.mapOfLists = mapOfLists;
+        }
+
+        public List<List<ServiceStatus>> getListOfLists() {
+            return listOfLists;
+        }
+
+        public void setListOfLists(List<List<ServiceStatus>> listOfLists) {
+            this.listOfLists = listOfLists;
+        }
+
+        public List<Map<String, ServiceStatus>> getListOfMaps() {
+            return listOfMaps;
+        }
+
+        public void setListOfMaps(List<Map<String, ServiceStatus>> listOfMaps) {
+            this.listOfMaps = listOfMaps;
+        }
+
+        public Optional<List<ServiceStatus>> getOptionalOfList() {
+            return optionalOfList;
+        }
+
+        public void setOptionalOfList(Optional<List<ServiceStatus>> optionalOfList) {
+            this.optionalOfList = optionalOfList;
+        }
+    }
+
+    @POST
+    @Path("/map-of-lists")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String mapOfLists(Request request) {
+        return request.getMapOfLists().get("group").get(0).getName();
+    }
+
+    @POST
+    @Path("/list-of-lists")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String listOfLists(Request request) {
+        return request.getListOfLists().get(0).get(0).getName();
+    }
+
+    @POST
+    @Path("/list-of-maps")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String listOfMaps(Request request) {
+        return request.getListOfMaps().get(0).get("key").getName();
+    }
+
+    @POST
+    @Path("/optional-of-list")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String optionalOfList(Request request) {
+        return request.getOptionalOfList().orElseThrow().get(0).getName();
+    }
+}


### PR DESCRIPTION
The generated reflection-free deserializer builds the target `JavaType` from the raw class of each type argument, via `constructParametricType(Class, Class...)`. A parameterized type nested inside another one collapses to its raw class: `Map<String, List<ServiceStatus>>` becomes `Map<String, List<Object>>`, Jackson deserializes the inner elements as `LinkedHashMap`s, and the first typed access throws a `ClassCastException`. One level of generics works; two do not.

This PR builds the `JavaType` recursively with the `constructParametricType(Class, JavaType...)` overload, so each type argument keeps its own generics. Type variables resolve from the contextual `valueTypes` at runtime, since no build-time constant can express them. Wildcards resolve to their upper bound, matching the previous behaviour. An array or primitive nested in a generic type makes the deserializer bail out to reflection-based Jackson — safer than the raw-class bytecode generated before.

`JacksonCodeGenerator#registerTypeToBeGenerated` now also recurses into nested type arguments, so a DTO reachable only through a nested position (the `ServiceStatus` above) gets its own generated deserializer.

The new test covers the four broken shapes (`Map<String, List<T>>`, `List<List<T>>`, `List<Map<String, T>>`, `Optional<List<T>>`) and dereferences the innermost element — the bug is invisible to echo-style tests because a `LinkedHashMap` re-serializes to the same JSON.


- Fixes: #55778.