### PR TITLE
Read the compareAndExchange witness correctly in ArC CurrentContextState.set

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CurrentManagedContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CurrentManagedContext.java
@@ -299,10 +299,13 @@ public abstract class CurrentManagedContext implements ManagedContext {
                     return false;
                 }
                 final byte newState = (byte) (state | bitMask);
-                state = (byte) STATE_UPDATER.compareAndExchange(this, state, newState);
-                if (state == newState) {
+                // compareAndExchange returns the witness (the value before the call); the swap
+                // succeeded only when that equals the expected value, not newState.
+                final byte witness = (byte) STATE_UPDATER.compareAndExchange(this, state, newState);
+                if (witness == state) {
                     return true;
                 }
+                state = witness;
             }
         }
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/currentmanaged/CurrentManagedContextConcurrentDestroyTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/currentmanaged/CurrentManagedContextConcurrentDestroyTest.java
@@ -1,0 +1,138 @@
+package io.quarkus.arc.test.contexts.currentmanaged;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ContextNotActiveException;
+import jakarta.enterprise.context.RequestScoped;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.arc.ContextInstanceHandle;
+import io.quarkus.arc.CurrentContext;
+import io.quarkus.arc.impl.ContextInstances;
+import io.quarkus.arc.impl.CurrentManagedContext;
+import io.quarkus.arc.impl.CurrentManagedContext.CurrentContextState;
+
+/**
+ * Reproduces the once-only violation in {@code CurrentContextState.set(byte)}: under concurrent
+ * {@code destroy(ContextState)}, the {@code @Destroyed} / beforeDestroyed notifiers must each fire
+ * exactly once. Fails on the pre-fix {@code compareAndExchange} witness bug; passes with the fix.
+ */
+public class CurrentManagedContextConcurrentDestroyTest {
+
+    private static final int THREADS = Math.max(4, Runtime.getRuntime().availableProcessors());
+
+    private static final int ROUNDS = 1000;
+
+    @Test
+    public void destroyedFiresExactlyOnceUnderConcurrentDestroy() throws Exception {
+        AtomicInteger destroyedCount = new AtomicInteger();
+        AtomicInteger beforeDestroyedCount = new AtomicInteger();
+
+        // Trivial ContextInstances (no beans); destroy(state) only iterates removeEach, a no-op here.
+        Supplier<ContextInstances> instances = () -> new ContextInstances() {
+            @Override
+            public ContextInstanceHandle<?> computeIfAbsent(String id, Supplier<ContextInstanceHandle<?>> supplier) {
+                return supplier.get();
+            }
+
+            @Override
+            public ContextInstanceHandle<?> getIfPresent(String id) {
+                return null;
+            }
+
+            @Override
+            public ContextInstanceHandle<?> remove(String id) {
+                return null;
+            }
+
+            @Override
+            public Set<ContextInstanceHandle<?>> getAllPresent() {
+                return Collections.emptySet();
+            }
+
+            @Override
+            public void removeEach(Consumer<? super ContextInstanceHandle<?>> action) {
+                // no contextual instances to destroy
+            }
+        };
+
+        // destroy(ContextState) never reads the CurrentContext, so a no-op impl is sufficient.
+        CurrentContext<CurrentContextState> currentContext = new CurrentContext<CurrentContextState>() {
+            private volatile CurrentContextState state;
+
+            @Override
+            public CurrentContextState get() {
+                return state;
+            }
+
+            @Override
+            public void set(CurrentContextState state) {
+                this.state = state;
+            }
+
+            @Override
+            public void remove() {
+                this.state = null;
+            }
+        };
+
+        CurrentManagedContext ctx = new CurrentManagedContext(currentContext, instances, null,
+                o -> beforeDestroyedCount.incrementAndGet(), o -> destroyedCount.incrementAndGet()) {
+            @Override
+            public Class<? extends Annotation> getScope() {
+                return RequestScoped.class;
+            }
+
+            @Override
+            protected ContextNotActiveException notActive() {
+                return new ContextNotActiveException("test context not active");
+            }
+        };
+
+        ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+        try {
+            for (int round = 0; round < ROUNDS; round++) {
+                destroyedCount.set(0);
+                beforeDestroyedCount.set(0);
+
+                // Fresh, valid state each round; initializeState() does not touch the CurrentContext.
+                CurrentContextState state = ctx.initializeState();
+
+                CountDownLatch start = new CountDownLatch(1);
+                Future<?>[] futures = new Future<?>[THREADS];
+                for (int t = 0; t < THREADS; t++) {
+                    futures[t] = pool.submit(() -> {
+                        start.await();
+                        ctx.destroy(state);
+                        return null;
+                    });
+                }
+
+                start.countDown();
+                for (Future<?> f : futures) {
+                    f.get(10, TimeUnit.SECONDS);
+                }
+
+                assertEquals(1, destroyedCount.get(),
+                        "@Destroyed notifier fired " + destroyedCount.get() + " times in round " + round);
+                assertEquals(1, beforeDestroyedCount.get(),
+                        "beforeDestroyed notifier fired " + beforeDestroyedCount.get() + " times in round " + round);
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
### Problem

`CurrentManagedContext.CurrentContextState.set(byte)` decides a CAS succeeded with `state == newState`:

```java
state = (byte) STATE_UPDATER.compareAndExchange(this, state, newState);
if (state == newState) {
    return true;
}
```

`VarHandle.compareAndExchange` returns the **witness** (the value observed before the call). On a *failed* swap the witness is the value another thread already installed — and since every concurrent caller computes the same `newState = state | bitMask`, that witness equals `newState` too. So the losing thread also returns `true`.

`set()` backs the once-only guarantees: `invalidate()` gates `@Destroyed` + bean destruction, `shouldFireBeforeDestroyedEvent()` gates `@BeforeDestroyed`. When two threads run `destroy(state)` on the same context state (normal in reactive / multi-threaded apps — the reason the CAS exists), both get `true`, so `@BeforeDestroyed`/`@Destroyed` fire more than once and contextual instances are destroyed more than once. Single-threaded paths are unaffected because the redundant second CAS masks it, which is likely why it went unnoticed.

### Fix

Compare the witness to the *expected* value (`witness == state`), and advance the retry loop with the observed value.

### Test

`CurrentManagedContextConcurrentDestroyTest` builds a `CurrentManagedContext` with counting notifiers and, for 1000 rounds, runs `destroy(state)` from N threads released on a shared latch, asserting the `@Destroyed`/beforeDestroyed notifiers each fire exactly once. It fails on the current code (observed the `@Destroyed` notifier firing 3× in round 0) and passes with the fix. No container/server needed. Formatter + impsort clean.