### PR TITLE
Support nested parametrized types in reflection-free Jackson serializers

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
@@ -874,10 +874,11 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
                 MethodDescriptor getTypeFactory = ofMethod(DeserializationContext.class, "getTypeFactory",
                         TypeFactory.class);
                 ResultHandle typeFactory = bytecode.invokeVirtualMethod(getTypeFactory, deserializationContext);
+                ResultHandle contentJavaType = constructJavaType(bytecode, typeFactory, contentType);
                 MethodDescriptor constructParametricType = ofMethod(TypeFactory.class,
-                        "constructParametricType", JavaType.class, Class.class, Class[].class);
-                ResultHandle paramTypes = bytecode.newArray(Class.class, 1);
-                bytecode.writeArrayValue(paramTypes, 0, bytecode.loadClass(contentType.name().toString()));
+                        "constructParametricType", JavaType.class, Class.class, JavaType[].class);
+                ResultHandle paramTypes = bytecode.newArray(JavaType.class, 1);
+                bytecode.writeArrayValue(paramTypes, 0, contentJavaType);
                 yield bytecode.invokeVirtualMethod(constructParametricType, typeFactory,
                         bytecode.loadClass(fieldTypeName), paramTypes);
             }
@@ -887,11 +888,13 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
                 MethodDescriptor getTypeFactory = ofMethod(DeserializationContext.class, "getTypeFactory",
                         TypeFactory.class);
                 ResultHandle typeFactory = bytecode.invokeVirtualMethod(getTypeFactory, deserializationContext);
+                ResultHandle keyJavaType = constructJavaType(bytecode, typeFactory, keyType);
+                ResultHandle valueJavaType = constructJavaType(bytecode, typeFactory, valueType);
                 MethodDescriptor constructParametricType = ofMethod(TypeFactory.class,
-                        "constructParametricType", JavaType.class, Class.class, Class[].class);
-                ResultHandle paramTypes = bytecode.newArray(Class.class, 2);
-                bytecode.writeArrayValue(paramTypes, 0, bytecode.loadClass(keyType.name().toString()));
-                bytecode.writeArrayValue(paramTypes, 1, bytecode.loadClass(valueType.name().toString()));
+                        "constructParametricType", JavaType.class, Class.class, JavaType[].class);
+                ResultHandle paramTypes = bytecode.newArray(JavaType.class, 2);
+                bytecode.writeArrayValue(paramTypes, 0, keyJavaType);
+                bytecode.writeArrayValue(paramTypes, 1, valueJavaType);
                 yield bytecode.invokeVirtualMethod(constructParametricType, typeFactory,
                         bytecode.loadClass(fieldTypeName), paramTypes);
             }
@@ -905,6 +908,23 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
         MethodDescriptor readTreeAsValue = ofMethod(DeserializationContext.class, "readTreeAsValue",
                 Object.class, JsonNode.class, fieldKind.isGeneric() ? JavaType.class : Class.class);
         return bytecode.invokeVirtualMethod(readTreeAsValue, deserializationContext, valueNode, typeHandle);
+    }
+
+    private static ResultHandle constructJavaType(BytecodeCreator bytecode, ResultHandle typeFactory, Type type) {
+        if (type.kind() == Type.Kind.PARAMETERIZED_TYPE) {
+            ParameterizedType pType = type.asParameterizedType();
+            java.util.List<Type> args = pType.arguments();
+            ResultHandle javaTypeArgs = bytecode.newArray(JavaType.class, args.size());
+            for (int i = 0; i < args.size(); i++) {
+                bytecode.writeArrayValue(javaTypeArgs, i, constructJavaType(bytecode, typeFactory, args.get(i)));
+            }
+            return bytecode.invokeVirtualMethod(
+                    ofMethod(TypeFactory.class, "constructParametricType", JavaType.class, Class.class, JavaType[].class),
+                    typeFactory, bytecode.loadClass(pType.name().toString()), javaTypeArgs);
+        }
+        return bytecode.invokeVirtualMethod(
+                ofMethod(TypeFactory.class, "constructType", JavaType.class, java.lang.reflect.Type.class),
+                typeFactory, bytecode.loadClass(type.name().toString()));
     }
 
     private void writeValueToObject(ClassInfo classInfo, ResultHandle objHandle, FieldSpecs fieldSpecs,

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/NestedParameterizedTypeReflectionFreeSerializerTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/NestedParameterizedTypeReflectionFreeSerializerTest.java
@@ -1,0 +1,84 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import static org.hamcrest.Matchers.is;
+
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+public class NestedParameterizedTypeReflectionFreeSerializerTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(NestedParameterizedTypeResource.class,
+                                    NestedParameterizedTypeResource.ServiceStatus.class,
+                                    NestedParameterizedTypeResource.MapOfListsRequest.class,
+                                    NestedParameterizedTypeResource.ListOfListsRequest.class,
+                                    NestedParameterizedTypeResource.ListOfMapsRequest.class,
+                                    NestedParameterizedTypeResource.OptionalListRequest.class)
+                            .addAsResource(
+                                    new StringAsset(
+                                            "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true\n"),
+                                    "application.properties");
+                }
+            });
+
+    @Test
+    public void testMapOfLists() {
+        RestAssured
+                .with()
+                .body("{\"mapOfLists\":{\"group\":[{\"name\":\"alpha\"}]}}")
+                .contentType("application/json")
+                .post("/nested-parameterized/map-of-lists")
+                .then()
+                .statusCode(200)
+                .body(is("alpha"));
+    }
+
+    @Test
+    public void testListOfLists() {
+        RestAssured
+                .with()
+                .body("{\"listOfLists\":[[{\"name\":\"beta\"}]]}")
+                .contentType("application/json")
+                .post("/nested-parameterized/list-of-lists")
+                .then()
+                .statusCode(200)
+                .body(is("beta"));
+    }
+
+    @Test
+    public void testListOfMaps() {
+        RestAssured
+                .with()
+                .body("{\"listOfMaps\":[{\"key\":{\"name\":\"gamma\"}}]}")
+                .contentType("application/json")
+                .post("/nested-parameterized/list-of-maps")
+                .then()
+                .statusCode(200)
+                .body(is("gamma"));
+    }
+
+    @Test
+    public void testOptionalList() {
+        RestAssured
+                .with()
+                .body("{\"optionalList\":[{\"name\":\"delta\"}]}")
+                .contentType("application/json")
+                .post("/nested-parameterized/optional-list")
+                .then()
+                .statusCode(200)
+                .body(is("delta"));
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/NestedParameterizedTypeResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/NestedParameterizedTypeResource.java
@@ -1,0 +1,107 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/nested-parameterized")
+public class NestedParameterizedTypeResource {
+
+    public static class ServiceStatus {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class MapOfListsRequest {
+        private Map<String, List<ServiceStatus>> mapOfLists;
+
+        public Map<String, List<ServiceStatus>> getMapOfLists() {
+            return mapOfLists;
+        }
+
+        public void setMapOfLists(Map<String, List<ServiceStatus>> mapOfLists) {
+            this.mapOfLists = mapOfLists;
+        }
+    }
+
+    public static class ListOfListsRequest {
+        private List<List<ServiceStatus>> listOfLists;
+
+        public List<List<ServiceStatus>> getListOfLists() {
+            return listOfLists;
+        }
+
+        public void setListOfLists(List<List<ServiceStatus>> listOfLists) {
+            this.listOfLists = listOfLists;
+        }
+    }
+
+    public static class ListOfMapsRequest {
+        private List<Map<String, ServiceStatus>> listOfMaps;
+
+        public List<Map<String, ServiceStatus>> getListOfMaps() {
+            return listOfMaps;
+        }
+
+        public void setListOfMaps(List<Map<String, ServiceStatus>> listOfMaps) {
+            this.listOfMaps = listOfMaps;
+        }
+    }
+
+    public static class OptionalListRequest {
+        private Optional<List<ServiceStatus>> optionalList;
+
+        public Optional<List<ServiceStatus>> getOptionalList() {
+            return optionalList;
+        }
+
+        public void setOptionalList(Optional<List<ServiceStatus>> optionalList) {
+            this.optionalList = optionalList;
+        }
+    }
+
+    @POST
+    @Path("/map-of-lists")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String mapOfLists(MapOfListsRequest request) {
+        return request.getMapOfLists().get("group").get(0).getName();
+    }
+
+    @POST
+    @Path("/list-of-lists")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String listOfLists(ListOfListsRequest request) {
+        return request.getListOfLists().get(0).get(0).getName();
+    }
+
+    @POST
+    @Path("/list-of-maps")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String listOfMaps(ListOfMapsRequest request) {
+        return request.getListOfMaps().get(0).get("key").getName();
+    }
+
+    @POST
+    @Path("/optional-list")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String optionalList(OptionalListRequest request) {
+        return request.getOptionalList().orElseThrow().get(0).getName();
+    }
+}


### PR DESCRIPTION
I checked that this fix is compatible with Jackson 2, so it should be possible to backport it to Quarkus 3.x branches without any change.

- Fixes: #55778