### PR TITLE
Fix static Mockito mocks in continuous testing

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -263,13 +263,9 @@ public class JunitTestRunner {
                                     currentNonDynamicTest.set(testIdentifier);
                                 }
                                 startTimes.put(testIdentifier, System.currentTimeMillis());
-                                String testClassName = "";
-                                Class<?> testClass = getTestClassFromSource(testIdentifier.getSource());
-                                if (testClass != null) {
-                                    testClassName = testClass.getName();
-                                }
+                                String testClassName = getTestClassNameFromSource(testIdentifier.getSource());
                                 for (TestRunListener listener : listeners) {
-                                    listener.testStarted(testIdentifier, testClassName);
+                                    listener.testStarted(testIdentifier, testClassName == null ? "" : testClassName);
                                 }
                                 touchedClasses.push(Collections.synchronizedSet(new HashSet<>()));
                             }
@@ -280,13 +276,13 @@ public class JunitTestRunner {
                                     return;
                                 }
                                 touchedClasses.pop();
-                                Class<?> testClass = getTestClassFromSource(testIdentifier.getSource());
-                                String displayName = getDisplayNameFromIdentifier(testIdentifier, testClass);
+                                String testClassName = getTestClassNameFromSource(testIdentifier.getSource());
+                                String displayName = getDisplayNameFromIdentifier(testIdentifier, testClassName);
                                 UniqueId id = UniqueId.parse(testIdentifier.getUniqueId());
-                                if (testClass != null) {
-                                    Map<UniqueId, TestResult> results = resultsByClass.computeIfAbsent(testClass.getName(),
+                                if (testClassName != null) {
+                                    Map<UniqueId, TestResult> results = resultsByClass.computeIfAbsent(testClassName,
                                             s -> new HashMap<>());
-                                    TestResult result = new TestResult(displayName, testClass.getName(),
+                                    TestResult result = new TestResult(displayName, testClassName,
                                             toTagList(testIdentifier),
                                             id, TestExecutionResult.aborted(null),
                                             logHandler.captureOutput(), testIdentifier.isTest(), runId, 0, true);
@@ -316,14 +312,13 @@ public class JunitTestRunner {
                                 }
                                 boolean dynamic = dynamicIds.contains(UniqueId.parse(testIdentifier.getUniqueId()));
                                 Set<String> touched = touchedClasses.pop();
-                                Class<?> testClass = getTestClassFromSource(testIdentifier.getSource());
-                                String displayName = getDisplayNameFromIdentifier(testIdentifier, testClass);
+                                String testClassName = getTestClassNameFromSource(testIdentifier.getSource());
+                                String displayName = getDisplayNameFromIdentifier(testIdentifier, testClassName);
                                 UniqueId id = UniqueId.parse(testIdentifier.getUniqueId());
 
-                                if (testClass == null) {
+                                if (testClassName == null) {
                                     return;
                                 }
-                                String testClassName = testClass.getName();
 
                                 if (testExecutionResult.getStatus() != TestExecutionResult.Status.ABORTED) {
                                     for (Set<String> i : touchedClasses) {
@@ -369,9 +364,9 @@ public class JunitTestRunner {
                                         results.put(UniqueId.parse(currentNonDynamicTest.get().getUniqueId()), result);
                                     } else if (testExecutionResult.getStatus() == TestExecutionResult.Status.FAILED) {
                                         Throwable throwable = testExecutionResult.getThrowable().get();
-                                        trimStackTrace(testClass, throwable);
+                                        trimStackTrace(testClassName, throwable);
                                         for (var i : throwable.getSuppressed()) {
-                                            trimStackTrace(testClass, i);
+                                            trimStackTrace(testClassName, i);
                                         }
                                     }
                                 } else if (testExecutionResult.getStatus() == TestExecutionResult.Status.FAILED) {
@@ -395,9 +390,9 @@ public class JunitTestRunner {
                                     }
 
                                     Throwable throwable = testExecutionResult.getThrowable().get();
-                                    trimStackTrace(testClass, throwable);
+                                    trimStackTrace(testClassName, throwable);
                                     for (var i : throwable.getSuppressed()) {
-                                        trimStackTrace(testClass, i);
+                                        trimStackTrace(testClassName, i);
                                     }
                                 }
                             }
@@ -459,16 +454,17 @@ public class JunitTestRunner {
                 .toList();
     }
 
-    private Class<?> getTestClassFromSource(Optional<TestSource> optionalTestSource) {
+    private String getTestClassNameFromSource(Optional<TestSource> optionalTestSource) {
         if (optionalTestSource.isPresent()) {
             var testSource = optionalTestSource.get();
+            // Avoid resolving the class again because its class loader may have been replaced in continuous testing.
             if (testSource instanceof ClassSource classSource) {
-                return classSource.getJavaClass();
+                return classSource.getClassName();
             } else if (testSource instanceof MethodSource methodSource) {
-                return methodSource.getJavaClass();
+                return methodSource.getClassName();
             } else if (testSource.getClass().getName().equals(ARCHUNIT_FIELDSOURCE_FQCN)) {
                 try {
-                    return (Class<?>) testSource.getClass().getMethod("getJavaClass").invoke(testSource);
+                    return ((Class<?>) testSource.getClass().getMethod("getJavaClass").invoke(testSource)).getName();
                 } catch (ReflectiveOperationException e) {
                     log.warnf(e, "Failed to read javaClass reflectively from %s. ArchUnit >= 0.23.0 is required.", testSource);
                 }
@@ -477,28 +473,33 @@ public class JunitTestRunner {
         return null;
     }
 
-    private String getDisplayNameFromIdentifier(TestIdentifier testIdentifier, Class<?> testClass) {
-        if (testIdentifier.getSource().isPresent() && testClass != null) {
+    private String getDisplayNameFromIdentifier(TestIdentifier testIdentifier, String testClassName) {
+        if (testIdentifier.getSource().isPresent() && testClassName != null) {
             var testSource = testIdentifier.getSource().get();
             if (testSource instanceof ClassSource) {
                 return testIdentifier.getDisplayName();
             } else if (testSource instanceof MethodSource
                     || testSource.getClass().getName().equals(ARCHUNIT_FIELDSOURCE_FQCN)) {
-                return testClass.getSimpleName() + "#" + testIdentifier.getDisplayName();
+                return getSimpleClassName(testClassName) + "#" + testIdentifier.getDisplayName();
             }
         }
         return testIdentifier.getDisplayName();
     }
 
-    private void trimStackTrace(Class<?> testClass, Throwable throwable) {
-        if (testClass != null) {
+    private String getSimpleClassName(String className) {
+        int separatorIndex = Math.max(className.lastIndexOf('.'), className.lastIndexOf('$'));
+        return className.substring(separatorIndex + 1);
+    }
+
+    private void trimStackTrace(String testClassName, Throwable throwable) {
+        if (testClassName != null) {
             //first we cut all the platform stuff out of the stack trace
             Throwable cause = throwable;
             while (cause != null) {
                 StackTraceElement[] st = cause.getStackTrace();
                 for (int i = st.length - 1; i >= 0; --i) {
                     StackTraceElement elem = st[i];
-                    if (elem.getClassName().equals(testClass.getName())) {
+                    if (elem.getClassName().equals(testClassName)) {
                         StackTraceElement[] newst = new StackTraceElement[i + 1];
                         System.arraycopy(st, 0, newst, 0, i + 1);
                         st = newst;

--- a/integration-tests/devmode/pom.xml
+++ b/integration-tests/devmode/pom.xml
@@ -96,12 +96,22 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit-component</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/mockito/MockStaticContinuousTestingTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/mockito/MockStaticContinuousTestingTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.test.mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.ContinuousTestingTestUtils;
+import io.quarkus.test.ContinuousTestingTestUtils.TestStatus;
+import io.quarkus.test.QuarkusDevModeTest;
+
+class MockStaticContinuousTestingTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest()
+            .withApplicationRoot(root -> root.addClass(StaticMockService.class)
+                    .add(new StringAsset(ContinuousTestingTestUtils.appProperties("quarkus.oidc.tenant-enabled=false")),
+                            "application.properties"))
+            .setTestArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(StaticMockET.class));
+
+    @Test
+    void staticMockIsClearedBetweenRuns() {
+        ContinuousTestingTestUtils testing = new ContinuousTestingTestUtils();
+        assertSuccessfulRun(testing.waitForNextCompletion());
+
+        config.modifyTestSourceFile(StaticMockET.class, source -> source.replace("expected-value", "updated-value"));
+
+        assertSuccessfulRun(testing.waitForNextCompletion());
+    }
+
+    private static void assertSuccessfulRun(TestStatus status) {
+        assertThat(status.getTestsPassed()).isEqualTo(2);
+        assertThat(status.getTestsFailed()).isZero();
+        assertThat(status.getTestsSkipped()).isZero();
+    }
+}

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/mockito/StaticMockET.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/mockito/StaticMockET.java
@@ -1,0 +1,34 @@
+package io.quarkus.test.mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDate;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class StaticMockET {
+
+    @Inject
+    StaticMockService service;
+
+    @Test
+    void mockStaticMethod() {
+        LocalDate date = LocalDate.of(2024, 6, 1);
+        try (MockedStatic<LocalDate> mockedLocalDate = Mockito.mockStatic(LocalDate.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedLocalDate.when(LocalDate::now).thenReturn(date);
+            assertEquals("2024-06-01-expected-value", service.value("expected-value"));
+        }
+    }
+
+    @Test
+    void callStaticMethod() {
+        assertEquals(LocalDate.now() + "-expected-value", service.value("expected-value"));
+    }
+}

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/mockito/StaticMockService.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/mockito/StaticMockService.java
@@ -1,0 +1,13 @@
+package io.quarkus.test.mockito;
+
+import java.time.LocalDate;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class StaticMockService {
+
+    public String value(String suffix) {
+        return LocalDate.now() + "-" + suffix;
+    }
+}


### PR DESCRIPTION
During continuous testing, the test classloader can be replaced between test runs. Resolving a test class again from JUnit's `ClassSource` or `MethodSource` while processing execution events can therefore use the wrong classloader and interfere with tests that use scoped static Mockito mocks.

Use the class names already exposed by the JUnit test sources when reporting test results, generating display names, and trimming stack traces. This avoids unnecessarily resolving the test class during event processing. A regression test covers a test using `mockStatic` followed by a continuous-testing rerun triggered by modifying its source.

* Fixes #55782