### PR TITLE
Include method names in parameterized test results

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -103,6 +103,8 @@ public class JunitTestRunner {
     private static final String ARCHUNIT_FIELDSOURCE_FQCN = "com.tngtech.archunit.junit.FieldSource";
     private static final String FACADE_CLASS_LOADER_NAME = "io.quarkus.test.junit.classloading.FacadeClassLoader";
     private static final String TEST_DISCOVERY_PROPERTY = "quarkus.continuous-tests-discovery";
+    // Matches TestTemplateInvocationTestDescriptor.SEGMENT_TYPE from JUnit Jupiter Engine
+    private static final String TEST_TEMPLATE_INVOCATION_SEGMENT_TYPE = "test-template-invocation";
 
     private final long runId;
     private final DevModeContext.ModuleInfo moduleInfo;
@@ -476,10 +478,16 @@ public class JunitTestRunner {
     private String getDisplayNameFromIdentifier(TestIdentifier testIdentifier, String testClassName) {
         if (testIdentifier.getSource().isPresent() && testClassName != null) {
             var testSource = testIdentifier.getSource().get();
-            if (testSource instanceof ClassSource) {
+            if (testSource instanceof MethodSource methodSource) {
+                if (testIdentifier.getUniqueIdObject().getLastSegment().getType()
+                        .equals(TEST_TEMPLATE_INVOCATION_SEGMENT_TYPE)) {
+                    return getSimpleClassName(testClassName) + "#" + methodSource.getMethodName() + "("
+                            + methodSource.getMethodParameterTypes() + ") " + testIdentifier.getDisplayName();
+                }
+                return getSimpleClassName(testClassName) + "#" + testIdentifier.getDisplayName();
+            } else if (testSource instanceof ClassSource) {
                 return testIdentifier.getDisplayName();
-            } else if (testSource instanceof MethodSource
-                    || testSource.getClass().getName().equals(ARCHUNIT_FIELDSOURCE_FQCN)) {
+            } else if (testSource.getClass().getName().equals(ARCHUNIT_FIELDSOURCE_FQCN)) {
                 return getSimpleClassName(testClassName) + "#" + testIdentifier.getDisplayName();
             }
         }

--- a/extensions/devui/deployment/src/test/java/io/quarkus/devui/testrunner/params/TestParameterizedTestCase.java
+++ b/extensions/devui/deployment/src/test/java/io/quarkus/devui/testrunner/params/TestParameterizedTestCase.java
@@ -1,5 +1,9 @@
 package io.quarkus.devui.testrunner.params;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -14,6 +18,7 @@ import io.quarkus.devui.tests.DevUIJsonRPCTest;
 import io.quarkus.test.ContinuousTestingTestUtils;
 import io.quarkus.test.ContinuousTestingTestUtils.TestStatus;
 import io.quarkus.test.QuarkusDevModeTest;
+import tools.jackson.databind.JsonNode;
 
 public class TestParameterizedTestCase extends DevUIJsonRPCTest {
 
@@ -46,6 +51,23 @@ public class TestParameterizedTestCase extends DevUIJsonRPCTest {
         Assertions.assertEquals(1L, ts.getTestsFailed());
         Assertions.assertEquals(4L, ts.getTestsPassed());
         Assertions.assertEquals(0L, ts.getTestsSkipped());
+
+        JsonNode testClassResults = super.executeJsonRPCMethod("getResults").get("results").get(ParamET.class.getName());
+        List<String> displayNames = new ArrayList<>();
+        for (String resultType : List.of("passing", "failing")) {
+            for (JsonNode testResult : testClassResults.get(resultType)) {
+                if (testResult.get("test").asBoolean()) {
+                    displayNames.add(testResult.get("displayName").asText());
+                }
+            }
+        }
+        assertThat(displayNames)
+                .filteredOn(name -> name.contains("shouldValidateOddNumbers"))
+                .containsExactlyInAnyOrder(
+                        "ParamET#shouldValidateOddNumbers(int) [1] x = 1",
+                        "ParamET#shouldValidateOddNumbers(int) [2] x = 4",
+                        "ParamET#shouldValidateOddNumbers(int) [3] x = 11",
+                        "ParamET#shouldValidateOddNumbers(int) [4] x = 17");
 
         super.executeJsonRPCMethod("runFailed");
 


### PR DESCRIPTION
Continuous testing currently reports parameterized test invocations using only their generated invocation labels, such as `[1] x = 1`. In test classes with many parameterized methods, this makes it difficult to identify which method produced each result.

Include the underlying method signature in test-template invocation names while preserving the invocation-specific parameter details. Regular test display names remain unchanged.

* Closes: #55781
