### PR TITLE
Update Artemis dependencies to relocated org.apache.artemis groupId

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -390,7 +390,7 @@
 
             <!-- Artemis test dependencies -->
             <dependency>
-                <groupId>org.apache.activemq</groupId>
+                <groupId>org.apache.artemis</groupId>
                 <artifactId>artemis-server</artifactId>
                 <version>${artemis.version}</version>
                 <scope>test</scope>
@@ -418,13 +418,13 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.apache.activemq</groupId>
+                <groupId>org.apache.artemis</groupId>
                 <artifactId>artemis-amqp-protocol</artifactId>
                 <version>${artemis.version}</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
-                        <groupId>org.apache.activemq</groupId>
+                        <groupId>org.apache.artemis</groupId>
                         <artifactId>artemis-server</artifactId>
                     </exclusion>
                 </exclusions>

--- a/extensions/smallrye-reactive-messaging-amqp/deployment/pom.xml
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/pom.xml
@@ -48,7 +48,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-server</artifactId>
             <scope>test</scope>
         </dependency>
@@ -63,7 +63,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-amqp-protocol</artifactId>
             <scope>test</scope>
         </dependency>

--- a/independent-projects/enforcer-rules/src/main/resources/enforcer-rules/quarkus-banned-dependencies.xml
+++ b/independent-projects/enforcer-rules/src/main/resources/enforcer-rules/quarkus-banned-dependencies.xml
@@ -119,6 +119,11 @@
                 <exclude>org.lz4:lz4-java</exclude>
                 <!-- org.fusesource.jansi:jansi is abandoned and has a CVE -->
                 <exclude>org.fusesource.jansi:jansi</exclude>
+                <!-- Artemis artifacts relocated from org.apache.activemq to org.apache.artemis -->
+                <!-- see https://artemis.apache.org/artemis-tlp-groupid-migration -->
+                <!-- Can't exclude them yet as the migration needs to be done in downstream
+                     quarkiverse extensions first: should not be a problem as there are relocations in place -->
+                <!-- exclude>org.apache.activemq:artemis-*</exclude -->
             </excludes>
             <includes>
                 <!-- this is for REST Assured -->

--- a/independent-projects/enforcer-rules/src/main/resources/enforcer-rules/quarkus-banned-dependencies.xml
+++ b/independent-projects/enforcer-rules/src/main/resources/enforcer-rules/quarkus-banned-dependencies.xml
@@ -121,6 +121,11 @@
                 <exclude>org.lz4:lz4-java</exclude>
                 <!-- org.fusesource.jansi:jansi is abandoned and has a CVE -->
                 <exclude>org.fusesource.jansi:jansi</exclude>
+                <!-- Artemis artifacts relocated from org.apache.activemq to org.apache.artemis -->
+                <!-- see https://artemis.apache.org/artemis-tlp-groupid-migration -->
+                <!-- Can't exclude them yet as the migration needs to be done in downstream
+                     quarkiverse extensions first: should not be a problem as there are relocations in place -->
+                <!-- exclude>org.apache.activemq:artemis-*</exclude -->
             </excludes>
             <includes>
                 <!-- this is for REST Assured -->

--- a/integration-tests/reactive-messaging-amqp/pom.xml
+++ b/integration-tests/reactive-messaging-amqp/pom.xml
@@ -56,12 +56,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-server</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-amqp-protocol</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
The org.apache.activemq:artemis-server and artemis-amqp-protocol artifacts were relocated to org.apache.artemis, per https://artemis.apache.org/artemis-tlp-groupid-migration.

Spotted because of IDEA project import warnings.
