### PR TITLE
Upgrade aesh to 3.16.6 and register MetadataRegistry for native image

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -204,8 +204,8 @@
         <!-- Check the compatibility matrix (https://github.com/opensearch-project/opensearch-testcontainers) before upgrading: -->
         <opensearch-testcontainers.version>2.1.3</opensearch-testcontainers.version>
         <com.dajudge.kindcontainer>2.0.0</com.dajudge.kindcontainer>
-        <aesh.version>3.16.4</aesh.version>
-        <aesh-readline.version>3.16.2</aesh-readline.version>
+        <aesh.version>3.16.6</aesh.version>
+        <aesh-readline.version>3.16.3</aesh-readline.version>
         <jline.version>4.2.1</jline.version> <!-- Keep in sync with dekorate -->
         <!-- these two artifacts needs to be compatible together -->
         <strimzi-oauth.version>0.16.1</strimzi-oauth.version>

--- a/docs/src/main/asciidoc/aesh.adoc
+++ b/docs/src/main/asciidoc/aesh.adoc
@@ -677,15 +677,16 @@ package com.acme.aesh;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
+import java.util.function.Consumer;
+
 import org.aesh.command.CommandNotFoundHandler;
-import org.aesh.command.shell.Shell;
 
 @ApplicationScoped
 public class MyNotFoundHandler implements CommandNotFoundHandler {
 
     @Override
-    public void handleCommandNotFound(String line, Shell shell) {
-        shell.writeln("Unknown command: " + line + ". Type 'help' for available commands.");
+    public void handleCommandNotFound(String line, Consumer<String> output) {
+        output.accept("Unknown command: " + line + ". Type 'help' for available commands.");
     }
 }
 ----

--- a/extensions/aesh/deployment/src/main/java/io/quarkus/aesh/deployment/AeshNativeImageProcessor.java
+++ b/extensions/aesh/deployment/src/main/java/io/quarkus/aesh/deployment/AeshNativeImageProcessor.java
@@ -22,6 +22,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
@@ -32,13 +33,19 @@ class AeshNativeImageProcessor {
     private static final Logger LOGGER = Logger.getLogger(AeshNativeImageProcessor.class);
 
     /**
-     * Registers aesh annotation processor generated {@code CommandMetadataProvider}
-     * implementations for ServiceLoader discovery in native images.
+     * Registers aesh metadata discovery resources for native images.
+     * <p>
+     * Aesh discovers {@code MetadataRegistry} implementations via a resource file
+     * ({@code META-INF/aesh/registry}) before falling back to ServiceLoader.
+     * Registering the resource file is sufficient and avoids ServiceLoader overhead
+     * at startup.
      */
     @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
-    void registerMetadataProviders(BuildProducer<ServiceProviderBuildItem> serviceProviders) {
+    void registerMetadataProviders(BuildProducer<ServiceProviderBuildItem> serviceProviders,
+            BuildProducer<NativeImageResourceBuildItem> nativeResources) {
         serviceProviders.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
                 "org.aesh.command.metadata.CommandMetadataProvider"));
+        nativeResources.produce(new NativeImageResourceBuildItem("META-INF/aesh/registry"));
     }
 
     @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
@@ -114,9 +121,11 @@ class AeshNativeImageProcessor {
                 .build()));
 
         // Register aesh internal classes that are instantiated reflectively at runtime.
-        // These are used as defaults or selected dynamically based on field types
+        // InternalCommandMetadataRegistry is loaded by resource-file discovery via Class.forName().
+        // The others are used as defaults or selected dynamically based on field types
         // (e.g. BooleanOptionCompleter for boolean fields, FileOptionCompleter for File fields).
         reflectiveClasses.produce(ReflectiveClassBuildItem.builder(
+                "org.aesh.command.internal.InternalCommandMetadataRegistry",
                 "org.aesh.command.impl.completer.BooleanOptionCompleter",
                 "org.aesh.command.impl.completer.FileOptionCompleter",
                 "org.aesh.command.impl.completer.NullOptionCompleter",

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/CommandNotFoundHandlerTest.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/CommandNotFoundHandlerTest.java
@@ -1,5 +1,7 @@
 package io.quarkus.aesh.deployment;
 
+import java.util.function.Consumer;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.aesh.command.Command;
@@ -7,7 +9,6 @@ import org.aesh.command.CommandDefinition;
 import org.aesh.command.CommandNotFoundHandler;
 import org.aesh.command.CommandResult;
 import org.aesh.command.invocation.CommandInvocation;
-import org.aesh.command.shell.Shell;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -61,8 +62,8 @@ public class CommandNotFoundHandlerTest {
     public static class MyNotFoundHandler implements CommandNotFoundHandler {
 
         @Override
-        public void handleCommandNotFound(String line, Shell shell) {
-            shell.writeln("Unknown command: " + line + ". Try: hello, calc");
+        public void handleCommandNotFound(String line, Consumer<String> output) {
+            output.accept("Unknown command: " + line + ". Try: hello, calc");
         }
     }
 }

--- a/integration-tests/aesh-native/src/main/java/io/quarkus/it/aesh/MetadataCheckCommand.java
+++ b/integration-tests/aesh-native/src/main/java/io/quarkus/it/aesh/MetadataCheckCommand.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.aesh;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.metadata.MetadataProviderRegistry;
+
+/**
+ * Verifies that the {@code MetadataRegistry} discovery works in native mode.
+ * <p>
+ * In native images, the {@code META-INF/aesh/registry} resource file must be
+ * registered so aesh can discover {@code InternalCommandMetadataRegistry} and
+ * look up annotation-processor-generated command metadata providers.
+ */
+@CommandDefinition(name = "metadata-check", description = "Verify metadata registry works")
+public class MetadataCheckCommand implements Command<CommandInvocation> {
+
+    @Override
+    public CommandResult execute(CommandInvocation invocation) {
+        var provider = MetadataProviderRegistry.getProvider(MetadataCheckCommand.class);
+        invocation.println("metadata-provider: " + (provider != null ? "found" : "missing"));
+        return CommandResult.SUCCESS;
+    }
+}

--- a/integration-tests/aesh-native/src/main/java/io/quarkus/it/aesh/TopAeshCommand.java
+++ b/integration-tests/aesh-native/src/main/java/io/quarkus/it/aesh/TopAeshCommand.java
@@ -8,7 +8,7 @@ import org.aesh.command.option.Option;
 
 @CommandDefinition(name = "app", description = "Test application", groupCommands = { HelloCommand.class, RunCommand.class,
         VersionCommand.class, FailCommand.class, ExplodingCommand.class, CdiGreetCommand.class, ListOptionsCommand.class,
-        MultiArgsCommand.class })
+        MultiArgsCommand.class, MetadataCheckCommand.class })
 public class TopAeshCommand implements Command<CommandInvocation> {
 
     @Option(shortName = 'v', name = "verbose", description = "Enable verbose output", hasValue = false)

--- a/integration-tests/aesh-native/src/test/java/io/quarkus/it/aesh/AeshTest.java
+++ b/integration-tests/aesh-native/src/test/java/io/quarkus/it/aesh/AeshTest.java
@@ -113,4 +113,14 @@ public class AeshTest {
         assertThat(hello2.exitCode()).isZero();
         assertThat(hello2.getOutput()).contains("Hello Second!");
     }
+
+    @Test
+    @Launch({ "metadata-check" })
+    public void testMetadataRegistryDiscovery(LaunchResult result) {
+        // Verifies that MetadataRegistry discovery works in native mode.
+        // If META-INF/aesh/registry is not registered as a native image resource,
+        // MetadataProviderRegistry.getProvider() would return null.
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.getOutput()).contains("metadata-provider: found");
+    }
 }


### PR DESCRIPTION
Register META-INF/aesh/registry as a native image resource so aesh can discover MetadataRegistry implementations via its resource-file discovery mechanism (faster than ServiceLoader). Also register InternalCommandMetadataRegistry for reflection since the resource-file discovery loads it via Class.forName().
