### PR TITLE
[3.x] Support @JsonSerialize/@JsonDeserialize in the reflection-free Jackson serializers

### DIFF
--- a/docs/src/main/asciidoc/rest.adoc
+++ b/docs/src/main/asciidoc/rest.adoc
@@ -1757,6 +1757,10 @@ When enabled, {project-name} generates `StdSerializer` and `StdDeserializer` imp
 
 Developers can further customize JSON processing by implementing the `ObjectMapperCustomizer` interface. This interface allows fine-grained control over the `ObjectMapper`, enabling the registration of custom serializers and deserializers while ensuring compatibility with the reflection-free optimization. If additional configuration is needed, implement an `ObjectMapperCustomizer` bean and register any necessary modules or settings.
 
+The generated serializers and deserializers honour `@JsonSerialize(using = ...)`, its `nullsUsing` companion, and `@JsonDeserialize(using = ...)` when declared on a property. The declared serializer or deserializer has to be a public concrete class with a public no-args constructor, and must not be one that Jackson contextualizes or resolves before use, so it cannot implement `ContextualSerializer`, `ResolvableSerializer`, `ContextualDeserializer` or `ResolvableDeserializer`.
+
+Other uses of these annotations are left to Jackson: a declaration at class level, the `contentUsing`, `keyUsing`, `as`, `keyAs`, `contentAs`, `converter` and `contentConverter` attributes, `@JsonSerialize#typing` and `@JsonDeserialize#builder`. The same applies to a `@JsonDeserialize#using` deserializer on a primitive or `char` property, whose value could not be written back. In all these cases the class is serialized and deserialized reflectively, and the build log reports why the generation was skipped.
+
 [NOTE]
 ====
 Reflection-free serializers are not compatible with Kotlin classes, since they break Kotlin-specific features such as default parameter values and non-null type enforcement. As a result, reflection-free serializers are not generated for Kotlin classes.

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -55,8 +55,12 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -75,6 +79,10 @@ public abstract class JacksonCodeGenerator {
 
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
     private static final DotName KOTLIN_METADATA = DotName.createSimple("kotlin.Metadata");
+
+    // the placeholders Jackson uses to mean that no serializer or deserializer has been specified
+    protected static final String NO_SERIALIZER = JsonSerializer.None.class.getName();
+    protected static final String NO_DESERIALIZER = JsonDeserializer.None.class.getName();
 
     private static final Set<String> SUPPORTED_JACKSON_ANNOTATIONS = Set.of(
             JacksonAnnotation.class.getName(),
@@ -95,8 +103,10 @@ public abstract class JacksonCodeGenerator {
             JsonNaming.class.getName(),
             JsonProperty.class.getName(),
             JsonPropertyDescription.class.getName(),
+            JsonDeserialize.class.getName(),
             JsonPropertyOrder.class.getName(),
             JsonRawValue.class.getName(),
+            JsonSerialize.class.getName(),
             JsonSetter.class.getName(),
             JsonSubTypes.class.getName(),
             JsonTypeInfo.class.getName(),
@@ -149,6 +159,12 @@ public abstract class JacksonCodeGenerator {
         if (unknownAnnotation.isPresent()) {
             log.infof("Skipping generation of reflection-free Jackson serializer for class %s" +
                     " because it contains the unsupported Jackson annotation %s", beanClassName, unknownAnnotation.get());
+            return Optional.empty();
+        }
+        Optional<String> unsupportedFeature = findUnsupportedFeature(classInfo);
+        if (unsupportedFeature.isPresent()) {
+            log.infof("Skipping generation of reflection-free Jackson serializer for class %s because %s",
+                    beanClassName, unsupportedFeature.get());
             return Optional.empty();
         }
 
@@ -238,6 +254,104 @@ public abstract class JacksonCodeGenerator {
                 .map(a -> a.name().toString())
                 .filter(FieldSpecs::isUnknownAnnotation)
                 .findFirst();
+    }
+
+    /**
+     * Vetoes the code generation for a class using a supported Jackson annotation in a way that cannot be reproduced
+     * here. The returned text is logged as the reason for falling back to the reflection based Jackson implementation.
+     */
+    protected abstract Optional<String> findUnsupportedFeature(ClassInfo classInfo);
+
+    protected String findUnsupportedAnnotationUsage(ClassInfo classInfo, DotName annotationName,
+            Function<AnnotationInstance, String> validator) {
+        for (AnnotationInstance annotation : classInfo.annotations()) {
+            if (annotation.name().equals(annotationName)) {
+                String reason = validator.apply(annotation);
+                if (reason != null) {
+                    return reason;
+                }
+            }
+        }
+        // the inherited properties are handled by this same generated class, so check them too.
+        // note that onSuperClass returns null, not an empty reason, when there is no superclass to inspect
+        return onSuperClass(classInfo,
+                superClassInfo -> findUnsupportedAnnotationUsage(superClassInfo, annotationName, validator));
+    }
+
+    protected static boolean isSet(AnnotationInstance annotation, String attribute, Set<String> unsetValues) {
+        AnnotationValue value = annotation.value(attribute);
+        return value != null && !unsetValues.contains(value.asClass().name().toString());
+    }
+
+    /**
+     * Checks that the serializer or deserializer declared by the given attribute can be instantiated with a plain
+     * {@code new} and used as is, and returns the reason why it cannot when that is not the case.
+     */
+    protected static String validateHandler(AnnotationInstance annotation, String attribute, String unsetValue,
+            Class<?> handlerType, Class<?>... typesNeedingContextualization) {
+        AnnotationValue value = annotation.value(attribute);
+        if (value == null) {
+            return null;
+        }
+        String handlerClassName = value.asClass().name().toString();
+        if (unsetValue.equals(handlerClassName)) {
+            return null;
+        }
+
+        Class<?> handlerClass;
+        try {
+            handlerClass = Class.forName(handlerClassName, false, Thread.currentThread().getContextClassLoader());
+        } catch (ClassNotFoundException | LinkageError e) {
+            return unusableHandler(annotation, handlerClassName, attribute, "it cannot be loaded at build time");
+        }
+        if (!handlerType.isAssignableFrom(handlerClass)) {
+            return unusableHandler(annotation, handlerClassName, attribute, "it is not a " + handlerType.getSimpleName());
+        }
+        if (!Modifier.isPublic(handlerClass.getModifiers()) || Modifier.isAbstract(handlerClass.getModifiers())) {
+            return unusableHandler(annotation, handlerClassName, attribute, "it is not a public concrete class");
+        }
+        for (Class<?> needingContextualization : typesNeedingContextualization) {
+            if (needingContextualization.isAssignableFrom(handlerClass)) {
+                return unusableHandler(annotation, handlerClassName, attribute, "it has to be contextualized by Jackson");
+            }
+        }
+        try {
+            handlerClass.getConstructor();
+        } catch (NoSuchMethodException e) {
+            return unusableHandler(annotation, handlerClassName, attribute, "it has no public no-args constructor");
+        }
+        return null;
+    }
+
+    private static String unusableHandler(AnnotationInstance annotation, String handlerClassName, String attribute,
+            String reason) {
+        return "the " + handlerClassName + " declared by @" + annotation.name().withoutPackagePrefix() + "#" + attribute
+                + " cannot be used in generated code since " + reason;
+    }
+
+    protected static Type targetType(AnnotationTarget target) {
+        if (target == null) {
+            return null;
+        }
+        return switch (target.kind()) {
+            case FIELD -> target.asField().type();
+            // a setter carries the property type as its only parameter, a getter as its return type
+            case METHOD -> target.asMethod().parametersCount() == 1
+                    ? target.asMethod().parameterType(0)
+                    : target.asMethod().returnType();
+            case METHOD_PARAMETER -> target.asMethodParameter().type();
+            case RECORD_COMPONENT -> target.asRecordComponent().type();
+            default -> null;
+        };
+    }
+
+    protected static boolean isCharacterTarget(AnnotationTarget target) {
+        Type targetType = targetType(target);
+        if (targetType == null) {
+            return false;
+        }
+        String typeName = targetType.name().toString();
+        return "char".equals(typeName) || "java.lang.Character".equals(typeName);
     }
 
     protected enum FieldKind {
@@ -737,6 +851,31 @@ public abstract class JacksonCodeGenerator {
                 case "NON_ABSENT" -> "NON_ABSENT";
                 default -> null;
             };
+        }
+
+        String customSerializerClass() {
+            return declaredHandler(JsonSerialize.class.getName(), "using", NO_SERIALIZER);
+        }
+
+        String nullSerializerClass() {
+            return declaredHandler(JsonSerialize.class.getName(), "nullsUsing", NO_SERIALIZER);
+        }
+
+        String customDeserializerClass() {
+            return declaredHandler(JsonDeserialize.class.getName(), "using", NO_DESERIALIZER);
+        }
+
+        private String declaredHandler(String annotationName, String attribute, String unsetValue) {
+            AnnotationInstance annotation = annotations.get(annotationName);
+            if (annotation == null) {
+                return null;
+            }
+            AnnotationValue value = annotation.value(attribute);
+            if (value == null) {
+                return null;
+            }
+            String handlerClassName = value.asClass().name().toString();
+            return unsetValue.equals(handlerClassName) ? null : handlerClassName;
         }
 
         static boolean isUnknownAnnotation(String ann) {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
@@ -19,7 +19,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
@@ -31,6 +34,7 @@ import org.jboss.jandex.VoidType;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.ObjectCodec;
@@ -43,14 +47,18 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.ResolvableDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.databind.util.Converter;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
@@ -224,6 +232,16 @@ import io.quarkus.resteasy.reactive.jackson.runtime.mappers.JacksonMapperUtil;
  */
 public class JacksonDeserializerFactory extends JacksonCodeGenerator {
 
+    private static final DotName JSON_DESERIALIZE = DotName.createSimple(JsonDeserialize.class.getName());
+    private static final DotName JSON_UNWRAPPED = DotName.createSimple(JsonUnwrapped.class.getName());
+
+    private static final Set<String> UNSET_CLASS_VALUES = Set.of(NO_DESERIALIZER, KeyDeserializer.None.class.getName(),
+            Void.class.getName(), Converter.None.class.getName());
+
+    // the @JsonDeserialize attributes that cannot be reproduced in the generated deserializer
+    private static final List<String> UNSUPPORTED_JSON_DESERIALIZE_ATTRIBUTES = List.of(
+            "contentUsing", "keyUsing", "as", "keyAs", "contentAs", "builder", "converter", "contentConverter");
+
     public JacksonDeserializerFactory(BuildProducer<GeneratedClassBuildItem> generatedClassBuildItemBuildProducer,
             IndexView jandexIndex) {
         super(generatedClassBuildItemBuildProducer, jandexIndex);
@@ -241,6 +259,40 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
 
     protected String[] getInterfacesNames(ClassInfo classInfo) {
         return classInfo.typeParameters().isEmpty() ? new String[0] : new String[] { ContextualDeserializer.class.getName() };
+    }
+
+    @Override
+    protected Optional<String> findUnsupportedFeature(ClassInfo classInfo) {
+        return Optional.ofNullable(
+                findUnsupportedAnnotationUsage(classInfo, JSON_DESERIALIZE, this::findUnsupportedJsonDeserializeUsage));
+    }
+
+    private String findUnsupportedJsonDeserializeUsage(AnnotationInstance annotation) {
+        AnnotationTarget target = annotation.target();
+        if (target != null && target.kind() == AnnotationTarget.Kind.CLASS) {
+            // a class level @JsonDeserialize replaces the deserialization of the whole type, which is what the
+            // generated deserializer does, so let Jackson use the declared deserializer instead
+            return "it declares a class level @JsonDeserialize";
+        }
+        for (String attribute : UNSUPPORTED_JSON_DESERIALIZE_ATTRIBUTES) {
+            if (isSet(annotation, attribute, UNSET_CLASS_VALUES)) {
+                return "it uses the unsupported @JsonDeserialize#" + attribute + " attribute";
+            }
+        }
+        if (target != null && target.annotations().stream().anyMatch(a -> a.name().equals(JSON_UNWRAPPED))) {
+            return "it combines @JsonDeserialize with @JsonUnwrapped";
+        }
+        if (isSet(annotation, "using", UNSET_CLASS_VALUES) && isUnwritableTarget(target)) {
+            // a char is read as a String, and a primitive cannot take the null returned for a json null
+            return "it declares a @JsonDeserialize#using deserializer on a primitive or char property";
+        }
+        return validateHandler(annotation, "using", NO_DESERIALIZER, JsonDeserializer.class,
+                ContextualDeserializer.class, ResolvableDeserializer.class);
+    }
+
+    private static boolean isUnwritableTarget(AnnotationTarget target) {
+        Type targetType = targetType(target);
+        return targetType != null && (targetType.kind() == Type.Kind.PRIMITIVE || isCharacterTarget(target));
     }
 
     @Override
@@ -277,6 +329,7 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
                 : createDeserializedObject(deserData);
 
         if (deserializedHandle == null) {
+            closeStaticInitializer(classCreator);
             return false;
         }
 
@@ -287,6 +340,7 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
             valid = deserializeObjectFields(deserData, deserializedHandle);
         }
         deserialize.returnValue(deserializedHandle);
+        closeStaticInitializer(classCreator);
         return valid;
     }
 
@@ -638,7 +692,11 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
                 .getFieldCreator(TRANSLATABLE_FIELD_NAMES, String[].class.getName())
                 .setModifiers(ACC_STATIC | ACC_FINAL);
         clinit.writeStaticField(fieldCreator.getFieldDescriptor(), namesArray);
-        clinit.returnVoid();
+        // the static initializer is closed by closeStaticInitializer, since reading the fields may still add to it
+    }
+
+    private static void closeStaticInitializer(ClassCreator classCreator) {
+        classCreator.getMethodCreator("<clinit>", void.class).setModifiers(ACC_STATIC).returnVoid();
     }
 
     private BranchResult iteratorHasNext(BytecodeCreator creator, ResultHandle iterator) {
@@ -808,6 +866,13 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
     private ResultHandle readValueFromJson(ClassCreator classCreator, BytecodeCreator bytecode,
             ResultHandle deserializationContext, FieldSpecs fieldSpecs, Map<String, Integer> typeParametersIndex,
             ResultHandle valueNode) {
+        String customDeserializerClassName = fieldSpecs.customDeserializerClass();
+        if (customDeserializerClassName != null) {
+            // @JsonDeserialize(using = ...) takes precedence over the type based reading of the value
+            return readValueWithCustomDeserializer(classCreator, bytecode, deserializationContext, fieldSpecs,
+                    customDeserializerClassName, valueNode);
+        }
+
         Type fieldType = fieldSpecs.fieldType;
         String fieldTypeName = fieldType.name().toString();
         if (JacksonSerializationUtils.isBasicJsonType(fieldType)) {
@@ -866,6 +931,29 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
         MethodDescriptor readTreeAsValue = ofMethod(DeserializationContext.class, "readTreeAsValue",
                 Object.class, JsonNode.class, fieldKind.isGeneric() ? JavaType.class : Class.class);
         return bytecode.invokeVirtualMethod(readTreeAsValue, deserializationContext, valueNode, typeHandle);
+    }
+
+    /**
+     * Reads the property through the deserializer declared by {@code @JsonDeserialize(using = ...)}, kept in a static
+     * field of the generated deserializer.
+     */
+    private static ResultHandle readValueWithCustomDeserializer(ClassCreator classCreator, BytecodeCreator bytecode,
+            ResultHandle deserializationContext, FieldSpecs fieldSpecs, String deserializerClassName,
+            ResultHandle valueNode) {
+        String fieldName = fieldSpecs.fieldName + "_DESERIALIZER";
+
+        MethodCreator clinit = classCreator.getMethodCreator("<clinit>", void.class).setModifiers(ACC_STATIC);
+        FieldCreator fieldCreator = classCreator.getFieldCreator(fieldName, JsonDeserializer.class.getName())
+                .setModifiers(ACC_STATIC | ACC_FINAL);
+        clinit.writeStaticField(fieldCreator.getFieldDescriptor(),
+                clinit.newInstance(MethodDescriptor.ofConstructor(deserializerClassName)));
+
+        ResultHandle deserializer = bytecode.readStaticField(
+                FieldDescriptor.of(classCreator.getClassName(), fieldName, JsonDeserializer.class.getName()));
+        return bytecode.invokeStaticMethod(
+                ofMethod(JacksonMapperUtil.class, "deserializeWithCustomDeserializer", Object.class,
+                        JsonNode.class, JsonDeserializer.class, DeserializationContext.class),
+                valueNode, deserializer, deserializationContext);
     }
 
     private void writeValueToObject(ClassInfo classInfo, ResultHandle objHandle, FieldSpecs fieldSpecs,

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
@@ -16,7 +16,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
@@ -24,6 +28,7 @@ import org.jboss.jandex.VoidType;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonToken;
@@ -31,13 +36,18 @@ import com.fasterxml.jackson.core.SerializableString;
 import com.fasterxml.jackson.core.io.SerializedString;
 import com.fasterxml.jackson.core.type.WritableTypeId;
 import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.ser.ContextualSerializer;
+import com.fasterxml.jackson.databind.ser.ResolvableSerializer;
 import com.fasterxml.jackson.databind.type.SimpleType;
+import com.fasterxml.jackson.databind.util.Converter;
 
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -179,6 +189,16 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
     private static final String SUPER_CLASS_NAME = GeneratedSerializer.class.getName();
     private static final String SER_STRINGS_CLASS_NAME = "SerializedStrings$quarkusjacksonserializer";
 
+    private static final DotName JSON_SERIALIZE = DotName.createSimple(JsonSerialize.class.getName());
+    private static final DotName JSON_UNWRAPPED = DotName.createSimple(JsonUnwrapped.class.getName());
+
+    private static final Set<String> UNSET_CLASS_VALUES = Set.of(NO_SERIALIZER, Void.class.getName(),
+            Converter.None.class.getName());
+
+    // the @JsonSerialize attributes that cannot be reproduced in the generated serializer
+    private static final List<String> UNSUPPORTED_JSON_SERIALIZE_ATTRIBUTES = List.of(
+            "contentUsing", "keyUsing", "as", "keyAs", "contentAs", "converter", "contentConverter");
+
     private final Map<String, Map<String, String>> generatedFields = new HashMap<>();
 
     public JacksonSerializerFactory(BuildProducer<GeneratedClassBuildItem> generatedClassBuildItemBuildProducer,
@@ -232,6 +252,44 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
     }
 
     @Override
+    protected Optional<String> findUnsupportedFeature(ClassInfo classInfo) {
+        return Optional.ofNullable(
+                findUnsupportedAnnotationUsage(classInfo, JSON_SERIALIZE, this::findUnsupportedJsonSerializeUsage));
+    }
+
+    private String findUnsupportedJsonSerializeUsage(AnnotationInstance annotation) {
+        AnnotationTarget target = annotation.target();
+        if (target != null && target.kind() == AnnotationTarget.Kind.CLASS) {
+            // a class level @JsonSerialize replaces the serialization of the whole type, which is what the
+            // generated serializer does, so let Jackson use the declared serializer instead
+            return "it declares a class level @JsonSerialize";
+        }
+        for (String attribute : UNSUPPORTED_JSON_SERIALIZE_ATTRIBUTES) {
+            if (isSet(annotation, attribute, UNSET_CLASS_VALUES)) {
+                return "it uses the unsupported @JsonSerialize#" + attribute + " attribute";
+            }
+        }
+        AnnotationValue typing = annotation.value("typing");
+        if (typing != null && !"DEFAULT_TYPING".equals(typing.asEnum())) {
+            return "it uses the unsupported @JsonSerialize#typing attribute";
+        }
+        if (target != null && target.annotations().stream().anyMatch(a -> a.name().equals(JSON_UNWRAPPED))) {
+            return "it combines @JsonSerialize with @JsonUnwrapped";
+        }
+        if (isSet(annotation, "using", UNSET_CLASS_VALUES) && isCharacterTarget(target)) {
+            // a char is turned into a String before being written, which a serializer of Character cannot accept
+            return "it declares a @JsonSerialize#using serializer on a char property";
+        }
+        String unusable = validateSerializer(annotation, "using");
+        return unusable != null ? unusable : validateSerializer(annotation, "nullsUsing");
+    }
+
+    private static String validateSerializer(AnnotationInstance annotation, String attribute) {
+        return validateHandler(annotation, attribute, NO_SERIALIZER, JsonSerializer.class,
+                ContextualSerializer.class, ResolvableSerializer.class);
+    }
+
+    @Override
     protected boolean createSerializationMethod(ClassInfo classInfo, ClassCreator classCreator, String beanClassName) {
         var jsonValueFieldSpecs = jsonValueFieldSpecs(classInfo);
         if (jsonValueFieldSpecs == null) {
@@ -249,7 +307,7 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
 
         if (isJsonValue) {
             SerializationContext ctx = new SerializationContext(contentMethod, beanClassName);
-            serializeJsonValue(ctx, contentMethod, jsonValueFieldSpecs.get());
+            serializeJsonValue(classCreator, ctx, contentMethod, jsonValueFieldSpecs.get());
         } else {
             Set<String> serializedFields = new HashSet<>();
             SerializationContext ctx = new SerializationContext(contentMethod, beanClassName);
@@ -261,8 +319,9 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
             if (serializedFields.isEmpty()) {
                 throwExceptionForEmptyBean(beanClassName, contentMethod, contentMethod.getMethodParam(1));
             }
-            classCreator.getMethodCreator("<clinit>", void.class).setModifiers(ACC_STATIC).returnVoid();
         }
+        // the static initializer may have been populated while writing the fields, so it is closed only now
+        classCreator.getMethodCreator("<clinit>", void.class).setModifiers(ACC_STATIC).returnVoid();
         contentMethod.returnVoid();
 
         if (isJsonValue || isArrayShape) {
@@ -349,9 +408,14 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
         return jsonValueMethodFieldSpecs;
     }
 
-    private void serializeJsonValue(SerializationContext ctx, MethodCreator bytecode, FieldSpecs jsonValueFieldSpecs) {
+    private void serializeJsonValue(ClassCreator classCreator, SerializationContext ctx, MethodCreator bytecode,
+            FieldSpecs jsonValueFieldSpecs) {
         String typeName = jsonValueFieldSpecs.fieldType.name().toString();
         ResultHandle arg = jsonValueFieldSpecs.toValueReaderHandle(bytecode, ctx.valueHandle);
+        if (jsonValueFieldSpecs.customSerializerClass() != null) {
+            writeCustomSerializedValue(classCreator, jsonValueFieldSpecs, bytecode, ctx, null, arg);
+            return;
+        }
         writeFieldValue(jsonValueFieldSpecs, bytecode, ctx, typeName, arg, null);
     }
 
@@ -414,7 +478,7 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
                             : getterVisibleHandle;
                     writeBranch = writeBranch.ifTrue(visibleHandle).trueBranch();
                 }
-                writeField(pkgName, fieldSpecs, writeBranch, ctx, classInclude);
+                writeField(classCreator, pkgName, fieldSpecs, writeBranch, ctx, classInclude);
             }
         }
 
@@ -516,13 +580,13 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
                         || methodInfo.hasAnnotation(JsonGetter.class));
     }
 
-    private void writeField(ClassInfo classInfo, FieldSpecs fieldSpecs, BytecodeCreator bytecode, SerializationContext ctx,
-            String classInclude) {
-        writeField(classInfo.name().packagePrefixName().toString(), fieldSpecs, bytecode, ctx, classInclude);
+    private void writeField(ClassCreator classCreator, ClassInfo classInfo, FieldSpecs fieldSpecs, BytecodeCreator bytecode,
+            SerializationContext ctx, String classInclude) {
+        writeField(classCreator, classInfo.name().packagePrefixName().toString(), fieldSpecs, bytecode, ctx, classInclude);
     }
 
-    private void writeField(String pkgName, FieldSpecs fieldSpecs, BytecodeCreator bytecode, SerializationContext ctx,
-            String classInclude) {
+    private void writeField(ClassCreator classCreator, String pkgName, FieldSpecs fieldSpecs, BytecodeCreator bytecode,
+            SerializationContext ctx, String classInclude) {
         ResultHandle arg = fieldSpecs.toValueReaderHandle(bytecode, ctx.valueHandle);
         bytecode = checkInclude(bytecode, ctx, arg, fieldSpecs, classInclude);
 
@@ -544,7 +608,10 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
             String typeName = fieldSpecs.fieldType.name().toString();
             String formatShape = fieldSpecs.formatShape();
 
-            if (fieldSpecs.isRawValue()) {
+            if (fieldSpecs.customSerializerClass() != null) {
+                // @JsonSerialize(using = ...) takes precedence over any other serialization directive
+                writeCustomSerializedValue(classCreator, fieldSpecs, bytecode, ctx, pkgName, arg);
+            } else if (fieldSpecs.isRawValue()) {
                 writeRawValue(fieldSpecs, bytecode, ctx, pkgName, arg);
             } else if (fieldSpecs.isFormatShapeNumber() && isEnumType(typeName)) {
                 writeFormattedValue(fieldSpecs, bytecode, ctx, pkgName, arg);
@@ -675,6 +742,42 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
 
     private static boolean isBooleanType(String typeName) {
         return "boolean".equals(typeName) || "java.lang.Boolean".equals(typeName);
+    }
+
+    /**
+     * Writes the property through the serializer declared by {@code @JsonSerialize(using = ...)}, kept in a static field
+     * of the generated serializer.
+     */
+    private static void writeCustomSerializedValue(ClassCreator classCreator, FieldSpecs fieldSpecs,
+            BytecodeCreator bytecode, SerializationContext ctx, String pkgName, ResultHandle arg) {
+        writeFieldName(fieldSpecs, bytecode, ctx, pkgName);
+
+        ResultHandle serializer = customSerializerHandle(classCreator, bytecode, fieldSpecs.fieldName + "_SERIALIZER",
+                fieldSpecs.customSerializerClass());
+        String nullSerializerClassName = fieldSpecs.nullSerializerClass();
+        ResultHandle nullSerializer = nullSerializerClassName == null
+                ? bytecode.loadNull()
+                : customSerializerHandle(classCreator, bytecode, fieldSpecs.fieldName + "_NULL_SERIALIZER",
+                        nullSerializerClassName);
+
+        MethodDescriptor serializeWithCustomSerializer = MethodDescriptor.ofMethod(JacksonMapperUtil.class.getName(),
+                "serializeWithCustomSerializer", void.class, Object.class, JsonSerializer.class, JsonSerializer.class,
+                JsonGenerator.class, SerializerProvider.class);
+        bytecode.invokeStaticMethod(serializeWithCustomSerializer, arg, serializer, nullSerializer,
+                ctx.jsonGenerator, ctx.serializerProvider);
+    }
+
+    private static ResultHandle customSerializerHandle(ClassCreator classCreator, BytecodeCreator bytecode, String fieldName,
+            String serializerClassName) {
+        MethodCreator clinit = classCreator.getMethodCreator("<clinit>", void.class).setModifiers(ACC_STATIC);
+
+        FieldCreator fieldCreator = classCreator.getFieldCreator(fieldName, JsonSerializer.class.getName())
+                .setModifiers(ACC_STATIC | ACC_FINAL);
+        clinit.writeStaticField(fieldCreator.getFieldDescriptor(),
+                clinit.newInstance(MethodDescriptor.ofConstructor(serializerClassName)));
+
+        return bytecode.readStaticField(
+                FieldDescriptor.of(classCreator.getClassName(), fieldName, JsonSerializer.class.getName()));
     }
 
     private static void writeRawValue(FieldSpecs fieldSpecs, BytecodeCreator bytecode, SerializationContext ctx, String pkgName,

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/JsonDeserializeReflectionFreeTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/JsonDeserializeReflectionFreeTest.java
@@ -1,0 +1,206 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.response.ValidatableResponse;
+
+public class JsonDeserializeReflectionFreeTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(JsonDeserializeResource.class, CustomDeserializedDto.class,
+                                    ContentUsingDto.class, ContextualUsingDto.class,
+                                    UpperCaseDeserializer.class, CsvListDeserializer.class,
+                                    ContextualUpperCaseDeserializer.class)
+                            .addAsResource(
+                                    new StringAsset(
+                                            "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true\n"),
+                                    "application.properties");
+                }
+            });
+
+    @Test
+    public void testCustomDeserializer() {
+        echo("/json-deserialize/custom", "{\"name\":\"bob\",\"age\":42,\"tags\":\"a,b,c\"}")
+                .body("name", is("BOB"))
+                .body("age", is(42))
+                .body("tags", contains("a", "b", "c"));
+    }
+
+    @Test
+    public void testNullValue() {
+        echo("/json-deserialize/custom", "{\"age\":7,\"name\":null}")
+                .body("name", nullValue())
+                .body("age", is(7));
+    }
+
+    @Test
+    public void testContentUsing() {
+        echo("/json-deserialize/content-using", "{\"tags\":[\"one\",\"two\"]}")
+                .body("tags", contains("ONE", "TWO"));
+    }
+
+    @Test
+    public void testContextualDeserializer() {
+        echo("/json-deserialize/contextual-using", "{\"name\":\"bob\"}")
+                .body("name", is("BOB"));
+    }
+
+    private static ValidatableResponse echo(String path, String request) {
+        return given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .post(path)
+                .then()
+                .statusCode(200);
+    }
+
+    @Path("/json-deserialize")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public static class JsonDeserializeResource {
+
+        @POST
+        @Path("/custom")
+        public CustomDeserializedDto custom(CustomDeserializedDto dto) {
+            return dto;
+        }
+
+        @POST
+        @Path("/content-using")
+        public ContentUsingDto contentUsing(ContentUsingDto dto) {
+            return dto;
+        }
+
+        @POST
+        @Path("/contextual-using")
+        public ContextualUsingDto contextualUsing(ContextualUsingDto dto) {
+            return dto;
+        }
+    }
+
+    public static class CustomDeserializedDto {
+
+        @JsonDeserialize(using = UpperCaseDeserializer.class)
+        private String name;
+
+        @JsonDeserialize(using = CsvListDeserializer.class)
+        private List<String> tags;
+
+        private int age;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public List<String> getTags() {
+            return tags;
+        }
+
+        public void setTags(List<String> tags) {
+            this.tags = tags;
+        }
+
+        public int getAge() {
+            return age;
+        }
+
+        public void setAge(int age) {
+            this.age = age;
+        }
+    }
+
+    public static class ContentUsingDto {
+
+        @JsonDeserialize(contentUsing = UpperCaseDeserializer.class)
+        private List<String> tags;
+
+        public List<String> getTags() {
+            return tags;
+        }
+
+        public void setTags(List<String> tags) {
+            this.tags = tags;
+        }
+    }
+
+    public static class ContextualUsingDto {
+
+        @JsonDeserialize(using = ContextualUpperCaseDeserializer.class)
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class UpperCaseDeserializer extends JsonDeserializer<String> {
+
+        @Override
+        public String deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+            return parser.getText().toUpperCase(Locale.ROOT);
+        }
+    }
+
+    public static class CsvListDeserializer extends JsonDeserializer<List<String>> {
+
+        @Override
+        public List<String> deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+            return List.of(parser.getText().split(","));
+        }
+    }
+
+    public static class ContextualUpperCaseDeserializer extends JsonDeserializer<String>
+            implements ContextualDeserializer {
+
+        @Override
+        public String deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+            return parser.getText().toUpperCase(Locale.ROOT);
+        }
+
+        @Override
+        public JsonDeserializer<?> createContextual(DeserializationContext context, BeanProperty property) {
+            return this;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/JsonSerializeReflectionFreeTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/JsonSerializeReflectionFreeTest.java
@@ -1,0 +1,255 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.ContextualSerializer;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class JsonSerializeReflectionFreeTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(JsonSerializeResource.class, CustomSerializedDto.class,
+                                    ContentUsingDto.class, ContextualUsingDto.class,
+                                    UpperCaseSerializer.class, MissingValueSerializer.class,
+                                    ContextualUpperCaseSerializer.class)
+                            .addAsResource(
+                                    new StringAsset(
+                                            "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true\n"),
+                                    "application.properties");
+                }
+            });
+
+    @Test
+    public void testCustomSerializer() {
+        CustomSerializedDto result = get("/json-serialize/custom", CustomSerializedDto.class);
+
+        assertThat(result.getName()).isEqualTo("BOB");
+        assertThat(result.getNickName()).isEqualTo("<none>");
+        assertThat(result.getAge()).isEqualTo(42);
+        assertThat(result.getSerializationStack())
+                .anyMatch(frame -> frame.contains("$quarkusjacksonserializer.serialize"))
+                .noneMatch(frame -> frame.contains("BeanSerializer.serialize"));
+    }
+
+    @Test
+    public void testContentUsing() {
+        ContentUsingDto result = get("/json-serialize/content-using", ContentUsingDto.class);
+
+        assertThat(result.getTags()).containsExactly("ONE", "TWO");
+        assertThat(result.getSerializationStack())
+                .anyMatch(frame -> frame.contains("BeanSerializer.serialize"))
+                .noneMatch(frame -> frame.contains("$quarkusjacksonserializer.serialize"));
+    }
+
+    @Test
+    public void testContextualSerializer() {
+        ContextualUsingDto result = get("/json-serialize/contextual-using", ContextualUsingDto.class);
+
+        assertThat(result.getName()).isEqualTo("BOB");
+        assertThat(result.getSerializationStack())
+                .anyMatch(frame -> frame.contains("BeanSerializer.serialize"))
+                .noneMatch(frame -> frame.contains("$quarkusjacksonserializer.serialize"));
+    }
+
+    private static <T> T get(String path, Class<T> type) {
+        return given()
+                .accept(MediaType.APPLICATION_JSON)
+                .get(path)
+                .then()
+                .statusCode(200)
+                .extract().body().as(type);
+    }
+
+    @Path("/json-serialize")
+    @Produces(MediaType.APPLICATION_JSON)
+    public static class JsonSerializeResource {
+
+        @GET
+        @Path("/custom")
+        public CustomSerializedDto custom() {
+            return new CustomSerializedDto("bob", null, 42);
+        }
+
+        @GET
+        @Path("/content-using")
+        public ContentUsingDto contentUsing() {
+            return new ContentUsingDto(List.of("one", "two"));
+        }
+
+        @GET
+        @Path("/contextual-using")
+        public ContextualUsingDto contextualUsing() {
+            return new ContextualUsingDto("bob");
+        }
+    }
+
+    /**
+     * Captures the stack that serialized the object, to tell whether the generated serializer or Jackson's own
+     * BeanSerializer produced the json.
+     */
+    public abstract static class StackCapturingDto {
+
+        private List<String> serializationStack;
+
+        public List<String> getSerializationStack() {
+            if (serializationStack == null) {
+                serializationStack = StackWalker.getInstance()
+                        .walk(frames -> frames.limit(10)
+                                .map(frame -> frame.getClassName() + "." + frame.getMethodName())
+                                .collect(Collectors.toList()));
+            }
+            return serializationStack;
+        }
+
+        public void setSerializationStack(List<String> serializationStack) {
+            this.serializationStack = serializationStack;
+        }
+    }
+
+    public static class CustomSerializedDto extends StackCapturingDto {
+
+        @JsonSerialize(using = UpperCaseSerializer.class)
+        private String name;
+
+        @JsonSerialize(using = UpperCaseSerializer.class, nullsUsing = MissingValueSerializer.class)
+        private String nickName;
+
+        private int age;
+
+        public CustomSerializedDto() {
+        }
+
+        public CustomSerializedDto(String name, String nickName, int age) {
+            this.name = name;
+            this.nickName = nickName;
+            this.age = age;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getNickName() {
+            return nickName;
+        }
+
+        public void setNickName(String nickName) {
+            this.nickName = nickName;
+        }
+
+        public int getAge() {
+            return age;
+        }
+
+        public void setAge(int age) {
+            this.age = age;
+        }
+    }
+
+    public static class ContentUsingDto extends StackCapturingDto {
+
+        @JsonSerialize(contentUsing = UpperCaseSerializer.class)
+        private List<String> tags;
+
+        public ContentUsingDto() {
+        }
+
+        public ContentUsingDto(List<String> tags) {
+            this.tags = tags;
+        }
+
+        public List<String> getTags() {
+            return tags;
+        }
+
+        public void setTags(List<String> tags) {
+            this.tags = tags;
+        }
+    }
+
+    public static class ContextualUsingDto extends StackCapturingDto {
+
+        @JsonSerialize(using = ContextualUpperCaseSerializer.class)
+        private String name;
+
+        public ContextualUsingDto() {
+        }
+
+        public ContextualUsingDto(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class UpperCaseSerializer extends JsonSerializer<String> {
+
+        @Override
+        public void serialize(String value, JsonGenerator generator, SerializerProvider serializerProvider)
+                throws IOException {
+            generator.writeString(value.toUpperCase(Locale.ROOT));
+        }
+    }
+
+    public static class MissingValueSerializer extends JsonSerializer<String> {
+
+        @Override
+        public void serialize(String value, JsonGenerator generator, SerializerProvider serializerProvider)
+                throws IOException {
+            generator.writeString("<none>");
+        }
+    }
+
+    public static class ContextualUpperCaseSerializer extends JsonSerializer<String> implements ContextualSerializer {
+
+        @Override
+        public void serialize(String value, JsonGenerator generator, SerializerProvider serializerProvider)
+                throws IOException {
+            generator.writeString(value.toUpperCase(Locale.ROOT));
+        }
+
+        @Override
+        public JsonSerializer<?> createContextual(SerializerProvider serializerProvider, BeanProperty property) {
+            return this;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
@@ -26,12 +26,15 @@ import java.util.TimeZone;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.SerializableString;
 import com.fasterxml.jackson.core.filter.FilteringGeneratorDelegate;
 import com.fasterxml.jackson.core.filter.TokenFilter;
 import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -291,6 +294,46 @@ public class JacksonMapperUtil {
             serializer.serialize(value, generator, serializerProvider);
         } else {
             generator.writePOJO(value);
+        }
+    }
+
+    /**
+     * Serializes a property through the serializer declared by {@code @JsonSerialize(using = ...)}. The nullSerializer is
+     * the one declared by {@code nullsUsing}, if any, and a plain json null is written when there is none.
+     */
+    public static void serializeWithCustomSerializer(Object value, JsonSerializer<Object> serializer,
+            JsonSerializer<Object> nullSerializer, JsonGenerator generator, SerializerProvider serializerProvider)
+            throws IOException {
+        if (value == null) {
+            if (nullSerializer == null) {
+                generator.writeNull();
+            } else {
+                nullSerializer.serialize(null, generator, serializerProvider);
+            }
+            return;
+        }
+        serializer.serialize(value, generator, serializerProvider);
+    }
+
+    /**
+     * Reads a property through the deserializer declared by {@code @JsonDeserialize(using = ...)}. The generated
+     * deserializer works on the parsed json tree, so the deserializer is given a parser over the subtree of this single
+     * property, positioned on its first token.
+     */
+    public static Object deserializeWithCustomDeserializer(JsonNode valueNode, JsonDeserializer<?> deserializer,
+            DeserializationContext context) throws IOException {
+        if (valueNode == null) {
+            return null;
+        }
+        if (valueNode.isNull()) {
+            // Jackson doesn't pass an explicit json null to a deserializer, it asks for its null value instead
+            return deserializer.getNullValue(context);
+        }
+        JsonParser owningParser = context.getParser();
+        ObjectCodec codec = owningParser == null ? null : owningParser.getCodec();
+        try (JsonParser valueParser = codec == null ? valueNode.traverse() : valueNode.traverse(codec)) {
+            valueParser.nextToken();
+            return deserializer.deserialize(valueParser, context);
         }
     }
 


### PR DESCRIPTION
Any class carrying `@JsonSerialize` or `@JsonDeserialize` anywhere was skipped by the reflection-free generation, so one
custom serializer on one property was enough to lose the optimization for the whole DTO. The common case, `using` on a
property, is easy to generate though: the declared serializer or deserializer is instantiated once into a static field
of the generated class and the property is delegated to it, with no reflection and nothing to register for native image.
`@JsonSerialize#nullsUsing` is handled as well.

What cannot be generated is still left to Jackson, so it keeps working as before: a declaration at class level, the
`contentUsing`, `keyUsing`, `as`,
`keyAs`, `contentAs`, `converter` and `contentConverter` attributes,
`@JsonSerialize#typing`, `@JsonDeserialize#builder`, and any serializer or deserializer that Jackson has to
contextualize or resolve first, which is the case for its own date handlers. The log now says which attribute or class
caused the fallback instead of just naming the annotation.

I'll also create a PR for the 4.x branch
