### PR TITLE
Optimize native images when the HTTP/3 extension is not present

### DIFF
--- a/extensions/http3/deployment/src/main/java/io/quarkus/http3/deployment/Http3Processor.java
+++ b/extensions/http3/deployment/src/main/java/io/quarkus/http3/deployment/Http3Processor.java
@@ -32,6 +32,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.http3.deployment.spi.Http3EnabledBuildItem;
 import io.quarkus.http3.runtime.CertOrigin;
@@ -65,6 +66,59 @@ class Http3Processor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
+    }
+
+    /*
+     * When the http3 extension is present, the Vert.x QUIC substitutions do not activate
+     * (IsQuarkusHttp3Absent returns false), so Quiche classes remain reachable.
+     *
+     * Their static initializers load native libraries or reference JNI-populated fields,
+     * so they must be deferred to runtime.
+     */
+    @BuildStep
+    void registerNettyQuicheRuntimeInitializedClasses(
+            BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClasses) {
+        runtimeInitializedClasses
+                .produce(new RuntimeInitializedClassBuildItem("io.netty.handler.codec.quic.BoringSSL"));
+        runtimeInitializedClasses
+                .produce(new RuntimeInitializedClassBuildItem("io.netty.handler.codec.quic.BoringSSLAsyncPrivateKeyMethod"));
+        runtimeInitializedClasses.produce(new RuntimeInitializedClassBuildItem(
+                "io.netty.handler.codec.quic.BoringSSLNativeStaticallyReferencedJniMethods"));
+        runtimeInitializedClasses
+                .produce(new RuntimeInitializedClassBuildItem("io.netty.handler.codec.quic.BoringSSLPrivateKeyMethod"));
+        runtimeInitializedClasses
+                .produce(new RuntimeInitializedClassBuildItem("io.netty.handler.codec.quic.ConnectionIdChannelMap"));
+        runtimeInitializedClasses
+                .produce(new RuntimeInitializedClassBuildItem("io.netty.handler.codec.quic.InsecureQuicTokenHandler"));
+        runtimeInitializedClasses
+                .produce(new RuntimeInitializedClassBuildItem("io.netty.handler.codec.quic.Quic"));
+        runtimeInitializedClasses
+                .produce(new RuntimeInitializedClassBuildItem("io.netty.handler.codec.quic.Quiche"));
+        runtimeInitializedClasses
+                .produce(new RuntimeInitializedClassBuildItem("io.netty.handler.codec.quic.QuicConnectionAddress"));
+        runtimeInitializedClasses
+                .produce(new RuntimeInitializedClassBuildItem("io.netty.handler.codec.quic.QuicheError"));
+        runtimeInitializedClasses
+                .produce(new RuntimeInitializedClassBuildItem(
+                        "io.netty.handler.codec.quic.QuicheNativeStaticallyReferencedJniMethods"));
+        runtimeInitializedClasses
+                .produce(new RuntimeInitializedClassBuildItem("io.netty.handler.codec.quic.QuicheQuicChannel"));
+        runtimeInitializedClasses
+                .produce(new RuntimeInitializedClassBuildItem("io.netty.handler.codec.quic.QuicheQuicCodec"));
+        runtimeInitializedClasses
+                .produce(new RuntimeInitializedClassBuildItem("io.netty.handler.codec.quic.QuicheQuicConnection"));
+        runtimeInitializedClasses
+                .produce(new RuntimeInitializedClassBuildItem("io.netty.handler.codec.quic.QuicheQuicServerCodec"));
+        runtimeInitializedClasses
+                .produce(new RuntimeInitializedClassBuildItem("io.netty.handler.codec.quic.QuicheQuicSslContext"));
+        runtimeInitializedClasses
+                .produce(new RuntimeInitializedClassBuildItem("io.netty.handler.codec.quic.QuicheQuicStreamChannel"));
+        runtimeInitializedClasses
+                .produce(new RuntimeInitializedClassBuildItem("io.netty.handler.codec.quic.QuicheSendInfo"));
+        runtimeInitializedClasses.produce(
+                new RuntimeInitializedClassBuildItem("io.netty.handler.codec.quic.SecureRandomQuicConnectionIdGenerator"));
+        runtimeInitializedClasses
+                .produce(new RuntimeInitializedClassBuildItem("io.netty.handler.codec.quic.SockaddrIn"));
     }
 
     @BuildStep

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -338,37 +338,12 @@ class NettyProcessor {
             log.debug("Not registering Netty native io_uring classes as they were not found");
         }
 
-        if (QuarkusClassLoader.isClassPresentAtRuntime("io.netty.handler.codec.quic.Quiche")) {
-            builder.addRuntimeInitializedClass("io.netty.handler.codec.quic.BoringSSL")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.BoringSSLAsyncPrivateKeyMethod")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.BoringSSLContextOption")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.BoringSSLKeylessPrivateKey")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.BoringSSLLoggingKeylog")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.BoringSSLNativeStaticallyReferencedJniMethods")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.BoringSSLPrivateKeyMethod")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.BoringSSLSessionCallback")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.ConnectionIdChannelMap")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.InsecureQuicTokenHandler")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.Quic")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.Quiche")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.QuicCongestionControlAlgorithm")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.QuicConnectionAddress")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.QuicheError")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.QuicheNativeStaticallyReferencedJniMethods")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.QuicheQuicChannel")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.QuicheQuicCodec")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.QuicheQuicConnection")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.QuicheQuicServerCodec")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.QuicheQuicSslContext")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.QuicheQuicStreamChannel")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.QuicheSendInfo")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.SecureRandomQuicConnectionIdGenerator")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.quic.SockaddrIn");
-        } else {
-            log.debug("Not registering Netty QUIC classes as they were not found");
-        }
+        // * [IMPORTANT] Netty QUIC/Quiche classes: runtime-init is NOT registered here.
+        // *
+        // * => When http3 is absent, Vert.x substitutions cut all reachability to these classes.
+        // * => When http3 is present, Http3Processor registers them for runtime initialization.
 
-        // tcnative is handled via RuntimeInitializedPackageBuildItem in a separate build step
+        // tcnative is handled via RuntimeInitializedPackageBuildItem in #runtimeInitQuicAndTcnative
 
         // Runtime initialize due to platform dependent initialization and to respect the run-time provided value of the
         // properties:

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/graal/VertxSubstitutions.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/graal/VertxSubstitutions.java
@@ -1,9 +1,12 @@
 package io.quarkus.vertx.core.runtime.graal;
 
+import static io.quarkus.vertx.core.runtime.graal.VertxSubstitutions.HTTP3_QUIC_NOT_AVAILABLE_MESSAGE;
+
 import java.lang.ref.Cleaner;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BooleanSupplier;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLException;
@@ -13,6 +16,7 @@ import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
+import io.netty.channel.Channel;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
@@ -100,6 +104,103 @@ final class Target_io_vertx_core_impl_WorkerExecutorImpl {
     }
 }
 
-class VertxSubstitutions {
+/*
+ * Vert.x core substitutions that cut QUIC reachability from always-reachable Vert.x classes.
+ * The Netty-level Quiche substitutions are in the netty extension NettySubstitutions class
+ * (to have the same JPMS module as the target classes).
+ */
 
+@TargetClass(className = "io.vertx.core.net.impl.ConnectionBase", onlyWith = IsQuarkusHttp3Absent.class)
+final class Target_io_vertx_core_net_impl_ConnectionBase {
+
+    @Alias
+    Channel channel;
+
+    @Alias
+    VertxInternal vertx;
+
+    @Substitute
+    io.vertx.core.net.SocketAddress channelRemoteAddress() {
+        java.net.SocketAddress addr = channel.remoteAddress();
+        return addr != null ? vertx.transport().convert(addr) : null;
+    }
+
+    @Substitute
+    io.vertx.core.net.SocketAddress channelLocalAddress() {
+        java.net.SocketAddress addr = channel.localAddress();
+        return addr != null ? vertx.transport().convert(addr) : null;
+    }
+}
+
+@TargetClass(className = "io.vertx.core.http.impl.HybridHttpServer", onlyWith = IsQuarkusHttp3Absent.class)
+final class Target_io_vertx_core_http_impl_HybridHttpServer {
+
+    @Substitute
+    public io.vertx.core.internal.http.HttpServerInternal quicServer(
+            io.vertx.core.spi.metrics.HttpServerMetrics<?, ?> httpMetrics) {
+        throw new UnsupportedOperationException(HTTP3_QUIC_NOT_AVAILABLE_MESSAGE);
+    }
+}
+
+@TargetClass(className = "io.vertx.core.net.impl.quic.QuicServerImpl", onlyWith = IsQuarkusHttp3Absent.class)
+final class Target_io_vertx_core_net_impl_quic_QuicServerImpl {
+
+    @Substitute
+    public static io.vertx.core.net.QuicServer create(VertxInternal vertx,
+            io.vertx.core.net.QuicServerConfig config,
+            io.vertx.core.net.ServerSSLOptions sslOptions) {
+        throw new UnsupportedOperationException(HTTP3_QUIC_NOT_AVAILABLE_MESSAGE);
+    }
+}
+
+@TargetClass(className = "io.vertx.core.net.impl.quic.QuicClientImpl", onlyWith = IsQuarkusHttp3Absent.class)
+final class Target_io_vertx_core_net_impl_quic_QuicClientImpl {
+
+    @Substitute
+    public static io.vertx.core.net.QuicClient create(VertxInternal vertx,
+            io.vertx.core.net.QuicClientConfig config,
+            io.vertx.core.net.ClientSSLOptions sslOptions) {
+        throw new UnsupportedOperationException(HTTP3_QUIC_NOT_AVAILABLE_MESSAGE);
+    }
+}
+
+@TargetClass(className = "io.vertx.core.http.impl.quic.QuicHttpServer", onlyWith = IsQuarkusHttp3Absent.class)
+final class Target_io_vertx_core_http_impl_quic_QuicHttpServer {
+
+    @Substitute
+    Target_io_vertx_core_http_impl_quic_QuicHttpServer(
+            VertxInternal vertx,
+            io.vertx.core.http.HttpServerConfig config,
+            io.vertx.core.net.ServerSSLOptions sslOptions,
+            io.vertx.core.spi.metrics.HttpServerMetrics<?, ?> httpMetrics) {
+        throw new UnsupportedOperationException(HTTP3_QUIC_NOT_AVAILABLE_MESSAGE);
+    }
+}
+
+@TargetClass(className = "io.vertx.core.http.impl.quic.QuicHttpClientTransport", onlyWith = IsQuarkusHttp3Absent.class)
+final class Target_io_vertx_core_http_impl_quic_QuicHttpClientTransport {
+
+    @Substitute
+    Target_io_vertx_core_http_impl_quic_QuicHttpClientTransport(
+            VertxInternal vertx,
+            io.vertx.core.http.HttpClientConfig config) {
+        throw new UnsupportedOperationException(HTTP3_QUIC_NOT_AVAILABLE_MESSAGE);
+    }
+}
+
+class IsQuarkusHttp3Absent implements BooleanSupplier {
+
+    @Override
+    public boolean getAsBoolean() {
+        try {
+            Class.forName("io.quarkus.http3.runtime.Http3Recorder");
+            return false;
+        } catch (ClassNotFoundException e) {
+            return true;
+        }
+    }
+}
+
+class VertxSubstitutions {
+    public static final String HTTP3_QUIC_NOT_AVAILABLE_MESSAGE = "HTTP/3 (QUIC) is not available - add the quarkus-http3 extension";
 }

--- a/integration-tests/resteasy-jackson/src/main/resources/application.properties
+++ b/integration-tests/resteasy-jackson/src/main/resources/application.properties
@@ -1,3 +1,6 @@
 message=Production
 quarkus.smallrye-openapi.store-schema-directory=target/generated
 resteasy.gzip.max.input=5000
+
+# Required for NativeHttp3AbsencePruningIT
+quarkus.native.enable-reports=true

--- a/integration-tests/resteasy-jackson/src/test/java/io/quarkus/it/resteasy/jackson/NativeHttp3AbsencePruningIT.java
+++ b/integration-tests/resteasy-jackson/src/test/java/io/quarkus/it/resteasy/jackson/NativeHttp3AbsencePruningIT.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.resteasy.jackson;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.nativeimage.ClassInclusionReport;
+
+@QuarkusIntegrationTest
+public class NativeHttp3AbsencePruningIT extends GreetingResourceTest {
+
+    @Test
+    public void verifyPruning() {
+        ClassInclusionReport report = ClassInclusionReport.load();
+        report.assertContainsNot("io.netty.handler.codec.quic.Quic");
+        report.assertContainsNot("io.netty.handler.codec.quic.Quiche");
+    }
+}


### PR DESCRIPTION
These changes cut the dependency to Netty QUIC classes using Vert.x substitutions when the http3 extension is not present.

These changes:

- move the `io.netty.handler.codec.quic` runtime initialization from the netty to the http3 extension,
- perform conditional substitution to cut Netty QUIC classes from the reachability graph in Vert.x classes (e.g, ConnectionBase) by removing some code branches.

These changes do not optimize native images when `quarkus.http3.enabled` is `false`, because one could still want to use a HTTP/3 client even when the Quarkus HTTP server is set not to support HTTP/3.

- Closes: #55788

