### PR TITLE
Make OpenTelemetry Metrics and Logs Stable and ON by default

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry-logging.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-logging.adoc
@@ -5,7 +5,8 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using OpenTelemetry Logging
 include::_attributes.adoc[]
-:extension-status: preview
+:extension-status: stable
+:categories: observability
 :summary: This guide explains how your Quarkus application can utilize OpenTelemetry Logging to provide centralised logging for interactive web applications.
 :topics: observability,opentelemetry,logging
 :extensions: io.quarkus:quarkus-opentelemetry
@@ -18,7 +19,6 @@ include::{includes}/observability-include.adoc[]
 
 [NOTE]
 ====
-- OpenTelemetry Logging is considered _tech preview_ and is disabled by default.
 - The xref:opentelemetry.adoc[OpenTelemetry Guide] is available with signal independent information about the OpenTelemetry extension.
 ====
 

--- a/docs/src/main/asciidoc/opentelemetry-logging.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-logging.adoc
@@ -3,9 +3,11 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
+[id=opentelemetry-logging]
 = Using OpenTelemetry Logging
+:extension-status: stable
 include::_attributes.adoc[]
-:extension-status: preview
+:diataxis-type: reference
 :summary: This guide explains how your Quarkus application can utilize OpenTelemetry Logging to provide centralised logging for interactive web applications.
 :topics: observability,opentelemetry,logging
 :extensions: io.quarkus:quarkus-opentelemetry
@@ -18,7 +20,6 @@ include::{includes}/observability-include.adoc[]
 
 [NOTE]
 ====
-- OpenTelemetry Logging is considered _tech preview_ and is disabled by default.
 - The xref:opentelemetry.adoc[OpenTelemetry Guide] is available with signal independent information about the OpenTelemetry extension.
 ====
 

--- a/docs/src/main/asciidoc/opentelemetry-metrics.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-metrics.adoc
@@ -5,7 +5,8 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using OpenTelemetry Metrics
 include::_attributes.adoc[]
-:extension-status: preview
+:extension-status: stable
+:categories: observability
 :summary: This guide explains how your Quarkus application can utilize OpenTelemetry to provide metrics for interactive web applications.
 :topics: observability,opentelemetry,metrics
 :extensions: io.quarkus:quarkus-opentelemetry
@@ -19,7 +20,6 @@ include::{includes}/observability-include.adoc[]
 
 [NOTE]
 ====
-- OpenTelemetry Metrics is considered _tech preview_ and is disabled by default.
 - Automatic metrics instrumentation in Quarkus is handled by xref:telemetry-micrometer.adoc[Micrometer] and the xref:telemetry-micrometer-to-opentelemetry.adoc[quarkus-micrometer-opentelemetry] extension bridges those metrics into OpenTelemetry.
 - The xref:opentelemetry.adoc[OpenTelemetry Guide] is available with signal independent information about the OpenTelemetry extension.
 - If you search more information about OpenTelemetry Tracing, please refer to the xref:opentelemetry-tracing.adoc[OpenTelemetry Tracing Guide].

--- a/docs/src/main/asciidoc/opentelemetry-metrics.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-metrics.adoc
@@ -3,9 +3,11 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
+[id=opentelemetry-metrics]
 = Using OpenTelemetry Metrics
+:extension-status: stable
 include::_attributes.adoc[]
-:extension-status: preview
+:diataxis-type: reference
 :summary: This guide explains how your Quarkus application can utilize OpenTelemetry to provide metrics for interactive web applications.
 :topics: observability,opentelemetry,metrics
 :extensions: io.quarkus:quarkus-opentelemetry
@@ -19,7 +21,6 @@ include::{includes}/observability-include.adoc[]
 
 [NOTE]
 ====
-- OpenTelemetry Metrics is considered _tech preview_ and is disabled by default.
 - Automatic metrics instrumentation in Quarkus is handled by xref:telemetry-micrometer.adoc[Micrometer] and the xref:telemetry-micrometer-to-opentelemetry.adoc[quarkus-micrometer-opentelemetry] extension bridges those metrics into OpenTelemetry.
 - The xref:opentelemetry.adoc[OpenTelemetry Guide] is available with signal independent information about the OpenTelemetry extension.
 - If you search more information about OpenTelemetry Tracing, please refer to the xref:opentelemetry-tracing.adoc[OpenTelemetry Tracing Guide].

--- a/docs/src/main/asciidoc/opentelemetry-tracing.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-tracing.adoc
@@ -3,8 +3,11 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
+[id=opentelemetry-tracing]
 = Using OpenTelemetry Tracing
+:extension-status: stable
 include::_attributes.adoc[]
+:diataxis-type: reference
 :summary: This guide explains how your Quarkus application can utilize OpenTelemetry Tracing to provide distributed tracing for interactive web applications.
 :topics: observability,opentelemetry,tracing
 :extensions: io.quarkus:quarkus-opentelemetry

--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -51,25 +51,11 @@ The tracing functionality is supported and *on* by default.
 
 === xref:opentelemetry-metrics.adoc[OpenTelemetry Metrics Guide]
 
-==== Enable Metrics
-The metrics functionality is tech preview and *off* by default. You will need to activate it by setting:
-
-[source,properties]
-----
-quarkus.otel.metrics.enabled=true
-----
-At build time on your `application.properties` file.
+The metrics functionality is supported and *on* by default.
 
 === xref:opentelemetry-logging.adoc[OpenTelemetry Logging Guide]
 
-==== Enable Logs
-The logging functionality is tech preview and *off* by default. You will need to activate it by setting:
-
-[source,properties]
-----
-quarkus.otel.logs.enabled=true
-----
-At build time on your `application.properties` file.
+The logging functionality is supported and *on* by default.
 
 == Using the extension
 
@@ -104,7 +90,7 @@ include::{includes}/opentelemetry-config.adoc[]
 
 === Disable all or parts of the OpenTelemetry extension
 
-Once you add the dependency, the extension will generate tracing data by default. To enable metrics or disable the OpenTelemetry extension globally or partially these are the properties to use (they are extracted from the config reference below):
+Once you add the dependency, the extension will generate tracing, metrics and logging data by default. To disable the OpenTelemetry extension globally or partially these are the properties to use (they are extracted from the config reference below):
 
 |===
 |Affected Signal | Property name |Default value |Description
@@ -138,8 +124,8 @@ Telemetry will be generated, contexts will be propagated but no telemetry will b
 
 | Metrics
 |`quarkus.otel.metrics.enabled`
-|false
-|Metrics are disabled by default at *build* time because they are tech preview.
+|true
+|If false, disable the OpenTelemetry metrics usage at *build* time.
 
 | Metrics output
 |`quarkus.otel.metrics.exporter`
@@ -148,8 +134,8 @@ Telemetry will be generated, contexts will be propagated but no telemetry will b
 
 | Logs
 |`quarkus.otel.logs.enabled`
-|false
-|Logs are disabled by default at *build* time because they are tech preview.
+|true
+|If false, disable the OpenTelemetry logs usage at *build* time.
 
 | Logs output
 |`quarkus.otel.logs.exporter`

--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -3,7 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
+[id=opentelemetry]
 = Using OpenTelemetry
+:extension-status: stable
 include::_attributes.adoc[]
 :diataxis-type: reference
 :summary: This guide explains how your Quarkus application can utilize OpenTelemetry to provide observability for interactive web applications.
@@ -51,25 +53,11 @@ The tracing functionality is supported and *on* by default.
 
 === xref:opentelemetry-metrics.adoc[OpenTelemetry Metrics Guide]
 
-==== Enable Metrics
-The metrics functionality is tech preview and *off* by default. You will need to activate it by setting:
-
-[source,properties]
-----
-quarkus.otel.metrics.enabled=true
-----
-At build time on your `application.properties` file.
+The metrics functionality is supported and *on* by default.
 
 === xref:opentelemetry-logging.adoc[OpenTelemetry Logging Guide]
 
-==== Enable Logs
-The logging functionality is tech preview and *off* by default. You will need to activate it by setting:
-
-[source,properties]
-----
-quarkus.otel.logs.enabled=true
-----
-At build time on your `application.properties` file.
+The logging functionality is supported and *on* by default.
 
 == Using the extension
 
@@ -104,7 +92,7 @@ include::{includes}/opentelemetry-config.adoc[]
 
 === Disable all or parts of the OpenTelemetry extension
 
-Once you add the dependency, the extension will generate tracing data by default. To enable metrics or disable the OpenTelemetry extension globally or partially these are the properties to use (they are extracted from the config reference below):
+Once you add the dependency, the extension will generate tracing, metrics and logging data by default. To disable the OpenTelemetry extension globally or partially these are the properties to use (they are extracted from the config reference below):
 
 |===
 |Affected Signal | Property name |Default value |Description
@@ -138,8 +126,8 @@ Telemetry will be generated, contexts will be propagated but no telemetry will b
 
 | Metrics
 |`quarkus.otel.metrics.enabled`
-|false
-|Metrics are disabled by default at *build* time because they are tech preview.
+|true
+|If false, disable the OpenTelemetry metrics usage at *build* time.
 
 | Metrics output
 |`quarkus.otel.metrics.exporter`
@@ -148,8 +136,8 @@ Telemetry will be generated, contexts will be propagated but no telemetry will b
 
 | Logs
 |`quarkus.otel.logs.enabled`
-|false
-|Logs are disabled by default at *build* time because they are tech preview.
+|true
+|If false, disable the OpenTelemetry logs usage at *build* time.
 
 | Logs output
 |`quarkus.otel.logs.exporter`

--- a/docs/src/main/asciidoc/telemetry-micrometer-to-opentelemetry.adoc
+++ b/docs/src/main/asciidoc/telemetry-micrometer-to-opentelemetry.adoc
@@ -6,7 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 [id=telemetry-micrometer-opentelemetry]
 = Micrometer and OpenTelemetry extension
 include::_attributes.adoc[]
-:extension-status: preview
+:extension-status: stable
 :diataxis-type: reference
 :summary: Guide to send Micrometer data to OpenTelemetry.
 :topics: observability,opentelemetry,metrics,micrometer,tracing,logs

--- a/docs/src/main/java/io/quarkus/docs/generation/YamlMetadataGenerator.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/YamlMetadataGenerator.java
@@ -536,6 +536,7 @@ public class YamlMetadataGenerator {
             switch (errorKey) {
                 case "missing-id":
                 case "not-diataxis-type":
+                case "missing-categories": // categories are injected from categories.yaml by InjectCategories at build time
                     return true;
             }
             return false;

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/DistributionSummaryTest.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/DistributionSummaryTest.java
@@ -31,7 +31,6 @@ public class DistributionSummaryTest {
                             .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
                             .add(new StringAsset("""
-                                    quarkus.otel.metrics.enabled=true\n
                                     quarkus.otel.traces.exporter=none\n
                                     quarkus.otel.logs.exporter=none\n
                                     quarkus.otel.metrics.exporter=in-memory\n

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/MetricsDisabledTest.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/MetricsDisabledTest.java
@@ -37,7 +37,6 @@ public class MetricsDisabledTest {
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
                             .add(new StringAsset("""
                                     quarkus.otel.sdk.disabled=true\n
-                                    quarkus.otel.metrics.enabled=true\n
                                     quarkus.otel.traces.exporter=none\n
                                     quarkus.otel.logs.exporter=none\n
                                     quarkus.otel.metrics.exporter=in-memory\n

--- a/extensions/micrometer-opentelemetry/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/micrometer-opentelemetry/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -12,6 +12,6 @@ metadata:
   guide: "https://quarkus.io/guides/telemetry-micrometer-to-opentelemetry"
   categories:
   - "observability"
-  status: "preview"
+  status: "stable"
   config:
   - "quarkus.micrometer.otel."

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/GlobalDefaultDisabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/GlobalDefaultDisabledTest.java
@@ -19,6 +19,7 @@ public class GlobalDefaultDisabledTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/MetricFiltersTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/MetricFiltersTest.java
@@ -22,6 +22,7 @@ public class MetricFiltersTest {
             .withApplicationRoot((jar) -> jar
                     .addClasses(AnnotatedFilter.class, NonAnnotatedFilter.class,
                             MeterFilterProducer.class))
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false");
 
     @Test

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/MetricsFromMetricsFactoryTestCase.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/MetricsFromMetricsFactoryTestCase.java
@@ -26,6 +26,7 @@ public class MetricsFromMetricsFactoryTestCase {
     @RegisterExtension
     static QuarkusExtensionTest runner = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/MicrometerBinderEnableAllPrecedenceOverBinderEnabledDefaultTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/MicrometerBinderEnableAllPrecedenceOverBinderEnabledDefaultTest.java
@@ -16,6 +16,7 @@ public class MicrometerBinderEnableAllPrecedenceOverBinderEnabledDefaultTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder.enable-all", "true")
             .overrideConfigKey("quarkus.micrometer.binder.jvm", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/MicrometerDisabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/MicrometerDisabledTest.java
@@ -20,6 +20,7 @@ public class MicrometerDisabledTest {
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar
                     .addAsResource(new StringAsset("quarkus.micrometer.enabled=false"), "application.properties"))
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
             .assertException(t -> {
                 Assertions.assertEquals(DeploymentException.class, t.getClass());

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/MicrometerEnabledAllPrecedenceOverJvmTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/MicrometerEnabledAllPrecedenceOverJvmTest.java
@@ -16,6 +16,7 @@ public class MicrometerEnabledAllPrecedenceOverJvmTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder.enable-all", "true")
             .overrideConfigKey("quarkus.micrometer.binder.jvm", "false")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/AgroalMetricsOnlyTestCase.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/AgroalMetricsOnlyTestCase.java
@@ -17,6 +17,7 @@ public class AgroalMetricsOnlyTestCase {
 
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.datasource.db-kind", "h2")
             .overrideConfigKey("quarkus.datasource.metrics.enabled", "true")
             .overrideRuntimeConfigKey("quarkus.datasource.username", "username-named");

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/EventBusScheduledMetricTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/EventBusScheduledMetricTest.java
@@ -21,6 +21,7 @@ public class EventBusScheduledMetricTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
             .withEmptyApplication();
 

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/GrpcMetricsDisabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/GrpcMetricsDisabledTest.java
@@ -15,6 +15,7 @@ public class GrpcMetricsDisabledTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder.grpc-client.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.binder.grpc-server.enabled", "true")
 

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/HttpDevModeConfigTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/HttpDevModeConfigTest.java
@@ -19,7 +19,8 @@ public class HttpDevModeConfigTest {
             .withApplicationRoot((jar) -> jar
                     .addClass(HelloResource.class)
                     .addClass(MeterResource.class)
-                    .add(new StringAsset("quarkus.micrometer.binder-enabled-default=false\n" +
+                    .add(new StringAsset("quarkus.otel.enabled=false\n" +
+                            "quarkus.micrometer.binder-enabled-default=false\n" +
                             "quarkus.micrometer.binder.http-client.enabled=true\n" +
                             "quarkus.micrometer.binder.http-server.enabled=true\n" +
                             "quarkus.micrometer.binder.http-server.ignore-patterns=/http\n" +

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/HttpTagExplosionPreventionTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/HttpTagExplosionPreventionTest.java
@@ -20,6 +20,7 @@ public class HttpTagExplosionPreventionTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.http-client.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.binder.http-server.enabled", "true")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/KafkaClientMetricsDisabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/KafkaClientMetricsDisabledTest.java
@@ -16,6 +16,7 @@ public class KafkaClientMetricsDisabledTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder.kafka.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/KafkaStreamsMetricsDisabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/KafkaStreamsMetricsDisabledTest.java
@@ -16,6 +16,7 @@ public class KafkaStreamsMetricsDisabledTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder.kafka.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/NettyMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/NettyMetricsTest.java
@@ -47,6 +47,7 @@ public class NettyMetricsTest {
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withApplicationRoot(jar -> jar.addClasses(HelloResource.class))
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.netty.enabled", "true")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false");

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/RedisClientMetricsDisabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/RedisClientMetricsDisabledTest.java
@@ -16,6 +16,7 @@ public class RedisClientMetricsDisabledTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder.redis.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/RedisClientMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/RedisClientMetricsTest.java
@@ -28,7 +28,8 @@ import io.vertx.redis.client.Request;
 public class RedisClientMetricsTest {
 
     @RegisterExtension
-    static final QuarkusExtensionTest config = new QuarkusExtensionTest();
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .overrideConfigKey("quarkus.otel.enabled", "false");
 
     final static SimpleMeterRegistry registry = new SimpleMeterRegistry();
 

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/RestClientRedirectPrometheusTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/RestClientRedirectPrometheusTest.java
@@ -27,6 +27,7 @@ public class RestClientRedirectPrometheusTest {
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .setFlatClassPath(true)
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.http-client.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.binder.http-server.enabled", "true")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/RestClientUriParameterTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/RestClientUriParameterTest.java
@@ -32,6 +32,7 @@ public class RestClientUriParameterTest {
     static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
             .withApplicationRoot(
                     jar -> jar.addClasses(Resource.class, Client.class))
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
             .overrideConfigKey("quarkus.rest-client.\"client\".url", "http://does-not-exist.io");
 

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/StorkMetricsDisabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/StorkMetricsDisabledTest.java
@@ -16,6 +16,7 @@ public class StorkMetricsDisabledTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder.stork.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/StorkMetricsLoadBalancerFailTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/StorkMetricsLoadBalancerFailTest.java
@@ -36,6 +36,7 @@ public class StorkMetricsLoadBalancerFailTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("pingpong/mp-rest/url", "stork://pingpong-service")
             .overrideConfigKey("quarkus.stork.pingpong-service.service-discovery.type", "static")
             .overrideConfigKey("quarkus.stork.pingpong-service.service-discovery.address-list", "${test.url}")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/StorkMetricsServiceDiscoveryFailTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/StorkMetricsServiceDiscoveryFailTest.java
@@ -39,6 +39,7 @@ public class StorkMetricsServiceDiscoveryFailTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.stork.pingpong-service.service-discovery.type", "mock")
             .overrideConfigKey("pingpong/mp-rest/url", "stork://pingpong-service")
             .overrideConfigKey("greeting/mp-rest/url", "stork://greeting-service/greeting")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/StorkMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/StorkMetricsTest.java
@@ -31,6 +31,7 @@ public class StorkMetricsTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("pingpong/mp-rest/url", "stork://pingpong-service")
             .overrideConfigKey("quarkus.stork.pingpong-service.service-discovery.type", "static")
             .overrideConfigKey("quarkus.stork.pingpong-service.service-discovery.address-list", "${test.url}")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagCorsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagCorsTest.java
@@ -20,6 +20,7 @@ public class UriTagCorsTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.http-server.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.binder.vertx.enabled", "true")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagTest.java
@@ -22,6 +22,7 @@ public class UriTagTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.http-client.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.binder.http-server.enabled", "true")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagWithHttpApplicationRootTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagWithHttpApplicationRootTest.java
@@ -30,6 +30,7 @@ public class UriTagWithHttpApplicationRootTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.http.root-path", "/foo")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.http-client.enabled", "true")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagWithHttpRootTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagWithHttpRootTest.java
@@ -27,6 +27,7 @@ public class UriTagWithHttpRootTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.http.root-path", "/foo")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.http-client.enabled", "true")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagWithInterfaceResourceTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagWithInterfaceResourceTest.java
@@ -26,6 +26,7 @@ class UriTagWithInterfaceResourceTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.http-server.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.binder.vertx.enabled", "true")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriWithMaxTagMeterFilterTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriWithMaxTagMeterFilterTest.java
@@ -19,6 +19,7 @@ public class UriWithMaxTagMeterFilterTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.http-client.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.binder.http-client.max-uri-tags", "1")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxConnectionMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxConnectionMetricsTest.java
@@ -40,6 +40,7 @@ public class VertxConnectionMetricsTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
             // Only allows 2 concurrent connections
             .overrideConfigKey("quarkus.http.limits.max-connections", "2")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxEventBusMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxEventBusMetricsTest.java
@@ -19,6 +19,7 @@ public class VertxEventBusMetricsTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
             .withEmptyApplication();
 

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxHttpClientMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxHttpClientMetricsTest.java
@@ -40,6 +40,7 @@ public class VertxHttpClientMetricsTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
             .withApplicationRoot((jar) -> jar
                     .addClasses(App.class, HttpClient.class, WsClient.class, Util.class,

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxTcpMetricsNoClientMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxTcpMetricsNoClientMetricsTest.java
@@ -27,6 +27,7 @@ public class VertxTcpMetricsNoClientMetricsTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
             .withApplicationRoot((jar) -> jar
                     .addClasses(NetServer.class, NetClient.class));

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxTcpMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxTcpMetricsTest.java
@@ -25,6 +25,7 @@ public class VertxTcpMetricsTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
             .withApplicationRoot((jar) -> jar
                     .addClasses(NetServer.class, NetClient.class));

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxUdpMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxUdpMetricsTest.java
@@ -23,6 +23,7 @@ public class VertxUdpMetricsTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
             .withApplicationRoot((jar) -> jar
                     .addClasses(ParticipantA.class, ParticipantB.class));

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxWithHttpDisabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxWithHttpDisabledTest.java
@@ -17,6 +17,7 @@ public class VertxWithHttpDisabledTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.vertx.enabled", "true")
             .overrideConfigKey("pingpong/mp-rest/url", "${test.url}")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxWithHttpEnabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxWithHttpEnabledTest.java
@@ -20,6 +20,7 @@ public class VertxWithHttpEnabledTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.http-client.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.binder.http-server.enabled", "true")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VirtualThreadMetricsDisabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VirtualThreadMetricsDisabledTest.java
@@ -16,6 +16,7 @@ public class VirtualThreadMetricsDisabledTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder.virtual-threads.enabled", "true")
 
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VirtualThreadMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VirtualThreadMetricsTest.java
@@ -19,6 +19,7 @@ public class VirtualThreadMetricsTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
             .withEmptyApplication();
 

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VirtualThreadMetricsWithTagsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VirtualThreadMetricsWithTagsTest.java
@@ -19,6 +19,7 @@ public class VirtualThreadMetricsWithTagsTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder.virtual-threads.tags", "k1=v1, k2=v2")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
             .withEmptyApplication();

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/AllRegistriesDisabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/AllRegistriesDisabledTest.java
@@ -19,6 +19,7 @@ public class AllRegistriesDisabledTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.export.json.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.export.prometheus.enabled", "false")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/JsonAndPrometheusRegistryEnabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/JsonAndPrometheusRegistryEnabledTest.java
@@ -19,6 +19,7 @@ public class JsonAndPrometheusRegistryEnabledTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.http.root-path", "/app")
             .overrideConfigKey("quarkus.http.non-application-root-path", "relative")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/JsonRegistryEnabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/JsonRegistryEnabledTest.java
@@ -18,6 +18,7 @@ public class JsonRegistryEnabledTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.http.root-path", "/app")
             .overrideConfigKey("quarkus.http.non-application-root-path", "relative")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/NoDefaultPrometheusTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/NoDefaultPrometheusTest.java
@@ -19,6 +19,7 @@ public class NoDefaultPrometheusTest {
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .setFlatClassPath(true)
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.jvm", "true")
             .overrideConfigKey("quarkus.micrometer.export.prometheus.enabled", "true")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/PrometheusEnabledOnManagementInterfaceTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/PrometheusEnabledOnManagementInterfaceTest.java
@@ -11,6 +11,7 @@ public class PrometheusEnabledOnManagementInterfaceTest {
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .setFlatClassPath(true)
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.export.prometheus.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/PrometheusEnabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/PrometheusEnabledTest.java
@@ -24,6 +24,7 @@ public class PrometheusEnabledTest {
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .setFlatClassPath(true)
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.export.prometheus.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/PrometheusRegistrationFailureTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/PrometheusRegistrationFailureTest.java
@@ -25,6 +25,7 @@ public class PrometheusRegistrationFailureTest {
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .setFlatClassPath(true)
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.export.prometheus.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/SecondPrometheusTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/SecondPrometheusTest.java
@@ -17,6 +17,7 @@ public class SecondPrometheusTest {
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .setFlatClassPath(true)
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.export.prometheus.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/pathparams/HttpPathParamLimitWithJaxRs400Test.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/pathparams/HttpPathParamLimitWithJaxRs400Test.java
@@ -20,6 +20,7 @@ public class HttpPathParamLimitWithJaxRs400Test {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.http-client.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.binder.http-server.enabled", "true")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/pathparams/HttpPathParamLimitWithJaxRs500Test.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/pathparams/HttpPathParamLimitWithJaxRs500Test.java
@@ -20,6 +20,7 @@ public class HttpPathParamLimitWithJaxRs500Test {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.http-client.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.binder.http-server.enabled", "true")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/pathparams/HttpPathParamLimitWithJaxRsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/pathparams/HttpPathParamLimitWithJaxRsTest.java
@@ -19,6 +19,7 @@ public class HttpPathParamLimitWithJaxRsTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.http-client.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.binder.http-server.enabled", "true")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/pathparams/HttpPathParamLimitWithProgrammaticRoutes400Test.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/pathparams/HttpPathParamLimitWithProgrammaticRoutes400Test.java
@@ -18,6 +18,7 @@ public class HttpPathParamLimitWithProgrammaticRoutes400Test {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.http-client.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.binder.http-server.enabled", "true")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/pathparams/HttpPathParamLimitWithProgrammaticRoutes500Test.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/pathparams/HttpPathParamLimitWithProgrammaticRoutes500Test.java
@@ -18,6 +18,7 @@ public class HttpPathParamLimitWithProgrammaticRoutes500Test {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.http-client.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.binder.http-server.enabled", "true")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/pathparams/HttpPathParamLimitWithProgrammaticRoutesTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/pathparams/HttpPathParamLimitWithProgrammaticRoutesTest.java
@@ -18,6 +18,7 @@ public class HttpPathParamLimitWithProgrammaticRoutesTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.http-client.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.binder.http-server.enabled", "true")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/pathparams/HttpPathParamLimitWithReactiveRoutes400Test.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/pathparams/HttpPathParamLimitWithReactiveRoutes400Test.java
@@ -19,6 +19,7 @@ public class HttpPathParamLimitWithReactiveRoutes400Test {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.http-client.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.binder.http-server.enabled", "true")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/pathparams/HttpPathParamLimitWithReactiveRoutes500Test.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/pathparams/HttpPathParamLimitWithReactiveRoutes500Test.java
@@ -19,6 +19,7 @@ public class HttpPathParamLimitWithReactiveRoutes500Test {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.http-client.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.binder.http-server.enabled", "true")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/pathparams/HttpPathParamLimitWithReactiveRoutesTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/pathparams/HttpPathParamLimitWithReactiveRoutesTest.java
@@ -18,6 +18,7 @@ public class HttpPathParamLimitWithReactiveRoutesTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.binder.http-client.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.binder.http-server.enabled", "true")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/runtime/MicrometerCounterInterceptorTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/runtime/MicrometerCounterInterceptorTest.java
@@ -26,6 +26,7 @@ public class MicrometerCounterInterceptorTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder.vertx.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/runtime/MicrometerTimedInterceptorTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/runtime/MicrometerTimedInterceptorTest.java
@@ -24,6 +24,7 @@ public class MicrometerTimedInterceptorTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.binder.vertx.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false")

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
@@ -70,6 +70,7 @@ import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.RemovedResourceBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -188,6 +189,16 @@ public class OpenTelemetryProcessor {
                 .map(KubernetesResourceMetadataBuildItem::getName)
                 .orElse(appInfo.getName());
         envProducer.produce(KubernetesEnvBuildItem.createSimpleVar(DEPLOYMENT_NAME_ENV, deploymentName, null));
+    }
+
+    @BuildStep
+    RunTimeConfigurationDefaultBuildItem setTestModeShutdownWaitTime(LaunchModeBuildItem launchMode) {
+        if (launchMode.getLaunchMode() == LaunchMode.TEST) {
+            // Tests take a long time to shutdown
+            return new RunTimeConfigurationDefaultBuildItem(
+                    "quarkus.otel.experimental.shutdown-wait-time", "100ms");
+        }
+        return null;
     }
 
     @BuildStep

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
@@ -71,6 +71,7 @@ import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.RemovedResourceBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -182,6 +183,16 @@ public class OpenTelemetryProcessor {
                 .map(KubernetesResourceMetadataBuildItem::getName)
                 .orElse(appInfo.getName());
         envProducer.produce(KubernetesEnvBuildItem.createSimpleVar(DEPLOYMENT_NAME_ENV, deploymentName, null));
+    }
+
+    @BuildStep
+    RunTimeConfigurationDefaultBuildItem setTestModeShutdownWaitTime(LaunchModeBuildItem launchMode) {
+        if (launchMode.getLaunchMode() == LaunchMode.TEST) {
+            // Tests take a long time to shutdown
+            return new RunTimeConfigurationDefaultBuildItem(
+                    "quarkus.otel.experimental.shutdown-wait-time", "100ms");
+        }
+        return null;
     }
 
     @BuildStep

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/InvalidAttributesConfigTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/InvalidAttributesConfigTest.java
@@ -15,6 +15,7 @@ public class InvalidAttributesConfigTest {
     @RegisterExtension
     static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
             .overrideConfigKey("quarkus.otel.resource.attributes", "pod.id=${SOMETHING}")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false")
             .assertException(new Consumer<Throwable>() {
                 @Override
                 public void accept(final Throwable throwable) {

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryContinuousTestingTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryContinuousTestingTest.java
@@ -30,7 +30,6 @@ public class OpenTelemetryContinuousTestingTest {
                             "quarkus.otel.traces.exporter=test-span-exporter",
                             "quarkus.otel.metrics.exporter=none",
                             "quarkus.otel.logs.exporter=none",
-                            "quarkus.observability.lgtm.enabled=false",
                             "quarkus.datasource.devservices.enabled=false")),
                             "application.properties"))
             .setTestArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryContinuousTestingTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryContinuousTestingTest.java
@@ -28,7 +28,10 @@ public class OpenTelemetryContinuousTestingTest {
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
                     .add(new StringAsset(ContinuousTestingTestUtils.appProperties(
                             "quarkus.otel.traces.exporter=test-span-exporter",
-                            "quarkus.otel.metrics.exporter=none")),
+                            "quarkus.otel.metrics.exporter=none",
+                            "quarkus.otel.logs.exporter=none",
+                            "quarkus.observability.lgtm.enabled=false",
+                            "quarkus.datasource.devservices.enabled=false")),
                             "application.properties"))
             .setTestArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClass(TracerRouterUT.class));

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryContinuousTestingTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryContinuousTestingTest.java
@@ -28,7 +28,9 @@ public class OpenTelemetryContinuousTestingTest {
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
                     .add(new StringAsset(ContinuousTestingTestUtils.appProperties(
                             "quarkus.otel.traces.exporter=test-span-exporter",
-                            "quarkus.otel.metrics.exporter=none")),
+                            "quarkus.otel.metrics.exporter=none",
+                            "quarkus.otel.logs.exporter=none",
+                            "quarkus.datasource.devservices.enabled=false")),
                             "application.properties"))
             .setTestArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClass(TracerRouterUT.class));

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDestroyerTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDestroyerTest.java
@@ -34,7 +34,6 @@ public class OpenTelemetryDestroyerTest {
                                     quarkus.otel.metrics.exporter=none
                                     quarkus.otel.logs.exporter=none
                                     quarkus.otel.experimental.shutdown-wait-time=PT60S
-                                    quarkus.observability.lgtm.enabled=false
                                     quarkus.datasource.devservices.enabled=false
                                     """),
                             "application.properties"));

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDestroyerTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDestroyerTest.java
@@ -32,7 +32,10 @@ public class OpenTelemetryDestroyerTest {
                             """
                                     quarkus.otel.traces.exporter=test-span-exporter
                                     quarkus.otel.metrics.exporter=none
+                                    quarkus.otel.logs.exporter=none
                                     quarkus.otel.experimental.shutdown-wait-time=PT60S
+                                    quarkus.observability.lgtm.enabled=false
+                                    quarkus.datasource.devservices.enabled=false
                                     """),
                             "application.properties"));
 

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDestroyerTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDestroyerTest.java
@@ -32,7 +32,9 @@ public class OpenTelemetryDestroyerTest {
                             """
                                     quarkus.otel.traces.exporter=test-span-exporter
                                     quarkus.otel.metrics.exporter=none
+                                    quarkus.otel.logs.exporter=none
                                     quarkus.otel.experimental.shutdown-wait-time=PT60S
+                                    quarkus.datasource.devservices.enabled=false
                                     """),
                             "application.properties"));
 

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDevModeTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDevModeTest.java
@@ -29,7 +29,6 @@ public class OpenTelemetryDevModeTest {
                             "quarkus.otel.traces.exporter=test-span-exporter",
                             "quarkus.otel.metrics.exporter=none",
                             "quarkus.otel.logs.exporter=none",
-                            "quarkus.observability.lgtm.enabled=false",
                             "quarkus.datasource.devservices.enabled=false")), "application.properties"));
 
     @Test

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDevModeTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDevModeTest.java
@@ -27,7 +27,10 @@ public class OpenTelemetryDevModeTest {
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
                     .add(new StringAsset(ContinuousTestingTestUtils.appProperties(
                             "quarkus.otel.traces.exporter=test-span-exporter",
-                            "quarkus.otel.metrics.exporter=none")), "application.properties"));
+                            "quarkus.otel.metrics.exporter=none",
+                            "quarkus.otel.logs.exporter=none",
+                            "quarkus.observability.lgtm.enabled=false",
+                            "quarkus.datasource.devservices.enabled=false")), "application.properties"));
 
     @Test
     void testDevMode() {

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDevModeTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDevModeTest.java
@@ -27,7 +27,9 @@ public class OpenTelemetryDevModeTest {
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
                     .add(new StringAsset(ContinuousTestingTestUtils.appProperties(
                             "quarkus.otel.traces.exporter=test-span-exporter",
-                            "quarkus.otel.metrics.exporter=none")), "application.properties"));
+                            "quarkus.otel.metrics.exporter=none",
+                            "quarkus.otel.logs.exporter=none",
+                            "quarkus.datasource.devservices.enabled=false")), "application.properties"));
 
     @Test
     void testDevMode() {

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDevServicesDatasourcesTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDevServicesDatasourcesTest.java
@@ -49,8 +49,10 @@ public class OpenTelemetryDevServicesDatasourcesTest {
                                     quarkus.datasource.jdbc.telemetry=true
                                     quarkus.otel.traces.exporter=test-span-exporter
                                     quarkus.otel.metrics.exporter=none
+                                    quarkus.otel.logs.exporter=none
                                     quarkus.otel.bsp.export.timeout=1s
                                     quarkus.otel.bsp.schedule.delay=50
+                                    quarkus.observability.lgtm.enabled=false
                                     """),
                             "application.properties"));
 

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDisabledSdkTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDisabledSdkTest.java
@@ -23,7 +23,8 @@ public class OpenTelemetryDisabledSdkTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withEmptyApplication()
-            .overrideConfigKey("quarkus.otel.sdk.disabled", "true");
+            .overrideConfigKey("quarkus.otel.sdk.disabled", "true")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Inject
     SpanExporter spanExporter;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDisabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDisabledTest.java
@@ -16,6 +16,7 @@ public class OpenTelemetryDisabledTest {
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withEmptyApplication()
             .overrideConfigKey("quarkus.otel.enabled", "false")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false")
             .assertException(t -> Assertions.assertEquals(DeploymentException.class, t.getClass()));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameAppNameTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameAppNameTest.java
@@ -19,5 +19,6 @@ public class OpenTelemetryServiceNameAppNameTest extends OpenTelemetryServiceNam
                     .addAsResource(new StringAsset("" +
                             "quarkus.otel.bsp.schedule.delay=50\n" +
                             "quarkus.otel.traces.sampler.arg=1.0d\n" +
-                            "quarkus.application.name=" + SERVICE_NAME + "\n"), "application.properties"));
+                            "quarkus.application.name=" + SERVICE_NAME + "\n" +
+                            "quarkus.datasource.devservices.enabled=false\n"), "application.properties"));
 }

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameCombinedResourceWinsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameCombinedResourceWinsTest.java
@@ -19,5 +19,6 @@ public class OpenTelemetryServiceNameCombinedResourceWinsTest extends OpenTeleme
             .overrideRuntimeConfigKey("quarkus.otel.bsp.schedule.delay", "50")// speed up test
             .overrideRuntimeConfigKey("quarkus.otel.service.name", SERVICE_NAME)
             .overrideRuntimeConfigKey("quarkus.otel.resource.attributes", "service.name=" + "attributes-must-fail")
-            .overrideRuntimeConfigKey("quarkus.otel.traces.sampler.arg", "1.0d");
+            .overrideRuntimeConfigKey("quarkus.otel.traces.sampler.arg", "1.0d")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 }

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameCombinedServiceWinsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameCombinedServiceWinsTest.java
@@ -18,5 +18,6 @@ public class OpenTelemetryServiceNameCombinedServiceWinsTest extends OpenTelemet
             .overrideConfigKey("quarkus.application.name", "application-name-must-fail")
             .overrideRuntimeConfigKey("quarkus.otel.bsp.schedule.delay", "50")// speed up test
             .overrideRuntimeConfigKey("quarkus.otel.resource.attributes", "service.name=" + SERVICE_NAME)
-            .overrideRuntimeConfigKey("quarkus.otel.traces.sampler.arg", "1.0d");
+            .overrideRuntimeConfigKey("quarkus.otel.traces.sampler.arg", "1.0d")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 }

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameNoResourceAttrsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameNoResourceAttrsTest.java
@@ -17,5 +17,6 @@ public class OpenTelemetryServiceNameNoResourceAttrsTest extends OpenTelemetrySe
                     .addClass(TestSpanExporterProvider.class))
             .overrideConfigKey("quarkus.otel.service.name", SERVICE_NAME)
             .overrideRuntimeConfigKey("quarkus.otel.bsp.schedule.delay", "50")// speed up test
-            .overrideRuntimeConfigKey("quarkus.otel.traces.sampler.arg", "1.0d");
+            .overrideRuntimeConfigKey("quarkus.otel.traces.sampler.arg", "1.0d")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 }

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameResourceAttrTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameResourceAttrTest.java
@@ -17,5 +17,6 @@ public class OpenTelemetryServiceNameResourceAttrTest extends OpenTelemetryServi
                     .addClass(TestSpanExporterProvider.class))
             .overrideRuntimeConfigKey("quarkus.otel.bsp.schedule.delay", "50")// speed up test
             .overrideRuntimeConfigKey("quarkus.otel.resource.attributes", "service.name=" + SERVICE_NAME)
-            .overrideRuntimeConfigKey("quarkus.otel.traces.sampler.arg", "1.0d");
+            .overrideRuntimeConfigKey("quarkus.otel.traces.sampler.arg", "1.0d")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 }

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriHealthRootPathTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriHealthRootPathTest.java
@@ -38,7 +38,6 @@ public class OpenTelemetrySuppressNonAppUriHealthRootPathTest {
                                     quarkus.otel.bsp.export.timeout=1s
                                     quarkus.otel.bsp.schedule.delay=50
                                     quarkus.smallrye-health.root-path=/observe/health
-                                    quarkus.observability.lgtm.enabled=false
                                     quarkus.datasource.devservices.enabled=false
                                     """),
                             "application.properties"));

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriHealthRootPathTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriHealthRootPathTest.java
@@ -34,9 +34,12 @@ public class OpenTelemetrySuppressNonAppUriHealthRootPathTest {
                             """
                                     quarkus.otel.traces.exporter=test-span-exporter
                                     quarkus.otel.metrics.exporter=none
+                                    quarkus.otel.logs.exporter=none
                                     quarkus.otel.bsp.export.timeout=1s
                                     quarkus.otel.bsp.schedule.delay=50
                                     quarkus.smallrye-health.root-path=/observe/health
+                                    quarkus.observability.lgtm.enabled=false
+                                    quarkus.datasource.devservices.enabled=false
                                     """),
                             "application.properties"));
 

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriHealthRootPathTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriHealthRootPathTest.java
@@ -34,9 +34,11 @@ public class OpenTelemetrySuppressNonAppUriHealthRootPathTest {
                             """
                                     quarkus.otel.traces.exporter=test-span-exporter
                                     quarkus.otel.metrics.exporter=none
+                                    quarkus.otel.logs.exporter=none
                                     quarkus.otel.bsp.export.timeout=1s
                                     quarkus.otel.bsp.schedule.delay=50
                                     quarkus.smallrye-health.root-path=/observe/health
+                                    quarkus.datasource.devservices.enabled=false
                                     """),
                             "application.properties"));
 

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriManagementInterfaceTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriManagementInterfaceTest.java
@@ -39,7 +39,6 @@ public class OpenTelemetrySuppressNonAppUriManagementInterfaceTest {
                                     quarkus.otel.bsp.schedule.delay=50
                                     quarkus.management.enabled=true
                                     quarkus.management.port=9001
-                                    quarkus.observability.lgtm.enabled=false
                                     quarkus.datasource.devservices.enabled=false
                                     """),
                             "application.properties"));

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriManagementInterfaceTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriManagementInterfaceTest.java
@@ -34,10 +34,12 @@ public class OpenTelemetrySuppressNonAppUriManagementInterfaceTest {
                             """
                                     quarkus.otel.traces.exporter=test-span-exporter
                                     quarkus.otel.metrics.exporter=none
+                                    quarkus.otel.logs.exporter=none
                                     quarkus.otel.bsp.export.timeout=1s
                                     quarkus.otel.bsp.schedule.delay=50
                                     quarkus.management.enabled=true
                                     quarkus.management.port=9001
+                                    quarkus.datasource.devservices.enabled=false
                                     """),
                             "application.properties"));
 

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriManagementInterfaceTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriManagementInterfaceTest.java
@@ -34,10 +34,13 @@ public class OpenTelemetrySuppressNonAppUriManagementInterfaceTest {
                             """
                                     quarkus.otel.traces.exporter=test-span-exporter
                                     quarkus.otel.metrics.exporter=none
+                                    quarkus.otel.logs.exporter=none
                                     quarkus.otel.bsp.export.timeout=1s
                                     quarkus.otel.bsp.schedule.delay=50
                                     quarkus.management.enabled=true
                                     quarkus.management.port=9001
+                                    quarkus.observability.lgtm.enabled=false
+                                    quarkus.datasource.devservices.enabled=false
                                     """),
                             "application.properties"));
 

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriTest.java
@@ -34,8 +34,11 @@ public class OpenTelemetrySuppressNonAppUriTest {
                             """
                                     quarkus.otel.traces.exporter=test-span-exporter
                                     quarkus.otel.metrics.exporter=none
+                                    quarkus.otel.logs.exporter=none
                                     quarkus.otel.bsp.export.timeout=1s
                                     quarkus.otel.bsp.schedule.delay=50
+                                    quarkus.observability.lgtm.enabled=false
+                                    quarkus.datasource.devservices.enabled=false
                                     """),
                             "application.properties"));
 

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriTest.java
@@ -37,7 +37,6 @@ public class OpenTelemetrySuppressNonAppUriTest {
                                     quarkus.otel.logs.exporter=none
                                     quarkus.otel.bsp.export.timeout=1s
                                     quarkus.otel.bsp.schedule.delay=50
-                                    quarkus.observability.lgtm.enabled=false
                                     quarkus.datasource.devservices.enabled=false
                                     """),
                             "application.properties"));

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriTest.java
@@ -34,8 +34,10 @@ public class OpenTelemetrySuppressNonAppUriTest {
                             """
                                     quarkus.otel.traces.exporter=test-span-exporter
                                     quarkus.otel.metrics.exporter=none
+                                    quarkus.otel.logs.exporter=none
                                     quarkus.otel.bsp.export.timeout=1s
                                     quarkus.otel.bsp.schedule.delay=50
+                                    quarkus.datasource.devservices.enabled=false
                                     """),
                             "application.properties"));
 

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/TracerAsBeanWhenOTelSDKDisabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/TracerAsBeanWhenOTelSDKDisabledTest.java
@@ -20,7 +20,8 @@ public class TracerAsBeanWhenOTelSDKDisabledTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar.addClasses(Resource.class))
-            .overrideRuntimeConfigKey("quarkus.otel.sdk.disabled", "true");
+            .overrideRuntimeConfigKey("quarkus.otel.sdk.disabled", "true")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Test
     public void test() {

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterConfigTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterConfigTest.java
@@ -19,7 +19,10 @@ public class OtlpExporterConfigTest {
             .overrideConfigKey("quarkus.otel.exporter.otlp.protocol", "wrong")
             .overrideConfigKey("quarkus.otel.exporter.otlp.traces.protocol", "grpc")
             .overrideConfigKey("quarkus.otel.exporter.otlp.traces.endpoint", "http://localhost ")
-            .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
+            .overrideConfigKey("quarkus.otel.exporter.otlp.metrics.protocol", "http/protobuf")
+            .overrideConfigKey("quarkus.otel.exporter.otlp.metrics.endpoint", "http://localhost ")
+            .overrideConfigKey("quarkus.otel.exporter.otlp.logs.protocol", "http/protobuf")
+            .overrideConfigKey("quarkus.otel.exporter.otlp.logs.endpoint", "http://localhost ")
             .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "50")
             .overrideConfigKey("quarkus.otel.bsp.export.timeout", "PT1S");
 
@@ -32,5 +35,15 @@ public class OtlpExporterConfigTest {
         assertEquals("grpc", config.traces().protocol().get().trim());
         assertTrue(config.traces().endpoint().isPresent());
         assertEquals("http://localhost", config.traces().endpoint().get().trim());
+
+        assertTrue(config.metrics().protocol().isPresent());
+        assertEquals("http/protobuf", config.metrics().protocol().get().trim());
+        assertTrue(config.metrics().endpoint().isPresent());
+        assertEquals("http://localhost", config.metrics().endpoint().get().trim());
+
+        assertTrue(config.logs().protocol().isPresent());
+        assertEquals("http/protobuf", config.logs().protocol().get().trim());
+        assertTrue(config.logs().endpoint().isPresent());
+        assertEquals("http://localhost", config.logs().endpoint().get().trim());
     }
 }

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpUpstreamAllExporterErrorTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpUpstreamAllExporterErrorTest.java
@@ -18,9 +18,7 @@ public class OtlpUpstreamAllExporterErrorTest {
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withEmptyApplication()
             .overrideConfigKey("quarkus.otel.traces.exporter", "otlp")
-            .overrideConfigKey("quarkus.otel.metrics.enabled", "true")
             .overrideConfigKey("quarkus.otel.metrics.exporter", "otlp")
-            .overrideConfigKey("quarkus.otel.logs.enabled", "true")
             .overrideConfigKey("quarkus.otel.logs.exporter", "otlp")
             .assertException(t -> {
                 assertEquals(DeploymentException.class, t.getClass());

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpUpstreamLogsExporterErrorTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpUpstreamLogsExporterErrorTest.java
@@ -17,7 +17,6 @@ public class OtlpUpstreamLogsExporterErrorTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withEmptyApplication()
-            .overrideConfigKey("quarkus.otel.logs.enabled", "true")
             .overrideConfigKey("quarkus.otel.logs.exporter", "otlp")
             .assertException(t -> {
                 assertEquals(DeploymentException.class, t.getClass());

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpUpstreamMetricsExporterErrorTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpUpstreamMetricsExporterErrorTest.java
@@ -17,7 +17,6 @@ public class OtlpUpstreamMetricsExporterErrorTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withEmptyApplication()
-            .overrideConfigKey("quarkus.otel.metrics.enabled", "true")
             .overrideConfigKey("quarkus.otel.metrics.exporter", "otlp")
             .assertException(t -> {
                 assertEquals(DeploymentException.class, t.getClass());

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GraphQLOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GraphQLOpenTelemetryTest.java
@@ -63,9 +63,13 @@ public class GraphQLOpenTelemetryTest {
                             smallrye.graphql.allowGet=true
                             smallrye.graphql.printDataFetcherException=true
                             smallrye.graphql.events.enabled=true
-                            quarkus.otel.metrics.exporter=none
                             quarkus.otel.traces.exporter=test-span-exporter
                             quarkus.otel.traces.sampler.arg=1.0d
+                            quarkus.otel.metrics.enabled=false
+                            quarkus.otel.logs.enabled=false
+                            quarkus.log.category."io.opentelemetry.usage".min-level=ALL
+                            quarkus.log.category."io.opentelemetry.usage".level=ALL
+                            quarkus.datasource.devservices.enabled=false
                             """),
                             "application.properties")
                     .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
@@ -127,6 +131,17 @@ public class GraphQLOpenTelemetryTest {
     @Test
     @Disabled
     // TODO: flaky test, find out how to fix it
+    // Research: This gets an additional span from the same parent:
+    // SpanData{spanContext=ImmutableSpanContext{traceId=50c4146f2399caabc90debb0d23e7946, spanId=d0d33ccd932ee37b,
+    // ...
+    // parentSpanContext=ImmutableSpanContext{traceId=50c4146f2399caabc90debb0d23e7946, spanId=8052926066139dd7,
+    // ...
+    // instrumentationScopeInfo=InstrumentationScopeInfo{name=io.quarkus.opentelemetry, version=null, schemaUrl=null,
+    // attributes={}}, name=GraphQL, kind=INTERNAL, startEpochNanos=1785750830560600719,
+    // endEpochNanos=1785750830589680922, attributes=AttributesMap{data={graphql.executionId=131475186260,
+    // graphql.operationName=, graphql.operationType=QUERY}, capacity=128, totalAddedValues=3},
+    // totalAttributeCount=3, events=[], totalRecordedEvents=0, links=[], totalRecordedLinks=0,
+    // status=ImmutableStatusData{statusCode=UNSET, description=}, hasEnded=true}
     void nestedCdiBeanInsideQueryTraceTest() throws ExecutionException, InterruptedException {
         String request = getPayload("query {\n" +
                 "  helloAfterSecond\n" +

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GraphQLOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GraphQLOpenTelemetryTest.java
@@ -59,14 +59,24 @@ public class GraphQLOpenTelemetryTest {
             .withApplicationRoot((jar) -> jar
                     .addClasses(HelloResource.class, CustomCDIBean.class, TestSpanExporterProvider.class,
                             TestSpanExporter.class, SemconvResolver.class)
-                    .addAsResource(new StringAsset("""
-                            smallrye.graphql.allowGet=true
-                            smallrye.graphql.printDataFetcherException=true
-                            smallrye.graphql.events.enabled=true
-                            quarkus.otel.metrics.exporter=none
-                            quarkus.otel.traces.exporter=test-span-exporter
-                            quarkus.otel.traces.sampler.arg=1.0d
-                            """),
+                    .addAsResource(
+                            new StringAsset(
+                                    """
+                                            smallrye.graphql.allowGet=true
+                                            smallrye.graphql.printDataFetcherException=true
+                                            smallrye.graphql.events.enabled=true
+                                            quarkus.otel.traces.exporter=test-span-exporter
+                                            quarkus.otel.traces.sampler.arg=1.0d
+                                            quarkus.otel.metrics.enabled=false
+                                            quarkus.otel.logs.enabled=false
+                                            quarkus.log.category."io.opentelemetry.usage".min-level=ALL
+                                            quarkus.log.category."io.opentelemetry.usage".level=ALL
+                                            quarkus.datasource.devservices.enabled=false
+                                            quarkus.otel.experimental.shutdown-wait-time=1000ms
+                                            quarkus.log.category.\\"io.quarkus.opentelemetry.runtime.propagation.OpenTelemetryMpContextPropagationProvider\\".level=DEBUG
+                                            quarkus.log.category.\\"io.quarkus.opentelemetry.runtime.QuarkusContextStorage\\".level=DEBUG
+                                            quarkus.log.category.\\"io.quarkus.opentelemetry.runtime.MDCEnabledContextStorage\\".level=DEBUG
+                                            """),
                             "application.properties")
                     .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
@@ -127,6 +137,17 @@ public class GraphQLOpenTelemetryTest {
     @Test
     @Disabled
     // TODO: flaky test, find out how to fix it
+    // Research: This gets an additional span from the same parent:
+    // SpanData{spanContext=ImmutableSpanContext{traceId=50c4146f2399caabc90debb0d23e7946, spanId=d0d33ccd932ee37b,
+    // ...
+    // parentSpanContext=ImmutableSpanContext{traceId=50c4146f2399caabc90debb0d23e7946, spanId=8052926066139dd7,
+    // ...
+    // instrumentationScopeInfo=InstrumentationScopeInfo{name=io.quarkus.opentelemetry, version=null, schemaUrl=null,
+    // attributes={}}, name=GraphQL, kind=INTERNAL, startEpochNanos=1785750830560600719,
+    // endEpochNanos=1785750830589680922, attributes=AttributesMap{data={graphql.executionId=131475186260,
+    // graphql.operationName=, graphql.operationType=QUERY}, capacity=128, totalAddedValues=3},
+    // totalAttributeCount=3, events=[], totalRecordedEvents=0, links=[], totalRecordedLinks=0,
+    // status=ImmutableStatusData{statusCode=UNSET, description=}, hasEnded=true}
     void nestedCdiBeanInsideQueryTraceTest() throws ExecutionException, InterruptedException {
         String request = getPayload("query {\n" +
                 "  helloAfterSecond\n" +

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GraphQLOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GraphQLOpenTelemetryTest.java
@@ -59,18 +59,24 @@ public class GraphQLOpenTelemetryTest {
             .withApplicationRoot((jar) -> jar
                     .addClasses(HelloResource.class, CustomCDIBean.class, TestSpanExporterProvider.class,
                             TestSpanExporter.class, SemconvResolver.class)
-                    .addAsResource(new StringAsset("""
-                            smallrye.graphql.allowGet=true
-                            smallrye.graphql.printDataFetcherException=true
-                            smallrye.graphql.events.enabled=true
-                            quarkus.otel.traces.exporter=test-span-exporter
-                            quarkus.otel.traces.sampler.arg=1.0d
-                            quarkus.otel.metrics.enabled=false
-                            quarkus.otel.logs.enabled=false
-                            quarkus.log.category."io.opentelemetry.usage".min-level=ALL
-                            quarkus.log.category."io.opentelemetry.usage".level=ALL
-                            quarkus.datasource.devservices.enabled=false
-                            """),
+                    .addAsResource(
+                            new StringAsset(
+                                    """
+                                            smallrye.graphql.allowGet=true
+                                            smallrye.graphql.printDataFetcherException=true
+                                            smallrye.graphql.events.enabled=true
+                                            quarkus.otel.traces.exporter=test-span-exporter
+                                            quarkus.otel.traces.sampler.arg=1.0d
+                                            quarkus.otel.metrics.enabled=false
+                                            quarkus.otel.logs.enabled=false
+                                            quarkus.log.category."io.opentelemetry.usage".min-level=ALL
+                                            quarkus.log.category."io.opentelemetry.usage".level=ALL
+                                            quarkus.datasource.devservices.enabled=false
+                                            quarkus.otel.experimental.shutdown-wait-time=1000ms
+                                            quarkus.log.category.\\"io.quarkus.opentelemetry.runtime.propagation.OpenTelemetryMpContextPropagationProvider\\".level=DEBUG
+                                            quarkus.log.category.\\"io.quarkus.opentelemetry.runtime.QuarkusContextStorage\\".level=DEBUG
+                                            quarkus.log.category.\\"io.quarkus.opentelemetry.runtime.MDCEnabledContextStorage\\".level=DEBUG
+                                            """),
                             "application.properties")
                     .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GrpcOpenInstrumentationDisabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GrpcOpenInstrumentationDisabledTest.java
@@ -57,7 +57,9 @@ public class GrpcOpenInstrumentationDisabledTest {
             .withConfigurationResource("application-default.properties")
             .overrideConfigKey("quarkus.grpc.clients.hello.host", "localhost")
             .overrideConfigKey("quarkus.grpc.clients.hello.port", "8081")
-            .overrideConfigKey("quarkus.otel.instrument.grpc", "false");
+            .overrideConfigKey("quarkus.otel.instrument.grpc", "false")
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false");
 
     @Inject
     TestSpanExporter spanExporter;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GrpcOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GrpcOpenTelemetryTest.java
@@ -91,7 +91,9 @@ public class GrpcOpenTelemetryTest {
             .overrideConfigKey("quarkus.grpc.clients.greeter.host", "localhost")
             .overrideConfigKey("quarkus.grpc.clients.greeter.port", "8081")
             .overrideConfigKey("quarkus.grpc.clients.streaming.host", "localhost")
-            .overrideConfigKey("quarkus.grpc.clients.streaming.port", "8081");
+            .overrideConfigKey("quarkus.grpc.clients.streaming.port", "8081")
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false");
 
     @Inject
     TestSpanExporter spanExporter;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/RestClientOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/RestClientOpenTelemetryTest.java
@@ -57,7 +57,9 @@ public class RestClientOpenTelemetryTest {
             .addAsResource(new StringAsset(InMemoryLogRecordExporterProvider.class.getCanonicalName()),
                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider"))
             .withConfigurationResource("application-default.properties")
-            .overrideConfigKey("quarkus.rest-client.client.url", "${test.url}");
+            .overrideConfigKey("quarkus.rest-client.client.url", "${test.url}")
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false");
 
     @Inject
     TestSpanExporter spanExporter;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/RestClientReadTimeoutOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/RestClientReadTimeoutOpenTelemetryTest.java
@@ -58,7 +58,9 @@ public class RestClientReadTimeoutOpenTelemetryTest {
                     "%d{HH:mm:ss} %-5p traceId=%X{traceId}, spanId=%X{spanId} [%c{2.}] (%t) %s%e%n")
             .overrideConfigKey("quarkus.log.category.\"io.quarkus.opentelemetry\".level", "DEBUG")
             .overrideConfigKey("quarkus.rest-client.slow-client.url", "${test.url}")
-            .overrideConfigKey("quarkus.rest-client.slow-client.read-timeout", "3000");
+            .overrideConfigKey("quarkus.rest-client.slow-client.read-timeout", "3000")
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false");
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(RestClientReadTimeoutOpenTelemetryTest.class);
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxClientOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxClientOpenTelemetryTest.java
@@ -57,7 +57,9 @@ public class VertxClientOpenTelemetryTest {
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
                     .addAsResource(new StringAsset(InMemoryLogRecordExporterProvider.class.getCanonicalName()),
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider"))
-            .withConfigurationResource("application-default.properties");
+            .withConfigurationResource("application-default.properties")
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false");
 
     @Inject
     TestSpanExporter spanExporter;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxEventBusInstrumentationDisabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxEventBusInstrumentationDisabledTest.java
@@ -39,10 +39,11 @@ public class VertxEventBusInstrumentationDisabledTest {
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
             .overrideConfigKey("quarkus.otel.traces.exporter", "test-span-exporter")
             .overrideConfigKey("quarkus.otel.traces.sampler.arg", "1.0d")
-            .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
-            .overrideConfigKey("quarkus.otel.logs.exporter", "none")
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
             .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "200")
-            .overrideConfigKey("quarkus.otel.instrument.vertx-event-bus", "false");
+            .overrideConfigKey("quarkus.otel.instrument.vertx-event-bus", "false")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Inject
     TestSpanExporter spanExporter;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxHttpInstrumentationDisabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxHttpInstrumentationDisabledTest.java
@@ -39,10 +39,11 @@ public class VertxHttpInstrumentationDisabledTest {
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
             .overrideConfigKey("quarkus.otel.traces.exporter", "test-span-exporter")
             .overrideConfigKey("quarkus.otel.traces.sampler.arg", "1.0d")
-            .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
-            .overrideConfigKey("quarkus.otel.logs.exporter", "none")
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
             .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "200")
-            .overrideConfigKey("quarkus.otel.instrument.vertx-http", "false");
+            .overrideConfigKey("quarkus.otel.instrument.vertx-http", "false")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Inject
     TestSpanExporter spanExporter;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxOpenTelemetryForwardedTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxOpenTelemetryForwardedTest.java
@@ -36,7 +36,9 @@ public class VertxOpenTelemetryForwardedTest {
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
                     .addAsResource(new StringAsset(InMemoryLogRecordExporterProvider.class.getCanonicalName()),
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider"))
-            .withConfigurationResource("application-default.properties");
+            .withConfigurationResource("application-default.properties")
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false");
 
     @Inject
     TestSpanExporter testSpanExporter;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxOpenTelemetryTest.java
@@ -63,9 +63,10 @@ public class VertxOpenTelemetryTest {
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
             .overrideConfigKey("quarkus.otel.traces.exporter", "test-span-exporter")
             .overrideConfigKey("quarkus.otel.traces.sampler.arg", "1.0d")
-            .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
-            .overrideConfigKey("quarkus.otel.logs.exporter", "none")
-            .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "200");
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
+            .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "200")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Inject
     TestSpanExporter spanExporter;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxOpenTelemetryXForwardedTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxOpenTelemetryXForwardedTest.java
@@ -36,7 +36,9 @@ public class VertxOpenTelemetryXForwardedTest {
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
                     .addAsResource(new StringAsset(InMemoryLogRecordExporterProvider.class.getCanonicalName()),
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider"))
-            .withConfigurationResource("application-default.properties");
+            .withConfigurationResource("application-default.properties")
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false");
 
     @Inject
     TestSpanExporter testSpanExporter;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/interceptor/AddingSpanAttributesInterceptorTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/interceptor/AddingSpanAttributesInterceptorTest.java
@@ -39,7 +39,7 @@ public class AddingSpanAttributesInterceptorTest {
                             .addAsManifestResource(
                                     "META-INF/services-config/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider",
                                     "services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
-                            .addAsResource("resource-config/application-no-metrics.properties", "application.properties"));
+                            .addAsResource("resource-config/application-just-tracing.properties", "application.properties"));
 
     @Inject
     HelloRouter helloRouter;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/interceptor/WithSpanInterceptorTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/interceptor/WithSpanInterceptorTest.java
@@ -55,7 +55,7 @@ public class WithSpanInterceptorTest {
                             .addAsManifestResource(
                                     "META-INF/services-config/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider",
                                     "services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
-                            .addAsResource("resource-config/application-no-metrics.properties", "application.properties"));
+                            .addAsResource("resource-config/application-just-tracing.properties", "application.properties"));
 
     @Inject
     SpanBean spanBean;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/LoggingFrameworkTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/LoggingFrameworkTest.java
@@ -32,8 +32,8 @@ public class LoggingFrameworkTest {
                             .addAsResource(new StringAsset(InMemoryLogRecordExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.logs.enabled=true\n" +
-                                            "quarkus.otel.traces.enabled=false\n"),
+                                    "quarkus.otel.traces.enabled=false\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/LoggingFrameworkTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/LoggingFrameworkTest.java
@@ -32,8 +32,7 @@ public class LoggingFrameworkTest {
                             .addAsResource(new StringAsset(InMemoryLogRecordExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.logs.enabled=true\n" +
-                                            "quarkus.otel.traces.enabled=false\n"),
+                                    "quarkus.otel.traces.enabled=false\n"),
                                     "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/LoggingFrameworkTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/LoggingFrameworkTest.java
@@ -32,7 +32,8 @@ public class LoggingFrameworkTest {
                             .addAsResource(new StringAsset(InMemoryLogRecordExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.traces.enabled=false\n"),
+                                    "quarkus.otel.traces.enabled=false\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingFileTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingFileTest.java
@@ -43,7 +43,8 @@ public class OtelLoggingFileTest {
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider")
                             .add(new StringAsset(
                                     "quarkus.log.file.enabled=true\n" + // enable log file
-                                            "quarkus.otel.traces.enabled=false\n"),
+                                            "quarkus.otel.traces.enabled=false\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingFileTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingFileTest.java
@@ -42,8 +42,7 @@ public class OtelLoggingFileTest {
                             .addAsResource(new StringAsset(InMemoryLogRecordExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.logs.enabled=true\n" +
-                                            "quarkus.log.file.enabled=true\n" + // enable log file
+                                    "quarkus.log.file.enabled=true\n" + // enable log file
                                             "quarkus.otel.traces.enabled=false\n"),
                                     "application.properties"));
 

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingFileTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingFileTest.java
@@ -42,9 +42,9 @@ public class OtelLoggingFileTest {
                             .addAsResource(new StringAsset(InMemoryLogRecordExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.logs.enabled=true\n" +
-                                            "quarkus.log.file.enabled=true\n" + // enable log file
-                                            "quarkus.otel.traces.enabled=false\n"),
+                                    "quarkus.log.file.enabled=true\n" + // enable log file
+                                            "quarkus.otel.traces.enabled=false\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingHandlerLevelTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingHandlerLevelTest.java
@@ -45,9 +45,9 @@ public class OtelLoggingHandlerLevelTest {
                             .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.logs.enabled=true\n" +
-                                            "quarkus.otel.logs.level=ERROR\n" +
-                                            "quarkus.otel.traces.enabled=true\n"),
+                                    "quarkus.otel.logs.level=ERROR\n" +
+                                            "quarkus.otel.traces.enabled=true\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingHandlerLevelTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingHandlerLevelTest.java
@@ -46,7 +46,8 @@ public class OtelLoggingHandlerLevelTest {
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
                             .add(new StringAsset(
                                     "quarkus.otel.logs.level=ERROR\n" +
-                                            "quarkus.otel.traces.enabled=true\n"),
+                                            "quarkus.otel.traces.enabled=true\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingHandlerLevelTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingHandlerLevelTest.java
@@ -45,8 +45,7 @@ public class OtelLoggingHandlerLevelTest {
                             .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.logs.enabled=true\n" +
-                                            "quarkus.otel.logs.level=ERROR\n" +
+                                    "quarkus.otel.logs.level=ERROR\n" +
                                             "quarkus.otel.traces.enabled=true\n"),
                                     "application.properties"));
 

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.NotFoundException;
 
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -117,17 +118,20 @@ public class OtelLoggingTest {
         assertEquals("hello", jBossLoggingBean.helloTraced(message));
 
         List<LogRecordData> finishedLogRecordItems = logRecordExporter.getFinishedLogRecordItemsAtLeast(1);
-        LogRecordData last = finishedLogRecordItems.get(finishedLogRecordItems.size() - 1);
+        LogRecordData loggedMessage = finishedLogRecordItems.stream()
+                .filter(logRecordData -> logRecordData.getBodyValue().asString().equals(message))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException("Log message was not found"));
 
         List<SpanData> spans = spanExporter.getFinishedSpanItems(1);
         final SpanData span = getSpanByKindAndParentId(spans, INTERNAL, "0000000000000000");
 
         assertThat(span.getName()).isEqualTo("JBossLoggingBean.helloTraced");
-        assertThat(last.getSpanContext().getSpanId()).isEqualTo(span.getSpanId());
-        assertThat(last.getSpanContext().getTraceId()).isEqualTo(span.getTraceId());
-        assertThat(last.getSpanContext().getTraceFlags()).isEqualTo(span.getSpanContext().getTraceFlags());
+        assertThat(loggedMessage.getSpanContext().getSpanId()).isEqualTo(span.getSpanId());
+        assertThat(loggedMessage.getSpanContext().getTraceId()).isEqualTo(span.getTraceId());
+        assertThat(loggedMessage.getSpanContext().getTraceFlags()).isEqualTo(span.getSpanContext().getTraceFlags());
 
-        assertThat(last)
+        assertThat(loggedMessage)
                 .hasSeverity(Severity.INFO)
                 .hasSeverityText("INFO")
                 .hasBody(message)

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingTest.java
@@ -53,8 +53,7 @@ public class OtelLoggingTest {
                             .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.logs.enabled=true\n" +
-                                            "quarkus.otel.traces.enabled=true\n" +
+                                    "quarkus.otel.traces.enabled=true\n" +
                                             "quarkus.otel.traces.sampler.arg=1.0d\n" +
                                             "quarkus.log.category.\"io.quarkus.opentelemetry\".level=INFO\n"),
                                     "application.properties"));

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingTest.java
@@ -55,7 +55,8 @@ public class OtelLoggingTest {
                             .add(new StringAsset(
                                     "quarkus.otel.traces.enabled=true\n" +
                                             "quarkus.otel.traces.sampler.arg=1.0d\n" +
-                                            "quarkus.log.category.\"io.quarkus.opentelemetry\".level=INFO\n"),
+                                            "quarkus.log.category.\"io.quarkus.opentelemetry\".level=INFO\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.NotFoundException;
 
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -53,10 +54,10 @@ public class OtelLoggingTest {
                             .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.logs.enabled=true\n" +
-                                            "quarkus.otel.traces.enabled=true\n" +
+                                    "quarkus.otel.traces.enabled=true\n" +
                                             "quarkus.otel.traces.sampler.arg=1.0d\n" +
-                                            "quarkus.log.category.\"io.quarkus.opentelemetry\".level=INFO\n"),
+                                            "quarkus.log.category.\"io.quarkus.opentelemetry\".level=INFO\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     @Inject
@@ -117,17 +118,20 @@ public class OtelLoggingTest {
         assertEquals("hello", jBossLoggingBean.helloTraced(message));
 
         List<LogRecordData> finishedLogRecordItems = logRecordExporter.getFinishedLogRecordItemsAtLeast(1);
-        LogRecordData last = finishedLogRecordItems.get(finishedLogRecordItems.size() - 1);
+        LogRecordData loggedMessage = finishedLogRecordItems.stream()
+                .filter(logRecordData -> logRecordData.getBodyValue().asString().equals(message))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException("Log message was not found"));
 
         List<SpanData> spans = spanExporter.getFinishedSpanItems(1);
         final SpanData span = getSpanByKindAndParentId(spans, INTERNAL, "0000000000000000");
 
         assertThat(span.getName()).isEqualTo("JBossLoggingBean.helloTraced");
-        assertThat(last.getSpanContext().getSpanId()).isEqualTo(span.getSpanId());
-        assertThat(last.getSpanContext().getTraceId()).isEqualTo(span.getTraceId());
-        assertThat(last.getSpanContext().getTraceFlags()).isEqualTo(span.getSpanContext().getTraceFlags());
+        assertThat(loggedMessage.getSpanContext().getSpanId()).isEqualTo(span.getSpanId());
+        assertThat(loggedMessage.getSpanContext().getTraceId()).isEqualTo(span.getTraceId());
+        assertThat(loggedMessage.getSpanContext().getTraceFlags()).isEqualTo(span.getSpanContext().getTraceFlags());
 
-        assertThat(last)
+        assertThat(loggedMessage)
                 .hasSeverity(Severity.INFO)
                 .hasSeverityText("INFO")
                 .hasBody(message)

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLogsDisabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLogsDisabledTest.java
@@ -21,7 +21,8 @@ public class OtelLogsDisabledTest {
                     () -> ShrinkWrap.create(JavaArchive.class)
                             .add(new StringAsset(
                                     "quarkus.otel.logs.enabled=false\n" +
-                                            "quarkus.otel.traces.enabled=false\n"),
+                                            "quarkus.otel.traces.enabled=false\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLogsHandlerDisabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLogsHandlerDisabledTest.java
@@ -31,9 +31,9 @@ public class OtelLogsHandlerDisabledTest {
                             .addAsResource(new StringAsset(InMemoryLogRecordExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.logs.enabled=true\n" +
-                                            "quarkus.otel.logs.handler.enabled=false\n" +
-                                            "quarkus.otel.traces.enabled=false\n"),
+                                    "quarkus.otel.logs.handler.enabled=false\n" +
+                                            "quarkus.otel.traces.enabled=false\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLogsHandlerDisabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLogsHandlerDisabledTest.java
@@ -32,7 +32,8 @@ public class OtelLogsHandlerDisabledTest {
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider")
                             .add(new StringAsset(
                                     "quarkus.otel.logs.handler.enabled=false\n" +
-                                            "quarkus.otel.traces.enabled=false\n"),
+                                            "quarkus.otel.traces.enabled=false\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLogsHandlerDisabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLogsHandlerDisabledTest.java
@@ -31,8 +31,7 @@ public class OtelLogsHandlerDisabledTest {
                             .addAsResource(new StringAsset(InMemoryLogRecordExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.logs.enabled=true\n" +
-                                            "quarkus.otel.logs.handler.enabled=false\n" +
+                                    "quarkus.otel.logs.handler.enabled=false\n" +
                                             "quarkus.otel.traces.enabled=false\n"),
                                     "application.properties"));
 

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/ClassCastExceptionTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/ClassCastExceptionTest.java
@@ -24,12 +24,12 @@ public class ClassCastExceptionTest {
                             .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.metrics.enabled=true\n" +
-                                            "quarkus.otel.metrics.exporter=in-memory\n" +
+                                    "quarkus.otel.metrics.exporter=in-memory\n" +
                                             "quarkus.otel.metric.export.interval=300ms\n" +
                                             "quarkus.http.limits.max-connections=50\n" +
                                             "quarkus.otel.traces.exporter=none\n" +
-                                            "quarkus.otel.logs.exporter=none\n"),
+                                            "quarkus.otel.logs.exporter=none\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     /**

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/ClassCastExceptionTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/ClassCastExceptionTest.java
@@ -24,8 +24,7 @@ public class ClassCastExceptionTest {
                             .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.metrics.enabled=true\n" +
-                                            "quarkus.otel.metrics.exporter=in-memory\n" +
+                                    "quarkus.otel.metrics.exporter=in-memory\n" +
                                             "quarkus.otel.metric.export.interval=300ms\n" +
                                             "quarkus.http.limits.max-connections=50\n" +
                                             "quarkus.otel.traces.exporter=none\n" +

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/ClassCastExceptionTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/ClassCastExceptionTest.java
@@ -28,7 +28,8 @@ public class ClassCastExceptionTest {
                                             "quarkus.otel.metric.export.interval=300ms\n" +
                                             "quarkus.http.limits.max-connections=50\n" +
                                             "quarkus.otel.traces.exporter=none\n" +
-                                            "quarkus.otel.logs.exporter=none\n"),
+                                            "quarkus.otel.logs.exporter=none\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     /**

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/GaugeCdiTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/GaugeCdiTest.java
@@ -44,9 +44,7 @@ public class GaugeCdiTest {
                             .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.metrics.enabled=true\n" +
-                                            "quarkus.otel.logs.enabled=true\n" +
-                                            "quarkus.datasource.db-kind=h2\n" +
+                                    "quarkus.datasource.db-kind=h2\n" +
                                             "quarkus.datasource.jdbc.telemetry=true\n" +
                                             "quarkus.otel.traces.exporter=test-span-exporter\n" +
                                             "quarkus.otel.metrics.exporter=in-memory,logging\n" +

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/JvmMetricsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/JvmMetricsTest.java
@@ -40,12 +40,12 @@ public class JvmMetricsTest extends BaseJvmMetricsTest {
                             .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.metrics.enabled=true\n" +
-                                            "quarkus.otel.traces.exporter=none\n" +
+                                    "quarkus.otel.traces.exporter=none\n" +
                                             "quarkus.otel.traces.sampler.arg=1.0d\n" +
                                             "quarkus.otel.logs.exporter=none\n" +
                                             "quarkus.otel.metrics.exporter=in-memory\n" +
-                                            "quarkus.otel.metric.export.interval=300ms\n"),
+                                            "quarkus.otel.metric.export.interval=300ms\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     @Test

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/JvmMetricsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/JvmMetricsTest.java
@@ -40,8 +40,7 @@ public class JvmMetricsTest extends BaseJvmMetricsTest {
                             .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.metrics.enabled=true\n" +
-                                            "quarkus.otel.traces.exporter=none\n" +
+                                    "quarkus.otel.traces.exporter=none\n" +
                                             "quarkus.otel.traces.sampler.arg=1.0d\n" +
                                             "quarkus.otel.logs.exporter=none\n" +
                                             "quarkus.otel.metrics.exporter=in-memory\n" +

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/JvmMetricsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/JvmMetricsTest.java
@@ -44,7 +44,8 @@ public class JvmMetricsTest extends BaseJvmMetricsTest {
                                             "quarkus.otel.traces.sampler.arg=1.0d\n" +
                                             "quarkus.otel.logs.exporter=none\n" +
                                             "quarkus.otel.metrics.exporter=in-memory\n" +
-                                            "quarkus.otel.metric.export.interval=300ms\n"),
+                                            "quarkus.otel.metric.export.interval=300ms\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     @Test

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MetricsDisabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MetricsDisabledTest.java
@@ -16,6 +16,7 @@ public class MetricsDisabledTest {
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withEmptyApplication()
             .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false")
             .assertException(t -> Assertions.assertEquals(DeploymentException.class, t.getClass()));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MetricsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MetricsTest.java
@@ -42,8 +42,7 @@ public class MetricsTest {
                             .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.metrics.enabled=true\n" +
-                                            "quarkus.otel.traces.exporter=none\n" +
+                                    "quarkus.otel.traces.exporter=none\n" +
                                             "quarkus.otel.logs.exporter=none\n" +
                                             "quarkus.otel.metrics.exporter=in-memory\n" +
                                             "quarkus.otel.metric.export.interval=300ms\n"),

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MetricsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MetricsTest.java
@@ -42,11 +42,11 @@ public class MetricsTest {
                             .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.metrics.enabled=true\n" +
-                                            "quarkus.otel.traces.exporter=none\n" +
+                                    "quarkus.otel.traces.exporter=none\n" +
                                             "quarkus.otel.logs.exporter=none\n" +
                                             "quarkus.otel.metrics.exporter=in-memory\n" +
-                                            "quarkus.otel.metric.export.interval=300ms\n"),
+                                            "quarkus.otel.metric.export.interval=300ms\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MetricsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MetricsTest.java
@@ -45,7 +45,8 @@ public class MetricsTest {
                                     "quarkus.otel.traces.exporter=none\n" +
                                             "quarkus.otel.logs.exporter=none\n" +
                                             "quarkus.otel.metrics.exporter=in-memory\n" +
-                                            "quarkus.otel.metric.export.interval=300ms\n"),
+                                            "quarkus.otel.metric.export.interval=300ms\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MpHttpServerMetricsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MpHttpServerMetricsTest.java
@@ -40,11 +40,11 @@ public class MpHttpServerMetricsTest {
                             .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.metrics.enabled=true\n" +
-                                            "quarkus.otel.traces.exporter=none\n" +
+                                    "quarkus.otel.traces.exporter=none\n" +
                                             "quarkus.otel.logs.exporter=none\n" +
                                             "quarkus.otel.metrics.exporter=in-memory\n" +
-                                            "quarkus.otel.metric.export.interval=300ms\n"),
+                                            "quarkus.otel.metric.export.interval=300ms\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MpHttpServerMetricsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MpHttpServerMetricsTest.java
@@ -43,7 +43,8 @@ public class MpHttpServerMetricsTest {
                                     "quarkus.otel.traces.exporter=none\n" +
                                             "quarkus.otel.logs.exporter=none\n" +
                                             "quarkus.otel.metrics.exporter=in-memory\n" +
-                                            "quarkus.otel.metric.export.interval=300ms\n"),
+                                            "quarkus.otel.metric.export.interval=300ms\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MpHttpServerMetricsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MpHttpServerMetricsTest.java
@@ -40,8 +40,7 @@ public class MpHttpServerMetricsTest {
                             .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.metrics.enabled=true\n" +
-                                            "quarkus.otel.traces.exporter=none\n" +
+                                    "quarkus.otel.traces.exporter=none\n" +
                                             "quarkus.otel.logs.exporter=none\n" +
                                             "quarkus.otel.metrics.exporter=in-memory\n" +
                                             "quarkus.otel.metric.export.interval=300ms\n"),

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MpJvmMetricsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MpJvmMetricsTest.java
@@ -26,11 +26,11 @@ public class MpJvmMetricsTest extends BaseJvmMetricsTest {
                             .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.metrics.enabled=true\n" +
-                                            "quarkus.otel.traces.exporter=none\n" +
+                                    "quarkus.otel.traces.exporter=none\n" +
                                             "quarkus.otel.logs.exporter=none\n" +
                                             "quarkus.otel.metrics.exporter=in-memory\n" +
-                                            "quarkus.otel.metric.export.interval=300ms\n"),
+                                            "quarkus.otel.metric.export.interval=300ms\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     // No need to reset between tests. Data is test independent. Will also run faster.

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MpJvmMetricsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MpJvmMetricsTest.java
@@ -26,8 +26,7 @@ public class MpJvmMetricsTest extends BaseJvmMetricsTest {
                             .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
                             .add(new StringAsset(
-                                    "quarkus.otel.metrics.enabled=true\n" +
-                                            "quarkus.otel.traces.exporter=none\n" +
+                                    "quarkus.otel.traces.exporter=none\n" +
                                             "quarkus.otel.logs.exporter=none\n" +
                                             "quarkus.otel.metrics.exporter=in-memory\n" +
                                             "quarkus.otel.metric.export.interval=300ms\n"),

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MpJvmMetricsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MpJvmMetricsTest.java
@@ -29,7 +29,8 @@ public class MpJvmMetricsTest extends BaseJvmMetricsTest {
                                     "quarkus.otel.traces.exporter=none\n" +
                                             "quarkus.otel.logs.exporter=none\n" +
                                             "quarkus.otel.metrics.exporter=in-memory\n" +
-                                            "quarkus.otel.metric.export.interval=300ms\n"),
+                                            "quarkus.otel.metric.export.interval=300ms\n" +
+                                            "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     // No need to reset between tests. Data is test independent. Will also run faster.

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/propagation/OpenTelemetryMpContextPropagationLeakTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/propagation/OpenTelemetryMpContextPropagationLeakTest.java
@@ -1,0 +1,114 @@
+package io.quarkus.opentelemetry.deployment.propagation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.context.spi.ThreadContextController;
+import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.quarkus.opentelemetry.runtime.propagation.OpenTelemetryMpContextPropagationProvider;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+/**
+ * Verifies that {@link OpenTelemetryMpContextPropagationProvider} does not leak
+ * the originating thread's OTel context onto the target thread after
+ * {@code endContext()} is called.
+ *
+ * <p>
+ * The leak scenario: a plain Java thread (no Vert.x context, no prior OTel
+ * context) receives a propagated span via {@code begin()}, then {@code endContext()}
+ * should restore the thread to its original clean state. Without the fix, the
+ * propagated span remains attached to the thread's storage.
+ */
+public class OpenTelemetryMpContextPropagationLeakTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(TestResource.class))
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
+            .overrideConfigKey("quarkus.otel.experimental.shutdown-wait-time", "1000ms")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false")
+            .overrideConfigKey(
+                    "quarkus.log.category.\"io.quarkus.opentelemetry.runtime.propagation.OpenTelemetryMpContextPropagationProvider\".level",
+                    "DEBUG");
+
+    @Test
+    void contextNotLeakedAfterEndContext() {
+        String response = RestAssured.when()
+                .get("/test-leak").then()
+                .statusCode(200)
+                .extract().asString();
+
+        String[] parts = response.split("\\|");
+        String traceIdBefore = parts[0];
+        boolean validAfterSubmit = Boolean.parseBoolean(parts[1]);
+        String traceIdAfterBegin = parts[2];
+        boolean validAfterEnd = Boolean.parseBoolean(parts[3]);
+        String traceIdAfterEnd = parts[4];
+
+        assertThat(validAfterSubmit)
+                .as("Target thread should have no valid span before begin()")
+                .isFalse();
+
+        assertThat(traceIdAfterBegin)
+                .as("Target thread should see the request's span during begin()")
+                .isEqualTo(traceIdBefore);
+
+        assertThat(validAfterEnd)
+                .as("Target thread must not retain a valid span after endContext()")
+                .isFalse();
+
+        assertThat(traceIdAfterEnd)
+                .as("Target thread must not retain the request's trace ID after endContext()")
+                .isNotEqualTo(traceIdBefore);
+    }
+
+    @ApplicationScoped
+    @Path("/")
+    public static class TestResource {
+
+        @GET
+        @Path("/test-leak")
+        public String testLeak() {
+            SpanContext otelContextBefore = Span.current().getSpanContext();
+            String traceIdBefore = otelContextBefore.getTraceId();
+
+            OpenTelemetryMpContextPropagationProvider provider = new OpenTelemetryMpContextPropagationProvider();
+            ThreadContextSnapshot snapshot = provider.currentContext(Map.of());
+
+            try (ExecutorService exec = Executors.newSingleThreadExecutor();) {
+                Future<String> result = exec.submit(() -> {
+                    boolean validAfterSubmit = Span.current().getSpanContext().isValid();
+
+                    ThreadContextController controller = snapshot.begin();
+                    String traceIdAfterBegin = Span.current().getSpanContext().getTraceId();
+
+                    controller.endContext();
+                    SpanContext spanAfterEnd = Span.current().getSpanContext();
+
+                    return validAfterSubmit + "|" + traceIdAfterBegin
+                            + "|" + spanAfterEnd.isValid() + "|" + spanAfterEnd.getTraceId();
+                });
+
+                return traceIdBefore + "|" + result.get();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/propagation/OpenTelemetryMpContextPropagationLeakTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/propagation/OpenTelemetryMpContextPropagationLeakTest.java
@@ -91,8 +91,7 @@ public class OpenTelemetryMpContextPropagationLeakTest {
             OpenTelemetryMpContextPropagationProvider provider = new OpenTelemetryMpContextPropagationProvider();
             ThreadContextSnapshot snapshot = provider.currentContext(Map.of());
 
-            ExecutorService exec = Executors.newSingleThreadExecutor();
-            try {
+            try (ExecutorService exec = Executors.newSingleThreadExecutor();) {
                 Future<String> result = exec.submit(() -> {
                     boolean validAfterSubmit = Span.current().getSpanContext().isValid();
 
@@ -109,8 +108,6 @@ public class OpenTelemetryMpContextPropagationLeakTest {
                 return traceIdBefore + "|" + result.get();
             } catch (Exception e) {
                 throw new RuntimeException(e);
-            } finally {
-                exec.shutdown();
             }
         }
     }

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/propagation/OpenTelemetryMpContextPropagationLeakTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/propagation/OpenTelemetryMpContextPropagationLeakTest.java
@@ -1,0 +1,117 @@
+package io.quarkus.opentelemetry.deployment.propagation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.context.spi.ThreadContextController;
+import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.quarkus.opentelemetry.runtime.propagation.OpenTelemetryMpContextPropagationProvider;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+/**
+ * Verifies that {@link OpenTelemetryMpContextPropagationProvider} does not leak
+ * the originating thread's OTel context onto the target thread after
+ * {@code endContext()} is called.
+ *
+ * <p>
+ * The leak scenario: a plain Java thread (no Vert.x context, no prior OTel
+ * context) receives a propagated span via {@code begin()}, then {@code endContext()}
+ * should restore the thread to its original clean state. Without the fix, the
+ * propagated span remains attached to the thread's storage.
+ */
+public class OpenTelemetryMpContextPropagationLeakTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(TestResource.class))
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
+            .overrideConfigKey("quarkus.otel.experimental.shutdown-wait-time", "1000ms")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false")
+            .overrideConfigKey(
+                    "quarkus.log.category.\"io.quarkus.opentelemetry.runtime.propagation.OpenTelemetryMpContextPropagationProvider\".level",
+                    "DEBUG");
+
+    @Test
+    void contextNotLeakedAfterEndContext() {
+        String response = RestAssured.when()
+                .get("/test-leak").then()
+                .statusCode(200)
+                .extract().asString();
+
+        String[] parts = response.split("\\|");
+        String traceIdBefore = parts[0];
+        boolean validAfterSubmit = Boolean.parseBoolean(parts[1]);
+        String traceIdAfterBegin = parts[2];
+        boolean validAfterEnd = Boolean.parseBoolean(parts[3]);
+        String traceIdAfterEnd = parts[4];
+
+        assertThat(validAfterSubmit)
+                .as("Target thread should have no valid span before begin()")
+                .isFalse();
+
+        assertThat(traceIdAfterBegin)
+                .as("Target thread should see the request's span during begin()")
+                .isEqualTo(traceIdBefore);
+
+        assertThat(validAfterEnd)
+                .as("Target thread must not retain a valid span after endContext()")
+                .isFalse();
+
+        assertThat(traceIdAfterEnd)
+                .as("Target thread must not retain the request's trace ID after endContext()")
+                .isNotEqualTo(traceIdBefore);
+    }
+
+    @ApplicationScoped
+    @Path("/")
+    public static class TestResource {
+
+        @GET
+        @Path("/test-leak")
+        public String testLeak() {
+            SpanContext otelContextBefore = Span.current().getSpanContext();
+            String traceIdBefore = otelContextBefore.getTraceId();
+
+            OpenTelemetryMpContextPropagationProvider provider = new OpenTelemetryMpContextPropagationProvider();
+            ThreadContextSnapshot snapshot = provider.currentContext(Map.of());
+
+            ExecutorService exec = Executors.newSingleThreadExecutor();
+            try {
+                Future<String> result = exec.submit(() -> {
+                    boolean validAfterSubmit = Span.current().getSpanContext().isValid();
+
+                    ThreadContextController controller = snapshot.begin();
+                    String traceIdAfterBegin = Span.current().getSpanContext().getTraceId();
+
+                    controller.endContext();
+                    SpanContext spanAfterEnd = Span.current().getSpanContext();
+
+                    return validAfterSubmit + "|" + traceIdAfterBegin
+                            + "|" + spanAfterEnd.isValid() + "|" + spanAfterEnd.getTraceId();
+                });
+
+                return traceIdBefore + "|" + result.get();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            } finally {
+                exec.shutdown();
+            }
+        }
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/propagation/OpenTelemetryMpContextPropagationTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/propagation/OpenTelemetryMpContextPropagationTest.java
@@ -26,7 +26,10 @@ public class OpenTelemetryMpContextPropagationTest {
     @RegisterExtension
     static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar
-                    .addClass(OpenTelemetryMpContextPropagationTest.TestResource.class));
+                    .addClass(OpenTelemetryMpContextPropagationTest.TestResource.class))
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Test
     void testOpenTelemetryContextPropagationWithCustomExecutorAndThreadContextProvider() {

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/propagation/OpenTelemetryMpContextPropagationVertxTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/propagation/OpenTelemetryMpContextPropagationVertxTest.java
@@ -1,0 +1,155 @@
+package io.quarkus.opentelemetry.deployment.propagation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.context.spi.ThreadContextController;
+import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.quarkus.opentelemetry.runtime.QuarkusContextStorage;
+import io.quarkus.opentelemetry.runtime.propagation.OpenTelemetryMpContextPropagationProvider;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+/**
+ * Complext test scenario verifying that {@link OpenTelemetryMpContextPropagationProvider} does not
+ * trash the Vert.x duplicated context (DC) when OTel scopes created OUTSIDE the
+ * begin/endContext window close INSIDE it.
+ *
+ * <p>
+ * The trashing scenario: on a Vert.x event loop thread, begin() attaches a
+ * captured context and records the DC's prior state ({@code otelBeforeAttach}).
+ * Between the ThreadContextProvider begin() and endContext(), other OTel scopes close (spans end),
+ * leaving the DC in a clean state. Without a guard, endContext()'s
+ * scope.close() unconditionally restores the stale {@code otelBeforeAttach},
+ * putting a dead span's context back on the DC.
+ */
+public class OpenTelemetryMpContextPropagationVertxTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(TestResource.class))
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
+            .overrideConfigKey("quarkus.otel.experimental.shutdown-wait-time", "1000ms")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false")
+            .overrideConfigKey(
+                    "quarkus.log.category.\"io.quarkus.opentelemetry.runtime.propagation.OpenTelemetryMpContextPropagationProvider\".level",
+                    "DEBUG")
+            .overrideConfigKey(
+                    "quarkus.log.category.\"io.quarkus.opentelemetry.runtime.QuarkusContextStorage\".level",
+                    "DEBUG");
+
+    @Test
+    void contextNotTrashedWhenExternalScopesCloseInsideBeginEnd() {
+        String response = RestAssured.when()
+                .get("/test-vertx-scope-guard").then()
+                .statusCode(200)
+                .extract().asString();
+
+        String[] parts = response.split("\\|");
+        String requestSpanId = parts[0];
+        String afterBeginSpanId = parts[1];
+        String afterEndSpanId = parts[2];
+        String grandchildSpanId = parts[3];
+
+        assertThat(afterBeginSpanId)
+                .as("After begin(), the captured child context should be current")
+                .isNotEqualTo(requestSpanId);
+
+        assertThat(afterEndSpanId)
+                .as("After endContext(), the DC should have the request span, not the stale grandchild")
+                .isEqualTo(requestSpanId);
+
+        assertThat(afterEndSpanId)
+                .as("After endContext(), the DC must not hold the stale grandchild context")
+                .isNotEqualTo(grandchildSpanId);
+    }
+
+    @ApplicationScoped
+    @Path("/")
+    public static class TestResource {
+
+        @Inject
+        Tracer tracer;
+
+        @GET
+        @Path("/test-vertx-scope-guard")
+        public String testVertxScopeGuard() {
+            // Running on Vert.x event loop with duplicated context (DC).
+            // DC has the HTTP server's request span.
+            Context requestCtx = QuarkusContextStorage.INSTANCE.current();
+            String requestSpanId = Span.fromContext(requestCtx).getSpanContext().getSpanId();
+
+            // Create a nested span hierarchy: request → child → grandchild
+            Span childSpan = tracer.spanBuilder("child").startSpan();
+            Context childCtx = childSpan.storeInContext(requestCtx);
+            Scope childOtelScope = QuarkusContextStorage.INSTANCE.attach(childCtx);
+            // DC = childCtx, childOtelScope.otelBeforeAttach = requestCtx
+
+            Span grandchildSpan = tracer.spanBuilder("grandchild").startSpan();
+            Context grandchildCtx = grandchildSpan.storeInContext(childCtx);
+            Scope grandchildOtelScope = QuarkusContextStorage.INSTANCE.attach(grandchildCtx);
+            String grandchildSpanId = grandchildSpan.getSpanContext().getSpanId();
+            // DC = grandchildCtx, grandchildOtelScope.otelBeforeAttach = childCtx
+
+            // Temporarily restore childCtx to capture a snapshot at that level
+            grandchildOtelScope.close(); // DC = childCtx
+
+            OpenTelemetryMpContextPropagationProvider provider = new OpenTelemetryMpContextPropagationProvider();
+            ThreadContextSnapshot snapshot = provider.currentContext(Map.of());
+            // capturedCtx = childCtx
+
+            // Re-attach grandchild so begin() will see a different context
+            grandchildOtelScope = QuarkusContextStorage.INSTANCE.attach(grandchildCtx);
+            // DC = grandchildCtx
+
+            // begin() — DC has grandchildCtx, snapshot has childCtx
+            // childCtx != grandchildCtx → QuarkusOTelScope(DC, childCtx, otelBeforeAttach=grandchildCtx)
+            // DC = childCtx
+            ThreadContextController controller = snapshot.begin();
+
+            String afterBeginSpanId = Span.current().getSpanContext().getSpanId();
+
+            // --- Between begin() and endContext(), external OTel scopes close ---
+            // This simulates spans ending during async processing (e.g. GraphQL
+            // operation and resolver spans finishing while MP context propagation
+            // is still active).
+
+            grandchildOtelScope.close();
+            // DC restored to childCtx (grandchild's otelBeforeAttach)
+            grandchildSpan.end();
+
+            childOtelScope.close();
+            // DC restored to requestCtx (child's otelBeforeAttach)
+            childSpan.end();
+
+            // DC is now requestCtx — correct clean state after all child spans ended.
+            // But scope_MP has otelBeforeAttach = grandchildCtx (STALE!)
+
+            // endContext()
+            controller.endContext();
+            // Without guard: unconditionally restores grandchildCtx → TRASHED
+            // With guard: current(requestCtx) != capturedCtx(childCtx) → skip → requestCtx (ok)
+
+            SpanContext afterEndCtx = Span.current().getSpanContext();
+            String afterEndSpanId = afterEndCtx.getSpanId();
+
+            return requestSpanId + "|" + afterBeginSpanId + "|" + afterEndSpanId + "|" + grandchildSpanId;
+        }
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/propagation/OpenTelemetryTextMapPropagatorCustomizerTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/propagation/OpenTelemetryTextMapPropagatorCustomizerTest.java
@@ -39,7 +39,7 @@ public class OpenTelemetryTextMapPropagatorCustomizerTest {
                     .addClass(TestSpanExporter.class)
                     .addClass(TestSpanExporterProvider.class)
                     .addClass(TestTextMapPropagatorCustomizer.class)
-                    .addAsResource("resource-config/application-no-metrics.properties", "application.properties")
+                    .addAsResource("resource-config/application-just-tracing.properties", "application.properties")
                     .addAsResource(
                             "META-INF/services-config/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider",
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"));

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/BatchSpanProcessorConfigTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/BatchSpanProcessorConfigTest.java
@@ -25,12 +25,13 @@ public class BatchSpanProcessorConfigTest {
     @RegisterExtension
     static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar.addClass(TestUtil.class))
-            .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
-            .overrideConfigKey("quarkus.otel.logs.exporter", "none")
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
             .overrideConfigKey("quarkus.otel.bsp.schedule.delay", SCHEDULE_DELAY.toMillis() + "ms")
             .overrideConfigKey("quarkus.otel.bsp.max.queue.size", String.valueOf(MAX_QUEUE_SIZE))
             .overrideConfigKey("quarkus.otel.bsp.max.export.batch.size", String.valueOf(MAX_EXPORT_BATCH_SIZE))
-            .overrideConfigKey("quarkus.otel.bsp.export.timeout", EXPORT_TIMEOUT.toMillis() + "ms");
+            .overrideConfigKey("quarkus.otel.bsp.export.timeout", EXPORT_TIMEOUT.toMillis() + "ms")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Inject
     OpenTelemetry openTelemetry;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/BatchSpanProcessorConfigTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/BatchSpanProcessorConfigTest.java
@@ -25,12 +25,13 @@ public class BatchSpanProcessorConfigTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar.addClass(TestUtil.class))
-            .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
-            .overrideConfigKey("quarkus.otel.logs.exporter", "none")
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
             .overrideConfigKey("quarkus.otel.bsp.schedule.delay", SCHEDULE_DELAY.toMillis() + "ms")
             .overrideConfigKey("quarkus.otel.bsp.max.queue.size", String.valueOf(MAX_QUEUE_SIZE))
             .overrideConfigKey("quarkus.otel.bsp.max.export.batch.size", String.valueOf(MAX_EXPORT_BATCH_SIZE))
-            .overrideConfigKey("quarkus.otel.bsp.export.timeout", EXPORT_TIMEOUT.toMillis() + "ms");
+            .overrideConfigKey("quarkus.otel.bsp.export.timeout", EXPORT_TIMEOUT.toMillis() + "ms")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Inject
     OpenTelemetry openTelemetry;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/BatchSpanProcessorGrpcExporterTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/BatchSpanProcessorGrpcExporterTest.java
@@ -21,9 +21,10 @@ public class BatchSpanProcessorGrpcExporterTest {
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar.addClass(TestUtil.class))
             .overrideConfigKey("quarkus.otel.exporter.otlp.protocol", "grpc")
-            .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
-            .overrideConfigKey("quarkus.otel.logs.exporter", "none")
-            .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "50ms");
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
+            .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "50ms")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Inject
     OpenTelemetry openTelemetry;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/BatchSpanProcessorGrpcExporterTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/BatchSpanProcessorGrpcExporterTest.java
@@ -21,9 +21,10 @@ public class BatchSpanProcessorGrpcExporterTest {
     static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar.addClass(TestUtil.class))
             .overrideConfigKey("quarkus.otel.exporter.otlp.protocol", "grpc")
-            .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
-            .overrideConfigKey("quarkus.otel.logs.exporter", "none")
-            .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "50ms");
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
+            .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "50ms")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Inject
     OpenTelemetry openTelemetry;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/BatchSpanProcessorHttpExporterTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/BatchSpanProcessorHttpExporterTest.java
@@ -20,9 +20,10 @@ public class BatchSpanProcessorHttpExporterTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar.addClass(TestUtil.class))
-            .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
-            .overrideConfigKey("quarkus.otel.logs.exporter", "none")
-            .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "50ms");
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
+            .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "50ms")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Inject
     OpenTelemetry openTelemetry;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/BatchSpanProcessorHttpExporterTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/BatchSpanProcessorHttpExporterTest.java
@@ -20,9 +20,10 @@ public class BatchSpanProcessorHttpExporterTest {
     @RegisterExtension
     static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar.addClass(TestUtil.class))
-            .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
-            .overrideConfigKey("quarkus.otel.logs.exporter", "none")
-            .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "50ms");
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
+            .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "50ms")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Inject
     OpenTelemetry openTelemetry;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/LoggingAndCdiSpanExporterTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/LoggingAndCdiSpanExporterTest.java
@@ -26,9 +26,10 @@ public class LoggingAndCdiSpanExporterTest {
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar.addClass(TestUtil.class))
             .overrideConfigKey("quarkus.otel.traces.exporter", "logging,cdi")
-            .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
-            .overrideConfigKey("quarkus.otel.logs.exporter", "none")
-            .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "50ms");
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
+            .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "50ms")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Inject
     OpenTelemetry openTelemetry;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/LoggingAndCdiSpanExporterTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/LoggingAndCdiSpanExporterTest.java
@@ -26,9 +26,10 @@ public class LoggingAndCdiSpanExporterTest {
     static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar.addClass(TestUtil.class))
             .overrideConfigKey("quarkus.otel.traces.exporter", "logging,cdi")
-            .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
-            .overrideConfigKey("quarkus.otel.logs.exporter", "none")
-            .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "50ms");
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
+            .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "50ms")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Inject
     OpenTelemetry openTelemetry;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/LoggingSpanExporterTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/LoggingSpanExporterTest.java
@@ -24,8 +24,9 @@ public class LoggingSpanExporterTest {
     static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar.addClass(TestUtil.class))
             .overrideConfigKey("quarkus.otel.traces.exporter", "logging")
-            .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
-            .overrideConfigKey("quarkus.otel.logs.exporter", "none");
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Inject
     OpenTelemetry openTelemetry;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/LoggingSpanExporterTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/LoggingSpanExporterTest.java
@@ -24,8 +24,9 @@ public class LoggingSpanExporterTest {
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar.addClass(TestUtil.class))
             .overrideConfigKey("quarkus.otel.traces.exporter", "logging")
-            .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
-            .overrideConfigKey("quarkus.otel.logs.exporter", "none");
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Inject
     OpenTelemetry openTelemetry;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/ManualTracingAndPropagationTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/ManualTracingAndPropagationTest.java
@@ -54,7 +54,7 @@ public class ManualTracingAndPropagationTest {
                             .addClasses(TestSpanExporter.class, TestSpanExporterProvider.class)
                             .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
-            .withConfigurationResource("resource-config/application-no-metrics.properties");
+            .withConfigurationResource("resource-config/application-just-tracing.properties");
 
     @Inject
     TestSpanExporter spanExporter;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/MutinyTracingHelperTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/MutinyTracingHelperTest.java
@@ -46,7 +46,8 @@ class MutinyTracingHelperTest {
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
                             .addAsResource(new StringAsset(
                                     "quarkus.otel.bsp.schedule.delay=50ms\n"
-                                            + "quarkus.otel.traces.sampler.arg=1.0d\n"),
+                                            + "quarkus.otel.traces.sampler.arg=1.0d\n"
+                                            + "quarkus.datasource.devservices.enabled=false\n"),
                                     "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/NonAppEndpointsDisabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/NonAppEndpointsDisabledTest.java
@@ -23,7 +23,7 @@ public class NonAppEndpointsDisabledTest {
                     .addClasses(TestSpanExporter.class, TestSpanExporterProvider.class)
                     .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
-            .withConfigurationResource("resource-config/application-no-metrics.properties");
+            .withConfigurationResource("resource-config/application-just-tracing.properties");
 
     @Inject
     TestSpanExporter testSpanExporter;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/NonAppEndpointsDisabledWithRootPathTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/NonAppEndpointsDisabledWithRootPathTest.java
@@ -23,7 +23,7 @@ public class NonAppEndpointsDisabledWithRootPathTest {
                     .addClasses(TestSpanExporter.class, TestSpanExporterProvider.class)
                     .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
-            .withConfigurationResource("resource-config/application-no-metrics.properties")
+            .withConfigurationResource("resource-config/application-just-tracing.properties")
             .overrideConfigKey("quarkus.http.root-path", "/app")
             .overrideConfigKey("quarkus.http.non-application-root-path", "quarkus");
 

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/NonAppEndpointsEnabledLegacyConfigurationTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/NonAppEndpointsEnabledLegacyConfigurationTest.java
@@ -23,7 +23,7 @@ public class NonAppEndpointsEnabledLegacyConfigurationTest {
                     .addClasses(TestSpanExporter.class, TestSpanExporterProvider.class)
                     .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
-            .withConfigurationResource("resource-config/application-no-metrics.properties")
+            .withConfigurationResource("resource-config/application-just-tracing.properties")
             .overrideConfigKey("quarkus.otel.traces.suppress-non-application-uris", "false");
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/NonAppEndpointsEnabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/NonAppEndpointsEnabledTest.java
@@ -23,7 +23,7 @@ public class NonAppEndpointsEnabledTest {
                     .addClasses(TestSpanExporter.class, TestSpanExporterProvider.class)
                     .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
-            .withConfigurationResource("resource-config/application-no-metrics.properties")
+            .withConfigurationResource("resource-config/application-just-tracing.properties")
             .overrideConfigKey("quarkus.otel.traces.suppress-non-application-uris", "false");
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/NonAppEndpointsEqualRootPath.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/NonAppEndpointsEqualRootPath.java
@@ -23,7 +23,7 @@ public class NonAppEndpointsEqualRootPath {
                     .addClasses(TestSpanExporter.class, TestSpanExporterProvider.class)
                     .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
-            .withConfigurationResource("resource-config/application-no-metrics.properties")
+            .withConfigurationResource("resource-config/application-just-tracing.properties")
             .overrideConfigKey("quarkus.http.root-path", "/app")
             .overrideConfigKey("quarkus.http.non-application-root-path", "/app");
 

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryCustomSamplerBeanTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryCustomSamplerBeanTest.java
@@ -43,7 +43,7 @@ public class OpenTelemetryCustomSamplerBeanTest {
                     .addClass(TestUtil.class)
                     .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
-            .withConfigurationResource("resource-config/application-no-metrics.properties");
+            .withConfigurationResource("resource-config/application-just-tracing.properties");
 
     @Inject
     OpenTelemetry openTelemetry;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryHttpCDITest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryHttpCDITest.java
@@ -42,7 +42,7 @@ public class OpenTelemetryHttpCDITest {
                             .addClasses(TestSpanExporter.class, TestSpanExporterProvider.class)
                             .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
-            .withConfigurationResource("resource-config/application-no-metrics.properties");
+            .withConfigurationResource("resource-config/application-just-tracing.properties");
 
     @Inject
     TestSpanExporter spanExporter;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryIdGeneratorTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryIdGeneratorTest.java
@@ -26,7 +26,10 @@ import io.quarkus.test.QuarkusExtensionTest;
 public class OpenTelemetryIdGeneratorTest {
     @RegisterExtension
     static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
-            .withApplicationRoot((jar) -> jar.addClass(TestUtil.class));
+            .withApplicationRoot((jar) -> jar.addClass(TestUtil.class))
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Inject
     OpenTelemetry openTelemetry;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryJdbcInstrumentationValidationTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryJdbcInstrumentationValidationTest.java
@@ -17,7 +17,8 @@ public class OpenTelemetryJdbcInstrumentationValidationTest {
             .withApplicationRoot((jar) -> jar
                     .addAsResource(new StringAsset(
                             "quarkus.datasource.db-kind=h2\n" +
-                                    "quarkus.otel.metrics.exporter=none\n" +
+                                    "quarkus.otel.metrics.enabled=false\n" +
+                                    "quarkus.otel.logs.enabled=false\n" +
                                     "quarkus.datasource.jdbc.driver=io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver\n"),
                             "application.properties"))
             .assertException(t -> {

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryReactiveRoutesTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryReactiveRoutesTest.java
@@ -34,7 +34,7 @@ public class OpenTelemetryReactiveRoutesTest {
                     .addClass(TestUtil.class)
                     .addClass(TestSpanExporter.class)
                     .addClass(TestSpanExporterProvider.class)
-                    .addAsResource("resource-config/application-no-metrics.properties", "application.properties")
+                    .addAsResource("resource-config/application-just-tracing.properties", "application.properties")
                     .addAsResource(
                             "META-INF/services-config/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider",
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"));

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetrySamplerBeanTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetrySamplerBeanTest.java
@@ -27,7 +27,7 @@ public class OpenTelemetrySamplerBeanTest {
                     .addClasses(TestSpanExporter.class, TestSpanExporterProvider.class)
                     .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
-            .withConfigurationResource("resource-config/application-no-metrics.properties");
+            .withConfigurationResource("resource-config/application-just-tracing.properties");
 
     @Inject
     OpenTelemetry openTelemetry;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetrySamplerParentBasedTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetrySamplerParentBasedTest.java
@@ -38,7 +38,7 @@ public class OpenTelemetrySamplerParentBasedTest {
                     .addClasses(TestSpanExporter.class, TestSpanExporterProvider.class, HelloResource.class)
                     .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
-            .withConfigurationResource("resource-config/application-no-metrics.properties")
+            .withConfigurationResource("resource-config/application-just-tracing.properties")
             .overrideConfigKey("quarkus.log.category.\"io.quarkus.opentelemetry\".level", "DEBUG")
             .overrideConfigKey("quarkus.otel.traces.sampler", "parentbased_always_on")
             .overrideConfigKey("quarkus.otel.traces.suppress-application-uris", "/hello");

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetrySamplerTraceidRatioTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetrySamplerTraceidRatioTest.java
@@ -25,7 +25,7 @@ public class OpenTelemetrySamplerTraceidRatioTest {
                     .addClasses(TestSpanExporter.class, TestSpanExporterProvider.class)
                     .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
-            .withConfigurationResource("resource-config/application-no-metrics.properties")
+            .withConfigurationResource("resource-config/application-just-tracing.properties")
             .overrideConfigKey("quarkus.otel.traces.sampler", "traceidratio")
             .overrideConfigKey("quarkus.otel.traces.sampler.arg", "0.5")
             .overrideConfigKey("quarkus.otel.traces.suppress-non-application-uris", "false");

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetrySpanSecurityEventsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetrySpanSecurityEventsTest.java
@@ -39,9 +39,11 @@ public class OpenTelemetrySpanSecurityEventsTest {
                             CustomSecurityEvent.class)
                     .addAsResource(new StringAsset("""
                             quarkus.otel.security-events.enabled=true
-                            quarkus.otel.metrics.exporter=none
+                            quarkus.otel.metrics.enabled=false
+                            quarkus.otel.logs.enabled=false
                             quarkus.otel.security-events.event-types=AUTHENTICATION_SUCCESS,AUTHORIZATION_SUCCESS,OTHER
                             quarkus.otel.traces.sampler.arg=1.0d
+                            quarkus.datasource.devservices.enabled=false
                             """), "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetrySuppressAppUrisTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetrySuppressAppUrisTest.java
@@ -35,7 +35,9 @@ public class OpenTelemetrySuppressAppUrisTest {
                     .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
                     .addClasses(TracerRouter.class, TraceMeResource.class))
-            .overrideConfigKey("quarkus.otel.traces.suppress-application-uris", "tracer,/hello/Itachi");
+            .overrideConfigKey("quarkus.otel.traces.suppress-application-uris", "tracer,/hello/Itachi")
+            .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false");
 
     @Inject
     InMemoryExporter exporter;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryTracingDisabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryTracingDisabledTest.java
@@ -14,7 +14,10 @@ public class OpenTelemetryTracingDisabledTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withEmptyApplication()
-            .overrideConfigKey("quarkus.otel.traces.enabled", "false");
+            .overrideConfigKey("quarkus.otel.traces.enabled", "false")
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Inject
     OpenTelemetry openTelemetry;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryTracingDisabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryTracingDisabledTest.java
@@ -14,9 +14,7 @@ public class OpenTelemetryTracingDisabledTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withEmptyApplication()
-            .overrideConfigKey("quarkus.otel.traces.enabled", "false")
-            .overrideConfigKey("quarkus.otel.metrics.enabled", "true")
-            .overrideConfigKey("quarkus.otel.logs.enabled", "true");
+            .overrideConfigKey("quarkus.otel.traces.enabled", "false");
 
     @Inject
     OpenTelemetry openTelemetry;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryTracingDisabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryTracingDisabledTest.java
@@ -15,8 +15,9 @@ public class OpenTelemetryTracingDisabledTest {
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withEmptyApplication()
             .overrideConfigKey("quarkus.otel.traces.enabled", "false")
-            .overrideConfigKey("quarkus.otel.metrics.enabled", "true")
-            .overrideConfigKey("quarkus.otel.logs.enabled", "true");
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Inject
     OpenTelemetry openTelemetry;

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/SimpleSpanProcessorTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/SimpleSpanProcessorTest.java
@@ -46,8 +46,9 @@ public class SimpleSpanProcessorTest {
             .overrideConfigKey("quarkus.otel.simple", "true")
             .overrideConfigKey("quarkus.otel.traces.exporter", "test-span-exporter")
             .overrideConfigKey("quarkus.otel.traces.sampler.arg", "1.0d")
-            .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
-            .overrideConfigKey("quarkus.otel.logs.exporter", "none");
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
 
     @Inject
     OpenTelemetry openTelemetry;

--- a/extensions/opentelemetry/deployment/src/test/resources/application-default.properties
+++ b/extensions/opentelemetry/deployment/src/test/resources/application-default.properties
@@ -11,3 +11,6 @@ quarkus.otel.metric.export.interval=300ms
 
 # Logs
 quarkus.otel.logs.exporter=in-memory
+
+# Other
+quarkus.datasource.devservices.enabled=false

--- a/extensions/opentelemetry/deployment/src/test/resources/resource-config/application-just-tracing.properties
+++ b/extensions/opentelemetry/deployment/src/test/resources/resource-config/application-just-tracing.properties
@@ -5,7 +5,8 @@ quarkus.otel.traces.exporter=test-span-exporter
 # Sampler should be at 100% for testing purposes
 quarkus.otel.traces.sampler.arg=1.0d
 quarkus.otel.bsp.schedule.delay=50ms
-quarkus.otel.metrics.exporter=none
-quarkus.otel.logs.exporter=none
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false
+quarkus.datasource.devservices.enabled=false
 
 quarkus.rest-client.client.url=${test.url}

--- a/extensions/opentelemetry/deployment/src/test/resources/resource-config/application-just-tracing.properties
+++ b/extensions/opentelemetry/deployment/src/test/resources/resource-config/application-just-tracing.properties
@@ -6,5 +6,6 @@ quarkus.otel.traces.exporter=test-span-exporter
 quarkus.otel.traces.sampler.arg=1.0d
 quarkus.otel.bsp.schedule.delay=50ms
 quarkus.otel.metrics.exporter=none
+quarkus.otel.logs.exporter=none
 
 quarkus.rest-client.client.url=${test.url}

--- a/extensions/opentelemetry/deployment/src/test/resources/resource-config/application-just-tracing.properties
+++ b/extensions/opentelemetry/deployment/src/test/resources/resource-config/application-just-tracing.properties
@@ -5,6 +5,8 @@ quarkus.otel.traces.exporter=test-span-exporter
 # Sampler should be at 100% for testing purposes
 quarkus.otel.traces.sampler.arg=1.0d
 quarkus.otel.bsp.schedule.delay=50ms
-quarkus.otel.metrics.exporter=none
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false
+quarkus.datasource.devservices.enabled=false
 
 quarkus.rest-client.client.url=${test.url}

--- a/extensions/opentelemetry/deployment/src/test/resources/resource-config/application.properties
+++ b/extensions/opentelemetry/deployment/src/test/resources/resource-config/application.properties
@@ -8,4 +8,6 @@ quarkus.otel.bsp.schedule.delay=50ms
 quarkus.otel.metrics.exporter=in-memory
 quarkus.otel.metric.export.interval=300ms
 
+quarkus.datasource.devservices.enabled=false
+
 quarkus.rest-client.client.url=${test.url}

--- a/extensions/opentelemetry/deployment/src/test/resources/resource-config/application.properties
+++ b/extensions/opentelemetry/deployment/src/test/resources/resource-config/application.properties
@@ -5,8 +5,9 @@ quarkus.otel.traces.exporter=test-span-exporter
 # Sampler should be at 100% for testing purposes
 quarkus.otel.traces.sampler.arg=1.0d
 quarkus.otel.bsp.schedule.delay=50ms
-quarkus.otel.metrics.enabled=true
 quarkus.otel.metrics.exporter=in-memory
 quarkus.otel.metric.export.interval=300ms
+
+quarkus.datasource.devservices.enabled=false
 
 quarkus.rest-client.client.url=${test.url}

--- a/extensions/opentelemetry/deployment/src/test/resources/resource-config/application.properties
+++ b/extensions/opentelemetry/deployment/src/test/resources/resource-config/application.properties
@@ -5,7 +5,6 @@ quarkus.otel.traces.exporter=test-span-exporter
 # Sampler should be at 100% for testing purposes
 quarkus.otel.traces.sampler.arg=1.0d
 quarkus.otel.bsp.schedule.delay=50ms
-quarkus.otel.metrics.enabled=true
 quarkus.otel.metrics.exporter=in-memory
 quarkus.otel.metric.export.interval=300ms
 

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/build/LogsBuildConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/build/LogsBuildConfig.java
@@ -17,7 +17,7 @@ public interface LogsBuildConfig {
      * The OpenTelemetry SDK ( {@link io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig#enabled()} )
      * is enabled by default and if disabled, OpenTelemetry Logs will also be disabled.
      */
-    @WithDefault("false")
+    @WithDefault("true")
     Optional<Boolean> enabled();
 
     /**

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/build/MetricsBuildConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/build/MetricsBuildConfig.java
@@ -18,7 +18,7 @@ public interface MetricsBuildConfig {
      * The OpenTelemetry SDK ( {@link io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig#enabled()} )
      * is enabled by default and if disabled, OpenTelemetry Metrics will also be disabled.
      */
-    @WithDefault("false")
+    @WithDefault("true")
     Optional<Boolean> enabled();
 
     /**

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxGrpcSender.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxGrpcSender.java
@@ -163,7 +163,6 @@ public final class VertxGrpcSender implements GrpcSender {
             Handler<GrpcClientRequest<Buffer, Buffer>> onSuccessHandler, Duration exportTimeout,
             Consumer<Throwable> onFailureCallback) {
         if (client == null) {
-            internalLogger.log(Level.INFO, "gRPC client is null, possibly during shutdown. Skipping send.");
             return;
         }
         Uni.createFrom().completionStage(new Supplier<CompletionStage<GrpcClientRequest<Buffer, Buffer>>>() {

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxGrpcSender.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxGrpcSender.java
@@ -55,7 +55,7 @@ public final class VertxGrpcSender implements GrpcSender {
     private static final Logger internalLogger = Logger.getLogger(VertxGrpcSender.class.getName());
     private static final int MAX_ATTEMPTS = 3;
 
-    private static final ThrottlingLogger logger = new ThrottlingLogger(internalLogger); // TODO: is there something in JBoss Logging we can use?
+    private final ThrottlingLogger logger = new ThrottlingLogger(internalLogger); // TODO: is there something in JBoss Logging we can use?
 
     // We only log unimplemented once since it's a configuration issue that won't be recovered.
     private final AtomicBoolean loggedUnimplemented = new AtomicBoolean();
@@ -123,6 +123,8 @@ public final class VertxGrpcSender implements GrpcSender {
 
         if (client == null) {
             logger.log(Level.FINE, "Client is null. Cannot close.");
+            // nothing to shutdown
+            shutdownResult.succeed();
             return shutdownResult;
         }
 
@@ -161,7 +163,7 @@ public final class VertxGrpcSender implements GrpcSender {
             Handler<GrpcClientRequest<Buffer, Buffer>> onSuccessHandler, Duration exportTimeout,
             Consumer<Throwable> onFailureCallback) {
         if (client == null) {
-            logger.log(Level.INFO, "gRPC client is null, possibly during shutdown. Skipping send.");
+            internalLogger.log(Level.INFO, "gRPC client is null, possibly during shutdown. Skipping send.");
             return;
         }
         Uni.createFrom().completionStage(new Supplier<CompletionStage<GrpcClientRequest<Buffer, Buffer>>>() {

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxGrpcSender.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxGrpcSender.java
@@ -123,24 +123,32 @@ public final class VertxGrpcSender implements GrpcSender {
 
         if (client == null) {
             logger.log(Level.FINE, "Client is null. Cannot close.");
+            // nothing to shutdown
+            shutdownResult.succeed();
             return shutdownResult;
         }
 
         try {
-            client.close()
-                    .onSuccess(
-                            new Handler<>() {
-                                @Override
-                                public void handle(Void event) {
-                                    shutdownResult.succeed();
-                                }
-                            })
-                    .onFailure(new Handler<>() {
-                        @Override
-                        public void handle(Throwable event) {
-                            shutdownResult.fail();
-                        }
-                    });
+            Future<Void> closeFuture = client.close();
+            if (closeFuture == null) {
+                logger.log(Level.INFO, "gRPC client close returned null, possibly already closed.");
+                shutdownResult.fail();
+            } else {
+                closeFuture
+                        .onSuccess(
+                                new Handler<>() {
+                                    @Override
+                                    public void handle(Void event) {
+                                        shutdownResult.succeed();
+                                    }
+                                })
+                        .onFailure(new Handler<>() {
+                            @Override
+                            public void handle(Throwable event) {
+                                shutdownResult.fail();
+                            }
+                        });
+            }
         } catch (RejectedExecutionException e) {
             internalLogger.log(Level.FINE, "Unable to complete shutdown", e);
             // if Netty's ThreadPool has been closed, this onSuccess() will immediately throw RejectedExecutionException
@@ -154,6 +162,9 @@ public final class VertxGrpcSender implements GrpcSender {
             int numberOfAttempts,
             Handler<GrpcClientRequest<Buffer, Buffer>> onSuccessHandler, Duration exportTimeout,
             Consumer<Throwable> onFailureCallback) {
+        if (client == null) {
+            return;
+        }
         Uni.createFrom().completionStage(new Supplier<CompletionStage<GrpcClientRequest<Buffer, Buffer>>>() {
             @Override
             public CompletionStage<GrpcClientRequest<Buffer, Buffer>> get() {

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxGrpcSender.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxGrpcSender.java
@@ -55,7 +55,7 @@ public final class VertxGrpcSender implements GrpcSender {
     private static final Logger internalLogger = Logger.getLogger(VertxGrpcSender.class.getName());
     private static final int MAX_ATTEMPTS = 3;
 
-    private final ThrottlingLogger logger = new ThrottlingLogger(internalLogger); // TODO: is there something in JBoss Logging we can use?
+    private static final ThrottlingLogger logger = new ThrottlingLogger(internalLogger); // TODO: is there something in JBoss Logging we can use?
 
     // We only log unimplemented once since it's a configuration issue that won't be recovered.
     private final AtomicBoolean loggedUnimplemented = new AtomicBoolean();
@@ -127,20 +127,26 @@ public final class VertxGrpcSender implements GrpcSender {
         }
 
         try {
-            client.close()
-                    .onSuccess(
-                            new Handler<>() {
-                                @Override
-                                public void handle(Void event) {
-                                    shutdownResult.succeed();
-                                }
-                            })
-                    .onFailure(new Handler<>() {
-                        @Override
-                        public void handle(Throwable event) {
-                            shutdownResult.fail();
-                        }
-                    });
+            Future<Void> closeFuture = client.close();
+            if (closeFuture == null) {
+                logger.log(Level.INFO, "gRPC client close returned null, possibly already closed.");
+                shutdownResult.fail();
+            } else {
+                closeFuture
+                        .onSuccess(
+                                new Handler<>() {
+                                    @Override
+                                    public void handle(Void event) {
+                                        shutdownResult.succeed();
+                                    }
+                                })
+                        .onFailure(new Handler<>() {
+                            @Override
+                            public void handle(Throwable event) {
+                                shutdownResult.fail();
+                            }
+                        });
+            }
         } catch (RejectedExecutionException e) {
             internalLogger.log(Level.FINE, "Unable to complete shutdown", e);
             // if Netty's ThreadPool has been closed, this onSuccess() will immediately throw RejectedExecutionException
@@ -154,6 +160,10 @@ public final class VertxGrpcSender implements GrpcSender {
             int numberOfAttempts,
             Handler<GrpcClientRequest<Buffer, Buffer>> onSuccessHandler, Duration exportTimeout,
             Consumer<Throwable> onFailureCallback) {
+        if (client == null) {
+            logger.log(Level.INFO, "gRPC client is null, possibly during shutdown. Skipping send.");
+            return;
+        }
         Uni.createFrom().completionStage(new Supplier<CompletionStage<GrpcClientRequest<Buffer, Buffer>>>() {
             @Override
             public CompletionStage<GrpcClientRequest<Buffer, Buffer>> get() {

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
@@ -27,6 +27,7 @@ import io.quarkus.vertx.core.runtime.BufferOutputStream;
 import io.smallrye.common.annotation.SuppressForbidden;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -43,9 +44,9 @@ public final class VertxHttpSender implements HttpSender {
     public static final String METRICS_PATH = "/v1/metrics";
     public static final String LOGS_PATH = "/v1/logs";
 
-    private static final Logger log = Logger.getLogger(VertxHttpSender.class.getName());
+    private static final Logger internalLogger = Logger.getLogger(VertxHttpSender.class.getName());
 
-    private static final ThrottlingLogger throttlingLogger = new ThrottlingLogger(
+    private final ThrottlingLogger throttlingLogger = new ThrottlingLogger(
             java.util.logging.Logger.getLogger(VertxHttpSender.class.getName()));
 
     private static final int MAX_ATTEMPTS = 3;
@@ -140,6 +141,9 @@ public final class VertxHttpSender implements HttpSender {
             int numberOfAttempts,
             Handler<HttpClientRequest> clientRequestSuccessHandler,
             Consumer<Throwable> onFailureCallback) {
+        if (client == null) {
+            return;
+        }
         Uni.createFrom().completionStage(new Supplier<CompletionStage<HttpClientRequest>>() {
             @Override
             public CompletionStage<HttpClientRequest> get() {
@@ -183,26 +187,34 @@ public final class VertxHttpSender implements HttpSender {
 
         if (client == null) {
             throttlingLogger.log(Level.FINE, "Client is null. Cannot close.");
+            // nothing to shutdown
+            shutdownResult.succeed();
             return shutdownResult;
         }
 
         try {
-            client.close()
-                    .onSuccess(
-                            new Handler<>() {
-                                @Override
-                                public void handle(Void event) {
-                                    shutdownResult.succeed();
-                                }
-                            })
-                    .onFailure(new Handler<>() {
-                        @Override
-                        public void handle(Throwable event) {
-                            shutdownResult.fail();
-                        }
-                    });
+            Future<Void> closeFuture = client.close();
+            if (closeFuture == null) {
+                throttlingLogger.log(Level.INFO, "HTTP client close returned null, possibly already closed.");
+                shutdownResult.fail();
+            } else {
+                closeFuture
+                        .onSuccess(
+                                new Handler<>() {
+                                    @Override
+                                    public void handle(Void event) {
+                                        shutdownResult.succeed();
+                                    }
+                                })
+                        .onFailure(new Handler<>() {
+                            @Override
+                            public void handle(Throwable event) {
+                                shutdownResult.fail();
+                            }
+                        });
+            }
         } catch (RejectedExecutionException e) {
-            log.debug("Unable to complete shutdown", e);
+            internalLogger.debug("Unable to complete shutdown", e);
             // if Netty's ThreadPool has been closed, this onSuccess() will immediately throw RejectedExecutionException
             // which we need to handle
             shutdownResult.fail();

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
@@ -27,6 +27,7 @@ import io.quarkus.vertx.core.runtime.BufferOutputStream;
 import io.smallrye.common.annotation.SuppressForbidden;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -140,6 +141,10 @@ public final class VertxHttpSender implements HttpSender {
             int numberOfAttempts,
             Handler<HttpClientRequest> clientRequestSuccessHandler,
             Consumer<Throwable> onFailureCallback) {
+        if (client == null) {
+            throttlingLogger.log(Level.INFO, "HTTP client is null, possibly during shutdown. Skipping send.");
+            return;
+        }
         Uni.createFrom().completionStage(new Supplier<CompletionStage<HttpClientRequest>>() {
             @Override
             public CompletionStage<HttpClientRequest> get() {
@@ -187,20 +192,26 @@ public final class VertxHttpSender implements HttpSender {
         }
 
         try {
-            client.close()
-                    .onSuccess(
-                            new Handler<>() {
-                                @Override
-                                public void handle(Void event) {
-                                    shutdownResult.succeed();
-                                }
-                            })
-                    .onFailure(new Handler<>() {
-                        @Override
-                        public void handle(Throwable event) {
-                            shutdownResult.fail();
-                        }
-                    });
+            Future<Void> closeFuture = client.close();
+            if (closeFuture == null) {
+                throttlingLogger.log(Level.INFO, "HTTP client close returned null, possibly already closed.");
+                shutdownResult.fail();
+            } else {
+                closeFuture
+                        .onSuccess(
+                                new Handler<>() {
+                                    @Override
+                                    public void handle(Void event) {
+                                        shutdownResult.succeed();
+                                    }
+                                })
+                        .onFailure(new Handler<>() {
+                            @Override
+                            public void handle(Throwable event) {
+                                shutdownResult.fail();
+                            }
+                        });
+            }
         } catch (RejectedExecutionException e) {
             log.debug("Unable to complete shutdown", e);
             // if Netty's ThreadPool has been closed, this onSuccess() will immediately throw RejectedExecutionException

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
@@ -44,7 +44,7 @@ public final class VertxHttpSender implements HttpSender {
     public static final String METRICS_PATH = "/v1/metrics";
     public static final String LOGS_PATH = "/v1/logs";
 
-    private static final Logger log = Logger.getLogger(VertxHttpSender.class.getName());
+    private static final Logger internalLogger = Logger.getLogger(VertxHttpSender.class.getName());
 
     private final ThrottlingLogger throttlingLogger = new ThrottlingLogger(
             java.util.logging.Logger.getLogger(VertxHttpSender.class.getName()));
@@ -142,7 +142,6 @@ public final class VertxHttpSender implements HttpSender {
             Handler<HttpClientRequest> clientRequestSuccessHandler,
             Consumer<Throwable> onFailureCallback) {
         if (client == null) {
-            log.info("HTTP client is null, possibly during shutdown. Skipping send.");
             return;
         }
         Uni.createFrom().completionStage(new Supplier<CompletionStage<HttpClientRequest>>() {
@@ -215,7 +214,7 @@ public final class VertxHttpSender implements HttpSender {
                         });
             }
         } catch (RejectedExecutionException e) {
-            log.debug("Unable to complete shutdown", e);
+            internalLogger.debug("Unable to complete shutdown", e);
             // if Netty's ThreadPool has been closed, this onSuccess() will immediately throw RejectedExecutionException
             // which we need to handle
             shutdownResult.fail();

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
@@ -46,7 +46,7 @@ public final class VertxHttpSender implements HttpSender {
 
     private static final Logger log = Logger.getLogger(VertxHttpSender.class.getName());
 
-    private static final ThrottlingLogger throttlingLogger = new ThrottlingLogger(
+    private final ThrottlingLogger throttlingLogger = new ThrottlingLogger(
             java.util.logging.Logger.getLogger(VertxHttpSender.class.getName()));
 
     private static final int MAX_ATTEMPTS = 3;
@@ -142,7 +142,7 @@ public final class VertxHttpSender implements HttpSender {
             Handler<HttpClientRequest> clientRequestSuccessHandler,
             Consumer<Throwable> onFailureCallback) {
         if (client == null) {
-            throttlingLogger.log(Level.INFO, "HTTP client is null, possibly during shutdown. Skipping send.");
+            log.info("HTTP client is null, possibly during shutdown. Skipping send.");
             return;
         }
         Uni.createFrom().completionStage(new Supplier<CompletionStage<HttpClientRequest>>() {
@@ -188,6 +188,8 @@ public final class VertxHttpSender implements HttpSender {
 
         if (client == null) {
             throttlingLogger.log(Level.FINE, "Client is null. Cannot close.");
+            // nothing to shutdown
+            shutdownResult.succeed();
             return shutdownResult;
         }
 

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/propagation/OpenTelemetryMpContextPropagationProvider.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/propagation/OpenTelemetryMpContextPropagationProvider.java
@@ -5,35 +5,64 @@ import java.util.Map;
 import org.eclipse.microprofile.context.spi.ThreadContextController;
 import org.eclipse.microprofile.context.spi.ThreadContextProvider;
 import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
+import org.jboss.logging.Logger;
 
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.quarkus.opentelemetry.runtime.OpenTelemetryUtil;
 import io.quarkus.opentelemetry.runtime.QuarkusContextStorage;
 
 public class OpenTelemetryMpContextPropagationProvider implements ThreadContextProvider {
 
+    private static final Logger logger = Logger.getLogger(OpenTelemetryMpContextPropagationProvider.class);
+
     @Override
     public ThreadContextSnapshot currentContext(Map<String, String> props) {
 
-        io.opentelemetry.context.Context context = QuarkusContextStorage.INSTANCE.current();
-
+        final Context capturedContext = QuarkusContextStorage.INSTANCE.current();
         // Use anonymous classes instead of lambdas for the native image
         return new ThreadContextSnapshot() {
 
             @Override
             public ThreadContextController begin() {
-                io.opentelemetry.context.Context currentContext = QuarkusContextStorage.INSTANCE.current();
-                if (context != null) {
-                    QuarkusContextStorage.INSTANCE.attach(context);
+                if (capturedContext != null) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debugv("begin(): attaching captured OTel context: {0}",
+                                OpenTelemetryUtil.getSpanData(capturedContext));
+                    }
+                    Scope scope = QuarkusContextStorage.INSTANCE.attach(capturedContext);
+                    if (logger.isDebugEnabled()) {
+                        logger.debugv("begin(): obtained scope: {0} (class: {1})",
+                                scope, scope.getClass().getName());
+                    }
                     return new ThreadContextController() {
                         @Override
                         public void endContext() throws IllegalStateException {
-                            io.opentelemetry.context.Context active = QuarkusContextStorage.INSTANCE.current();
-                            if ((active != null && active != context) || currentContext == null) {
-                                return;
+                            Context current = QuarkusContextStorage.INSTANCE.current();
+                            if (logger.isDebugEnabled()) {
+                                logger.debugv(
+                                        "endContext(): current context: {0}, captured context: {1}, scope class: {2}",
+                                        current == null ? "null" : OpenTelemetryUtil.getSpanData(current),
+                                        OpenTelemetryUtil.getSpanData(capturedContext),
+                                        scope.getClass().getName());
                             }
-                            Span span = Span.fromContext(currentContext);
-                            if (span != null && span.isRecording()) {
-                                QuarkusContextStorage.INSTANCE.attach(currentContext);
+                            // Guard: only close the scope if the current context is still what
+                            // begin() attached. If other OTel scopes have closed between begin()
+                            // and now (e.g. spans ending during async processing), the DC has
+                            // already been cleaned up — unconditionally restoring the stale
+                            // otelBeforeAttach would trash it. This mirrors the guard in
+                            // ThreadLocalContextStorage.ScopeImpl.close().
+                            if (current == capturedContext) {
+                                scope.close();
+                                if (logger.isDebugEnabled()) {
+                                    Context afterClose = QuarkusContextStorage.INSTANCE.current();
+                                    logger.debugv("endContext(): context after close: {0}",
+                                            afterClose == null ? "null"
+                                                    : OpenTelemetryUtil.getSpanData(afterClose));
+                                }
+                            } else if (logger.isDebugEnabled()) {
+                                logger.debugv(
+                                        "endContext(): skipping scope.close() — context was changed by other scopes");
                             }
                         }
                     };

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/propagation/OpenTelemetryMpContextPropagationProvider.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/propagation/OpenTelemetryMpContextPropagationProvider.java
@@ -5,35 +5,64 @@ import java.util.Map;
 import org.eclipse.microprofile.context.spi.ThreadContextController;
 import org.eclipse.microprofile.context.spi.ThreadContextProvider;
 import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
+import org.jboss.logging.Logger;
 
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.quarkus.opentelemetry.runtime.OpenTelemetryUtil;
 import io.quarkus.opentelemetry.runtime.QuarkusContextStorage;
 
 public class OpenTelemetryMpContextPropagationProvider implements ThreadContextProvider {
 
+    private static final Logger logger = Logger.getLogger(OpenTelemetryMpContextPropagationProvider.class);
+
     @Override
     public ThreadContextSnapshot currentContext(Map<String, String> props) {
 
-        io.opentelemetry.context.Context context = QuarkusContextStorage.INSTANCE.current();
-
+        final Context capturedContext = QuarkusContextStorage.INSTANCE.current();
         // Use anonymous classes instead of lambdas for the native image
         return new ThreadContextSnapshot() {
 
             @Override
             public ThreadContextController begin() {
-                io.opentelemetry.context.Context currentContext = QuarkusContextStorage.INSTANCE.current();
-                if (context != null) {
-                    QuarkusContextStorage.INSTANCE.attach(context);
+                if (capturedContext != null) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debugv("begin(): attaching captured OTel context: {0}",
+                                OpenTelemetryUtil.getSpanData(capturedContext));
+                    }
+                    Scope scope = QuarkusContextStorage.INSTANCE.attach(capturedContext);
+                    if (logger.isDebugEnabled()) {
+                        logger.debugv("begin(): obtained scope: {0} (class: {1})",
+                                scope, scope.getClass().getName());
+                    }
                     return new ThreadContextController() {
                         @Override
                         public void endContext() throws IllegalStateException {
-                            io.opentelemetry.context.Context active = QuarkusContextStorage.INSTANCE.current();
-                            if (active != null && active != context) {
-                                return;
+                            Context current = QuarkusContextStorage.INSTANCE.current();
+                            if (logger.isDebugEnabled()) {
+                                logger.debugv(
+                                        "endContext(): current context: {0}, captured context: {1}, scope class: {2}",
+                                        current == null ? "null" : OpenTelemetryUtil.getSpanData(current),
+                                        OpenTelemetryUtil.getSpanData(capturedContext),
+                                        scope.getClass().getName());
                             }
-                            Span span = Span.fromContext(currentContext);
-                            if (span != null && span.isRecording()) {
-                                QuarkusContextStorage.INSTANCE.attach(currentContext);
+                            // Guard: only close the scope if the current context is still what
+                            // begin() attached. If other OTel scopes have closed between begin()
+                            // and now (e.g. spans ending during async processing), the DC has
+                            // already been cleaned up — unconditionally restoring the stale
+                            // otelBeforeAttach would trash it. This mirrors the guard in
+                            // ThreadLocalContextStorage.ScopeImpl.close().
+                            if (current == capturedContext) {
+                                scope.close();
+                                if (logger.isDebugEnabled()) {
+                                    Context afterClose = QuarkusContextStorage.INSTANCE.current();
+                                    logger.debugv("endContext(): context after close: {0}",
+                                            afterClose == null ? "null"
+                                                    : OpenTelemetryUtil.getSpanData(afterClose));
+                                }
+                            } else if (logger.isDebugEnabled()) {
+                                logger.debugv(
+                                        "endContext(): skipping scope.close() — context was changed by other scopes");
                             }
                         }
                     };

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/propagation/OpenTelemetryMpContextPropagationProvider.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/propagation/OpenTelemetryMpContextPropagationProvider.java
@@ -28,7 +28,7 @@ public class OpenTelemetryMpContextPropagationProvider implements ThreadContextP
                         @Override
                         public void endContext() throws IllegalStateException {
                             io.opentelemetry.context.Context active = QuarkusContextStorage.INSTANCE.current();
-                            if (active != null && active != context) {
+                            if ((active != null && active != context) || currentContext == null) {
                                 return;
                             }
                             Span span = Span.fromContext(currentContext);

--- a/integration-tests/jfr-opentelemetry/src/main/resources/application.properties
+++ b/integration-tests/jfr-opentelemetry/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 quarkus.native.monitoring=jfr
+
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false

--- a/integration-tests/logging-json/src/main/resources/application.properties
+++ b/integration-tests/logging-json/src/main/resources/application.properties
@@ -1,2 +1,5 @@
 quarkus.log.file.enabled=true
 quarkus.log.file.json.log-format=gcp
+
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false

--- a/integration-tests/micrometer-prometheus-opentelemetry/src/main/resources/application.properties
+++ b/integration-tests/micrometer-prometheus-opentelemetry/src/main/resources/application.properties
@@ -40,4 +40,3 @@ quarkus.http.auth.permission.secured.policy=authenticated
 quarkus.http.auth.permission.secured.paths=/secured/*
 
 quarkus.otel.traces.sampler=always_on
-

--- a/integration-tests/opentelemetry-exporter-logging/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-exporter-logging/src/main/resources/application.properties
@@ -2,3 +2,6 @@ quarkus.application.name=myservice
 quarkus.otel.metrics.exporter=logging
 # Force quick output of metrics to increase test reliability.
 quarkus.otel.metric.export.interval=100ms
+
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false

--- a/integration-tests/opentelemetry-grpc-only/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-grpc-only/src/main/resources/application.properties
@@ -4,4 +4,4 @@ quarkus.grpc.clients.hello.port=8081
 quarkus.otel.bsp.schedule.delay=100
 quarkus.otel.bsp.export.timeout=5s
 
-quarkus.otel.metrics.enabled=true
+quarkus.otel.logs.enabled=false

--- a/integration-tests/opentelemetry-grpc/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-grpc/src/main/resources/application.properties
@@ -5,3 +5,6 @@ quarkus.otel.bsp.schedule.delay=100
 quarkus.otel.bsp.export.timeout=5s
 # Sampler should be at 100% for testing purposes
 quarkus.otel.traces.sampler.arg=1.0d
+
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/main/resources/application.properties
@@ -55,3 +55,6 @@ quarkus.otel.bsp.export.timeout=5s
 
 # Sampler should be at 100% for testing purposes
 quarkus.otel.traces.sampler.arg=1.0d
+
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false

--- a/integration-tests/opentelemetry-minimal/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-minimal/src/main/resources/application.properties
@@ -3,6 +3,5 @@ quarkus.application.name=opentelemetry-minimal
 # speed up build
 quarkus.otel.bsp.schedule.delay=100
 quarkus.otel.bsp.export.timeout=5s
-quarkus.otel.metrics.enabled=true
 quarkus.otel.metric.export.interval=100ms
-#quarkus.otel.logs.enabled=true
+quarkus.otel.logs.enabled=false

--- a/integration-tests/opentelemetry-mongodb-client-instrumentation/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-mongodb-client-instrumentation/src/main/resources/application.properties
@@ -19,3 +19,6 @@ quarkus.mongodb.tracing.enabled=true
 quarkus.mongodb.tracing.command-detail-level=FULL
 %sanitized.quarkus.mongodb.tracing.command-detail-level=SANITIZED
 %off.quarkus.mongodb.tracing.command-detail-level=OFF
+
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false

--- a/integration-tests/opentelemetry-quartz/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-quartz/src/main/resources/application.properties
@@ -5,3 +5,6 @@ quarkus.otel.bsp.export.timeout=5s
 quarkus.scheduler.tracing.enabled=true
 # Sampler should be at 100% for testing purposes
 quarkus.otel.traces.sampler.arg=1.0d
+
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false

--- a/integration-tests/opentelemetry-quickstart/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-quickstart/src/main/resources/application.properties
@@ -3,3 +3,6 @@ quarkus.otel.bsp.schedule.delay=0
 quarkus.otel.bsp.export.timeout=5s
 # Sampler should be at 100% for testing purposes
 quarkus.otel.traces.sampler.arg=1.0d
+
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false

--- a/integration-tests/opentelemetry-reactive-messaging/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-reactive-messaging/src/main/resources/application.properties
@@ -12,3 +12,6 @@ quarkus.otel.bsp.export.timeout=5s
 
 # Sampler should be at 100% for testing purposes
 quarkus.otel.traces.sampler.arg=1.0d
+
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false

--- a/integration-tests/opentelemetry-reactive/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-reactive/src/main/resources/application.properties
@@ -15,3 +15,6 @@ quarkus.http.auth.permission.secured.policy=authenticated
 quarkus.http.auth.permission.secured.paths=/foo/secured/*
 
 quarkus.otel.security-events.enabled=true
+
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false

--- a/integration-tests/opentelemetry-redis-instrumentation/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-redis-instrumentation/src/main/resources/application.properties
@@ -11,3 +11,6 @@ quarkus.otel.bsp.export.timeout=5s
 
 # Sampler should be at 100% for testing purposes
 quarkus.otel.traces.sampler.arg=1.0d
+
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false

--- a/integration-tests/opentelemetry-scheduler/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-scheduler/src/main/resources/application.properties
@@ -5,3 +5,6 @@ quarkus.otel.bsp.export.timeout=5s
 quarkus.scheduler.tracing.enabled=true
 # Sampler should be at 100% for testing purposes
 quarkus.otel.traces.sampler.arg=1.0d
+
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false

--- a/integration-tests/opentelemetry-spi/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-spi/src/main/resources/application.properties
@@ -11,3 +11,6 @@ quarkus.otel.bsp.export.timeout=5s
 
 pingpong/mp-rest/url=${test.url}
 simple/mp-rest/url=${test.url}
+
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false

--- a/integration-tests/opentelemetry-vertx-exporter/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-vertx-exporter/src/main/resources/application.properties
@@ -1,6 +1,4 @@
 quarkus.application.name=integration test
-quarkus.otel.metrics.enabled=true
 quarkus.otel.metric.export.interval=1000ms
-quarkus.otel.logs.enabled=true
 # Sampler should be at 100% for testing purposes
 quarkus.otel.traces.sampler.arg=1.0d

--- a/integration-tests/opentelemetry-vertx/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-vertx/src/main/resources/application.properties
@@ -6,3 +6,6 @@ quarkus.otel.bsp.export.timeout=5s
 
 # Sampler should be at 100% for testing purposes
 quarkus.otel.traces.sampler.arg=1.0d
+
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false

--- a/integration-tests/opentelemetry/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry/src/main/resources/application.properties
@@ -5,10 +5,7 @@ quarkus.application.version=999-SNAPSHOT
 # speed up build
 quarkus.otel.bsp.schedule.delay=100
 quarkus.otel.bsp.export.timeout=5s
-quarkus.otel.metrics.enabled=true
 quarkus.otel.metric.export.interval=100ms
-
-quarkus.otel.logs.enabled=true
 
 pingpong/mp-rest/url=${test.url}
 simple/mp-rest/url=${test.url}

--- a/integration-tests/reactive-messaging-context-propagation/src/main/resources/application.properties
+++ b/integration-tests/reactive-messaging-context-propagation/src/main/resources/application.properties
@@ -20,3 +20,6 @@ mp.messaging.outgoing.flowers-out.topic=flowers
 # Uncomment the following line to enable request-scoped messaging, disabled by default:
 #quarkus.messaging.request-scoped.enabled=true
 quarkus.messaging.connector-context-propagation=CDI
+
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false

--- a/integration-tests/rest-client-reactive/src/main/resources/application.properties
+++ b/integration-tests/rest-client-reactive/src/main/resources/application.properties
@@ -15,3 +15,6 @@ quarkus.otel.bsp.schedule.delay=10
 
 # Sampler should be at 100% for testing purposes
 quarkus.otel.traces.sampler.arg=1.0d
+
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/main/resources/application.properties
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/main/resources/application.properties
@@ -24,3 +24,6 @@ mp.messaging.incoming.countries-t2-in.auto.offset.reset=earliest
 quarkus.package.jar.decompiler.enabled=true
 
 test.prop=test
+
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false


### PR DESCRIPTION
## Main work

Right now only OTel stable signal is Tracing. OTel Metrics and Logs are now stable and enabled by default. 
This is also making `quarkus-micrometer-opentelemetry` stable.
Documentation updated across 4 asciidoc files: removed "tech preview" / "disabled by default" language, updated config tables with new defaults.

## Required fixes

Some issues surfaced with the defaults change and required attention:

* Fixed a context-trashing bug in `OpenTelemetryMpContextPropagationProvider.endContext()` on the Vert.x path. See details bellow.
* Null-safety guards added to `VertxGrpcSender` and `VertxHttpSender` for `client.close()` returning null and client being null during shutdown races.
*   With metrics/logs now defaulting to true, tests that only exercise traces/config were bootstrapping full metrics and logs SDK infrastructure unnecessarily. This caused **Metaspace exhaustion** (currently `-XX:MaxMetaspaceSize=1500m`) across ~80 tests sharing a single JVM fork, and slow shutdown from periodic exporters needing graceful termination.
     * All tests not requiring metrics and logs have  `*.enabled=false`
     * Test shutdown time reduced: `quarkus.otel.experimental.shutdown-wait-time` defaults to 100ms in `LaunchMode.TEST` via a build step.
     * The LGTM dev service (Grafana/Loki/Tempo/Mimir container) and the H2 DB in many tests because of the auto start. Deployment tests shouldn't need dev services. Set `quarkus.datasource.devservices.enabled=false` on tests.

### The MP Context Propagation fix

#### The problem

`OpenTelemetryMpContextPropagationProvider` implements the MicroProfile `ThreadContextProvider` contract, which propagates OTel context across async boundaries. It has a three-phase lifecycle: capture the current context on the originating thread, begin (apply it on the target thread), and endContext (restore the target thread to its prior state).

#### The previous implementation had two bugs:

1. Context leak on plain threads. Something that users should not be seeing in practice but need attention. When a task runs on a clean executor thread (no prior OTel context), `endContext()` tried to restore the prior state by calling `attach(null)`. But in the OTel SDK, attach(null) is explicitly a no-op — it returns a `NoopScope` without modifying the `ThreadLocal`. The propagated span remained stuck on the thread, leaking into subsequent unrelated tasks that reused it.

2. Context trashing on Vert.x threads. On the Vert.x event loop, OTel context is stored in the Vert.x `DuplicatedContext` (DC) rather than a `ThreadLocal`. When spans end between `begin()` and `endContext()` — which happens naturally during async processing (e.g., GraphQL operation and resolver spans finishing while MP context propagation is still active) — the DC
reaches a correct clean state through normal scope cleanup. But `endContext()` then unconditionally restores a stale snapshot captured at `begin()` time, putting a dead span's context back on the DC.

#### The fix

Replace `attach(prior)` in `endContext()` with `scope.close()`, guarded by a current-context check:

```java
Scope scope = QuarkusContextStorage.INSTANCE.attach(capturedContext);
return () -> {
    Context current = QuarkusContextStorage.INSTANCE.current();
    if (current == capturedContext) {
        scope.close();
    }
};
``` 
This works because `attach()` already captures the prior state internally (as `otelBeforeAttach` inside `QuarkusContextStorage`) and `Scope.close()` restores it — including restoring `null`, which `attach(null)` cannot do. The guard `current == capturedContext` prevents the trashing: if other scopes have already cleaned up the context between `begin()` and `endContext()`, the current state is correct and we skip the close rather than overwriting it with a stale snapshot.

The guard mirrors the one already present in the OTel SDK's own `ThreadLocalContextStorage.ScopeImpl.close()`, which checks `current() == toAttach` before restoring.


---

- Closes: https://github.com/quarkusio/quarkus/issues/55432
