### PR TITLE
Quarkus REST: fix NPE when serializing JSON entity from sub-resource server exception mapper

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -625,7 +625,7 @@ public abstract class ResteasyReactiveRequestContext
 
     public Annotation[] getMethodAnnotations() {
         if (methodAnnotations == null) {
-            if (target == null) {
+            if (target == null || target.getLazyMethod() == null) {
                 return EMPTY_ANNOTATIONS;
             }
             return target.getLazyMethod().getAnnotations();


### PR DESCRIPTION
* closes: https://github.com/quarkusio/quarkus/issues/55818
