### PR TITLE
Merge isPublicConstructors() when a reflective class is registered twice

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageReflectConfigStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageReflectConfigStep.java
@@ -203,6 +203,9 @@ public class NativeImageReflectConfigStep {
                 if (classBuildItem.isConstructors()) {
                     existing.constructors = true;
                 }
+                if (classBuildItem.isPublicConstructors()) {
+                    existing.publicConstructors = true;
+                }
                 if (classBuildItem.isQueryConstructors()) {
                     existing.queryConstructors = true;
                 }


### PR DESCRIPTION
The `publicConstructors` flag needs to be set when any of the combined instances had it set.

* Fixes #55848
