### PR TITLE
Allow listing all public methods of a class for reflection

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
@@ -18,6 +18,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
     // The names of the classes that should be registered for reflection
     private final Collection<String> className;
     private final boolean methods;
+    private final boolean publicMethods;
     private final boolean queryMethods;
     private final boolean fields;
     private final boolean classes;
@@ -55,7 +56,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
     private ReflectiveClassBuildItem(boolean constructors, boolean queryConstructors, boolean methods, boolean queryMethods,
             boolean fields, boolean getClasses, boolean weak, boolean serialization, boolean unsafeAllocated, String reason,
             Class<?>... classes) {
-        this(constructors, false, queryConstructors, methods, queryMethods, fields, getClasses, weak, serialization,
+        this(constructors, false, queryConstructors, methods, false, queryMethods, fields, getClasses, weak, serialization,
                 unsafeAllocated, reason, stream(classes).map(Class::getName).toArray(String[]::new));
     }
 
@@ -81,20 +82,20 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
     ReflectiveClassBuildItem(boolean constructors, boolean queryConstructors, boolean methods, boolean queryMethods,
             boolean fields, boolean weak, boolean serialization,
             boolean unsafeAllocated, String... className) {
-        this(constructors, false, queryConstructors, methods, queryMethods, fields, false, weak, serialization, unsafeAllocated,
-                null, className);
+        this(constructors, false, queryConstructors, methods, false, queryMethods, fields, false, weak, serialization,
+                unsafeAllocated, null, className);
     }
 
     ReflectiveClassBuildItem(boolean constructors, boolean publicConstructors, boolean queryConstructors, boolean methods,
-            boolean queryMethods,
+            boolean publicMethods, boolean queryMethods,
             boolean fields, boolean classes, boolean weak, boolean serialization,
             boolean unsafeAllocated, String reason, String... className) {
-        this(constructors, publicConstructors, queryConstructors, methods, queryMethods, fields, classes, weak, serialization,
-                unsafeAllocated, reason, Arrays.asList(className));
+        this(constructors, publicConstructors, queryConstructors, methods, publicMethods, queryMethods, fields, classes, weak,
+                serialization, unsafeAllocated, reason, Arrays.asList(className));
     }
 
     ReflectiveClassBuildItem(boolean constructors, boolean publicConstructors, boolean queryConstructors, boolean methods,
-            boolean queryMethods,
+            boolean publicMethods, boolean queryMethods,
             boolean fields, boolean classes, boolean weak, boolean serialization,
             boolean unsafeAllocated, String reason, Collection<String> className) {
         for (String i : className) {
@@ -104,6 +105,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         }
         this.className = className;
         this.methods = methods;
+        this.publicMethods = publicMethods;
         if (methods && queryMethods) {
             log.warnf(
                     "Both methods and queryMethods are set to true for classes: %s. queryMethods is redundant and will be ignored",
@@ -136,6 +138,10 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
 
     public boolean isMethods() {
         return methods;
+    }
+
+    public boolean isPublicMethods() {
+        return publicMethods;
     }
 
     public boolean isQueryMethods() {
@@ -184,6 +190,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         private boolean publicConstructors = false;
         private boolean queryConstructors;
         private boolean methods;
+        private boolean publicMethods = false;
         private boolean queryMethods;
         private boolean fields;
         private boolean classes;
@@ -248,7 +255,9 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
 
         /**
          * Configures whether methods should be registered for reflection.
-         * Setting this enables getting all declared methods for the class as well as invoking them reflectively.
+         * Setting this enables getting all methods <strong>declared</strong> by the class, regardless of their
+         * visibility, as well as invoking them reflectively, i.e. {@link Class#getDeclaredMethods()}.
+         * This does not include methods inherited from superclasses or interfaces.
          */
         public Builder methods(boolean methods) {
             this.methods = methods;
@@ -257,6 +266,22 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
 
         public Builder methods() {
             return methods(true);
+        }
+
+        /**
+         * Configures whether public methods should be registered for reflection.
+         * Setting this enables getting all <strong>public</strong> methods of the class, including those
+         * inherited from superclasses and interfaces, as well as invoking them reflectively.
+         * This is narrower than {@link #methods()} in visibility (public only)
+         * but broader in scope (inherited methods included).
+         */
+        public Builder publicMethods(boolean publicMethods) {
+            this.publicMethods = publicMethods;
+            return this;
+        }
+
+        public Builder publicMethods() {
+            return publicMethods(true);
         }
 
         /**
@@ -348,7 +373,8 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         }
 
         public ReflectiveClassBuildItem build() {
-            return new ReflectiveClassBuildItem(constructors, publicConstructors, queryConstructors, methods, queryMethods,
+            return new ReflectiveClassBuildItem(constructors, publicConstructors, queryConstructors, methods, publicMethods,
+                    queryMethods,
                     fields, classes, weak,
                     serialization, unsafeAllocated, reason, className);
         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageReflectConfigStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageReflectConfigStep.java
@@ -113,6 +113,9 @@ public class NativeImageReflectConfigStep {
                     extractToJsonArray(info.queriedMethodSet, queriedMethodsArray);
                 }
             }
+            if (info.publicMethods) {
+                json.put("allPublicMethods", true);
+            }
             if (!methodsArray.isEmpty()) {
                 json.put("methods", methodsArray);
             }
@@ -209,6 +212,9 @@ public class NativeImageReflectConfigStep {
                 if (classBuildItem.isMethods()) {
                     existing.methods = true;
                 }
+                if (classBuildItem.isPublicMethods()) {
+                    existing.publicMethods = true;
+                }
                 if (classBuildItem.isQueryMethods()) {
                     existing.queryMethods = true;
                 }
@@ -255,6 +261,7 @@ public class NativeImageReflectConfigStep {
         boolean publicConstructors;
         boolean queryConstructors;
         boolean methods;
+        boolean publicMethods;
         boolean queryMethods;
         boolean fields;
         boolean classes;
@@ -272,6 +279,7 @@ public class NativeImageReflectConfigStep {
 
         private ReflectionInfo(ReflectiveClassBuildItem classBuildItem, String typeReachable) {
             this.methods = classBuildItem.isMethods();
+            this.publicMethods = classBuildItem.isPublicMethods();
             this.queryMethods = classBuildItem.isQueryMethods();
             this.fields = classBuildItem.isFields();
             this.classes = classBuildItem.isClasses();

--- a/core/deployment/src/test/java/io/quarkus/deployment/steps/NativeImageReflectConfigStepTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/steps/NativeImageReflectConfigStepTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.deployment.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.pkg.TestNativeConfig;
+
+class NativeImageReflectConfigStepTest {
+
+    private static final String CLASS_NAME = "org.acme.Foo";
+
+    @Test
+    void publicMethodsRegistersAllPublicMethodsNotAllDeclaredMethods() {
+        String json = generateReflectConfigJson(List.of(
+                ReflectiveClassBuildItem.builder(CLASS_NAME).constructors(false).publicMethods().build()));
+
+        assertThat(json).contains("\"allPublicMethods\":true");
+        assertThat(json).doesNotContain("allDeclaredMethods");
+    }
+
+    @Test
+    void registeringSameClassWithMethodsAndPublicMethodsMergesBothFlags() {
+        // Simulates two independent build steps registering the same class differently - the resulting
+        // reflect-config.json entry must be the union of both, not just the last one applied.
+        String json = generateReflectConfigJson(List.of(
+                ReflectiveClassBuildItem.builder(CLASS_NAME).constructors(false).publicMethods().build(),
+                ReflectiveClassBuildItem.builder(CLASS_NAME).constructors(false).methods().build()));
+
+        assertThat(json).contains("\"allPublicMethods\":true");
+        assertThat(json).contains("\"allDeclaredMethods\":true");
+    }
+
+    private static String generateReflectConfigJson(List<ReflectiveClassBuildItem> reflectiveClassBuildItems) {
+        NativeImageReflectConfigStep step = new NativeImageReflectConfigStep();
+        List<GeneratedResourceBuildItem> produced = new ArrayList<>();
+
+        step.generateReflectConfig(produced::add, new TestNativeConfig("mandrel"),
+                List.of(), List.of(),
+                reflectiveClassBuildItems,
+                List.of(), List.of(), List.of());
+
+        assertThat(produced).hasSize(1);
+        assertThat(produced.get(0).getName()).isEqualTo("META-INF/native-image/reflect-config.json");
+        return new String(produced.get(0).getData(), StandardCharsets.UTF_8).replaceAll("\\s+", "");
+    }
+}


### PR DESCRIPTION
This allows generating `allPublicMethods:true` in the generated `reflect-config.json` resources for GraalVM.

(We only had the ability to generate `allDeclaredMethods` - which has a subtle different semantics. While at it, also updated the javadoc to clarify the difference between the two methods.
