### PR TITLE
Allow configuring the init-task view-jobs Role name and generation

### DIFF
--- a/docs/src/main/asciidoc/init-tasks.adoc
+++ b/docs/src/main/asciidoc/init-tasks.adoc
@@ -154,11 +154,9 @@ You can customize the generated Role:
 
 [source,properties]
 ----
-# Base Role name (default: view-jobs)
+# Base Role name (default: view-jobs). The application name is always prepended,
+# so the effective Role is `{application-name}-view-jobs`.
 quarkus.kubernetes.init-task-defaults.rbac.name=view-jobs
-
-# Prefix the Role name with the application name (default: true)
-quarkus.kubernetes.init-task-defaults.rbac.prefix-name=true
 
 # Generate the Role. Set to false to keep the Job and wait-for init container,
 # but skip Role generation (for example when a shared Role already exists).

--- a/docs/src/main/asciidoc/init-tasks.adoc
+++ b/docs/src/main/asciidoc/init-tasks.adoc
@@ -154,8 +154,8 @@ You can customize the generated Role:
 
 [source,properties]
 ----
-# Base Role name (default: view-jobs). The application name is always prepended,
-# so the effective Role is `{application-name}-view-jobs`.
+# Exact Role name (optional). When unset, defaults to `{application-name}-view-jobs`.
+# No application-name prefix is applied to the value you set.
 quarkus.kubernetes.init-task-defaults.rbac.name=view-jobs
 
 # Generate the Role. Set to false to keep the Job and wait-for init container,

--- a/docs/src/main/asciidoc/init-tasks.adoc
+++ b/docs/src/main/asciidoc/init-tasks.adoc
@@ -149,6 +149,27 @@ quarkus.kubernetes.init-tasks.flyway.wait-for-container.image-pull-policy=if-not
 For an init container to be able to perform the `wait for job`, it needs to be able to perform `get` operations on the job resource.
 This is done automatically and the generated manifests include the required `Role` and `RoleBinding` resources.
 
+By default, the Role is named `{application-name}-view-jobs` so that multiple Quarkus applications can be deployed in the same namespace without conflicting on a shared `view-jobs` Role name.
+
+You can customize the generated Role:
+
+[source,properties]
+----
+# Exact Role name (optional). When unset, defaults to `{application-name}-view-jobs`.
+# No application-name prefix is applied to the value you set.
+quarkus.kubernetes.init-task-defaults.rbac.name=view-jobs
+
+# Generate the Role. Set to false to keep the Job and wait-for init container,
+# but skip Role generation (for example when a shared Role already exists).
+quarkus.kubernetes.init-task-defaults.rbac.generate=true
+----
+
+[NOTE]
+====
+These properties are only honored on `init-task-defaults`. A single Role is shared by all init tasks of the application.
+Generic `quarkus.kubernetes.rbac.roles` configuration is additive and does not rename or replace this built-in Role.
+====
+
 If, for any reason, additional permissions are required either by the init container or the job, they can be configured with the xref:deploying-to-kubernetes.adoc#generating-rbac-resources[Kubernetes RBAC configuration].
 
 [NOTE]

--- a/docs/src/main/asciidoc/init-tasks.adoc
+++ b/docs/src/main/asciidoc/init-tasks.adoc
@@ -148,6 +148,29 @@ quarkus.kubernetes.init-tasks.flyway.wait-for-container.image-pull-policy=if-not
 For an init container to be able to perform the `wait for job`, it needs to be able to perform `get` operations on the job resource.
 This is done automatically and the generated manifests include the required `Role` and `RoleBinding` resources.
 
+By default, the Role is named `{application-name}-view-jobs` so that multiple Quarkus applications can be deployed in the same namespace without conflicting on a shared `view-jobs` Role name.
+
+You can customize the generated Role:
+
+[source,properties]
+----
+# Base Role name (default: view-jobs)
+quarkus.kubernetes.init-task-defaults.rbac.name=view-jobs
+
+# Prefix the Role name with the application name (default: true)
+quarkus.kubernetes.init-task-defaults.rbac.prefix-name=true
+
+# Generate the Role. Set to false to keep the Job and wait-for init container,
+# but skip Role generation (for example when a shared Role already exists).
+quarkus.kubernetes.init-task-defaults.rbac.generate=true
+----
+
+[NOTE]
+====
+These properties are only honored on `init-task-defaults`. A single Role is shared by all init tasks of the application.
+Generic `quarkus.kubernetes.rbac.roles` configuration is additive and does not rename or replace this built-in Role.
+====
+
 If, for any reason, additional permissions are required either by the init container or the job, they can be configured with the xref:deploying-to-kubernetes.adoc#generating-rbac-resources[Kubernetes RBAC configuration].
 
 [NOTE]

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskConfig.java
@@ -51,12 +51,11 @@ public interface InitTaskConfig {
 
     interface InitTaskRbacConfig {
         /**
-         * The name of the Role. The application name is always prepended, producing a unique
-         * name per application (e.g. {@code my-app-view-jobs}). This prevents name conflicts when
-         * multiple applications sharing the same namespace each manage their own Role.
+         * The name of the Role. When unset, defaults to {@code {application-name}-view-jobs}
+         * so multiple applications in the same namespace each get a unique Role. Set this to the
+         * exact Role name you want (no application-name prefix is applied).
          */
-        @WithDefault("view-jobs")
-        String name();
+        Optional<String> name();
 
         /**
          * If the Role is meant to be generated. When {@code false}, only the RoleBinding is

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskConfig.java
@@ -51,7 +51,9 @@ public interface InitTaskConfig {
 
     interface InitTaskRbacConfig {
         /**
-         * The name of the Role.
+         * The name of the Role. The application name is always prepended, producing a unique
+         * name per application (e.g. {@code my-app-view-jobs}). This prevents name conflicts when
+         * multiple applications sharing the same namespace each manage their own Role.
          */
         @WithDefault("view-jobs")
         String name();
@@ -62,13 +64,5 @@ public interface InitTaskConfig {
          */
         @WithDefault("true")
         boolean generate();
-
-        /**
-         * If set to true, the Role name is prefixed with the application name, producing a unique
-         * name per application (e.g. {@code my-app-view-jobs}). This prevents name conflicts when
-         * multiple applications sharing the same namespace each manage their own Role.
-         */
-        @WithDefault("true")
-        boolean prefixName();
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskConfig.java
@@ -25,6 +25,16 @@ public interface InitTaskConfig {
      */
     InitTaskContainerConfig waitForContainer();
 
+    /**
+     * Configuration of the Role and RoleBinding generated so the wait-for init container can
+     * {@code get} Job resources.
+     * <p>
+     * Only honored when set on {@code quarkus.kubernetes.init-task-defaults.rbac}
+     * (or the OpenShift equivalent). Per-task {@code init-tasks.*.rbac} values are ignored
+     * because a single Role is shared by all init tasks.
+     */
+    InitTaskRbacConfig rbac();
+
     interface InitTaskContainerConfig {
         /**
          * The init task image to use by the init container.
@@ -37,5 +47,21 @@ public interface InitTaskConfig {
          */
         @WithDefault("always")
         ImagePullPolicy imagePullPolicy();
+    }
+
+    interface InitTaskRbacConfig {
+        /**
+         * The name of the Role. When unset, defaults to {@code {application-name}-view-jobs}
+         * so multiple applications in the same namespace each get a unique Role. Set this to the
+         * exact Role name you want (no application-name prefix is applied).
+         */
+        Optional<String> name();
+
+        /**
+         * If the Role is meant to be generated. When {@code false}, only the RoleBinding is
+         * generated (pointing at an existing Role with the resolved name).
+         */
+        @WithDefault("true")
+        boolean generate();
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskConfig.java
@@ -25,6 +25,16 @@ public interface InitTaskConfig {
      */
     InitTaskContainerConfig waitForContainer();
 
+    /**
+     * Configuration of the Role and RoleBinding generated so the wait-for init container can
+     * {@code get} Job resources.
+     * <p>
+     * Only honored when set on {@code quarkus.kubernetes.init-task-defaults.rbac}
+     * (or the OpenShift equivalent). Per-task {@code init-tasks.*.rbac} values are ignored
+     * because a single Role is shared by all init tasks.
+     */
+    InitTaskRbacConfig rbac();
+
     interface InitTaskContainerConfig {
         /**
          * The init task image to use by the init container.
@@ -37,5 +47,28 @@ public interface InitTaskConfig {
          */
         @WithDefault("always")
         ImagePullPolicy imagePullPolicy();
+    }
+
+    interface InitTaskRbacConfig {
+        /**
+         * The name of the Role.
+         */
+        @WithDefault("view-jobs")
+        String name();
+
+        /**
+         * If the Role is meant to be generated. When {@code false}, only the RoleBinding is
+         * generated (pointing at an existing Role with the resolved name).
+         */
+        @WithDefault("true")
+        boolean generate();
+
+        /**
+         * If set to true, the Role name is prefixed with the application name, producing a unique
+         * name per application (e.g. {@code my-app-view-jobs}). This prevents name conflicts when
+         * multiple applications sharing the same namespace each manage their own Role.
+         */
+        @WithDefault("true")
+        boolean prefixName();
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskProcessor.java
@@ -19,6 +19,8 @@ import io.quarkus.kubernetes.spi.KubernetesRoleBindingBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesRoleBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesServiceAccountBuildItem;
 import io.quarkus.kubernetes.spi.PolicyRule;
+import io.quarkus.kubernetes.spi.RoleRef;
+import io.quarkus.kubernetes.spi.Subject;
 
 public class InitTaskProcessor {
 
@@ -77,13 +79,25 @@ public class InitTaskProcessor {
         }
 
         if (generateRoleForJobs) {
-            roles.produce(new KubernetesRoleBuildItem("view-jobs", Collections.singletonList(
-                    new PolicyRule(
-                            Collections.singletonList("batch"),
-                            Collections.singletonList("jobs"),
-                            List.of("get"))),
-                    target));
-            roleBindings.produce(new KubernetesRoleBindingBuildItem(null, "view-jobs", false, target));
+            InitTaskConfig.InitTaskRbacConfig rbac = initTaskDefaults.rbac();
+            // Dynamic default: {application-name}-view-jobs. When set, use the exact name.
+            String roleName = rbac.name().orElse(name + "-view-jobs");
+
+            if (rbac.generate()) {
+                roles.produce(new KubernetesRoleBuildItem(roleName, Collections.singletonList(
+                        new PolicyRule(
+                                Collections.singletonList("batch"),
+                                Collections.singletonList("jobs"),
+                                List.of("get"))),
+                        target));
+            }
+
+            // Set the binding name explicitly so it stays in sync with the Role name (and so the
+            // default {app}-view-jobs Role is not double-prefixed as {app}-{app}-view-jobs).
+            roleBindings.produce(new KubernetesRoleBindingBuildItem(
+                    roleName, null, target, Collections.emptyMap(),
+                    new RoleRef(roleName, false),
+                    new Subject("", "ServiceAccount", null, null)));
             serviceAccount.produce(new KubernetesServiceAccountBuildItem(true));
         }
     }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskProcessor.java
@@ -19,6 +19,8 @@ import io.quarkus.kubernetes.spi.KubernetesRoleBindingBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesRoleBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesServiceAccountBuildItem;
 import io.quarkus.kubernetes.spi.PolicyRule;
+import io.quarkus.kubernetes.spi.RoleRef;
+import io.quarkus.kubernetes.spi.Subject;
 
 public class InitTaskProcessor {
 
@@ -77,13 +79,27 @@ public class InitTaskProcessor {
         }
 
         if (generateRoleForJobs) {
-            roles.produce(new KubernetesRoleBuildItem("view-jobs", Collections.singletonList(
-                    new PolicyRule(
-                            Collections.singletonList("batch"),
-                            Collections.singletonList("jobs"),
-                            List.of("get"))),
-                    target));
-            roleBindings.produce(new KubernetesRoleBindingBuildItem(null, "view-jobs", false, target));
+            InitTaskConfig.InitTaskRbacConfig rbac = initTaskDefaults.rbac();
+            String roleName = rbac.prefixName()
+                    ? name + "-" + rbac.name()
+                    : rbac.name();
+
+            if (rbac.generate()) {
+                roles.produce(new KubernetesRoleBuildItem(roleName, Collections.singletonList(
+                        new PolicyRule(
+                                Collections.singletonList("batch"),
+                                Collections.singletonList("jobs"),
+                                List.of("get"))),
+                        target));
+            }
+
+            // When the role name is prefixed, set the binding name explicitly so the Kubernetes
+            // extension does not double-prefix it as {app}-{app}-{role}.
+            String bindingName = rbac.prefixName() ? roleName : null;
+            roleBindings.produce(new KubernetesRoleBindingBuildItem(
+                    bindingName, null, target, Collections.emptyMap(),
+                    new RoleRef(roleName, false),
+                    new Subject("", "ServiceAccount", null, null)));
             serviceAccount.produce(new KubernetesServiceAccountBuildItem(true));
         }
     }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskProcessor.java
@@ -80,7 +80,8 @@ public class InitTaskProcessor {
 
         if (generateRoleForJobs) {
             InitTaskConfig.InitTaskRbacConfig rbac = initTaskDefaults.rbac();
-            String roleName = name + "-" + rbac.name();
+            // Dynamic default: {application-name}-view-jobs. When set, use the exact name.
+            String roleName = rbac.name().orElse(name + "-view-jobs");
 
             if (rbac.generate()) {
                 roles.produce(new KubernetesRoleBuildItem(roleName, Collections.singletonList(
@@ -91,8 +92,8 @@ public class InitTaskProcessor {
                         target));
             }
 
-            // Set the binding name explicitly so the Kubernetes extension does not double-prefix
-            // it as {app}-{app}-{role}.
+            // Set the binding name explicitly so it stays in sync with the Role name (and so the
+            // default {app}-view-jobs Role is not double-prefixed as {app}-{app}-view-jobs).
             roleBindings.produce(new KubernetesRoleBindingBuildItem(
                     roleName, null, target, Collections.emptyMap(),
                     new RoleRef(roleName, false),

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskProcessor.java
@@ -80,9 +80,7 @@ public class InitTaskProcessor {
 
         if (generateRoleForJobs) {
             InitTaskConfig.InitTaskRbacConfig rbac = initTaskDefaults.rbac();
-            String roleName = rbac.prefixName()
-                    ? name + "-" + rbac.name()
-                    : rbac.name();
+            String roleName = name + "-" + rbac.name();
 
             if (rbac.generate()) {
                 roles.produce(new KubernetesRoleBuildItem(roleName, Collections.singletonList(
@@ -93,11 +91,10 @@ public class InitTaskProcessor {
                         target));
             }
 
-            // When the role name is prefixed, set the binding name explicitly so the Kubernetes
-            // extension does not double-prefix it as {app}-{app}-{role}.
-            String bindingName = rbac.prefixName() ? roleName : null;
+            // Set the binding name explicitly so the Kubernetes extension does not double-prefix
+            // it as {app}-{app}-{role}.
             roleBindings.produce(new KubernetesRoleBindingBuildItem(
-                    bindingName, null, target, Collections.emptyMap(),
+                    roleName, null, target, Collections.emptyMap(),
                     new RoleRef(roleName, false),
                     new Subject("", "ServiceAccount", null, null)));
             serviceAccount.produce(new KubernetesServiceAccountBuildItem(true));

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitBase.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitBase.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.api.model.rbac.Role;
 import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 
 public class KubernetesWithFlywayInitBase {
@@ -24,6 +25,7 @@ public class KubernetesWithFlywayInitBase {
         List<HasMetadata> kubernetesList = DeserializationUtil.deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
 
         String jobName = name + "-" + taskName + "-init";
+        String roleName = name + "-view-jobs";
         Optional<Deployment> deployment = kubernetesList.stream()
                 .filter(d -> "Deployment".equals(d.getKind())
                         && name.equals(d.getMetadata().getName()))
@@ -80,9 +82,21 @@ public class KubernetesWithFlywayInitBase {
             });
         });
 
+        Optional<Role> role = kubernetesList.stream()
+                .filter(r -> r instanceof Role && roleName.equals(r.getMetadata().getName()))
+                .map(r -> (Role) r).findFirst();
+        assertTrue(role.isPresent());
+        assertThat(role.get().getRules()).singleElement().satisfies(rule -> {
+            assertThat(rule.getApiGroups()).containsExactly("batch");
+            assertThat(rule.getResources()).containsExactly("jobs");
+            assertThat(rule.getVerbs()).containsExactly("get");
+        });
+
         Optional<RoleBinding> roleBinding = kubernetesList.stream().filter(
-                r -> r instanceof RoleBinding && (name + "-view-jobs").equals(r.getMetadata().getName()))
+                r -> r instanceof RoleBinding && roleName.equals(r.getMetadata().getName()))
                 .map(r -> (RoleBinding) r).findFirst();
         assertTrue(roleBinding.isPresent());
+        assertThat(roleBinding.get().getRoleRef().getName()).isEqualTo(roleName);
+        assertThat(roleBinding.get().getRoleRef().getKind()).isEqualTo("Role");
     }
 }


### PR DESCRIPTION
This PR adds `quarkus.kubernetes.init-task-defaults.rbac` (and the OpenShift equivalent) with:

- `name` (optional) — the exact Role name; when unset, defaults to `{application-name}-view-jobs`
- `generate` (default `true`) to skip Role generation while keeping the Job and wait-for init container

The RoleBinding name and `roleRef` stay in sync with the resolved Role name.

**Breaking change:** the generated Role name defaults to `{application-name}-view-jobs` instead of `view-jobs`. To keep the previous shared name, set `quarkus.kubernetes.init-task-defaults.rbac.name=view-jobs`.

---

- Closes: #45748