### PR TITLE
Use JDK 21 in `.sdkmanrc`

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,4 +1,4 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=17.0.16-tem
+java=21.0.12-tem
 mvnd=1.0.3


### PR DESCRIPTION
As we've now bumped to JDK 21 as the baseline, 
`.sdmanrc` also needs to be updated in order to
make working with the source code easier