### PR TITLE
Reduce config converter reflection metadata generated by MicroProfile Config

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -136,6 +136,39 @@ import io.smallrye.config.SmallRyeConfigProviderResolver;
 public class ConfigGenerationBuildStep {
     private static final String SERVICES_PREFIX = "META-INF/services/";
 
+    // Types with a SmallRye Config built-in converter (Converters.ALL_CONVERTERS) that Quarkus core does
+    // NOT also register a converter for via the Converter SPI - these need no reflection at all.
+    //
+    // Types Quarkus DOES register an SPI converter for (e.g. Duration, Locale, InetAddress, Pattern) are
+    // deliberately excluded here, even where SmallRye also has a built-in: the generated config builder
+    // resolves the SPI converter's target type via Class.forName(String) at runtime (see
+    // AbstractConfigBuilder#withConverter), and on Mandrel that resolution is only reliable when the
+    // class has at least its public methods registered - constructors-only is not enough (see
+    // registerConverterReflection below, which registers public methods for every type not in this set).
+    // (Copied as a constant to avoid the processing overhead of computing the list, as it rarely changes -
+    // kept in sync via ConfigGenerationBuildStepTest)
+    private static final Set<String> SMALLRYE_BUILT_IN_CONVERTER_TYPES = Set.of(
+            "java.lang.String",
+            "java.lang.Boolean",
+            "java.lang.Double",
+            "java.lang.Float",
+            "java.lang.Long",
+            "java.lang.Integer",
+            "java.lang.Short",
+            "java.lang.Byte",
+            "java.lang.Character",
+            "java.lang.Class",
+            "java.util.UUID",
+            "java.util.Currency",
+            "java.util.BitSet",
+            "java.io.File",
+            "java.net.URI",
+            "java.time.format.DateTimeFormatter",
+            "java.lang.CharSequence",
+            "java.util.OptionalInt",
+            "java.util.OptionalLong",
+            "java.util.OptionalDouble");
+
     @BuildStep
     void nativeSupport(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClassProducer) {
         runtimeInitializedClassProducer.produce(new RuntimeInitializedClassBuildItem(InetRunTime.class.getName()));
@@ -348,10 +381,7 @@ public class ConfigGenerationBuildStep {
                             .reason("Required by Config Converter " + mapProperty.getKeyConvertWith().getName())
                             .build());
                 } else {
-                    reflectiveClasses.produce(ReflectiveClassBuildItem.builder(mapProperty.getKeyRawType())
-                            .reason("Required by Config Converter " + mapProperty.getKeyRawType().getName())
-                            .methods()
-                            .build());
+                    registerConverterReflection(mapProperty.getKeyRawType(), reflectiveClasses);
                 }
 
                 registerImplicitConverter(mapProperty.getValueProperty(), reflectiveClasses);
@@ -370,16 +400,34 @@ public class ConfigGenerationBuildStep {
                         .reason("Required by Config Converter " + leafProperty.getConvertWith().getName())
                         .build());
             } else {
-                reflectiveClasses.produce(ReflectiveClassBuildItem.builder(leafProperty.getValueRawType())
-                        .reason("Required by Config Converter " + leafProperty.getValueRawType().getName())
-                        .methods()
-                        .build());
+                registerConverterReflection(leafProperty.getValueRawType(), reflectiveClasses);
             }
         } else if (property.isOptional()) {
             registerImplicitConverter(property.asOptional().getNestedProperty(), reflectiveClasses);
         } else if (property.isCollection()) {
             registerImplicitConverter(property.asCollection().getElement(), reflectiveClasses);
         }
+    }
+
+    /**
+     * Registers a config property's raw type for reflection, unless it's in
+     * {@link #SMALLRYE_BUILT_IN_CONVERTER_TYPES}. Public methods are enough: types with no explicit
+     * converter rely on this for SmallRye to probe implicit converter methods ({@code valueOf},
+     * {@code parse}, {@code of}, ...), which per the MicroProfile Config spec are always public.
+     */
+    private static void registerConverterReflection(
+            Class<?> rawType,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
+
+        String rawTypeName = rawType.getName();
+        if (SMALLRYE_BUILT_IN_CONVERTER_TYPES.contains(rawTypeName)) {
+            return;
+        }
+
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(rawType)
+                .reason("Required by Config Converter " + rawTypeName)
+                .publicMethods()
+                .build());
     }
 
     @BuildStep(onlyIf = SystemOnlySources.class)

--- a/core/deployment/src/test/java/io/quarkus/deployment/steps/ConfigGenerationBuildStepTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/steps/ConfigGenerationBuildStepTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.deployment.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.config.spi.Converter;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.deployment.util.ServiceUtil;
+import io.smallrye.config.Converters;
+
+/**
+ * Verifies that ConfigGenerationBuildStep#SMALLRYE_BUILT_IN_CONVERTER_TYPES matches SmallRye's own
+ * built-in converters (Converters.ALL_CONVERTERS), minus any type Quarkus core also registers a
+ * converter for via the Converter SPI. If this test fails, update the hardcoded set.
+ */
+class ConfigGenerationBuildStepTest {
+
+    private static final String CONVERTER_SERVICES = "META-INF/services/" + Converter.class.getName();
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void smallRyeBuiltInConverterTypesIsCorrect() throws Exception {
+        Set<String> expectedTypes = new TreeSet<>(smallRyeBuiltInConverterTypes());
+        expectedTypes.removeAll(quarkusServiceLoadedConverterTypes());
+
+        Field field = ConfigGenerationBuildStep.class.getDeclaredField("SMALLRYE_BUILT_IN_CONVERTER_TYPES");
+        field.setAccessible(true);
+        Set<String> hardcodedTypes = (Set<String>) field.get(null);
+
+        assertThat(new TreeSet<>(hardcodedTypes)).isEqualTo(expectedTypes);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Set<String> smallRyeBuiltInConverterTypes() throws Exception {
+        Field smallryeField = Converters.class.getDeclaredField("ALL_CONVERTERS");
+        smallryeField.setAccessible(true);
+        Map<Type, ?> allConverters = (Map<Type, ?>) smallryeField.get(null);
+        return allConverters.keySet().stream()
+                .filter(t -> t instanceof Class<?>)
+                .map(t -> ((Class<?>) t).getName())
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * The converter target types Quarkus core registers via the {@link Converter} SPI. Only the Quarkus core
+     * runtime declares such a service file on this module's test classpath, so this resolves to the
+     * contents of {@code core/runtime/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter}.
+     */
+    private static Set<String> quarkusServiceLoadedConverterTypes() throws Exception {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        Set<String> converterNames = ServiceUtil.classNamesNamedIn(classLoader, CONVERTER_SERVICES);
+        assertThat(converterNames)
+                .as("The Quarkus core Converter service file should be on the test classpath")
+                .isNotEmpty();
+
+        Set<String> types = new TreeSet<>();
+        for (String converterName : converterNames) {
+            Class<?> converterClass = Class.forName(converterName, false, classLoader);
+            Type converterType = Converters.getConverterType(converterClass);
+            assertThat(converterType)
+                    .as("Unable to resolve the converted type of " + converterName)
+                    .isInstanceOf(Class.class);
+            types.add(((Class<?>) converterType).getName());
+        }
+        return types;
+    }
+}


### PR DESCRIPTION
This reduces the registrations to methods that it actually needs, and most importantly avoids pulling in the entire Serialization mechanism of the JDK.

This is possibly just negligible in a large and complex application but has very significant impact for users crafting smaller binaries; in my hobby project this reduces binary sizes by about 10% and also brings substantial improvements in total memory required to build the application, having a beneficial impact on build time as well.

Avoiding the Serialization mechanism can be valuable: several applications don't quite need it, and stripping it has value from an angle of security considerations.

N.B. this PR is not sufficient to fully strip Serialization as it's also being included by some Vert.x utilities - I plan to work on those separately.

