### PR TITLE
ArC: fix client proxy name collision for producers

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -161,7 +161,9 @@ public class BeanGenerator extends AbstractGenerator {
         String declaringClassBase = declaringClass.name().withoutPackagePrefix();
 
         StringBuilder sigBuilder = new StringBuilder();
-        sigBuilder.append(producerMethod.name())
+        sigBuilder.append(declaringClass.name())
+                .append(UNDERSCORE)
+                .append(producerMethod.name())
                 .append(UNDERSCORE)
                 .append(producerMethod.returnType().name());
         for (Type parameterType : producerMethod.parameterTypes()) {
@@ -181,7 +183,8 @@ public class BeanGenerator extends AbstractGenerator {
         ClassInfo declaringClass = producerField.declaringClass();
         String declaringClassBase = declaringClass.name().withoutPackagePrefix();
 
-        String baseName = declaringClassBase + PRODUCER_FIELD_SUFFIX + UNDERSCORE + producerField.name();
+        String baseName = declaringClassBase + PRODUCER_FIELD_SUFFIX + UNDERSCORE + producerField.name()
+                + UNDERSCORE + Hashes.sha1_base64(declaringClass.name() + UNDERSCORE + producerField.name());
         this.beanToGeneratedBaseName.put(bean, baseName);
         String targetPackage = DotNames.packagePrefix(declaringClass.name());
         String generatedName = generatedNameFromTarget(targetPackage, baseName, BEAN_SUFFIX);

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestContainer.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestContainer.java
@@ -478,12 +478,17 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
             String deploymentName = testClass.getName().replace('.', '_');
             BeanProcessor.Builder builder = configureBeanProcessorBuilder(deploymentName,
                     immutableBeanArchiveIndex, applicationIndex, buildCompatibleExtensions);
+            Set<String> generatedClassNames = new HashSet<>();
             builder.setOutput(new ResourceOutput() {
 
                 @Override
                 public void writeResource(Resource resource) throws IOException {
                     switch (resource.getType()) {
                         case JAVA_CLASS:
+                            if (!generatedClassNames.add(resource.getFullyQualifiedName())) {
+                                throw new IllegalStateException(
+                                        "Duplicate generated class detected: " + resource.getFullyQualifiedName());
+                            }
                             resource.writeTo(testOutputDirectory);
                             break;
                         case SERVICE_PROVIDER:

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/proxynamecollision/MyBean.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/proxynamecollision/MyBean.java
@@ -1,0 +1,17 @@
+package io.quarkus.arc.test.clientproxy.proxynamecollision;
+
+public class MyBean {
+
+    private String source;
+
+    public MyBean() {
+    }
+
+    public MyBean(String source) {
+        this.source = source;
+    }
+
+    public String getSource() {
+        return source;
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/proxynamecollision/ProducerClientProxyNameCollisionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/proxynamecollision/ProducerClientProxyNameCollisionTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.arc.test.clientproxy.proxynamecollision;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ManagedContext;
+import io.quarkus.arc.test.ArcTestContainer;
+
+/**
+ * Verifies that producer methods and fields declared in classes with the same
+ * simple name but different packages do not produce colliding client proxy
+ * class names.
+ */
+public class ProducerClientProxyNameCollisionTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(
+            io.quarkus.arc.test.clientproxy.proxynamecollision.alpha.BeanProducer.class,
+            io.quarkus.arc.test.clientproxy.proxynamecollision.beta.BeanProducer.class,
+            io.quarkus.arc.test.clientproxy.proxynamecollision.alpha.FieldProducer.class,
+            io.quarkus.arc.test.clientproxy.proxynamecollision.beta.FieldProducer.class,
+            MyBean.class,
+            Source.class);
+
+    @Test
+    public void testProducerMethodsWithSameSimpleClassNameInDifferentPackages() {
+        ManagedContext requestContext = Arc.container().requestContext();
+        requestContext.activate();
+        try {
+            MyBean alpha = Arc.container().instance(MyBean.class, new Source.Literal("alpha")).get();
+            assertEquals("alpha", alpha.getSource());
+
+            MyBean beta = Arc.container().instance(MyBean.class, new Source.Literal("beta")).get();
+            assertEquals("beta", beta.getSource());
+        } finally {
+            requestContext.terminate();
+        }
+    }
+
+    @Test
+    public void testProducerFieldsWithSameSimpleClassNameInDifferentPackages() {
+        ManagedContext requestContext = Arc.container().requestContext();
+        requestContext.activate();
+        try {
+            MyBean alphaField = Arc.container().instance(MyBean.class, new Source.Literal("alphaField")).get();
+            assertEquals("alphaField", alphaField.getSource());
+
+            MyBean betaField = Arc.container().instance(MyBean.class, new Source.Literal("betaField")).get();
+            assertEquals("betaField", betaField.getSource());
+        } finally {
+            requestContext.terminate();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/proxynamecollision/Source.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/proxynamecollision/Source.java
@@ -1,0 +1,36 @@
+package io.quarkus.arc.test.clientproxy.proxynamecollision;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+@Qualifier
+@Target({ TYPE, METHOD, FIELD, PARAMETER })
+@Retention(RUNTIME)
+public @interface Source {
+
+    String value();
+
+    @SuppressWarnings("serial")
+    final class Literal extends AnnotationLiteral<Source> implements Source {
+
+        private final String value;
+
+        Literal(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/proxynamecollision/alpha/BeanProducer.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/proxynamecollision/alpha/BeanProducer.java
@@ -1,0 +1,19 @@
+package io.quarkus.arc.test.clientproxy.proxynamecollision.alpha;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import io.quarkus.arc.test.clientproxy.proxynamecollision.MyBean;
+import io.quarkus.arc.test.clientproxy.proxynamecollision.Source;
+
+@Singleton
+public class BeanProducer {
+
+    @Produces
+    @ApplicationScoped
+    @Source("alpha")
+    MyBean myBean() {
+        return new MyBean("alpha");
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/proxynamecollision/alpha/FieldProducer.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/proxynamecollision/alpha/FieldProducer.java
@@ -1,0 +1,17 @@
+package io.quarkus.arc.test.clientproxy.proxynamecollision.alpha;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import io.quarkus.arc.test.clientproxy.proxynamecollision.MyBean;
+import io.quarkus.arc.test.clientproxy.proxynamecollision.Source;
+
+@Singleton
+public class FieldProducer {
+
+    @Produces
+    @ApplicationScoped
+    @Source("alphaField")
+    MyBean myBean = new MyBean("alphaField");
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/proxynamecollision/beta/BeanProducer.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/proxynamecollision/beta/BeanProducer.java
@@ -1,0 +1,19 @@
+package io.quarkus.arc.test.clientproxy.proxynamecollision.beta;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import io.quarkus.arc.test.clientproxy.proxynamecollision.MyBean;
+import io.quarkus.arc.test.clientproxy.proxynamecollision.Source;
+
+@Singleton
+public class BeanProducer {
+
+    @Produces
+    @RequestScoped
+    @Source("beta")
+    MyBean myBean() {
+        return new MyBean("beta");
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/proxynamecollision/beta/FieldProducer.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/proxynamecollision/beta/FieldProducer.java
@@ -1,0 +1,17 @@
+package io.quarkus.arc.test.clientproxy.proxynamecollision.beta;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import io.quarkus.arc.test.clientproxy.proxynamecollision.MyBean;
+import io.quarkus.arc.test.clientproxy.proxynamecollision.Source;
+
+@Singleton
+public class FieldProducer {
+
+    @Produces
+    @RequestScoped
+    @Source("betaField")
+    MyBean myBean = new MyBean("betaField");
+}


### PR DESCRIPTION
Adds the declaring class name into the hash pro producers - this prevents potential proxy name collisions.
I prefer this compared to the bean identifier as it creates more stable proxy names and should be more than sufficient.
But if Martin and Lada both insist, I could be convinced otherwise :shrimp: 

Also, the duplicate proxy creation would not be caught at all during test runs. Such validation is only run in `AbstractJarBuilder#checkConsistency` which is a code path run only outside of tests. I have therefore added a similar check to `ArcTestContainer` so that we can detect any such issues in the future.

Also of note - the `checkConsistency` was introduced at around 3.29 version which explains the original user report. Older versions would silently override the duplicate proxy and continue with that, seemingly "working well".

Zulip link - https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/Quarkus.203.2E33.3A.20duplicate.20ClientProxy/with/614716974