### PR TITLE
Allow generation of reflection-free Jackson serializers for JPA entity not doing lazy loading

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -78,6 +78,15 @@ public abstract class JacksonCodeGenerator {
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
     private static final DotName KOTLIN_METADATA = DotName.createSimple("kotlin.Metadata");
 
+    private static final Set<String> UNSUPPORTED_JAKARTA_PERSISTENCE_ANNOTATIONS = Set.of(
+            "jakarta.persistence.Transient",
+            "jakarta.persistence.Basic",
+            "jakarta.persistence.OneToMany",
+            "jakarta.persistence.ManyToOne",
+            "jakarta.persistence.OneToOne",
+            "jakarta.persistence.ManyToMany",
+            "jakarta.persistence.ElementCollection");
+
     private static final Set<String> SUPPORTED_JACKSON_ANNOTATIONS = Set.of(
             JacksonAnnotation.class.getName(),
             JacksonAnnotationsInside.class.getName(),
@@ -149,7 +158,7 @@ public abstract class JacksonCodeGenerator {
         }
         Optional<String> unknownAnnotation = findUnknownAnnotation(classInfo);
         if (unknownAnnotation.isPresent()) {
-            log.infof("Skipping generation of reflection-free Jackson serializer for class %s" +
+            log.debugf("Skipping generation of reflection-free Jackson serializer for class %s" +
                     " because it contains the unsupported Jackson annotation %s", beanClassName, unknownAnnotation.get());
             return Optional.empty();
         }
@@ -236,11 +245,16 @@ public abstract class JacksonCodeGenerator {
                 || className.startsWith("tools.jackson.databind.");
     }
 
-    private static Optional<String> findUnknownAnnotation(ClassInfo classInfo) {
-        return classInfo.annotations().stream()
+    private Optional<String> findUnknownAnnotation(ClassInfo classInfo) {
+        Optional<String> unknown = classInfo.annotations().stream()
                 .map(a -> a.name().toString())
                 .filter(FieldSpecs::isUnknownAnnotation)
                 .findFirst();
+        if (unknown.isPresent()) {
+            return unknown;
+        }
+        Optional<String> fromSuperClass = onSuperClass(classInfo, this::findUnknownAnnotation);
+        return fromSuperClass != null ? fromSuperClass : Optional.empty();
     }
 
     protected enum FieldKind {
@@ -764,7 +778,8 @@ public abstract class JacksonCodeGenerator {
             if (ann.startsWith("com.fasterxml.jackson.")) {
                 return !SUPPORTED_JACKSON_ANNOTATIONS.contains(ann);
             }
-            return ann.startsWith("jakarta.persistence.");
+            return ann.startsWith("jakarta.persistence.") &&
+                    UNSUPPORTED_JAKARTA_PERSISTENCE_ANNOTATIONS.contains(ann);
         }
 
         String[] viewClasses() {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/UnsupportedAnnotationWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/UnsupportedAnnotationWithReflectionFreeSerializersTest.java
@@ -26,7 +26,8 @@ public class UnsupportedAnnotationWithReflectionFreeSerializersTest extends Abst
                                     "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true\n"),
                                     "application.properties");
                 }
-            }).setLogRecordPredicate(record -> record.getLevel().equals(Level.INFO)
+            }).traceCategories("io.quarkus.resteasy.reactive.jackson.deployment.processor.JacksonCodeGenerator")
+            .setLogRecordPredicate(record -> record.getLevel().equals(Level.FINE)
                     && record.getLoggerName().equals(
                             "io.quarkus.resteasy.reactive.jackson.deployment.processor.JacksonCodeGenerator"))
             .assertLogRecords(records -> assertThat(records).isNotEmpty());


### PR DESCRIPTION
- Fixes: #55854
