### PR TITLE
Fix Dev UI MCP Tools and Resources pages crashing when Dev MCP is disabled

### DIFF
--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-resources.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-resources.js
@@ -136,10 +136,10 @@ export class QwcDevMCPResources extends observeState(LitElement) {
 
     _loadResources(){
         this.jsonRpc.list().then(jsonRpcResponse => {
-            let er = jsonRpcResponse.result.resources;
+            let er = jsonRpcResponse.result?.resources;
             er = (er ?? []).map(o => ({ ...o, enabled: true }));
             this.jsonRpc.listDisabled().then(jsonRpcResponse => {
-                let dr = jsonRpcResponse.result.resources;
+                let dr = jsonRpcResponse.result?.resources;
                 dr = (dr ?? []).map(o => ({ ...o, enabled: false }));
                 
                 const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-setting.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-setting.js
@@ -172,7 +172,7 @@ export class QwcDevMCPSetting extends QwcHotReloadElement {
       ${this._renderAgentMcpSection()}
       <hr class="separator">
       ${this._renderDevMcpSection()}
-      ${this._renderUnlistedPagesLinks()}
+      ${this._configuration?.enabled ? this._renderUnlistedPagesLinks() : ''}
     `;
   }
 

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-tools.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-tools.js
@@ -350,11 +350,11 @@ export class QwcDevMCPTools extends QwcHotReloadElement {
 
     _loadTools(){
         this.jsonRpc.list().then(jsonRpcResponse => {
-            let et = jsonRpcResponse.result.tools;
+            let et = jsonRpcResponse.result?.tools;
             et = (et ?? []).map(o => ({ ...o, enabled: true }));
-            
+
             this.jsonRpc.listDisabled().then(jsonRpcResponse => {
-                let dt = jsonRpcResponse.result.tools;
+                let dt = jsonRpcResponse.result?.tools;
                 dt = (dt ?? []).map(o => ({ ...o, enabled: false }));
                 
                 const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });


### PR DESCRIPTION
When Dev MCP is disabled (the default state), navigating to the Dev UI MCP Tools or Resources pages via Settings > Dev MCP causes a JavaScript TypeError crash. This happens because `McpToolsService.list()` and `McpResourcesService.list()` return `null` when Dev MCP is not enabled, and the page JavaScript accesses `.tools` / `.resources` on the undefined result without null-safe access.

The page gets stuck showing an infinite "Fetching tools..." / "Fetching resources..." spinner.

This change:
- Adds optional chaining (`?.`) on `jsonRpcResponse.result` in both the Tools and Resources pages so they gracefully show an empty grid instead of crashing
- Hides the Tools and Resources navigation links on the Dev MCP settings page when Dev MCP is disabled, since those pages have no data to show in that state