### PR TITLE
Avoid OpenTelemetry API misuse when sampling Prometheus exemplars

### DIFF
--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/exemplars/OpenTelemetryExemplarSamplerProvider.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/exemplars/OpenTelemetryExemplarSamplerProvider.java
@@ -6,6 +6,7 @@ import java.util.function.Function;
 import jakarta.enterprise.inject.Produces;
 
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import io.quarkus.opentelemetry.runtime.QuarkusContextStorage;
 
 public class OpenTelemetryExemplarSamplerProvider {
@@ -34,7 +35,14 @@ public class OpenTelemetryExemplarSamplerProvider {
             }
 
             private <T> T get(Function<io.opentelemetry.api.trace.SpanContext, T> valueExtractor) {
-                return Optional.ofNullable(Span.fromContextOrNull(QuarkusContextStorage.INSTANCE.current()))
+                // QuarkusContextStorage.current() may return null when there is no Vert.x / fallback
+                // context. OpenTelemetry 1.62+ treats Span.fromContextOrNull(null) as API misuse and
+                // emits a WARNING on io.opentelemetry.usage (#55855).
+                Context context = QuarkusContextStorage.INSTANCE.current();
+                if (context == null) {
+                    return null;
+                }
+                return Optional.ofNullable(Span.fromContextOrNull(context))
                         .map(Span::getSpanContext)
                         .map(valueExtractor)
                         .orElse(null);

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/export/exemplars/OpenTelemetryExemplarSamplerProviderTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/export/exemplars/OpenTelemetryExemplarSamplerProviderTest.java
@@ -1,8 +1,10 @@
 package io.quarkus.micrometer.runtime.export.exemplars;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -14,7 +16,22 @@ import java.util.logging.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.quarkus.opentelemetry.runtime.QuarkusContextStorage;
+
+/**
+ * Regression test for <a href="https://github.com/quarkusio/quarkus/issues/55855">#55855</a>:
+ * Prometheus exemplar sampling must not pass a null OpenTelemetry {@link Context} into
+ * {@link Span#fromContextOrNull(Context)}, which OpenTelemetry 1.62+ reports as API misuse.
+ */
 public class OpenTelemetryExemplarSamplerProviderTest {
 
     private static final Logger USAGE_LOGGER = Logger.getLogger("io.opentelemetry.usage");
@@ -38,8 +55,10 @@ public class OpenTelemetryExemplarSamplerProviderTest {
 
     @BeforeEach
     void installRecordingHandler() {
+        usageRecords.clear();
         originalLevel = USAGE_LOGGER.getLevel();
-        USAGE_LOGGER.setLevel(Level.ALL);
+        // WARNING is the user-visible symptom; FINEST carries the detailed misuse text.
+        USAGE_LOGGER.setLevel(Level.FINEST);
         USAGE_LOGGER.addHandler(recordingHandler);
     }
 
@@ -51,15 +70,48 @@ public class OpenTelemetryExemplarSamplerProviderTest {
 
     @Test
     void noOpenTelemetryApiUsageComplaintWhenNoContextIsActive() {
-        // outside any Vert.x/OpenTelemetry context, e.g. registry setup on the main thread
-        var spanContext = new OpenTelemetryExemplarSamplerProvider().exemplarSampler().orElseThrow();
+        assertNull(QuarkusContextStorage.INSTANCE.current());
 
-        assertNull(spanContext.getCurrentTraceId());
-        assertNull(spanContext.getCurrentSpanId());
-        assertFalse(spanContext.isCurrentSpanSampled());
+        // Prove FINEST misuse capture works before asserting absence (no reflection).
+        Span.fromContextOrNull(null);
+        assertTrue(hasNullContextMisuseDetail(),
+                "test must capture ApiUsageLogger FINEST misuse detail; otherwise absence checks are meaningless");
+        usageRecords.clear();
 
-        assertTrue(usageRecords.isEmpty(),
-                "querying the exemplar sampler without an active context should not trip the OpenTelemetry API usage logger, but got: "
-                        + usageRecords.stream().map(LogRecord::getMessage).toList());
+        io.prometheus.metrics.tracer.common.SpanContext sampler = new OpenTelemetryExemplarSamplerProvider()
+                .exemplarSampler().orElseThrow();
+
+        try (MockedStatic<Span> span = Mockito.mockStatic(Span.class, Mockito.CALLS_REAL_METHODS)) {
+            assertNull(sampler.getCurrentTraceId());
+            assertNull(sampler.getCurrentSpanId());
+            assertFalse(sampler.isCurrentSpanSampled());
+
+            assertFalse(hasNullContextMisuseDetail(),
+                    "fromContextOrNull(null) misuse should not be logged on io.opentelemetry.usage");
+            span.verify(() -> Span.fromContextOrNull(null), never());
+        }
+    }
+
+    @Test
+    void currentSpanIsExposedToPrometheusExemplarSampler() {
+        String traceId = "0123456789abcdef0123456789abcdef";
+        String spanId = "0123456789abcdef";
+        Span span = Span.wrap(SpanContext.create(traceId, spanId, TraceFlags.getSampled(), TraceState.getDefault()));
+
+        io.prometheus.metrics.tracer.common.SpanContext sampler = new OpenTelemetryExemplarSamplerProvider()
+                .exemplarSampler().orElseThrow();
+
+        try (Scope scope = QuarkusContextStorage.INSTANCE.attach(Context.root().with(span))) {
+            assertEquals(traceId, sampler.getCurrentTraceId());
+            assertEquals(spanId, sampler.getCurrentSpanId());
+            assertTrue(sampler.isCurrentSpanSampled());
+        }
+
+        assertFalse(hasNullContextMisuseDetail());
+    }
+
+    private boolean hasNullContextMisuseDetail() {
+        return usageRecords.stream().anyMatch(record -> record.getMessage() != null
+                && record.getMessage().contains("fromContextOrNull(): context is null"));
     }
 }

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/export/exemplars/OpenTelemetryExemplarSamplerProviderTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/export/exemplars/OpenTelemetryExemplarSamplerProviderTest.java
@@ -6,6 +6,17 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.never;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -14,6 +25,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.common.impl.ApiUsageLogger;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.quarkus.opentelemetry.runtime.QuarkusContextStorage;
@@ -25,19 +37,74 @@ import io.quarkus.opentelemetry.runtime.QuarkusContextStorage;
  */
 public class OpenTelemetryExemplarSamplerProviderTest {
 
+    private static final String API_USAGE_WARNING = "OpenTelemetry API usage issue detected";
+
+    private static final Logger OTEL_USAGE_LOGGER = Logger.getLogger("io.opentelemetry.usage");
+
+    private final List<LogRecord> usageRecords = new ArrayList<>();
+    private final Handler usageHandler = new Handler() {
+        @Override
+        public void publish(LogRecord record) {
+            usageRecords.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    };
+
+    private Level previousLevel;
+    private AtomicBoolean warnOnce;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        usageRecords.clear();
+        warnOnce = warnOnceFlag();
+        warnOnce.set(false);
+
+        previousLevel = OTEL_USAGE_LOGGER.getLevel();
+        // WARNING is what users see; FINEST carries the detailed misuse text.
+        OTEL_USAGE_LOGGER.setLevel(Level.FINEST);
+        OTEL_USAGE_LOGGER.addHandler(usageHandler);
+    }
+
+    @AfterEach
+    void tearDown() {
+        OTEL_USAGE_LOGGER.removeHandler(usageHandler);
+        OTEL_USAGE_LOGGER.setLevel(previousLevel);
+        warnOnce.set(false);
+    }
+
     @Test
-    void noCurrentContextDoesNotPassNullToFromContextOrNull() {
+    void noCurrentContextDoesNotPassNullToFromContextOrNullOrLogApiMisuse() {
         assertNull(QuarkusContextStorage.INSTANCE.current());
+
+        // Prove log capture works in this JVM before asserting absence of misuse logs.
+        // ApiUsageLogger emits the user-visible WARNING only once unless WARN_ONCE is reset.
+        Span.fromContextOrNull(null);
+        assertTrue(hasApiUsageWarning(),
+                "test must capture ApiUsageLogger WARNING; otherwise absence checks are meaningless");
+        warnOnce.set(false);
+        usageRecords.clear();
 
         io.prometheus.metrics.tracer.common.SpanContext sampler = new OpenTelemetryExemplarSamplerProvider()
                 .exemplarSampler().orElseThrow();
 
-        // Assert the call site itself — do not scrape JUL logs. Log capture is brittle under
-        // JBoss LogManager and ApiUsageLogger only emits the detailed misuse text at FINEST.
+        // CALLS_REAL_METHODS keeps ApiUsageLogger active if null is passed (old buggy path).
         try (MockedStatic<Span> span = Mockito.mockStatic(Span.class, Mockito.CALLS_REAL_METHODS)) {
             assertNull(sampler.getCurrentTraceId());
             assertNull(sampler.getCurrentSpanId());
             assertFalse(sampler.isCurrentSpanSampled());
+
+            // Assert logs first (user-visible symptom from #55855), then the call site.
+            assertFalse(warnOnce.get(), "OpenTelemetry API misuse should not be recorded");
+            assertFalse(hasApiUsageWarning(), "io.opentelemetry.usage WARNING should not be logged");
+            assertFalse(hasNullContextMisuseDetail(),
+                    "detailed fromContextOrNull(null) misuse should not be logged at FINEST");
             span.verify(() -> Span.fromContextOrNull(null), never());
         }
     }
@@ -56,5 +123,25 @@ public class OpenTelemetryExemplarSamplerProviderTest {
             assertEquals(spanId, sampler.getCurrentSpanId());
             assertTrue(sampler.isCurrentSpanSampled());
         }
+
+        assertFalse(warnOnce.get());
+        assertFalse(hasApiUsageWarning());
+    }
+
+    private boolean hasApiUsageWarning() {
+        return usageRecords.stream().anyMatch(record -> record.getLevel() == Level.WARNING
+                && record.getMessage() != null
+                && record.getMessage().contains(API_USAGE_WARNING));
+    }
+
+    private boolean hasNullContextMisuseDetail() {
+        return usageRecords.stream().anyMatch(record -> record.getMessage() != null
+                && record.getMessage().contains("fromContextOrNull(): context is null"));
+    }
+
+    private static AtomicBoolean warnOnceFlag() throws Exception {
+        Field warnOnceField = ApiUsageLogger.class.getDeclaredField("WARN_ONCE");
+        warnOnceField.setAccessible(true);
+        return (AtomicBoolean) warnOnceField.get(null);
     }
 }

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/export/exemplars/OpenTelemetryExemplarSamplerProviderTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/export/exemplars/OpenTelemetryExemplarSamplerProviderTest.java
@@ -4,17 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Handler;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
-import java.util.logging.Logger;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
@@ -31,53 +25,21 @@ import io.quarkus.opentelemetry.runtime.QuarkusContextStorage;
  */
 public class OpenTelemetryExemplarSamplerProviderTest {
 
-    private static final Logger OTEL_USAGE_LOGGER = Logger.getLogger("io.opentelemetry.usage");
-
-    private final List<LogRecord> usageRecords = new ArrayList<>();
-    private final Handler usageHandler = new Handler() {
-        @Override
-        public void publish(LogRecord record) {
-            usageRecords.add(record);
-        }
-
-        @Override
-        public void flush() {
-        }
-
-        @Override
-        public void close() {
-        }
-    };
-
-    private Level previousLevel;
-
-    @BeforeEach
-    void setUp() {
-        usageRecords.clear();
-        previousLevel = OTEL_USAGE_LOGGER.getLevel();
-        OTEL_USAGE_LOGGER.setLevel(Level.FINEST);
-        OTEL_USAGE_LOGGER.addHandler(usageHandler);
-    }
-
-    @AfterEach
-    void tearDown() {
-        OTEL_USAGE_LOGGER.removeHandler(usageHandler);
-        OTEL_USAGE_LOGGER.setLevel(previousLevel);
-    }
-
     @Test
-    void noCurrentContextDoesNotTriggerOpenTelemetryApiUsageWarning() {
+    void noCurrentContextDoesNotPassNullToFromContextOrNull() {
         assertNull(QuarkusContextStorage.INSTANCE.current());
 
         io.prometheus.metrics.tracer.common.SpanContext sampler = new OpenTelemetryExemplarSamplerProvider()
                 .exemplarSampler().orElseThrow();
 
-        assertNull(sampler.getCurrentTraceId());
-        assertNull(sampler.getCurrentSpanId());
-        assertFalse(sampler.isCurrentSpanSampled());
-
-        assertFalse(usageRecords.stream().anyMatch(OpenTelemetryExemplarSamplerProviderTest::isNullContextMisuse),
-                "OpenTelemetry API misuse should not be logged when there is no current Context");
+        // Assert the call site itself — do not scrape JUL logs. Log capture is brittle under
+        // JBoss LogManager and ApiUsageLogger only emits the detailed misuse text at FINEST.
+        try (MockedStatic<Span> span = Mockito.mockStatic(Span.class, Mockito.CALLS_REAL_METHODS)) {
+            assertNull(sampler.getCurrentTraceId());
+            assertNull(sampler.getCurrentSpanId());
+            assertFalse(sampler.isCurrentSpanSampled());
+            span.verify(() -> Span.fromContextOrNull(null), never());
+        }
     }
 
     @Test
@@ -94,12 +56,5 @@ public class OpenTelemetryExemplarSamplerProviderTest {
             assertEquals(spanId, sampler.getCurrentSpanId());
             assertTrue(sampler.isCurrentSpanSampled());
         }
-
-        assertFalse(usageRecords.stream().anyMatch(OpenTelemetryExemplarSamplerProviderTest::isNullContextMisuse));
-    }
-
-    private static boolean isNullContextMisuse(LogRecord record) {
-        String message = record.getMessage();
-        return message != null && message.contains("fromContextOrNull(): context is null");
     }
 }

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/export/exemplars/OpenTelemetryExemplarSamplerProviderTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/export/exemplars/OpenTelemetryExemplarSamplerProviderTest.java
@@ -1,0 +1,105 @@
+package io.quarkus.micrometer.runtime.export.exemplars;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.quarkus.opentelemetry.runtime.QuarkusContextStorage;
+
+/**
+ * Regression test for <a href="https://github.com/quarkusio/quarkus/issues/55855">#55855</a>:
+ * Prometheus exemplar sampling must not pass a null OpenTelemetry {@link Context} into
+ * {@link Span#fromContextOrNull(Context)}, which OpenTelemetry 1.62+ reports as API misuse.
+ */
+public class OpenTelemetryExemplarSamplerProviderTest {
+
+    private static final Logger OTEL_USAGE_LOGGER = Logger.getLogger("io.opentelemetry.usage");
+
+    private final List<LogRecord> usageRecords = new ArrayList<>();
+    private final Handler usageHandler = new Handler() {
+        @Override
+        public void publish(LogRecord record) {
+            usageRecords.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    };
+
+    private Level previousLevel;
+
+    @BeforeEach
+    void setUp() {
+        usageRecords.clear();
+        previousLevel = OTEL_USAGE_LOGGER.getLevel();
+        OTEL_USAGE_LOGGER.setLevel(Level.FINEST);
+        OTEL_USAGE_LOGGER.addHandler(usageHandler);
+    }
+
+    @AfterEach
+    void tearDown() {
+        OTEL_USAGE_LOGGER.removeHandler(usageHandler);
+        OTEL_USAGE_LOGGER.setLevel(previousLevel);
+    }
+
+    @Test
+    void noCurrentContextDoesNotTriggerOpenTelemetryApiUsageWarning() {
+        assertNull(QuarkusContextStorage.INSTANCE.current());
+
+        io.prometheus.metrics.tracer.common.SpanContext sampler = new OpenTelemetryExemplarSamplerProvider()
+                .exemplarSampler().orElseThrow();
+
+        assertNull(sampler.getCurrentTraceId());
+        assertNull(sampler.getCurrentSpanId());
+        assertFalse(sampler.isCurrentSpanSampled());
+
+        assertFalse(usageRecords.stream().anyMatch(OpenTelemetryExemplarSamplerProviderTest::isNullContextMisuse),
+                "OpenTelemetry API misuse should not be logged when there is no current Context");
+    }
+
+    @Test
+    void currentSpanIsExposedToPrometheusExemplarSampler() {
+        String traceId = "0123456789abcdef0123456789abcdef";
+        String spanId = "0123456789abcdef";
+        Span span = Span.wrap(SpanContext.create(traceId, spanId, TraceFlags.getSampled(), TraceState.getDefault()));
+
+        io.prometheus.metrics.tracer.common.SpanContext sampler = new OpenTelemetryExemplarSamplerProvider()
+                .exemplarSampler().orElseThrow();
+
+        try (Scope scope = QuarkusContextStorage.INSTANCE.attach(Context.root().with(span))) {
+            assertEquals(traceId, sampler.getCurrentTraceId());
+            assertEquals(spanId, sampler.getCurrentSpanId());
+            assertTrue(sampler.isCurrentSpanSampled());
+        }
+
+        assertFalse(usageRecords.stream().anyMatch(OpenTelemetryExemplarSamplerProviderTest::isNullContextMisuse));
+    }
+
+    private static boolean isNullContextMisuse(LogRecord record) {
+        String message = record.getMessage();
+        return message != null && message.contains("fromContextOrNull(): context is null");
+    }
+}


### PR DESCRIPTION
When Micrometer Prometheus exemplars are enabled together with OpenTelemetry, scraping metrics outside a request context called `Span.fromContextOrNull(null)` because `QuarkusContextStorage.current()` can return null. OpenTelemetry 1.62+
reports that as API misuse and logs a one-time WARNING on `io.opentelemetry.usage`.

Guard against a null context before resolving the current span.

- Fixes: #55855