### PR TITLE
Fix 3 stale native image substitutions

### DIFF
--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/HttpContentCompressorSubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/HttpContentCompressorSubstitutions.java
@@ -42,7 +42,7 @@ final class Target_io_netty_handler_codec_compression_ZstdConstants {
 
     static final int MAX_COMPRESSION_LEVEL = 0;
 
-    static final int MAX_BLOCK_SIZE = 0;
+    static final int DEFAULT_MAX_ENCODE_SIZE = 0;
 
     static final int DEFAULT_BLOCK_SIZE = 0;
 }

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/ZLibSubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/ZLibSubstitutions.java
@@ -52,22 +52,32 @@ final class Target_io_netty_handler_codec_compression_ZlibCodecFactory {
 
     @Substitute
     public static ZlibDecoder newZlibDecoder() {
-        return new JdkZlibDecoder();
+        return new JdkZlibDecoder(true, 0);
+    }
+
+    @Substitute
+    public static ZlibDecoder newZlibDecoder(int maxAllocation) {
+        return new JdkZlibDecoder(true, maxAllocation);
     }
 
     @Substitute
     public static ZlibDecoder newZlibDecoder(ZlibWrapper wrapper) {
-        return new JdkZlibDecoder(wrapper);
+        return new JdkZlibDecoder(wrapper, true, 0);
     }
 
     @Substitute
     public static ZlibDecoder newZlibDecoder(ZlibWrapper wrapper, int maxAllocation) {
-        return new JdkZlibDecoder(wrapper, maxAllocation);
+        return new JdkZlibDecoder(wrapper, true, maxAllocation);
     }
 
     @Substitute
     public static ZlibDecoder newZlibDecoder(byte[] dictionary) {
         return new JdkZlibDecoder(dictionary);
+    }
+
+    @Substitute
+    public static ZlibDecoder newZlibDecoder(byte[] dictionary, int maxAllocation) {
+        return new JdkZlibDecoder(dictionary, maxAllocation);
     }
 }
 

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/graal/VertxSubstitutions.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/graal/VertxSubstitutions.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.function.BooleanSupplier;
 
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManagerFactory;
 
@@ -51,6 +52,15 @@ final class Target_DefaultSslContextFactory {
     @Alias
     private ClientAuth clientAuth;
 
+    @Alias
+    private SNIServerName serverName;
+
+    @Alias
+    private String endpointIdentificationAlgorithm;
+
+    @Alias
+    private Set<String> enabledProtocols;
+
     @Substitute
     private SslContext createContext(boolean useAlpn, boolean client, KeyManagerFactory kmf, TrustManagerFactory tmf)
             throws SSLException {
@@ -77,12 +87,23 @@ final class Target_DefaultSslContextFactory {
         if (useAlpn && applicationProtocols != null && applicationProtocols.size() > 0) {
             builder.applicationProtocolConfig(new ApplicationProtocolConfig(
                     ApplicationProtocolConfig.Protocol.ALPN,
-                    ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
-                    ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+                    ApplicationProtocolConfig.SelectorFailureBehavior.FATAL_ALERT,
+                    ApplicationProtocolConfig.SelectedListenerFailureBehavior.FATAL_ALERT,
                     applicationProtocols));
         }
-        if (clientAuth != null) {
-            builder.clientAuth(clientAuth);
+        if (client) {
+            if (serverName != null) {
+                builder.serverName(serverName);
+            }
+            builder.endpointIdentificationAlgorithm(
+                    endpointIdentificationAlgorithm == null ? "" : endpointIdentificationAlgorithm);
+        } else {
+            if (clientAuth != null) {
+                builder.clientAuth(clientAuth);
+            }
+        }
+        if (enabledProtocols != null) {
+            builder.protocols(enabledProtocols);
         }
         return builder.build();
     }


### PR DESCRIPTION
- Vert.x DefaultSslContextFactory: fix ALPN failure behavior for JDK provider, add missing client-side SNI/endpoint identification/protocol settings, restrict clientAuth to server mode only
- Netty ZstdConstants: rename MAX_BLOCK_SIZE to DEFAULT_MAX_ENCODE_SIZE to match Netty 4.2.x
- Netty ZlibCodecFactory: add 2 missing newZlibDecoder overloads and fix decompressConcatenated default to match upstream factory
