### PR TITLE
Bump to Vert.x 5.1.6

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -57,7 +57,7 @@
         <smallrye-context-propagation.version>2.3.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
-        <smallrye-openssl.version>0.1.4</smallrye-openssl.version>
+        <smallrye-openssl.version>0.2.0</smallrye-openssl.version>
         <smallrye-mutiny-vertx-binding.version>4.0.1</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>5.0.0-beta4</smallrye-reactive-messaging.version>
         <smallrye-stork.version>3.0.0</smallrye-stork.version>
@@ -136,7 +136,7 @@
         <infinispan.version>16.0.14</infinispan.version>
         <infinispan.protostream.version>6.0.7</infinispan.protostream.version>
         <caffeine.version>3.2.4</caffeine.version>
-        <netty-tcnative.version>2.0.76.Final</netty-tcnative.version>
+        <netty-tcnative.version>2.0.81.Final</netty-tcnative.version>
         <netty.version>4.2.17.Final</netty.version>
         <brotli4j.version>1.23.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -58,7 +58,7 @@
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
         <smallrye-openssl.version>0.1.4</smallrye-openssl.version>
-        <smallrye-mutiny-vertx-binding.version>4.0.0</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>4.0.1</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>5.0.0-beta4</smallrye-reactive-messaging.version>
         <smallrye-stork.version>3.0.0</smallrye-stork.version>
         <jakarta.activation.version>2.1.4</jakarta.activation.version>
@@ -113,7 +113,7 @@
         <wildfly-elytron.version>2.9.2.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.3.0</jboss-marshalling.version>
         <jboss-threads.version>3.9.2</jboss-threads.version>
-        <vertx.version>5.1.5</vertx.version>
+        <vertx.version>5.1.6</vertx.version>
         <httpclient5.version>5.6.1</httpclient5.version>
         <httpcore5.version>5.4.3</httpcore5.version>
         <httpclient.version>4.5.14</httpclient.version>
@@ -137,7 +137,7 @@
         <infinispan.protostream.version>6.0.7</infinispan.protostream.version>
         <caffeine.version>3.2.4</caffeine.version>
         <netty-tcnative.version>2.0.76.Final</netty-tcnative.version>
-        <netty.version>4.2.16.Final</netty.version>
+        <netty.version>4.2.17.Final</netty.version>
         <brotli4j.version>1.23.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -57,7 +57,7 @@
         <smallrye-context-propagation.version>2.3.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
-        <smallrye-openssl.version>0.2.0</smallrye-openssl.version>
+        <smallrye-openssl.version>0.2.3</smallrye-openssl.version>
         <smallrye-mutiny-vertx-binding.version>4.0.1</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>5.0.0-beta4</smallrye-reactive-messaging.version>
         <smallrye-stork.version>3.0.0</smallrye-stork.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -56,9 +56,9 @@
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
 
         <mutiny.version>3.3.0</mutiny.version>
-        <smallrye-mutiny-vertx-core.version>4.0.0</smallrye-mutiny-vertx-core.version>
+        <smallrye-mutiny-vertx-core.version>4.0.1</smallrye-mutiny-vertx-core.version>
         <smallrye-common.version>2.20.0</smallrye-common.version>
-        <vertx.version>5.1.5</vertx.version>
+        <vertx.version>5.1.6</vertx.version>
         <rest-assured.version>6.0.1</rest-assured.version>
         <commons-logging-jboss-logging.version>2.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>3.1.4</jackson-bom.version>

--- a/independent-projects/vertx-utils/pom.xml
+++ b/independent-projects/vertx-utils/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
-        <vertx.version>5.1.5</vertx.version>
+        <vertx.version>5.1.6</vertx.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This also aligns to:
- Netty 4.2.17.Final
- Vert.x Mutiny bindings 4.0.1

See downstream release notes:
- https://github.com/vert-x3/wiki/wiki/5.1.6-Release-Notes
- https://netty.io/news/2026/08/04/4-2-17-Final.html

