### PR TITLE
Fix exclusion of netty-codecs' `reflect-config.json` files

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyOverrideMetadata.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyOverrideMetadata.java
@@ -6,8 +6,8 @@ import io.quarkus.deployment.builditem.nativeimage.ExcludeConfigBuildItem;
 
 public class NettyOverrideMetadata {
 
-    static final String NETTY_CODEC_JAR_MATCH_REGEX = "io\\.netty\\.netty-codec";
-    static final String NETTY_CODEC_REFLECT_CONFIG_MATCH_REGEX = "/META-INF/native-image/io\\.netty/netty-codec/generated/handlers/reflect-config\\.json";
+    static final String NETTY_CODEC_JAR_MATCH_REGEX = "io\\.netty\\.netty-codec.*";
+    static final String NETTY_CODEC_REFLECT_CONFIG_MATCH_REGEX = "/META-INF/native-image/io\\.netty/netty-codec.*/generated/handlers/reflect-config\\.json";
     static final String NETTY_HANDLER_JAR_MATCH_REGEX = "io\\.netty\\.netty-handler";
     static final String NETTY_HANDLER_REFLECT_CONFIG_MATCH_REGEX = "/META-INF/native-image/io\\.netty/netty-handler/generated/handlers/reflect-config\\.json";
 


### PR DESCRIPTION
`reflect-config.json` files were moved from the parent `netty-codec` to the individual `netty-codec-*` artifacts in netty 4.2

Fixes #55144