### PR TITLE
Add Martin to be notified of Kubernetes issues

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -350,7 +350,7 @@ triage:
     - id: kubernetes
       labels: [area/kubernetes]
       titleBody: "kubernetes"
-      notify: [geoand, metacosm]
+      notify: [geoand, metacosm, xstefank]
       directories:
         - extensions/kubernetes/
         - extensions/kubernetes-client/


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/pull/52846#issuecomment-5193117032 made me think of it, although something odd happened with that PR since @metacosm and @geoand weren't notified either. I think Christophe wasn't notified because he got added to the maintainers list after the PR was created, but I can't explain why Georgios wasn't. 