### PR TITLE
Migrate the default OpenTelemetry protocol from grpc to http/protobuf.

### DIFF
--- a/docs/src/main/asciidoc/_includes/opentelemetry-config.adoc
+++ b/docs/src/main/asciidoc/_includes/opentelemetry-config.adoc
@@ -1,11 +1,11 @@
-By default, the exporters will send out data in batches, using the gRPC protocol and endpoint `http://localhost:4317`.
+By default, the exporters will send out data in batches, using the `http/protobuf` protocol and endpoint `http://localhost:4318`.
 
-If you need to change any of the default property values, here is an example on how to configure the default OTLP gRPC Exporter within the application, using the `src/main/resources/application.properties` file:
+If you need to change any of the default property values, here is an example on how to configure the default OTLP Exporter within the application, using the `src/main/resources/application.properties` file:
 
 [source,properties]
 ----
 quarkus.application.name=myservice // <1>
-quarkus.otel.exporter.otlp.endpoint=http://localhost:4317 // <2>
+quarkus.otel.exporter.otlp.endpoint=http://localhost:4318 // <2>
 quarkus.otel.exporter.otlp.headers=authorization=Bearer my_secret // <3>
 quarkus.log.console.format=%d{HH:mm:ss} %-5p traceId=%X{traceId}, parentId=%X{parentId}, spanId=%X{spanId}, sampled=%X{sampled} [%c{2.}] (%t) %s%e%n  // <4>
 
@@ -14,22 +14,22 @@ quarkus.http.access-log.pattern="...traceId=%{X,traceId} spanId=%{X,spanId}" // 
 ----
 
 <1> All telemetry created from the application will include an OpenTelemetry `Resource` attribute indicating the telemetry was created by the `myservice` application. If not set, it will default to the artifact id.
-<2> gRPC endpoint to send the telemetry. If not set, it will default to `http://localhost:4317`.
-<3> Optional gRPC headers commonly used for authentication
+<2> OTLP endpoint to send the telemetry. If not set, it will default to `http://localhost:4318`.
+<3> Optional headers commonly used for authentication
 <4> Add tracing information into log messages.
 <5> You can also only put the trace info into the access log. In this case you must omit the info in the console log format.
 
 We provide signal agnostic configurations for the connection related properties, meaning that you can use the same properties for both tracing and metrics when you set:
 [source,properties]
 ----
-quarkus.otel.exporter.otlp.endpoint=http://localhost:4317
+quarkus.otel.exporter.otlp.endpoint=http://localhost:4318
 ----
 If you need different configurations for each signal, you can use the specific properties:
 [source,properties]
 ----
-quarkus.otel.exporter.otlp.traces.endpoint=http://trace-uri:4317 // <1>
-quarkus.otel.exporter.otlp.metrics.endpoint=http://metrics-uri:4317 // <2>
-quarkus.otel.exporter.otlp.logs.endpoint=http://logs-uri:4317 // <3>
+quarkus.otel.exporter.otlp.traces.endpoint=http://trace-uri:4318 // <1>
+quarkus.otel.exporter.otlp.metrics.endpoint=http://metrics-uri:4318 // <2>
+quarkus.otel.exporter.otlp.logs.endpoint=http://logs-uri:4318 // <3>
 ----
 <1> The endpoint for the traces exporter.
 <2> The endpoint for the metrics exporter.

--- a/docs/src/main/asciidoc/opentelemetry-logging.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-logging.adoc
@@ -50,7 +50,7 @@ include::{includes}/devtools/create-app.adoc[]
 
 This command generates the Maven project and imports the `quarkus-opentelemetry` extension,
 which includes the default OpenTelemetry support,
-and a gRPC span exporter for https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md[OTLP].
+and an OTLP span exporter for https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md[OTLP].
 
 If you already have your Quarkus project configured, you can add the `quarkus-opentelemetry` extension
 to your project by running the following command in your project base directory:
@@ -113,13 +113,13 @@ The only mandatory configuration for OpenTelemetry Logging is the one enabling i
 quarkus.otel.logs.enabled=true
 ----
 
-To change any of the default property values, here is an example on how to configure the default OTLP gRPC Exporter within the application, using the `src/main/resources/application.properties` file:
+To change any of the default property values, here is an example on how to configure the default OTLP Exporter within the application, using the `src/main/resources/application.properties` file:
 
 [source,properties]
 ----
 quarkus.application.name=myservice // <1>
 quarkus.otel.logs.enabled=true // <2>
-quarkus.otel.exporter.otlp.logs.endpoint=http://localhost:4317 // <3>
+quarkus.otel.exporter.otlp.logs.endpoint=http://localhost:4318 // <3>
 quarkus.otel.exporter.otlp.logs.headers=authorization=Bearer my_secret // <4>
 ----
 
@@ -127,9 +127,9 @@ quarkus.otel.exporter.otlp.logs.headers=authorization=Bearer my_secret // <4>
 If not set, it will default to the artifact id.
 <2> Enable the OpenTelemetry logging.
 Must be set at build time.
-<3> gRPC endpoint to send the logs.
-If not set, it will default to `http://localhost:4317`.
-<4> Optional gRPC headers commonly used for authentication.
+<3> OTLP endpoint to send the logs.
+If not set, it will default to `http://localhost:4318`.
+<4> Optional headers commonly used for authentication.
 
 To configure the connection using the same properties for all signals, please check the base xref:opentelemetry.adoc#create-the-configuration[configuration section of the OpenTelemetry guide].
 

--- a/docs/src/main/asciidoc/opentelemetry-metrics.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-metrics.adoc
@@ -54,7 +54,7 @@ include::{includes}/devtools/create-app.adoc[]
 
 This command generates the Maven project and imports the `quarkus-opentelemetry` extension,
 which includes the default OpenTelemetry support,
-and a gRPC span exporter for https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md[OTLP].
+and an OTLP span exporter for https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md[OTLP].
 
 If you already have your Quarkus project configured, you can add the `quarkus-opentelemetry` extension
 to your project by running the following command in your project base directory:
@@ -135,13 +135,13 @@ The only mandatory configuration for OpenTelemetry Metrics is the one enabling i
 quarkus.otel.metrics.enabled=true
 ----
 
-To change any of the default property values, here is an example on how to configure the default OTLP gRPC Exporter within the application, using the `src/main/resources/application.properties` file:
+To change any of the default property values, here is an example on how to configure the default OTLP Exporter within the application, using the `src/main/resources/application.properties` file:
 
 [source,properties]
 ----
 quarkus.application.name=myservice // <1>
 quarkus.otel.metrics.enabled=true // <2>
-quarkus.otel.exporter.otlp.metrics.endpoint=http://localhost:4317 // <3>
+quarkus.otel.exporter.otlp.metrics.endpoint=http://localhost:4318 // <3>
 quarkus.otel.exporter.otlp.metrics.headers=authorization=Bearer my_secret // <4>
 ----
 
@@ -149,9 +149,9 @@ quarkus.otel.exporter.otlp.metrics.headers=authorization=Bearer my_secret // <4>
 If not set, it will default to the artifact id.
 <2> Enable the OpenTelemetry metrics.
 Must be set at build time.
-<3> gRPC endpoint to send the metrics.
-If not set, it will default to `http://localhost:4317`.
-<4> Optional gRPC headers commonly used for authentication.
+<3> OTLP endpoint to send the metrics.
+If not set, it will default to `http://localhost:4318`.
+<4> Optional headers commonly used for authentication.
 
 To configure the connection using the same properties for all signals, please check the base xref:opentelemetry.adoc#create-the-configuration[configuration section of the OpenTelemetry guide].
 
@@ -205,9 +205,9 @@ If using `application.properties` to configure the tracer:
 
 include::{includes}/devtools/dev.adoc[]
 
-or if configuring the OTLP gRPC endpoint via JVM arguments:
+or if configuring the OTLP endpoint via JVM arguments:
 
-:dev-additional-parameters: -Djvm.args="-Dquarkus.otel.exporter.otlp.endpoint=http://localhost:4317"
+:dev-additional-parameters: -Djvm.args="-Dquarkus.otel.exporter.otlp.endpoint=http://localhost:4318"
 include::{includes}/devtools/dev.adoc[]
 :!dev-additional-parameters:
 

--- a/docs/src/main/asciidoc/opentelemetry-tracing.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-tracing.adoc
@@ -49,7 +49,7 @@ include::{includes}/devtools/create-app.adoc[]
 
 This command generates the Maven project and imports the `quarkus-opentelemetry` extension,
 which includes the default OpenTelemetry support,
-and a gRPC span exporter for https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md[OTLP].
+and an OTLP span exporter for https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md[OTLP].
 
 If you already have your Quarkus project configured, you can add the `quarkus-opentelemetry` extension
 to your project by running the following command in your project base directory:
@@ -192,9 +192,9 @@ Now we are ready to run our application. If using `application.properties` to co
 
 include::{includes}/devtools/dev.adoc[]
 
-or if configuring the OTLP gRPC endpoint via JVM arguments:
+or if configuring the OTLP endpoint via JVM arguments:
 
-:dev-additional-parameters: -Djvm.args="-Dquarkus.otel.exporter.otlp.traces.endpoint=http://localhost:4317"
+:dev-additional-parameters: -Djvm.args="-Dquarkus.otel.exporter.otlp.traces.endpoint=http://localhost:4318"
 include::{includes}/devtools/dev.adoc[]
 :!dev-additional-parameters:
 

--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -332,13 +332,13 @@ When creating manual instrumentation, while naming metrics or attributes you sho
 
 === The Default
 
-The Quarkus OpenTelemetry extension uses its own signal exporters built on top of Vert.x for optimal performance and maintainability. All *Quarkus built in exporters use the OTLP protocol* through a couple of data senders, using `grpc` (the default) and `http/protobuf`.
+The Quarkus OpenTelemetry extension uses its own signal exporters built on top of Vert.x for optimal performance and maintainability. All *Quarkus built in exporters use the OTLP protocol* through a couple of data senders, using `http/protobuf` (the default) and `grpc`.
 
 The active exporter is automatically wired by CDI, that's why the `quarkus.otel.traces.exporter`, `quarkus.otel.metrics.exporter` and `quarkus.otel.logs.exporter` properties default value is `cdi`. This is not because of the protocol being used in the data transfer but because of how the exporters are wired.
 
 CDI (Context Dependency Injection) will manage the exporters to use, according to the selected protocol or when applications implement their own CDI exporter, like in tests.
 
-The `quarkus.otel.exporter.otlp.protocol` property instructs Quarkus to switch the senders and defaults to `grpc` but `http/protobuf` can also be used.
+The `quarkus.otel.exporter.otlp.protocol` property instructs Quarkus to switch the senders and defaults to `http/protobuf` but `grpc` can also be used.
 
 NOTE: If you change the protocol, you also need to change the port in the endpoint. The default port for `grpc` is `4317` and for `http/protobuf` is `4318`.
 

--- a/extensions/opentelemetry/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/opentelemetry/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -148,8 +148,8 @@ If @QuarkusIntegrationTest is required, because of native, a `ExporterResource` 
 
 ### Common Pitfalls
 
-- **Use default protocol.** Unless instructed otherwise, use the default `grpc`.
-- **Protocol and port must match.** Default `grpc` uses port 4317, `http/protobuf` uses port 4318. A mismatch causes silent export failures.
+- **Use default protocol.** Unless instructed otherwise, use the default `http/protobuf`.
+- **Protocol and port must match.** Default `http/protobuf` uses port 4318, `grpc` uses port 4317. A mismatch causes silent export failures.
 - **Build-time vs runtime.** `quarkus.otel.exporter.otlp.endpoint` is a runtime property. `quarkus.otel.traces.enabled` is build-time. Changing a build-time property at runtime has no effect.
 - **Serverless requires simple export.** Set `quarkus.otel.simple=true` for immediate export instead of batching — batched spans may be lost when the function terminates.
 - **Disable specific instrumentation** with `quarkus.otel.instrument.<extension>=false` (e.g., `quarkus.otel.instrument.rest=false`).

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterConfigTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterConfigTest.java
@@ -17,7 +17,7 @@ public class OtlpExporterConfigTest {
             .withEmptyApplication()
             .overrideConfigKey("quarkus.otel.traces.exporter", "cdi")
             .overrideConfigKey("quarkus.otel.exporter.otlp.protocol", "wrong")
-            .overrideConfigKey("quarkus.otel.exporter.otlp.traces.protocol", "http/protobuf")
+            .overrideConfigKey("quarkus.otel.exporter.otlp.traces.protocol", "grpc")
             .overrideConfigKey("quarkus.otel.exporter.otlp.traces.endpoint", "http://localhost ")
             .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
             .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "50")
@@ -29,7 +29,7 @@ public class OtlpExporterConfigTest {
     @Test
     void config() {
         assertTrue(config.traces().protocol().isPresent());
-        assertEquals("http/protobuf", config.traces().protocol().get().trim());
+        assertEquals("grpc", config.traces().protocol().get().trim());
         assertTrue(config.traces().endpoint().isPresent());
         assertEquals("http://localhost", config.traces().endpoint().get().trim());
     }

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterOverrideConfigTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterOverrideConfigTest.java
@@ -16,7 +16,7 @@ public class OtlpExporterOverrideConfigTest {
     static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
             .withEmptyApplication()
             .overrideConfigKey("quarkus.otel.traces.exporter", "cdi")
-            .overrideConfigKey("quarkus.otel.exporter.otlp.protocol", "http/protobuf")
+            .overrideConfigKey("quarkus.otel.exporter.otlp.protocol", "grpc")
             .overrideConfigKey("quarkus.otel.exporter.otlp.endpoint", "http://localhost ")
             .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "50")
             .overrideConfigKey("quarkus.otel.bsp.export.timeout", "PT1S");
@@ -27,7 +27,7 @@ public class OtlpExporterOverrideConfigTest {
     @Test
     void config() {
         assertTrue(config.traces().protocol().isPresent());
-        assertEquals("http/protobuf", config.traces().protocol().get().trim());
+        assertEquals("grpc", config.traces().protocol().get().trim());
         assertTrue(config.traces().endpoint().isPresent());
         assertEquals("http://localhost", config.traces().endpoint().get().trim());
     }

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/BatchSpanProcessorHttpExporterTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/BatchSpanProcessorHttpExporterTest.java
@@ -20,7 +20,6 @@ public class BatchSpanProcessorHttpExporterTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar.addClass(TestUtil.class))
-            .overrideConfigKey("quarkus.otel.exporter.otlp.protocol", "http/protobuf")
             .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
             .overrideConfigKey("quarkus.otel.logs.exporter", "none")
             .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "50ms");

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/LoggingAndCdiSpanExporterTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/LoggingAndCdiSpanExporterTest.java
@@ -17,7 +17,7 @@ import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.quarkus.opentelemetry.deployment.common.TestUtil;
-import io.quarkus.opentelemetry.runtime.exporter.otlp.tracing.VertxGrpcSpanExporter;
+import io.quarkus.opentelemetry.runtime.exporter.otlp.tracing.VertxHttpSpanExporter;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class LoggingAndCdiSpanExporterTest {
@@ -47,18 +47,18 @@ public class LoggingAndCdiSpanExporterTest {
     }
 
     @Test
-    void bothLoggingAndVertxGrpcExportersAreUsed() throws Exception {
+    void bothLoggingAndVertxHttpExportersAreUsed() throws Exception {
         List<SpanExporter> exporters = TestUtil.getAllSpanExporters(openTelemetry);
 
         boolean hasLogging = exporters.stream()
                 .anyMatch(e -> e instanceof LoggingSpanExporter);
-        boolean hasVertxGrpc = exporters.stream()
-                .anyMatch(e -> e instanceof VertxGrpcSpanExporter);
+        boolean hasVertxHttp = exporters.stream()
+                .anyMatch(e -> e instanceof VertxHttpSpanExporter);
 
         assertTrue(hasLogging,
                 "LoggingSpanExporter should be present. Found exporters: " + exporterNames(exporters));
-        assertTrue(hasVertxGrpc,
-                "VertxGrpcSpanExporter should be present. Found exporters: " + exporterNames(exporters));
+        assertTrue(hasVertxHttp,
+                "VertxHttpSpanExporter should be present. Found exporters: " + exporterNames(exporters));
         assertEquals(2, exporters.size(),
                 "There should be exactly 2 span exporters. Found: " + exporterNames(exporters));
     }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/exporter/OtlpExporterConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/exporter/OtlpExporterConfig.java
@@ -17,7 +17,7 @@ public interface OtlpExporterConfig {
 
     /**
      * Sets the OTLP endpoint to send telemetry data. If unset, defaults to
-     * {@value OtlpExporterRuntimeConfig#DEFAULT_GRPC_BASE_URI}.
+     * {@value OtlpExporterRuntimeConfig#DEFAULT_HTTP_BASE_URI}.
      * <p>
      * There is a generic property, that will apply to all signals and a signal specific one, following the pattern:
      * `quarkus.otel.exporter.otlp.<signal-type>.endpoint` where <signal-type> is one of the supported signal types,
@@ -26,7 +26,7 @@ public interface OtlpExporterConfig {
      * If protocol is `http/protobuf` the version and signal will be appended to the path (e.g. v1/traces or v1/metrics)
      * and the default port will be {@value OtlpExporterRuntimeConfig#DEFAULT_HTTP_BASE_URI}.
      */
-    @ConfigDocDefault(DEFAULT_GRPC_BASE_URI)
+    @ConfigDocDefault(DEFAULT_HTTP_BASE_URI)
     Optional<String> endpoint();
 
     /**
@@ -74,7 +74,7 @@ public interface OtlpExporterConfig {
      * `quarkus.otel.exporter.otlp.<signal-type>.protocol` where <signal-type> is one of the supported signal types,
      * like `traces` or `metrics`.
      */
-    @ConfigDocDefault(OtlpExporterConfig.Protocol.GRPC)
+    @ConfigDocDefault(Protocol.HTTP_PROTOBUF)
     Optional<String> protocol();
 
     /**

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/exporter/OtlpExporterConfigBuilder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/exporter/OtlpExporterConfigBuilder.java
@@ -1,7 +1,7 @@
 package io.quarkus.opentelemetry.runtime.config.runtime.exporter;
 
-import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.DEFAULT_GRPC_BASE_URI;
-import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.Protocol.GRPC;
+import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.DEFAULT_HTTP_BASE_URI;
+import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.Protocol.HTTP_PROTOBUF;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,8 +30,8 @@ public class OtlpExporterConfigBuilder implements ConfigBuilder {
     @Override
     public SmallRyeConfigBuilder configBuilder(final SmallRyeConfigBuilder builder) {
         // Main defaults
-        builder.withDefaultValue("quarkus.otel.exporter.otlp.endpoint", DEFAULT_GRPC_BASE_URI);
-        builder.withDefaultValue("quarkus.otel.exporter.otlp.protocol", GRPC);
+        builder.withDefaultValue("quarkus.otel.exporter.otlp.endpoint", DEFAULT_HTTP_BASE_URI);
+        builder.withDefaultValue("quarkus.otel.exporter.otlp.protocol", HTTP_PROTOBUF);
         builder.withDefaultValue("quarkus.otel.exporter.otlp.timeout", "10s");
         builder.withDefaultValue("quarkus.otel.exporter.otlp.proxy-options.enabled", "false");
 

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OTelExporterRecorder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OTelExporterRecorder.java
@@ -1,9 +1,9 @@
 package io.quarkus.opentelemetry.runtime.exporter.otlp;
 
 import static io.opentelemetry.sdk.common.internal.StandardComponentId.ExporterType.OTLP_GRPC_METRIC_EXPORTER;
+import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.DEFAULT_HTTP_BASE_URI;
 import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.Protocol.GRPC;
 import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.Protocol.HTTP_PROTOBUF;
-import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterRuntimeConfig.DEFAULT_GRPC_BASE_URI;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -424,7 +424,7 @@ public class OTelExporterRecorder {
                 .filter(OTelExporterRecorder::excludeDefaultEndpoint)
                 .orElse(runtimeConfig.endpoint()
                         .filter(OTelExporterRecorder::excludeDefaultEndpoint)
-                        .orElse(DEFAULT_GRPC_BASE_URI));
+                        .orElse(DEFAULT_HTTP_BASE_URI));
         return endpoint.trim();
     }
 
@@ -433,7 +433,7 @@ public class OTelExporterRecorder {
                 .filter(OTelExporterRecorder::excludeDefaultEndpoint)
                 .orElse(runtimeConfig.endpoint()
                         .filter(OTelExporterRecorder::excludeDefaultEndpoint)
-                        .orElse(DEFAULT_GRPC_BASE_URI));
+                        .orElse(DEFAULT_HTTP_BASE_URI));
         return endpoint.trim();
     }
 
@@ -442,12 +442,12 @@ public class OTelExporterRecorder {
                 .filter(OTelExporterRecorder::excludeDefaultEndpoint)
                 .orElse(runtimeConfig.endpoint()
                         .filter(OTelExporterRecorder::excludeDefaultEndpoint)
-                        .orElse(DEFAULT_GRPC_BASE_URI));
+                        .orElse(DEFAULT_HTTP_BASE_URI));
         return endpoint.trim();
     }
 
     private static boolean excludeDefaultEndpoint(String endpoint) {
-        return !DEFAULT_GRPC_BASE_URI.equals(endpoint);
+        return !DEFAULT_HTTP_BASE_URI.equals(endpoint);
     }
 
     static class HttpClientOptionsConsumer implements Consumer<HttpClientOptions> {

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/config/OpenTelemetryConfigTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/config/OpenTelemetryConfigTest.java
@@ -2,8 +2,7 @@ package io.quarkus.opentelemetry.runtime.config;
 
 import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.CompressionType.GZIP;
 import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.CompressionType.NONE;
-import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.DEFAULT_GRPC_BASE_URI;
-import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.Protocol.GRPC;
+import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.DEFAULT_HTTP_BASE_URI;
 import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.Protocol.HTTP_PROTOBUF;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -47,14 +46,14 @@ class OpenTelemetryConfigTest {
 
         OtlpExporterRuntimeConfig mapping = config.getConfigMapping(OtlpExporterRuntimeConfig.class);
         assertTrue(mapping.endpoint().isPresent());
-        assertEquals(DEFAULT_GRPC_BASE_URI, mapping.endpoint().get());
+        assertEquals(DEFAULT_HTTP_BASE_URI, mapping.endpoint().get());
         assertTrue(mapping.headers().isPresent());
         assertIterableEquals(List.of("foo", "bar"), mapping.headers().get());
         assertTrue(mapping.compression().isPresent());
         assertEquals(NONE, mapping.compression().get());
         assertEquals(DurationConverter.parseDuration("10s"), mapping.timeout());
         assertTrue(mapping.protocol().isPresent());
-        assertEquals(GRPC, mapping.protocol().get());
+        assertEquals(HTTP_PROTOBUF, mapping.protocol().get());
         assertTrue(mapping.keyCert().keys().isPresent());
         assertIterableEquals(List.of("keys"), mapping.keyCert().keys().get());
         assertTrue(mapping.keyCert().certs().isPresent());
@@ -75,14 +74,14 @@ class OpenTelemetryConfigTest {
 
         OtlpExporterTracesConfig traces = mapping.traces();
         assertTrue(traces.endpoint().isPresent());
-        assertEquals(DEFAULT_GRPC_BASE_URI, traces.endpoint().get());
+        assertEquals(DEFAULT_HTTP_BASE_URI, traces.endpoint().get());
         assertTrue(traces.headers().isPresent());
         assertIterableEquals(List.of("foo", "bar"), traces.headers().get());
         assertTrue(traces.compression().isPresent());
         assertEquals(NONE, traces.compression().get());
         assertEquals(DurationConverter.parseDuration("10s"), traces.timeout());
         assertTrue(traces.protocol().isPresent());
-        assertEquals(GRPC, traces.protocol().get());
+        assertEquals(HTTP_PROTOBUF, traces.protocol().get());
         assertTrue(traces.keyCert().keys().isPresent());
         assertIterableEquals(List.of("keys"), traces.keyCert().keys().get());
         assertTrue(traces.keyCert().certs().isPresent());
@@ -103,14 +102,14 @@ class OpenTelemetryConfigTest {
 
         OtlpExporterMetricsConfig metrics = mapping.metrics();
         assertTrue(metrics.endpoint().isPresent());
-        assertEquals(DEFAULT_GRPC_BASE_URI, metrics.endpoint().get());
+        assertEquals(DEFAULT_HTTP_BASE_URI, metrics.endpoint().get());
         assertTrue(metrics.headers().isPresent());
         assertIterableEquals(List.of("foo", "bar"), metrics.headers().get());
         assertTrue(metrics.compression().isPresent());
         assertEquals(NONE, metrics.compression().get());
         assertEquals(DurationConverter.parseDuration("10s"), metrics.timeout());
         assertTrue(metrics.protocol().isPresent());
-        assertEquals(GRPC, metrics.protocol().get());
+        assertEquals(HTTP_PROTOBUF, metrics.protocol().get());
         assertTrue(metrics.keyCert().keys().isPresent());
         assertIterableEquals(List.of("keys"), metrics.keyCert().keys().get());
         assertTrue(metrics.keyCert().certs().isPresent());

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OtlpExporterProviderTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OtlpExporterProviderTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.opentelemetry.runtime.exporter.otlp;
 
-import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterRuntimeConfig.DEFAULT_GRPC_BASE_URI;
+import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.DEFAULT_HTTP_BASE_URI;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
@@ -28,28 +28,28 @@ class OtlpExporterProviderTest {
         assertEquals("http://localhost:1111/",
                 OTelExporterRecorder.resolveTraceEndpoint(createOtlpExporterRuntimeConfig(
                         "http://localhost:1111/",
-                        DEFAULT_GRPC_BASE_URI)));
+                        DEFAULT_HTTP_BASE_URI)));
     }
 
     @Test
     public void resolveTraceEndpoint_legacyTraceWins() {
         assertEquals("http://localhost:2222/",
                 OTelExporterRecorder.resolveTraceEndpoint(createOtlpExporterRuntimeConfig(
-                        DEFAULT_GRPC_BASE_URI,
+                        DEFAULT_HTTP_BASE_URI,
                         "http://localhost:2222/")));
     }
 
     @Test
     public void resolveTraceEndpoint_legacyGlobalWins() {
-        assertEquals(DEFAULT_GRPC_BASE_URI,
+        assertEquals(DEFAULT_HTTP_BASE_URI,
                 OTelExporterRecorder.resolveTraceEndpoint(createOtlpExporterRuntimeConfig(
-                        DEFAULT_GRPC_BASE_URI,
+                        DEFAULT_HTTP_BASE_URI,
                         null)));
     }
 
     @Test
     public void resolveTraceEndpoint_testIsSet() {
-        assertEquals(DEFAULT_GRPC_BASE_URI,
+        assertEquals(DEFAULT_HTTP_BASE_URI,
                 OTelExporterRecorder.resolveTraceEndpoint(createOtlpExporterRuntimeConfig(
                         null,
                         null)));
@@ -68,28 +68,28 @@ class OtlpExporterProviderTest {
         assertEquals("http://localhost:1111/",
                 OTelExporterRecorder.resolveMetricEndpoint(createOtlpExporterRuntimeConfig(
                         "http://localhost:1111/",
-                        DEFAULT_GRPC_BASE_URI)));
+                        DEFAULT_HTTP_BASE_URI)));
     }
 
     @Test
     public void resolveMetricEndpoint_legacyTraceWins() {
         assertEquals("http://localhost:2222/",
                 OTelExporterRecorder.resolveMetricEndpoint(createOtlpExporterRuntimeConfig(
-                        DEFAULT_GRPC_BASE_URI,
+                        DEFAULT_HTTP_BASE_URI,
                         "http://localhost:2222/")));
     }
 
     @Test
     public void resolveMetricEndpoint_legacyGlobalWins() {
-        assertEquals(DEFAULT_GRPC_BASE_URI,
+        assertEquals(DEFAULT_HTTP_BASE_URI,
                 OTelExporterRecorder.resolveMetricEndpoint(createOtlpExporterRuntimeConfig(
-                        DEFAULT_GRPC_BASE_URI,
+                        DEFAULT_HTTP_BASE_URI,
                         null)));
     }
 
     @Test
     public void resolveMetricEndpoint_testIsSet() {
-        assertEquals(DEFAULT_GRPC_BASE_URI,
+        assertEquals(DEFAULT_HTTP_BASE_URI,
                 OTelExporterRecorder.resolveMetricEndpoint(createOtlpExporterRuntimeConfig(
                         null,
                         null)));
@@ -108,28 +108,28 @@ class OtlpExporterProviderTest {
         assertEquals("http://localhost:1111/",
                 OTelExporterRecorder.resolveLogsEndpoint(createOtlpExporterRuntimeConfig(
                         "http://localhost:1111/",
-                        DEFAULT_GRPC_BASE_URI)));
+                        DEFAULT_HTTP_BASE_URI)));
     }
 
     @Test
     public void resolveLogsEndpoint_legacyTraceWins() {
         assertEquals("http://localhost:2222/",
                 OTelExporterRecorder.resolveLogsEndpoint(createOtlpExporterRuntimeConfig(
-                        DEFAULT_GRPC_BASE_URI,
+                        DEFAULT_HTTP_BASE_URI,
                         "http://localhost:2222/")));
     }
 
     @Test
     public void resolveLogsEndpoint_legacyGlobalWins() {
-        assertEquals(DEFAULT_GRPC_BASE_URI,
+        assertEquals(DEFAULT_HTTP_BASE_URI,
                 OTelExporterRecorder.resolveLogsEndpoint(createOtlpExporterRuntimeConfig(
-                        DEFAULT_GRPC_BASE_URI,
+                        DEFAULT_HTTP_BASE_URI,
                         null)));
     }
 
     @Test
     public void resolveLogsEndpoint_testIsSet() {
-        assertEquals(DEFAULT_GRPC_BASE_URI,
+        assertEquals(DEFAULT_HTTP_BASE_URI,
                 OTelExporterRecorder.resolveLogsEndpoint(createOtlpExporterRuntimeConfig(
                         null,
                         null)));

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmLifecycleTest.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmLifecycleTest.java
@@ -21,7 +21,6 @@ public class LgtmLifecycleTest extends LgtmConfigTestBase {
         @Override
         public Map<String, String> getConfigOverrides() {
             return Map.of(
-                    "quarkus.otel.exporter.otlp.protocol", "http/protobuf",
                     "quarkus.otel.exporter.otlp.endpoint", "http://${otel-collector.url}",
                     "quarkus.observability.dev-resources", "false",
                     "quarkus.observability.enabled", "false");

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmResourcesTest.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmResourcesTest.java
@@ -21,7 +21,6 @@ public class LgtmResourcesTest extends LgtmConfigTestBase {
         @Override
         public Map<String, String> getConfigOverrides() {
             return Map.of(
-                    "quarkus.otel.exporter.otlp.protocol", "http/protobuf",
                     "quarkus.otel.exporter.otlp.endpoint", "http://${otel-collector.url}",
                     "quarkus.observability.dev-resources", "true",
                     "quarkus.observability.enabled", "false",

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/OtelCollectorLifecycleManager.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/OtelCollectorLifecycleManager.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.opentelemetry.vertx.exporter;
 
 import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.Protocol.GRPC;
+import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.Protocol.HTTP_PROTOBUF;
 import static org.testcontainers.Testcontainers.exposeHostPorts;
 
 import java.util.HashMap;
@@ -12,7 +13,6 @@ import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.images.PullPolicy;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
@@ -55,7 +55,7 @@ public class OtelCollectorLifecycleManager implements QuarkusTestResourceLifecyc
     private SelfSignedCertificate serverTls;
     private SelfSignedCertificate clientTlS;
 
-    private String protocol = GRPC;
+    private String protocol = HTTP_PROTOBUF;
     private boolean enableTLS = false;
     private boolean preventTrustCert = false;
     private boolean enableCompression = false;
@@ -108,7 +108,6 @@ public class OtelCollectorLifecycleManager implements QuarkusTestResourceLifecyc
         clientTlS = SelfSignedCertificate.create();
 
         collector = new GenericContainer<>(DockerImageName.parse(COLLECTOR_IMAGE))
-                .withImagePullPolicy(PullPolicy.alwaysPull())
                 .withEnv("LOGGING_EXPORTER_VERBOSITY_LEVEL", "basic") // basic, normal, detailed
                 .withCopyFileToContainer(
                         MountableFile.forHostPath(serverTls.certificatePath(), 0555),

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcNoTLSNoCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcNoTLSNoCompressionTest.java
@@ -3,10 +3,11 @@ package io.quarkus.it.opentelemetry.vertx.exporter.grpc;
 import io.quarkus.it.opentelemetry.vertx.exporter.AbstractExporterTest;
 import io.quarkus.it.opentelemetry.vertx.exporter.OtelCollectorLifecycleManager;
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "protocol", value = "grpc"), restrictToAnnotatedClass = true)
 public class GrpcNoTLSNoCompressionTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcNoTLSReusableDataTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcNoTLSReusableDataTest.java
@@ -4,12 +4,13 @@ import io.quarkus.it.opentelemetry.vertx.exporter.AbstractExporterTest;
 import io.quarkus.it.opentelemetry.vertx.exporter.OtelCollectorLifecycleManager;
 import io.quarkus.it.opentelemetry.vertx.exporter.ReusableDataProfile;
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(ReusableDataProfile.class)
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "protocol", value = "grpc"), restrictToAnnotatedClass = true)
 public class GrpcNoTLSReusableDataTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcNoTLSWithCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcNoTLSWithCompressionTest.java
@@ -7,7 +7,9 @@ import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "enableCompression", value = "true"), restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
+        @ResourceArg(name = "enableCompression", value = "true"),
+        @ResourceArg(name = "protocol", value = "grpc") }, restrictToAnnotatedClass = true)
 public class GrpcNoTLSWithCompressionTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcWithTLSNoCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcWithTLSNoCompressionTest.java
@@ -7,7 +7,10 @@ import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "enableTLS", value = "true"), restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
+        @ResourceArg(name = "enableTLS", value = "true"),
+        @ResourceArg(name = "protocol", value = "grpc")
+}, restrictToAnnotatedClass = true)
 public class GrpcWithTLSNoCompressionTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcWithTLSWithCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcWithTLSWithCompressionTest.java
@@ -9,7 +9,8 @@ import io.quarkus.test.junit.QuarkusTest;
 @QuarkusTest
 @QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
         @ResourceArg(name = "enableTLS", value = "true"),
-        @ResourceArg(name = "enableCompression", value = "true")
+        @ResourceArg(name = "enableCompression", value = "true"),
+        @ResourceArg(name = "protocol", value = "grpc")
 }, restrictToAnnotatedClass = true)
 public class GrpcWithTLSWithCompressionTest extends AbstractExporterTest {
 

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcWithTLSWithTrustAllWithCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcWithTLSWithTrustAllWithCompressionTest.java
@@ -25,7 +25,8 @@ public class GrpcWithTLSWithTrustAllWithCompressionTest extends AbstractExporter
             return Collections.singletonList(
                     new TestResourceEntry(
                             OtelCollectorLifecycleManager.class,
-                            Map.of("enableTLS", "true", "enableCompression", "true", "preventTrustCert", "true")));
+                            Map.of("enableTLS", "true", "enableCompression", "true", "preventTrustCert", "true", "protocol",
+                                    "grpc")));
         }
     }
 

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/SimpleGrpcNoTLSNoCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/SimpleGrpcNoTLSNoCompressionTest.java
@@ -4,11 +4,12 @@ import io.quarkus.it.opentelemetry.vertx.exporter.AbstractExporterTest;
 import io.quarkus.it.opentelemetry.vertx.exporter.OtelCollectorLifecycleManager;
 import io.quarkus.it.opentelemetry.vertx.exporter.SimpleProfile;
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "protocol", value = "grpc"), restrictToAnnotatedClass = true)
 @TestProfile(SimpleProfile.class)
 public class SimpleGrpcNoTLSNoCompressionTest extends AbstractExporterTest {
 

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/SimpleGrpcNoTLSWithCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/SimpleGrpcNoTLSWithCompressionTest.java
@@ -9,7 +9,10 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "enableCompression", value = "true"), restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
+        @ResourceArg(name = "enableCompression", value = "true"),
+        @ResourceArg(name = "protocol", value = "grpc")
+}, restrictToAnnotatedClass = true)
 @TestProfile(SimpleProfile.class)
 public class SimpleGrpcNoTLSWithCompressionTest extends AbstractExporterTest {
 

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/SimpleGrpcWithTLSNoCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/SimpleGrpcWithTLSNoCompressionTest.java
@@ -9,7 +9,10 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "enableTLS", value = "true"), restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
+        @ResourceArg(name = "enableTLS", value = "true"),
+        @ResourceArg(name = "protocol", value = "grpc")
+}, restrictToAnnotatedClass = true)
 @TestProfile(SimpleProfile.class)
 public class SimpleGrpcWithTLSNoCompressionTest extends AbstractExporterTest {
 

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/SimpleGrpcWithTLSWithCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/SimpleGrpcWithTLSWithCompressionTest.java
@@ -11,7 +11,8 @@ import io.quarkus.test.junit.TestProfile;
 @QuarkusTest
 @QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
         @ResourceArg(name = "enableTLS", value = "true"),
-        @ResourceArg(name = "enableCompression", value = "true")
+        @ResourceArg(name = "enableCompression", value = "true"),
+        @ResourceArg(name = "protocol", value = "grpc")
 }, restrictToAnnotatedClass = true)
 @TestProfile(SimpleProfile.class)
 public class SimpleGrpcWithTLSWithCompressionTest extends AbstractExporterTest {

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/SimpleGrpcWithTLSWithTrustAllWithCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/SimpleGrpcWithTLSWithTrustAllWithCompressionTest.java
@@ -25,7 +25,8 @@ public class SimpleGrpcWithTLSWithTrustAllWithCompressionTest extends AbstractEx
             return Collections.singletonList(
                     new TestResourceEntry(
                             OtelCollectorLifecycleManager.class,
-                            Map.of("enableTLS", "true", "enableCompression", "true", "preventTrustCert", "true")));
+                            Map.of("enableTLS", "true", "enableCompression", "true", "preventTrustCert", "true", "protocol",
+                                    "grpc")));
         }
     }
 

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpNoTLSNoCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpNoTLSNoCompressionTest.java
@@ -3,11 +3,10 @@ package io.quarkus.it.opentelemetry.vertx.exporter.http;
 import io.quarkus.it.opentelemetry.vertx.exporter.AbstractExporterTest;
 import io.quarkus.it.opentelemetry.vertx.exporter.OtelCollectorLifecycleManager;
 import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "protocol", value = "http/protobuf"), restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, restrictToAnnotatedClass = true)
 public class HttpNoTLSNoCompressionTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpNoTLSReusableDataTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpNoTLSReusableDataTest.java
@@ -4,13 +4,12 @@ import io.quarkus.it.opentelemetry.vertx.exporter.AbstractExporterTest;
 import io.quarkus.it.opentelemetry.vertx.exporter.OtelCollectorLifecycleManager;
 import io.quarkus.it.opentelemetry.vertx.exporter.ReusableDataProfile;
 import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(ReusableDataProfile.class)
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "protocol", value = "http/protobuf"), restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, restrictToAnnotatedClass = true)
 public class HttpNoTLSReusableDataTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpNoTLSWithCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpNoTLSWithCompressionTest.java
@@ -7,10 +7,7 @@ import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
-        @ResourceArg(name = "enableCompression", value = "true"),
-        @ResourceArg(name = "protocol", value = "http/protobuf")
-}, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "enableCompression", value = "true"), restrictToAnnotatedClass = true)
 public class HttpNoTLSWithCompressionTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpWithTLSNoCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpWithTLSNoCompressionTest.java
@@ -7,10 +7,7 @@ import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
-        @ResourceArg(name = "enableTLS", value = "true"),
-        @ResourceArg(name = "protocol", value = "http/protobuf")
-}, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "enableTLS", value = "true"), restrictToAnnotatedClass = true)
 public class HttpWithTLSNoCompressionTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpWithTLSWithCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpWithTLSWithCompressionTest.java
@@ -9,8 +9,7 @@ import io.quarkus.test.junit.QuarkusTest;
 @QuarkusTest
 @QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
         @ResourceArg(name = "enableTLS", value = "true"),
-        @ResourceArg(name = "enableCompression", value = "true"),
-        @ResourceArg(name = "protocol", value = "http/protobuf")
+        @ResourceArg(name = "enableCompression", value = "true")
 }, restrictToAnnotatedClass = true)
 public class HttpWithTLSWithCompressionTest extends AbstractExporterTest {
 

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpWithTLSWithCompressionUsingRegistryTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpWithTLSWithCompressionUsingRegistryTest.java
@@ -10,7 +10,6 @@ import io.quarkus.test.junit.QuarkusTest;
 @QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
         @ResourceArg(name = "enableTLS", value = "true"),
         @ResourceArg(name = "enableCompression", value = "true"),
-        @ResourceArg(name = "protocol", value = "http/protobuf"),
         @ResourceArg(name = "tlsRegistryName", value = "otel")
 }, restrictToAnnotatedClass = true)
 public class HttpWithTLSWithCompressionUsingRegistryTest extends AbstractExporterTest {

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpWithTLSWithTrustAllWithCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpWithTLSWithTrustAllWithCompressionTest.java
@@ -25,8 +25,7 @@ public class HttpWithTLSWithTrustAllWithCompressionTest extends AbstractExporter
             return Collections.singletonList(
                     new TestResourceEntry(
                             OtelCollectorLifecycleManager.class,
-                            Map.of("enableTLS", "true", "enableCompression", "true", "preventTrustCert", "true", "protocol",
-                                    "http/protobuf")));
+                            Map.of("enableTLS", "true", "enableCompression", "true", "preventTrustCert", "true")));
         }
     }
 

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/SimpleHttpNoTLSNoCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/SimpleHttpNoTLSNoCompressionTest.java
@@ -4,12 +4,11 @@ import io.quarkus.it.opentelemetry.vertx.exporter.AbstractExporterTest;
 import io.quarkus.it.opentelemetry.vertx.exporter.OtelCollectorLifecycleManager;
 import io.quarkus.it.opentelemetry.vertx.exporter.SimpleProfile;
 import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "protocol", value = "http/protobuf"), restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, restrictToAnnotatedClass = true)
 @TestProfile(SimpleProfile.class)
 public class SimpleHttpNoTLSNoCompressionTest extends AbstractExporterTest {
 

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/SimpleHttpNoTLSWithCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/SimpleHttpNoTLSWithCompressionTest.java
@@ -9,10 +9,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
-        @ResourceArg(name = "enableCompression", value = "true"),
-        @ResourceArg(name = "protocol", value = "http/protobuf")
-}, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "enableCompression", value = "true"), restrictToAnnotatedClass = true)
 @TestProfile(SimpleProfile.class)
 public class SimpleHttpNoTLSWithCompressionTest extends AbstractExporterTest {
 

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/SimpleHttpWithTLSNoCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/SimpleHttpWithTLSNoCompressionTest.java
@@ -10,8 +10,7 @@ import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
-        @ResourceArg(name = "enableTLS", value = "true"),
-        @ResourceArg(name = "protocol", value = "http/protobuf")
+        @ResourceArg(name = "enableTLS", value = "true")
 }, restrictToAnnotatedClass = true)
 @TestProfile(SimpleProfile.class)
 public class SimpleHttpWithTLSNoCompressionTest extends AbstractExporterTest {

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/SimpleHttpWithTLSWithCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/SimpleHttpWithTLSWithCompressionTest.java
@@ -11,8 +11,7 @@ import io.quarkus.test.junit.TestProfile;
 @QuarkusTest
 @QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
         @ResourceArg(name = "enableTLS", value = "true"),
-        @ResourceArg(name = "enableCompression", value = "true"),
-        @ResourceArg(name = "protocol", value = "http/protobuf")
+        @ResourceArg(name = "enableCompression", value = "true")
 }, restrictToAnnotatedClass = true)
 @TestProfile(SimpleProfile.class)
 public class SimpleHttpWithTLSWithCompressionTest extends AbstractExporterTest {

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/SimpleHttpWithTLSWithCompressionUsingRegistryTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/SimpleHttpWithTLSWithCompressionUsingRegistryTest.java
@@ -12,7 +12,6 @@ import io.quarkus.test.junit.TestProfile;
 @QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
         @ResourceArg(name = "enableTLS", value = "true"),
         @ResourceArg(name = "enableCompression", value = "true"),
-        @ResourceArg(name = "protocol", value = "http/protobuf"),
         @ResourceArg(name = "tlsRegistryName", value = "otel")
 }, restrictToAnnotatedClass = true)
 @TestProfile(SimpleProfile.class)

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/SimpleHttpWithTLSWithTrustAllWithCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/SimpleHttpWithTLSWithTrustAllWithCompressionTest.java
@@ -25,8 +25,7 @@ public class SimpleHttpWithTLSWithTrustAllWithCompressionTest extends AbstractEx
             return Collections.singletonList(
                     new TestResourceEntry(
                             OtelCollectorLifecycleManager.class,
-                            Map.of("enableTLS", "true", "enableCompression", "true", "preventTrustCert", "true", "protocol",
-                                    "http/protobuf")));
+                            Map.of("enableTLS", "true", "enableCompression", "true", "preventTrustCert", "true")));
         }
     }
 


### PR DESCRIPTION
- Closes: #41522

**This is a breaking change**
----

## Migrating to the new default OpenTelemetry OTLP protocol (`http/protobuf`)

### What changed

Starting with Quarkus 4.x, the default OTLP exporter protocol has changed from `grpc` to `http/protobuf`, and the default endpoint port from `4317` to `4318`. This aligns Quarkus with the [OpenTelemetry 
specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.28.0/specification/protocol/exporter.md#specify-protocol) and its [Java implementation.](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/9993)

| | Before | After |
|---|---|---|
| Default protocol | `grpc` | `http/protobuf` |
| Default endpoint | `http://localhost:4317` | `http://localhost:4318` |

> [!WARNING]
> **Protocol and port must match.**

### Who is affected

- Applications that rely on the **default** OTLP exporter configuration (i.e., no explicit `quarkus.otel.exporter.otlp.protocol` or `quarkus.otel.exporter.otlp.endpoint` set)
- Applications sending telemetry to a collector that only listens on the gRPC port (4317)

If you already set `quarkus.otel.exporter.otlp.protocol` and `quarkus.otel.exporter.otlp.endpoint` explicitly, **no action is required**.

### How to migrate

#### Option 1: Accept the new default (recommended)

If your OTLP collector supports `http/protobuf` on port 4318 (most modern collectors do), no configuration change is needed. Just verify your collector is listening on port 4318.

#### Option 2: Keep using gRPC

If you need to continue using gRPC, explicitly set the protocol and endpoint:

```properties

# To all signals: 

quarkus.otel.exporter.otlp.protocol=grpc
quarkus.otel.exporter.otlp.endpoint=http://localhost:4317

# Or per-signal:

quarkus.otel.exporter.otlp.traces.protocol=grpc
quarkus.otel.exporter.otlp.traces.endpoint=http://localhost:4317

quarkus.otel.exporter.otlp.metrics.protocol=grpc
quarkus.otel.exporter.otlp.metrics.endpoint=http://localhost:4317

quarkus.otel.exporter.otlp.logs.protocol=grpc
quarkus.otel.exporter.otlp.logs.endpoint=http://localhost:4317
```

### Missconfiguraton example

After upgrading, if you see warnings like this in your application logs, your exporter protocol and collector port might be  mismatched:

```log
WARN  [io.qua.ope.run.exp.otl.sen.VertxHttpSender] Failed to export spans. The request could not be executed. Full error message: Connection refused: localhost/127.0.0.1:4318
``` 

  This means your collector is likely still listening only on port `4317` (gRPC). Either:
  - Configure your collector to also accept `http/protobuf` on port `4318`, or
  - Explicitly set the Quarkus exporter back to gRPC:



