### PR TITLE
Bump CycloneDX to `13.0.0`

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -19,7 +19,7 @@
         <bouncycastle.version>1.84</bouncycastle.version>
         <bouncycastle.fips.version>2.1.2</bouncycastle.fips.version>
         <bouncycastle.tls.fips.version>2.1.24</bouncycastle.tls.fips.version>
-        <cyclonedx.version>12.2.0</cyclonedx.version>
+        <cyclonedx.version>13.0.0</cyclonedx.version>
         <expressly.version>6.0.0</expressly.version>
         <findbugs.version>3.0.2</findbugs.version>
         <jandex.version>3.6.0</jandex.version>
@@ -5424,7 +5424,6 @@
                 <artifactId>cyclonedx-core-java</artifactId>
                 <version>${cyclonedx.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>org.wildfly.openssl</groupId>
                 <artifactId>wildfly-openssl-java</artifactId>

--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -22,6 +22,17 @@
         <quarkus.version>${project.version}</quarkus.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.networknt</groupId>
+                <artifactId>json-schema-validator</artifactId>
+                <!-- this needs to match what CycloneDX uses -->
+                <version>3.0.6</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/devui/deployment/pom.xml
+++ b/extensions/devui/deployment/pom.xml
@@ -63,20 +63,6 @@
                     <groupId>org.apache.maven.resolver</groupId>
                     <artifactId>maven-resolver-connector-basic</artifactId>
                 </exclusion>
-                <!-- 
-                Ideally `quarkus-devtools-common` would not have a dependency on Jackson 2, but currently that is not possible
-                 because `json-schema-validator` uses Jackson 2.
-                 Note that although there is a new version of the library that uses Jackson 3, we can't use that because CycloneDX uses
-                 `json-schema-validator` but not the version that leverages to Jackson 3
-                 -->
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.dataformat</groupId>
-                    <artifactId>jackson-dataformat-yaml</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
 

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -62,7 +62,7 @@
         <system-stubs-jupiter.version>2.0.2</system-stubs-jupiter.version>
         <awaitility.version>4.3.0</awaitility.version>
         <java-properties.version>0.0.7</java-properties.version>
-        <networknt-schema-validator.version>2.0.1</networknt-schema-validator.version>
+        <networknt-schema-validator.version>3.0.6</networknt-schema-validator.version>
     </properties>
     <modules>
         <module>registry-client</module>


### PR DESCRIPTION
This now allows us to completely
remove Jackson 2 from the `quarkus-devtools-common`
module, as CycloneDX now depends on a newer
`networknt-schema-validator` version which
uses Jackson 3

- Replaces: https://github.com/quarkusio/quarkus/pull/55808
