### PR TITLE
Scheduler: document halted start mode as a testing workaround

### DIFF
--- a/docs/src/main/asciidoc/scheduler-reference.adoc
+++ b/docs/src/main/asciidoc/scheduler-reference.adoc
@@ -579,6 +579,46 @@ The scheduler can be disabled through the runtime config property `quarkus.sched
 If set to `false` the scheduler is not started even though the application contains scheduled methods.
 You can even disable the scheduler for particular <<getting-started-testing#testing_different_profiles,Test Profiles>>.
 
+=== Controlling the Scheduler in Tests
+
+In a `@QuarkusTest` the scheduler normally starts after the test application bootstrap, which means that `@Scheduled` methods may be invoked _before_ the test infrastructure is ready; for example, before `@InjectMock` has had a chance to install mocks.
+If a scheduled method depends on a CDI bean that is mocked in the test, the first invocations can observe the real bean instead of the mock.
+
+To avoid this, start the scheduler in _halted_ mode and resume it manually in each test method after all mocks are configured:
+
+.application.properties
+[source,properties]
+----
+%test.quarkus.scheduler.start-mode=halted
+----
+
+.Test class
+[source,java]
+----
+@QuarkusTest
+class MyScheduledTest {
+
+    @Inject
+    Scheduler scheduler;
+
+    @InjectMock
+    MyService mock;
+
+    @Test
+    void testScheduledMethod() throws InterruptedException {
+        Mockito.when(mock.doWork()).thenReturn("test-value");
+        scheduler.resume(); // <1>
+        try {
+            // ...assert scheduled behavior
+        } finally {
+            scheduler.pause(); // <2>
+        }
+    }
+}
+----
+<1> Resume the scheduler after all mocks are configured so that `@Scheduled` methods only observe mocked beans.
+<2> Pause the scheduler again to prevent interference with subsequent test methods.
+
 == Metrics
 
 Some basic metrics are published out of the box if `quarkus.scheduler.metrics.enabled` is set to `true` and a metrics extension is present.


### PR DESCRIPTION
- describe how scheduled methods can fire before test infrastructure is ready, and how to avoid it by setting %test.quarkus.scheduler.start-mode=halted and manually resuming the scheduler in each test method
- resolves #55834

Note that we've tried to find a reasonable solution - see for example #55870, but it seems that every solution we can think of adds as many problems as it solves.