### PR TITLE
Guard against a JWT with no parts in OidcCommonUtils and OidcUtils

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -997,6 +997,10 @@ public class OidcCommonUtils {
 
     public static String getJwtContentPart(String jwt) {
         StringTokenizer tokens = new StringTokenizer(jwt, ".");
+        if (!tokens.hasMoreTokens()) {
+            // An empty or delimiter-only token has no parts at all.
+            return null;
+        }
         // part 1: skip the token headers
         tokens.nextToken();
         if (!tokens.hasMoreTokens()) {

--- a/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/OidcCommonUtilsTest.java
+++ b/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/OidcCommonUtilsTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.oidc.common.runtime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -584,6 +585,37 @@ public class OidcCommonUtilsTest {
             return null;
         }
         return encodedContent;
+    }
+
+    @Test
+    public void testDecodeJwtContentWithNoParts() {
+        // An empty or delimiter-only bearer token has zero StringTokenizer tokens.
+        // These used to throw NoSuchElementException out of getJwtContentPart, which
+        // escaped BearerAuthenticationMechanism as a non-AuthenticationFailedException
+        // and surfaced as HTTP 500 instead of a 401 challenge.
+        assertNull(OidcCommonUtils.decodeJwtContent(""));
+        assertNull(OidcCommonUtils.decodeJwtContent("."));
+        assertNull(OidcCommonUtils.decodeJwtContent(".."));
+        assertNull(OidcCommonUtils.decodeJwtContent("..."));
+        assertNull(OidcCommonUtils.decodeJwtContent("...."));
+    }
+
+    @Test
+    public void testGetJwtContentPartWithNoParts() {
+        assertNull(OidcCommonUtils.getJwtContentPart(""));
+        assertNull(OidcCommonUtils.getJwtContentPart("."));
+        assertNull(OidcCommonUtils.getJwtContentPart(".."));
+        assertNull(OidcCommonUtils.getJwtContentPart("..."));
+    }
+
+    @Test
+    public void testGetJwtContentPartStillRejectsWrongPartCounts() {
+        // Regression guard: the new zero-token check must not change how tokens
+        // with the wrong number of parts are treated.
+        assertNull(OidcCommonUtils.getJwtContentPart("onlyonepart"));
+        assertNull(OidcCommonUtils.getJwtContentPart("two.parts"));
+        assertNull(OidcCommonUtils.getJwtContentPart("a.b.c.d"));
+        assertEquals("b", OidcCommonUtils.getJwtContentPart("a.b.c"));
     }
 
     private static JsonObject decodeAsJsonObject(String encodedContent) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -265,11 +265,17 @@ public final class OidcUtils {
 
     public static JsonObject decodeJwtHeaders(String jwt) {
         StringTokenizer tokens = new StringTokenizer(jwt, ".");
+        if (!tokens.hasMoreTokens()) {
+            return null;
+        }
         return decodeAsJsonObject(tokens.nextToken());
     }
 
     public static String decodeJwtHeadersAsString(String jwt) {
         StringTokenizer tokens = new StringTokenizer(jwt, ".");
+        if (!tokens.hasMoreTokens()) {
+            return null;
+        }
         return base64UrlDecode(tokens.nextToken());
     }
 


### PR DESCRIPTION
Fixes #55887

As offered in the issue — thanks @sberyozkin, @geoand.

## The fix

`getJwtContentPart` already returns `null` for "not a JWT", and already guards its *second* `nextToken()`. It just never guarded the first:

```java
StringTokenizer tokens = new StringTokenizer(jwt, ".");
if (!tokens.hasMoreTokens()) {   // added
    return null;
}
// part 1: skip the token headers
tokens.nextToken();
```

`StringTokenizer` treats delimiters purely as separators, so an empty or dots-only token yields **zero** tokens and `nextToken()` threw `NoSuchElementException`. Since that isn't an `AuthenticationFailedException` it escaped `BearerAuthenticationMechanism`, and `AbstractHttpAuthorizer` turned it into `routingContext.fail(t)` — HTTP 500 with an ERROR stack trace, remotely triggerable by any unauthenticated caller on any bearer-protected endpoint. Access control was never affected; the request is still refused.

Because `null` is the method's existing "not a JWT" contract, no caller changes are needed: `isOpaqueToken` returns `true` and the request falls through to normal opaque/401 handling.

`OidcUtils.decodeJwtHeaders` and `decodeJwtHeadersAsString` carried the identical unguarded call — reachable via the `DPoP` header when `token.authorization-scheme=DPoP` — and are fixed the same way in this PR, as suggested in the issue.

## Tests

Three methods added to `OidcCommonUtilsTest`:

- `testDecodeJwtContentWithNoParts` — `""`, `"."`, `".."`, `"..."`, `"...."`
- `testGetJwtContentPartWithNoParts` — same set at the lower level
- `testGetJwtContentPartStillRejectsWrongPartCounts` — a **regression guard**, so the new check cannot quietly change how wrong-part-count tokens are treated: `"onlyonepart"`, `"two.parts"` and `"a.b.c.d"` stay `null` while `"a.b.c"` still yields `"b"`

## What I verified, and what I did not

I could not complete a local build: Quarkus `main` does not build on Java 25, and that is the only JDK on this machine — it fails in `quarkus-arc`, upstream of the modules touched here, so the failure is unrelated to this change. Rather than claim a test run I did not do, I extracted the post-patch method verbatim and ran it standalone:

```
"" . .. ... ....   -> null   (previously NoSuchElementException)
a.b.c              -> b      (unchanged)
a.b                -> null   (unchanged)
a.b.c.d            -> null   (unchanged)
onlyonepart        -> null   (unchanged)
```

So the behaviour is proven, but CI is the first full run of the added tests. Happy to adjust naming, placement, or split the `OidcUtils` change out if you'd prefer it separate.