### PR TITLE
Use AbstractConnection to prevent input loss, upgrade aesh to 3.16.8

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -204,8 +204,8 @@
         <!-- Check the compatibility matrix (https://github.com/opensearch-project/opensearch-testcontainers) before upgrading: -->
         <opensearch-testcontainers.version>2.1.3</opensearch-testcontainers.version>
         <com.dajudge.kindcontainer>2.0.0</com.dajudge.kindcontainer>
-        <aesh.version>3.16.6</aesh.version>
-        <aesh-readline.version>3.16.3</aesh-readline.version>
+        <aesh.version>3.16.8</aesh.version>
+        <aesh-readline.version>3.16.4</aesh-readline.version>
         <jline.version>4.2.1</jline.version> <!-- Keep in sync with dekorate -->
         <!-- these two artifacts needs to be compatible together -->
         <strimzi-oauth.version>0.16.1</strimzi-oauth.version>

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/CliConfigPromptTest.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/CliConfigPromptTest.java
@@ -106,7 +106,7 @@ public class CliConfigPromptTest {
 
         @Override
         public org.aesh.terminal.Device device() {
-            return null;
+            return new org.aesh.terminal.BaseDevice("test");
         }
 
         @Override

--- a/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/AeshStreamConnection.java
+++ b/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/AeshStreamConnection.java
@@ -5,38 +5,35 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.function.Consumer;
 
+import org.aesh.terminal.AbstractConnection;
 import org.aesh.terminal.Attributes;
 import org.aesh.terminal.BaseDevice;
-import org.aesh.terminal.Connection;
 import org.aesh.terminal.Device;
+import org.aesh.terminal.EventDecoder;
 import org.aesh.terminal.tty.Capability;
-import org.aesh.terminal.tty.Signal;
 import org.aesh.terminal.tty.Size;
 import org.aesh.terminal.utils.Parser;
 
 /**
- * A {@link Connection} backed by JDK {@link InputStream}/{@link OutputStream} pairs.
+ * A {@link org.aesh.terminal.Connection} backed by JDK {@link InputStream}/{@link OutputStream} pairs.
+ * <p>
+ * Extends {@link AbstractConnection} to leverage its {@link EventDecoder} which
+ * buffers input in a queue when no {@code stdinHandler} is set. This prevents
+ * input loss during the window between readline cycles where the handler is
+ * temporarily null (see <a href="https://github.com/aeshell/aesh-readline/issues/233">aesh-readline#233</a>).
  * <p>
  * Used by {@link CliRunner} when running in test mode. The test framework
  * provides the streams via {@link AeshTestConnectionHolder}, and this
  * class wraps them into a proper aesh Connection -- all within the
  * runtime classloader, avoiding cross-classloader type issues.
  */
-class AeshStreamConnection implements Connection {
+class AeshStreamConnection extends AbstractConnection {
 
     private final Device device = new BaseDevice("test");
     private final Size size = new Size(120, 40);
     private final InputStream input;
     private final OutputStream output;
-
-    private Consumer<Size> sizeHandler;
-    private Consumer<Signal> signalHandler;
-    private Consumer<int[]> stdinHandler;
-    private Consumer<int[]> stdoutHandler;
-    private Consumer<Void> closeHandler;
-    private Attributes attributes;
 
     private volatile boolean closed = false;
     private Thread readerThread;
@@ -44,7 +41,9 @@ class AeshStreamConnection implements Connection {
     AeshStreamConnection(InputStream input, OutputStream output) {
         this.input = input;
         this.output = output;
-        this.stdoutHandler = data -> {
+        this.attributes = new Attributes();
+        this.eventDecoder = new EventDecoder(this.attributes);
+        this.stdout = data -> {
             try {
                 String text = Parser.fromCodePoints(data);
                 output.write(text.getBytes(StandardCharsets.UTF_8));
@@ -66,55 +65,6 @@ class AeshStreamConnection implements Connection {
     }
 
     @Override
-    public Consumer<Size> sizeHandler() {
-        return sizeHandler;
-    }
-
-    @Override
-    public void setSizeHandler(Consumer<Size> handler) {
-        this.sizeHandler = handler;
-    }
-
-    @Override
-    public Consumer<Signal> signalHandler() {
-        return signalHandler;
-    }
-
-    @Override
-    public void setSignalHandler(Consumer<Signal> handler) {
-        this.signalHandler = handler;
-    }
-
-    @Override
-    public Consumer<int[]> stdinHandler() {
-        return stdinHandler;
-    }
-
-    @Override
-    public void setStdinHandler(Consumer<int[]> handler) {
-        this.stdinHandler = handler;
-        // When the stdinHandler is set, start reading from the input stream
-        if (handler != null && readerThread == null) {
-            startReader();
-        }
-    }
-
-    @Override
-    public Consumer<int[]> stdoutHandler() {
-        return stdoutHandler;
-    }
-
-    @Override
-    public void setCloseHandler(Consumer<Void> handler) {
-        this.closeHandler = handler;
-    }
-
-    @Override
-    public Consumer<Void> closeHandler() {
-        return closeHandler;
-    }
-
-    @Override
     public void close() {
         closed = true;
         // Close the input stream to unblock the reader thread
@@ -130,7 +80,6 @@ class AeshStreamConnection implements Connection {
 
     @Override
     public void openBlocking() {
-        // Start reading and block until closed
         startReader();
         try {
             if (readerThread != null) {
@@ -149,16 +98,6 @@ class AeshStreamConnection implements Connection {
     @Override
     public boolean put(Capability capability, Object... params) {
         return false;
-    }
-
-    @Override
-    public Attributes attributes() {
-        return attributes != null ? attributes : new Attributes();
-    }
-
-    @Override
-    public void setAttributes(Attributes attr) {
-        this.attributes = attr;
     }
 
     @Override
@@ -188,9 +127,12 @@ class AeshStreamConnection implements Connection {
                     if (n == -1) {
                         break;
                     }
-                    if (n > 0 && stdinHandler != null) {
+                    if (n > 0) {
                         String text = new String(buffer, 0, n, StandardCharsets.UTF_8);
-                        stdinHandler.accept(Parser.toCodePoints(text));
+                        // Deliver input via EventDecoder which buffers in its
+                        // inputQueue when stdinHandler is null, preventing
+                        // input loss between readline cycles.
+                        eventDecoder.accept(Parser.toCodePoints(text));
                     }
                 }
             } catch (IOException e) {
@@ -200,5 +142,4 @@ class AeshStreamConnection implements Connection {
         readerThread.setDaemon(true);
         readerThread.start();
     }
-
 }

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketAuthenticatedTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketAuthenticatedTest.java
@@ -98,6 +98,12 @@ public class AeshWebSocketAuthenticatedTest {
             var ws = ar.result();
             AeshWebSocketTestHelper.sendCommandOnPrompt(ws, "hello", "Hello World!", output, latch);
             ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+            // Retry init if server did not respond (handles slow JVMs like Semeru)
+            vertx.setTimer(2000, id -> {
+                if (output.length() == 0) {
+                    ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+                }
+            });
         });
 
         boolean completed = latch.await(30, TimeUnit.SECONDS);

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketConcurrentSessionsTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketConcurrentSessionsTest.java
@@ -81,6 +81,12 @@ public class AeshWebSocketConcurrentSessionsTest {
                     }).start();
 
                     ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+                    // Retry init if server did not respond (handles slow JVMs like Semeru)
+                    vertx.setTimer(2000, id -> {
+                        if (sessionOutput.length() == 0) {
+                            ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+                        }
+                    });
                 });
             }
 

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketConnectionTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketConnectionTest.java
@@ -58,6 +58,12 @@ public class AeshWebSocketConnectionTest {
             var ws = ar.result();
             AeshWebSocketTestHelper.sendCommandOnPrompt(ws, "hello", "Hello World!", output, latch);
             ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+            // Retry init if server did not respond (handles slow JVMs like Semeru)
+            vertx.setTimer(2000, id -> {
+                if (output.length() == 0) {
+                    ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+                }
+            });
         });
 
         boolean completed = latch.await(30, TimeUnit.SECONDS);

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketIdleTimeoutTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketIdleTimeoutTest.java
@@ -65,6 +65,12 @@ public class AeshWebSocketIdleTimeoutTest {
                 ws.closeHandler(v -> closedLatch.countDown());
 
                 ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+                // Retry init if server did not respond (handles slow JVMs like Semeru)
+                vertx.setTimer(2000, id -> {
+                    if (output.length() == 0) {
+                        ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+                    }
+                });
             });
 
             // Verify the command works

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketRolesAllowedTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketRolesAllowedTest.java
@@ -100,6 +100,12 @@ public class AeshWebSocketRolesAllowedTest {
             var ws = ar.result();
             AeshWebSocketTestHelper.sendCommandOnPrompt(ws, "hello", "Hello World!", output, latch);
             ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+            // Retry init if server did not respond (handles slow JVMs like Semeru)
+            vertx.setTimer(2000, id -> {
+                if (output.length() == 0) {
+                    ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+                }
+            });
         });
 
         boolean completed = latch.await(30, TimeUnit.SECONDS);


### PR DESCRIPTION
Extend AbstractConnection instead of implementing Connection directly in AeshStreamConnection.

Bump aesh to 3.16.8 and aesh-readline to 3.16.4

See: https://github.com/aeshell/aesh-readline/issues/233
See: https://github.com/aeshell/aesh/issues/570
