### PR TITLE
Fix PathTreeBuilder.getExcludes() returning the includes list

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTreeBuilder.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTreeBuilder.java
@@ -56,7 +56,7 @@ public class PathTreeBuilder {
     }
 
     List<String> getExcludes() {
-        return includes;
+        return excludes;
     }
 
     PathFilter getPathFilter() {

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/PathTreeBuilderTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/PathTreeBuilderTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PathTreeBuilderTest {
+
+    @Test
+    void getIncludesReturnsIncludes() {
+        PathTreeBuilder builder = new PathTreeBuilder().include("in*");
+        assertThat(builder.getIncludes()).containsExactly("in*");
+    }
+
+    @Test
+    void getExcludesReturnsExcludes() {
+        PathTreeBuilder builder = new PathTreeBuilder().exclude("ex*");
+        assertThat(builder.getExcludes()).containsExactly("ex*");
+    }
+
+    @Test
+    void includesAndExcludesAreIndependent() {
+        PathTreeBuilder builder = new PathTreeBuilder().include("in*").exclude("ex*");
+        assertThat(builder.getIncludes()).containsExactly("in*");
+        assertThat(builder.getExcludes()).containsExactly("ex*");
+    }
+}


### PR DESCRIPTION
Fixes the `getExcludes()` accessor in `PathTreeBuilder`, which returned the `includes` list instead of `excludes`. Adds a small unit test covering both accessors.

Part of #55815