### PR TITLE
Improve quarkus run command with auto-build and --clean fix

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/Run.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Run.java
@@ -1,11 +1,16 @@
 package io.quarkus.cli;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
+import io.quarkus.cli.common.BuildOptions;
 import io.quarkus.cli.common.BuildToolContext;
 import io.quarkus.cli.common.BuildToolDelegatingCommand;
+import io.quarkus.cli.common.build.BuildSystemRunner;
 import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
+import picocli.CommandLine.ExitCode;
 
 @CommandLine.Command(name = "run", sortOptions = false, mixinStandardHelpOptions = false, header = "Run application.")
 public class Run extends BuildToolDelegatingCommand {
@@ -15,6 +20,10 @@ public class Run extends BuildToolDelegatingCommand {
 
     @CommandLine.Option(names = { "--target" }, description = "Run target.")
     String target;
+
+    @CommandLine.Option(names = {
+            "--also-build" }, description = "Build the project before running if not already built. True by default.", negatable = true, defaultValue = "true")
+    boolean alsoBuild = true;
 
     @Override
     public void populateContext(BuildToolContext context) {
@@ -26,6 +35,85 @@ public class Run extends BuildToolDelegatingCommand {
     @Override
     public Map<BuildTool, String> getActionMapping() {
         return ACTION_MAPPING;
+    }
+
+    @Override
+    public void prepareMaven(BuildToolContext context) {
+        BuildSystemRunner runner = getRunner(context);
+        boolean cleanRequested = context.getBuildOptions().clean;
+        boolean needsBuild = cleanRequested || (alsoBuild && !isMavenProjectBuilt(context));
+
+        if (needsBuild) {
+            output.info(cleanRequested ? "Clean build requested, building project first..."
+                    : "Project not built yet, building automatically...");
+
+            // Use 'install' for the build action (same as 'quarkus build')
+            // Create separate build options that skip tests for faster builds
+            BuildOptions buildOpts = new BuildOptions();
+            buildOpts.clean = cleanRequested;
+            buildOpts.offline = context.getBuildOptions().offline;
+            buildOpts.buildNative = context.getBuildOptions().buildNative;
+            buildOpts.skipTests = true; // Skip tests when building as part of run
+
+            BuildSystemRunner.BuildCommandArgs buildArgs = runner.prepareAction("install", buildOpts,
+                    context.getRunModeOption(),
+                    context.getParams());
+
+            if (context.getRunModeOption().isDryRun()) {
+                output.info(" " + buildArgs.showCommand());
+            } else {
+                int buildExitCode = runner.run(buildArgs);
+                if (buildExitCode != ExitCode.OK) {
+                    throw new RuntimeException("Build failed with exit code: " + buildExitCode);
+                }
+            }
+
+            // Reset clean flag so that the subsequent 'quarkus:run' action (executed by
+            // the parent call() method) does NOT prepend another 'clean' phase.
+            // This fixes the double-clean bug reported in #41380.
+            context.getBuildOptions().clean = false;
+        } else {
+            // No build needed, but still need resources:resources for the run.
+            // Use fresh BuildOptions without clean to avoid the double-clean bug.
+            BuildOptions resourceOpts = new BuildOptions();
+            resourceOpts.offline = context.getBuildOptions().offline;
+
+            BuildSystemRunner.BuildCommandArgs compileArgs = runner.prepareAction("resources:resources",
+                    resourceOpts,
+                    context.getRunModeOption(),
+                    context.getParams());
+
+            if (getParentCommand().isPresent()) {
+                return;
+            } else if (context.getRunModeOption().isDryRun()) {
+                output.info(" " + compileArgs.showCommand());
+            } else {
+                int compileExitCode = runner.run(compileArgs);
+                if (compileExitCode != ExitCode.OK) {
+                    throw new RuntimeException(
+                            "Failed to compile. Compilation exited with exit code:" + compileExitCode);
+                }
+            }
+
+            // Also reset clean here to prevent 'quarkus:run' from getting a spurious clean
+            context.getBuildOptions().clean = false;
+        }
+    }
+
+    /**
+     * Checks if a Maven project has been built by looking for the target directory
+     * with compiled output.
+     */
+    private boolean isMavenProjectBuilt(BuildToolContext context) {
+        Path projectRoot = context.getProjectRoot();
+        Path targetDir = projectRoot.resolve("target");
+        if (!Files.isDirectory(targetDir)) {
+            return false;
+        }
+        // Check for quarkus-app directory (fast-jar packaging) or classes directory
+        Path quarkusApp = targetDir.resolve("quarkus-app");
+        Path classes = targetDir.resolve("classes");
+        return Files.isDirectory(quarkusApp) || Files.isDirectory(classes);
     }
 
     @Override


### PR DESCRIPTION
Improve the `quarkus run` CLI command to automatically build the project when needed and fix the double-clean bug.

## Changes

- **Auto-build detection**: Before running, checks if the project has been built (looks for `target/quarkus-app/` or `target/classes/`). If not, automatically runs `install` (same as `quarkus build`) before `quarkus:run`.
- **`--also-build` flag** (default: `true`): Controls whether auto-build is performed. Users can opt out with `--no-also-build`.
- **Fix double-clean bug**: When `--clean` is passed, the clean phase is applied only to the build invocation. The subsequent `quarkus:run` no longer receives a spurious `clean` prefix (previously it would clean what was just built).
- **Skip tests on auto-build**: When building as part of `run`, tests are skipped for faster startup.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| `quarkus run` (not built) | ❌ Fails | ✅ Auto-builds then runs |
| `quarkus run` (already built) | ✅ Works | ✅ Works (unchanged) |
| `quarkus run --clean` | ❌ Double-clean bug | ✅ Single clean + install, then run |
| `quarkus run --no-also-build` | N/A | Skips auto-build (old behavior) |

## Notes

- Only Maven is addressed in this PR. Gradle support can follow in a separate issue.
- The `install` action is used (consistent with `quarkus build`). If `package` is preferred for the run use case, happy to adjust.

* Fixes #41380