### PR TITLE
Remove unreachable duplicate Claims.groups branch in CognitoPrincipal

### DIFF
--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/CognitoPrincipal.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/CognitoPrincipal.java
@@ -40,8 +40,6 @@ public class CognitoPrincipal implements JsonWebToken {
     public <T> T getClaim(String claimName) {
         if (claimName.equals(Claims.groups)) {
             return (T) getGroups();
-        } else if (claimName.equals(Claims.groups)) {
-            return (T) getAudience();
         } else if (claimName.equals(Claims.exp)) {
             return (T) Long.valueOf(getExpirationTime());
         } else if (claimName.equals(Claims.iat)) {

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/CognitoPrincipal.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/CognitoPrincipal.java
@@ -37,8 +37,6 @@ public class CognitoPrincipal implements JsonWebToken {
     public <T> T getClaim(String claimName) {
         if (claimName.equals(Claims.groups)) {
             return (T) getGroups();
-        } else if (claimName.equals(Claims.groups)) {
-            return (T) getAudience();
         } else if (claimName.equals(Claims.exp)) {
             return (T) Long.valueOf(getExpirationTime());
         } else if (claimName.equals(Claims.iat)) {


### PR DESCRIPTION
`CognitoPrincipal.getClaim()` checked `Claims.groups` in two consecutive branches, so the second branch (returning `getAudience()`) was dead code that could never execute. The audience value is already returned by the `Claims.aud` branch. Removes the duplicate in both the `amazon-lambda-http` and `amazon-lambda-rest` copies.

Part of #55815