### PR TITLE
[3.x] Bump to Vert.x 4.5.32 and Netty 4.1.137.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -57,7 +57,7 @@
         <smallrye-context-propagation.version>2.3.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
-        <smallrye-openssl.version>0.1.4</smallrye-openssl.version>
+        <smallrye-openssl.version>0.2.3</smallrye-openssl.version>
         <smallrye-mutiny-vertx-binding.version>3.23.0</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.37.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.7.10</smallrye-stork.version>
@@ -113,7 +113,7 @@
         <wildfly-elytron.version>2.9.2.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.3.0</jboss-marshalling.version>
         <jboss-threads.version>3.9.2</jboss-threads.version>
-        <vertx.version>4.5.31</vertx.version>
+        <vertx.version>4.5.32</vertx.version>
         <httpclient5.version>5.6.1</httpclient5.version>
         <httpcore5.version>5.4.3</httpcore5.version>
         <httpclient.version>4.5.14</httpclient.version>
@@ -136,8 +136,8 @@
         <infinispan.version>16.0.13</infinispan.version>
         <infinispan.protostream.version>6.0.7</infinispan.protostream.version>
         <caffeine.version>3.2.4</caffeine.version>
-        <netty-tcnative.version>2.0.76.Final</netty-tcnative.version>
-        <netty.version>4.1.136.Final</netty.version>
+        <netty-tcnative.version>2.0.81.Final</netty-tcnative.version>
+        <netty.version>4.1.137.Final</netty.version>
         <brotli4j.version>1.23.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
@@ -172,7 +172,7 @@
         <snakeyaml.version>2.6</snakeyaml.version>
         <osgi.version>6.0.0</osgi.version>
         <mongo-client.version>5.6.5</mongo-client.version>
-        <proton-j.version>0.34.1</proton-j.version>
+        <proton-j.version>0.35.0</proton-j.version>
         <javaparser.version>3.28.2</javaparser.version>
         <flapdoodle.mongo.version>4.24.0</flapdoodle.mongo.version>
         <quarkus-spring-api.version>6.2.SP3</quarkus-spring-api.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -57,7 +57,7 @@
         <smallrye-context-propagation.version>2.3.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
-        <smallrye-openssl.version>0.1.4</smallrye-openssl.version>
+        <smallrye-openssl.version>0.2.3</smallrye-openssl.version>
         <smallrye-mutiny-vertx-binding.version>3.23.0</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.36.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.7.10</smallrye-stork.version>
@@ -113,7 +113,7 @@
         <wildfly-elytron.version>2.9.2.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.3.0</jboss-marshalling.version>
         <jboss-threads.version>3.9.2</jboss-threads.version>
-        <vertx.version>4.5.31</vertx.version>
+        <vertx.version>4.5.32</vertx.version>
         <httpclient5.version>5.6.1</httpclient5.version>
         <httpcore5.version>5.4.3</httpcore5.version>
         <httpclient.version>4.5.14</httpclient.version>
@@ -136,8 +136,8 @@
         <infinispan.version>16.0.13</infinispan.version>
         <infinispan.protostream.version>6.0.7</infinispan.protostream.version>
         <caffeine.version>3.2.4</caffeine.version>
-        <netty-tcnative.version>2.0.76.Final</netty-tcnative.version>
-        <netty.version>4.1.136.Final</netty.version>
+        <netty-tcnative.version>2.0.81.Final</netty-tcnative.version>
+        <netty.version>4.1.137.Final</netty.version>
         <brotli4j.version>1.23.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
@@ -172,7 +172,7 @@
         <snakeyaml.version>2.6</snakeyaml.version>
         <osgi.version>6.0.0</osgi.version>
         <mongo-client.version>5.6.5</mongo-client.version>
-        <proton-j.version>0.34.1</proton-j.version>
+        <proton-j.version>0.35.0</proton-j.version>
         <javaparser.version>3.28.2</javaparser.version>
         <flapdoodle.mongo.version>4.24.0</flapdoodle.mongo.version>
         <quarkus-spring-api.version>6.2.SP3</quarkus-spring-api.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -58,7 +58,7 @@
         <mutiny.version>3.3.0</mutiny.version>
         <smallrye-mutiny-vertx-core.version>3.23.0</smallrye-mutiny-vertx-core.version>
         <smallrye-common.version>2.19.0</smallrye-common.version>
-        <vertx.version>4.5.31</vertx.version>
+        <vertx.version>4.5.32</vertx.version>
         <rest-assured.version>6.0.0</rest-assured.version>
         <commons-logging-jboss-logging.version>2.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.22.0</jackson-bom.version>

--- a/independent-projects/vertx-utils/pom.xml
+++ b/independent-projects/vertx-utils/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
-        <vertx.version>4.5.31</vertx.version>
+        <vertx.version>4.5.32</vertx.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Release notes and corresponding Netty CVEs:
- https://netty.io/news/2026/08/06/4-1-137-Final.html
- https://github.com/vert-x3/wiki/wiki/4.5.32-Release-Notes

tcnative and smallrye-openssl are also aligned to match Netty requirements.

proton-j had to be bumped as well, or we'd get class not found exceptions.
