### PR TITLE
Fire `StartedExecution` CDI event for scheduled jobs

### DIFF
--- a/docs/src/main/asciidoc/scheduler-reference.adoc
+++ b/docs/src/main/asciidoc/scheduler-reference.adoc
@@ -62,6 +62,9 @@ Some CDI events are fired synchronously and asynchronously when specific events 
 |===
 |Type |Event description
 
+|`io.quarkus.scheduler.StartedExecution`
+|An execution of a scheduled job was started.
+
 |`io.quarkus.scheduler.SuccessfulExecution`
 |An execution of a scheduled job completed successfully.
 
@@ -70,6 +73,9 @@ Some CDI events are fired synchronously and asynchronously when specific events 
 
 |`io.quarkus.scheduler.SkippedExecution`
 |An execution of a scheduled job was skipped.
+
+|`io.quarkus.scheduler.DelayedExecution`
+|An execution of a scheduled job was delayed.
 
 |`io.quarkus.scheduler.SchedulerPaused`
 |The scheduler was paused.

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/ConcurrentExecutionSkipTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/ConcurrentExecutionSkipTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.scheduler.FailedExecution;
 import io.quarkus.scheduler.Scheduled;
 import io.quarkus.scheduler.SkippedExecution;
+import io.quarkus.scheduler.StartedExecution;
 import io.quarkus.scheduler.SuccessfulExecution;
 import io.quarkus.test.QuarkusExtensionTest;
 
@@ -34,8 +35,9 @@ public class ConcurrentExecutionSkipTest {
             if (Jobs.SKIPPED_LATCH.await(10, TimeUnit.SECONDS)) {
                 // Exactly one job is blocked
                 assertEquals(1, Jobs.COUNTER.get());
-                // Skipped Execution does not fire SuccessfulExecution event
+                // Skipped Execution does not fire SuccessfulExecution or StartedExecution event
                 assertEquals(0, Jobs.SUCCESS_COUNTER.get());
+                assertEquals(1, Jobs.STARTED_COUNTER.get());
                 // Unblock all executions
                 Jobs.BLOCKING_LATCH.countDown();
             } else {
@@ -58,11 +60,12 @@ public class ConcurrentExecutionSkipTest {
         static final AtomicInteger COUNTER = new AtomicInteger(0);
         static final AtomicInteger FAILING_COUNTER = new AtomicInteger(0);
         static final AtomicInteger SUCCESS_COUNTER = new AtomicInteger(0);
+        static final AtomicInteger STARTED_COUNTER = new AtomicInteger(0);
         static final AtomicInteger FAILURE_COUNTER = new AtomicInteger(0);
         static final CountDownLatch SKIPPED_LATCH = new CountDownLatch(1);
         static final CountDownLatch FAILED_LATCH = new CountDownLatch(1);
 
-        @Scheduled(every = "1s", concurrentExecution = SKIP)
+        @Scheduled(identity = "nonconcurrent", every = "1s", concurrentExecution = SKIP)
         void nonconcurrent() throws InterruptedException {
             COUNTER.incrementAndGet();
             if (!BLOCKING_LATCH.await(10, TimeUnit.SECONDS)) {
@@ -84,6 +87,12 @@ public class ConcurrentExecutionSkipTest {
 
         void onSuccess(@Observes SuccessfulExecution event) {
             SUCCESS_COUNTER.incrementAndGet();
+        }
+
+        void onStarted(@Observes StartedExecution event) {
+            if ("nonconcurrent".equals(event.getExecution().getTrigger().getId())) {
+                STARTED_COUNTER.incrementAndGet();
+            }
         }
 
         void onFailure(@Observes FailedExecution event) {

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/FailedExecutionTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/FailedExecutionTest.java
@@ -1,8 +1,11 @@
 package io.quarkus.quartz.test;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -13,6 +16,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.scheduler.FailedExecution;
 import io.quarkus.scheduler.Scheduled;
+import io.quarkus.scheduler.StartedExecution;
 import io.quarkus.test.QuarkusExtensionTest;
 
 public class FailedExecutionTest {
@@ -23,17 +27,31 @@ public class FailedExecutionTest {
                     .addClasses(FailedExecutionTest.Jobs.class));
 
     static final CountDownLatch ERROR_LATCH = new CountDownLatch(2);
+    static final CountDownLatch STARTED_LATCH = new CountDownLatch(2);
+    static final List<String> EVENT_ORDER = new CopyOnWriteArrayList<>();
     static FailedExecution failedExecution;
+    static StartedExecution startedExecution;
 
     @Test
     public void testTriggerErrorStatus() throws InterruptedException {
+        assertTrue(STARTED_LATCH.await(5, TimeUnit.SECONDS));
+        assertNotNull(startedExecution.getExecution());
         assertTrue(ERROR_LATCH.await(5, TimeUnit.SECONDS));
         assertInstanceOf(RuntimeException.class, failedExecution.getException());
+        assertTrue(EVENT_ORDER.indexOf("started") < EVENT_ORDER.indexOf("failed"),
+                "StartedExecution must fire before FailedExecution");
     }
 
     void observeFailedExecution(@Observes FailedExecution failedExecution) {
+        EVENT_ORDER.add("failed");
         FailedExecutionTest.failedExecution = failedExecution;
         ERROR_LATCH.countDown();
+    }
+
+    void observeStartedExecution(@Observes StartedExecution startedExecution) {
+        EVENT_ORDER.add("started");
+        FailedExecutionTest.startedExecution = startedExecution;
+        STARTED_LATCH.countDown();
     }
 
     static class Jobs {

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/SuccessfulExecutionTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/SuccessfulExecutionTest.java
@@ -1,7 +1,10 @@
 package io.quarkus.quartz.test;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -11,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.scheduler.Scheduled;
+import io.quarkus.scheduler.StartedExecution;
 import io.quarkus.scheduler.SuccessfulExecution;
 import io.quarkus.test.QuarkusExtensionTest;
 
@@ -22,16 +26,31 @@ public class SuccessfulExecutionTest {
                     .addClasses(SuccessfulExecutionTest.Jobs.class));
 
     static final CountDownLatch SUCCESS_LATCH = new CountDownLatch(2);
+    static final CountDownLatch STARTED_LATCH = new CountDownLatch(2);
+    static final List<String> EVENT_ORDER = new CopyOnWriteArrayList<>();
     static SuccessfulExecution successfulExecution;
+    static StartedExecution startedExecution;
 
     @Test
     public void testTriggerErrorStatus() throws InterruptedException {
+        assertTrue(STARTED_LATCH.await(5, TimeUnit.SECONDS));
+        assertNotNull(startedExecution.getExecution());
         assertTrue(SUCCESS_LATCH.await(5, TimeUnit.SECONDS));
+        assertNotNull(successfulExecution.getExecution());
+        assertTrue(EVENT_ORDER.indexOf("started") < EVENT_ORDER.indexOf("success"),
+                "StartedExecution must fire before SuccessfulExecution");
     }
 
-    void observeFailedExecution(@Observes SuccessfulExecution successfulExecution) {
+    void observeSuccessfulExecution(@Observes SuccessfulExecution successfulExecution) {
+        EVENT_ORDER.add("success");
         SuccessfulExecutionTest.successfulExecution = successfulExecution;
         SUCCESS_LATCH.countDown();
+    }
+
+    void observeStartedExecution(@Observes StartedExecution startedExecution) {
+        EVENT_ORDER.add("started");
+        SuccessfulExecutionTest.startedExecution = startedExecution;
+        STARTED_LATCH.countDown();
     }
 
     static class Jobs {

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
@@ -77,6 +77,7 @@ import io.quarkus.scheduler.Scheduler;
 import io.quarkus.scheduler.SchedulerPaused;
 import io.quarkus.scheduler.SchedulerResumed;
 import io.quarkus.scheduler.SkippedExecution;
+import io.quarkus.scheduler.StartedExecution;
 import io.quarkus.scheduler.SuccessfulExecution;
 import io.quarkus.scheduler.Trigger;
 import io.quarkus.scheduler.common.runtime.AbstractJobDefinition;
@@ -119,7 +120,8 @@ public class QuartzSchedulerImpl extends BaseScheduler implements QuartzSchedule
     public QuartzSchedulerImpl(SchedulerContext context, QuartzSupport quartzSupport,
             SchedulerRuntimeConfig schedulerRuntimeConfig,
             Event<SkippedExecution> skippedExecutionEvent, Event<SuccessfulExecution> successExecutionEvent,
-            Event<FailedExecution> failedExecutionEvent, Event<DelayedExecution> delayedExecutionEvent,
+            Event<FailedExecution> failedExecutionEvent, Event<StartedExecution> startedExecutionEvent,
+            Event<DelayedExecution> delayedExecutionEvent,
             Event<SchedulerPaused> schedulerPausedEvent,
             Event<SchedulerResumed> schedulerResumedEvent, Event<ScheduledJobPaused> scheduledJobPausedEvent,
             Event<ScheduledJobResumed> scheduledJobResumedEvent,
@@ -127,7 +129,8 @@ public class QuartzSchedulerImpl extends BaseScheduler implements QuartzSchedule
             Vertx vertx, SchedulerConfig schedulerConfig, Instance<JobInstrumenter> jobInstrumenter,
             ScheduledExecutorService blockingExecutor) {
         super(vertx, new CronParser(context.getCronType()), schedulerRuntimeConfig.overdueGracePeriod(),
-                new Events(skippedExecutionEvent, successExecutionEvent, failedExecutionEvent, delayedExecutionEvent,
+                new Events(skippedExecutionEvent, successExecutionEvent, failedExecutionEvent, startedExecutionEvent,
+                        delayedExecutionEvent,
                         schedulerPausedEvent, schedulerResumedEvent, scheduledJobPausedEvent, scheduledJobResumedEvent),
                 jobInstrumenter, blockingExecutor);
         this.shutdownWaitTime = quartzSupport.getRuntimeConfig().shutdownWaitTime();

--- a/extensions/scheduler/api/src/main/java/io/quarkus/scheduler/StartedExecution.java
+++ b/extensions/scheduler/api/src/main/java/io/quarkus/scheduler/StartedExecution.java
@@ -1,0 +1,25 @@
+package io.quarkus.scheduler;
+
+/**
+ * This event is fired synchronously and asynchronously when an execution of a scheduled method starts.
+ */
+public class StartedExecution {
+
+    private final ScheduledExecution execution;
+
+    public StartedExecution(ScheduledExecution execution) {
+        this.execution = execution;
+    }
+
+    public ScheduledExecution getExecution() {
+        return execution;
+    }
+
+    @Override
+    public String toString() {
+        return "Started execution of [" +
+                execution.getTrigger().getId() +
+                "]";
+    }
+
+}

--- a/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/BaseScheduler.java
+++ b/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/BaseScheduler.java
@@ -41,7 +41,7 @@ public class BaseScheduler {
             ConcurrentExecution concurrentExecution, Scheduled.SkipPredicate skipPredicate, JobInstrumenter instrumenter,
             Vertx vertx, boolean skipOffloadingInvoker,
             OptionalLong delay, ScheduledExecutorService blockingExecutor) {
-        invoker = new StatusEmitterInvoker(invoker, events.successExecution, events.failedExecution);
+        invoker = new StatusEmitterInvoker(invoker, events.successExecution, events.failedExecution, events.startedExecution);
         if (concurrentExecution == ConcurrentExecution.SKIP) {
             invoker = new SkipConcurrentExecutionInvoker(invoker, events.skippedExecution);
         }

--- a/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/Events.java
+++ b/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/Events.java
@@ -14,6 +14,7 @@ import io.quarkus.scheduler.ScheduledJobResumed;
 import io.quarkus.scheduler.SchedulerPaused;
 import io.quarkus.scheduler.SchedulerResumed;
 import io.quarkus.scheduler.SkippedExecution;
+import io.quarkus.scheduler.StartedExecution;
 import io.quarkus.scheduler.SuccessfulExecution;
 
 public final class Events {
@@ -23,6 +24,7 @@ public final class Events {
     public final Event<SkippedExecution> skippedExecution;
     public final Event<SuccessfulExecution> successExecution;
     public final Event<FailedExecution> failedExecution;
+    public final Event<StartedExecution> startedExecution;
     public final Event<DelayedExecution> delayedExecution;
     public final Event<SchedulerPaused> schedulerPaused;
     public final Event<SchedulerResumed> schedulerResumed;
@@ -30,13 +32,15 @@ public final class Events {
     public final Event<ScheduledJobResumed> scheduledJobResumed;
 
     public Events(Event<SkippedExecution> skippedExecution, Event<SuccessfulExecution> successExecution,
-            Event<FailedExecution> failedExecution, Event<DelayedExecution> delayedExecution,
+            Event<FailedExecution> failedExecution, Event<StartedExecution> startedExecution,
+            Event<DelayedExecution> delayedExecution,
             Event<SchedulerPaused> schedulerPaused, Event<SchedulerResumed> schedulerResumed,
             Event<ScheduledJobPaused> scheduledJobPaused, Event<ScheduledJobResumed> scheduledJobResumed) {
         super();
         this.skippedExecution = skippedExecution;
         this.successExecution = successExecution;
         this.failedExecution = failedExecution;
+        this.startedExecution = startedExecution;
         this.delayedExecution = delayedExecution;
         this.schedulerPaused = schedulerPaused;
         this.schedulerResumed = schedulerResumed;

--- a/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/StatusEmitterInvoker.java
+++ b/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/StatusEmitterInvoker.java
@@ -8,11 +8,13 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.scheduler.FailedExecution;
 import io.quarkus.scheduler.ScheduledExecution;
+import io.quarkus.scheduler.StartedExecution;
 import io.quarkus.scheduler.SuccessfulExecution;
 
 /**
- * An invoker wrapper that fires CDI events when an execution of a scheduled method is finished.
+ * An invoker wrapper that fires CDI events when an execution of a scheduled method is started and finished.
  *
+ * @see StartedExecution
  * @see SuccessfulExecution
  * @see FailedExecution
  */
@@ -22,16 +24,19 @@ public final class StatusEmitterInvoker extends DelegateInvoker {
 
     private final Event<SuccessfulExecution> successfulEvent;
     private final Event<FailedExecution> failedEvent;
+    private final Event<StartedExecution> startedEvent;
 
     public StatusEmitterInvoker(ScheduledInvoker delegate, Event<SuccessfulExecution> successfulEvent,
-            Event<FailedExecution> failedEvent) {
+            Event<FailedExecution> failedEvent, Event<StartedExecution> startedEvent) {
         super(delegate);
         this.successfulEvent = successfulEvent;
         this.failedEvent = failedEvent;
+        this.startedEvent = startedEvent;
     }
 
     @Override
     public CompletionStage<Void> invoke(ScheduledExecution execution) throws Exception {
+        Events.fire(startedEvent, new StartedExecution(execution));
         return invokeDelegate(execution).whenComplete((v, t) -> {
             if (t != null) {
                 LOG.errorf(t, "Error occurred while executing task for trigger %s", execution.getTrigger());

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/ConcurrentExecutionSkipTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/ConcurrentExecutionSkipTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.scheduler.FailedExecution;
 import io.quarkus.scheduler.Scheduled;
 import io.quarkus.scheduler.SkippedExecution;
+import io.quarkus.scheduler.StartedExecution;
 import io.quarkus.scheduler.SuccessfulExecution;
 import io.quarkus.test.QuarkusExtensionTest;
 
@@ -34,8 +35,9 @@ public class ConcurrentExecutionSkipTest {
             if (Jobs.SKIPPED_LATCH.await(10, TimeUnit.SECONDS)) {
                 // Exactly one job is blocked
                 assertEquals(1, Jobs.COUNTER.get());
-                // Skipped Execution does not fire SuccessfulExecution event
+                // Skipped Execution does not fire SuccessfulExecution or StartedExecution event
                 assertEquals(0, Jobs.SUCCESS_COUNTER.get());
+                assertEquals(1, Jobs.STARTED_COUNTER.get());
                 // Unblock all executions
                 Jobs.BLOCKING_LATCH.countDown();
             } else {
@@ -58,11 +60,12 @@ public class ConcurrentExecutionSkipTest {
         static final AtomicInteger COUNTER = new AtomicInteger(0);
         static final AtomicInteger FAILING_COUNTER = new AtomicInteger(0);
         static final AtomicInteger SUCCESS_COUNTER = new AtomicInteger(0);
+        static final AtomicInteger STARTED_COUNTER = new AtomicInteger(0);
         static final AtomicInteger FAILURE_COUNTER = new AtomicInteger(0);
         static final CountDownLatch SKIPPED_LATCH = new CountDownLatch(1);
         static final CountDownLatch FAILED_LATCH = new CountDownLatch(1);
 
-        @Scheduled(every = "1s", concurrentExecution = SKIP)
+        @Scheduled(identity = "nonconcurrent", every = "1s", concurrentExecution = SKIP)
         void nonconcurrent() throws InterruptedException {
             COUNTER.incrementAndGet();
             if (!BLOCKING_LATCH.await(10, TimeUnit.SECONDS)) {
@@ -84,6 +87,12 @@ public class ConcurrentExecutionSkipTest {
 
         void onSuccess(@Observes SuccessfulExecution event) {
             SUCCESS_COUNTER.incrementAndGet();
+        }
+
+        void onStarted(@Observes StartedExecution event) {
+            if ("nonconcurrent".equals(event.getExecution().getTrigger().getId())) {
+                STARTED_COUNTER.incrementAndGet();
+            }
         }
 
         void onFailure(@Observes FailedExecution event) {

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/FailedExecutionTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/FailedExecutionTest.java
@@ -1,8 +1,11 @@
 package io.quarkus.scheduler.test;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -13,6 +16,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.scheduler.FailedExecution;
 import io.quarkus.scheduler.Scheduled;
+import io.quarkus.scheduler.StartedExecution;
 import io.quarkus.test.QuarkusExtensionTest;
 
 public class FailedExecutionTest {
@@ -23,17 +27,31 @@ public class FailedExecutionTest {
                     .addClasses(FailedExecutionTest.Jobs.class));
 
     static final CountDownLatch ERROR_LATCH = new CountDownLatch(2);
+    static final CountDownLatch STARTED_LATCH = new CountDownLatch(2);
+    static final List<String> EVENT_ORDER = new CopyOnWriteArrayList<>();
     static FailedExecution failedExecution;
+    static StartedExecution startedExecution;
 
     @Test
     public void testTriggerErrorStatus() throws InterruptedException {
+        assertTrue(STARTED_LATCH.await(5, TimeUnit.SECONDS));
+        assertNotNull(startedExecution.getExecution());
         assertTrue(ERROR_LATCH.await(5, TimeUnit.SECONDS));
         assertInstanceOf(RuntimeException.class, failedExecution.getException());
+        assertTrue(EVENT_ORDER.indexOf("started") < EVENT_ORDER.indexOf("failed"),
+                "StartedExecution must fire before FailedExecution");
     }
 
     void observeFailedExecution(@Observes FailedExecution failedExecution) {
+        EVENT_ORDER.add("failed");
         FailedExecutionTest.failedExecution = failedExecution;
         ERROR_LATCH.countDown();
+    }
+
+    void observeStartedExecution(@Observes StartedExecution startedExecution) {
+        EVENT_ORDER.add("started");
+        FailedExecutionTest.startedExecution = startedExecution;
+        STARTED_LATCH.countDown();
     }
 
     static class Jobs {

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/SuccessfulExecutionTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/SuccessfulExecutionTest.java
@@ -1,7 +1,10 @@
 package io.quarkus.scheduler.test;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -11,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.scheduler.Scheduled;
+import io.quarkus.scheduler.StartedExecution;
 import io.quarkus.scheduler.SuccessfulExecution;
 import io.quarkus.test.QuarkusExtensionTest;
 
@@ -22,16 +26,31 @@ public class SuccessfulExecutionTest {
                     .addClasses(Jobs.class));
 
     static final CountDownLatch SUCCESS_LATCH = new CountDownLatch(2);
+    static final CountDownLatch STARTED_LATCH = new CountDownLatch(2);
+    static final List<String> EVENT_ORDER = new CopyOnWriteArrayList<>();
     static SuccessfulExecution successfulExecution;
+    static StartedExecution startedExecution;
 
     @Test
     public void testTriggerErrorStatus() throws InterruptedException {
+        assertTrue(STARTED_LATCH.await(5, TimeUnit.SECONDS));
+        assertNotNull(startedExecution.getExecution());
         assertTrue(SUCCESS_LATCH.await(5, TimeUnit.SECONDS));
+        assertNotNull(successfulExecution.getExecution());
+        assertTrue(EVENT_ORDER.indexOf("started") < EVENT_ORDER.indexOf("success"),
+                "StartedExecution must fire before SuccessfulExecution");
     }
 
-    void observeFailedExecution(@Observes SuccessfulExecution successfulExecution) {
+    void observeSuccessfulExecution(@Observes SuccessfulExecution successfulExecution) {
+        EVENT_ORDER.add("success");
         SuccessfulExecutionTest.successfulExecution = successfulExecution;
         SUCCESS_LATCH.countDown();
+    }
+
+    void observeStartedExecution(@Observes StartedExecution startedExecution) {
+        EVENT_ORDER.add("started");
+        SuccessfulExecutionTest.startedExecution = startedExecution;
+        STARTED_LATCH.countDown();
     }
 
     static class Jobs {

--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SimpleScheduler.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SimpleScheduler.java
@@ -46,6 +46,7 @@ import io.quarkus.scheduler.Scheduler;
 import io.quarkus.scheduler.SchedulerPaused;
 import io.quarkus.scheduler.SchedulerResumed;
 import io.quarkus.scheduler.SkippedExecution;
+import io.quarkus.scheduler.StartedExecution;
 import io.quarkus.scheduler.SuccessfulExecution;
 import io.quarkus.scheduler.Trigger;
 import io.quarkus.scheduler.common.runtime.AbstractJobDefinition;
@@ -78,13 +79,15 @@ public class SimpleScheduler extends BaseScheduler implements Scheduler {
 
     public SimpleScheduler(SchedulerContext context, SchedulerRuntimeConfig schedulerRuntimeConfig,
             Event<SkippedExecution> skippedExecutionEvent, Event<SuccessfulExecution> successExecutionEvent,
-            Event<FailedExecution> failedExecutionEvent, Event<DelayedExecution> delayedExecutionEvent,
+            Event<FailedExecution> failedExecutionEvent, Event<StartedExecution> startedExecutionEvent,
+            Event<DelayedExecution> delayedExecutionEvent,
             Event<SchedulerPaused> schedulerPausedEvent, Event<SchedulerResumed> schedulerResumedEvent,
             Event<ScheduledJobPaused> scheduledJobPausedEvent,
             Event<ScheduledJobResumed> scheduledJobResumedEvent, Vertx vertx, SchedulerConfig schedulerConfig,
             Instance<JobInstrumenter> jobInstrumenter, ScheduledExecutorService blockingExecutor) {
         super(vertx, new CronParser(context.getCronType()), schedulerRuntimeConfig.overdueGracePeriod(),
-                new Events(skippedExecutionEvent, successExecutionEvent, failedExecutionEvent, delayedExecutionEvent,
+                new Events(skippedExecutionEvent, successExecutionEvent, failedExecutionEvent, startedExecutionEvent,
+                        delayedExecutionEvent,
                         schedulerPausedEvent, schedulerResumedEvent, scheduledJobPausedEvent, scheduledJobResumedEvent),
                 jobInstrumenter, blockingExecutor);
         this.running = true;


### PR DESCRIPTION
Resolves #55911

Adds a CDI event fired sync/async whenever scheduler starts an execution. Reuses logic we already have in `StatusEmitterInvoker` to achieve that.
Enriches existing tests to verify the events is fired in positive cases, respects ordering compared to events and is not fired in case of skipped execution.

FTR I picked the name `StartedExecution` since that aligns with many others we have but I don't mind picking another name.

Also adds missing `DelayedExecution` to the docs events table.

FYI @victoralc