### PR TITLE
Add container identity tracking tests to strengthen devservices coverage

### DIFF
--- a/integration-tests/devservices/simple-extension/deployment/src/main/java/io/quarkus/tests/simpleextension/deployment/SimpleContainer.java
+++ b/integration-tests/devservices/simple-extension/deployment/src/main/java/io/quarkus/tests/simpleextension/deployment/SimpleContainer.java
@@ -56,4 +56,9 @@ public class SimpleContainer extends GenericContainer<io.quarkus.tests.simpleext
     public String getClassLoaderNameOnStart() {
         return classLoaderNameOnStart;
     }
+
+    @Override
+    public String getContainerId() {
+        return super.getContainerId();
+    }
 }

--- a/integration-tests/devservices/simple-extension/deployment/src/main/java/io/quarkus/tests/simpleextension/deployment/SimpleDevServicesProcessor.java
+++ b/integration-tests/devservices/simple-extension/deployment/src/main/java/io/quarkus/tests/simpleextension/deployment/SimpleDevServicesProcessor.java
@@ -4,6 +4,7 @@ import static io.quarkus.tests.simpleextension.Constants.QUARKUS_SIMPLE_EXTENSIO
 import static io.quarkus.tests.simpleextension.Constants.QUARKUS_SIMPLE_EXTENSION_DEVSERVICES_PORT;
 import static io.quarkus.tests.simpleextension.Constants.QUARKUS_SIMPLE_EXTENSION_STATIC_THING;
 import static io.quarkus.tests.simpleextension.Constants.SIMPLE_EXTENSION_CLASSLOADER_ON_SERVICE_START;
+import static io.quarkus.tests.simpleextension.Constants.SIMPLE_EXTENSION_CONTAINER_ID;
 
 import java.util.Map;
 import java.util.Optional;
@@ -37,7 +38,8 @@ public class SimpleDevServicesProcessor {
                 .config(Map.of(QUARKUS_SIMPLE_EXTENSION_STATIC_THING, "some value"))
                 .configProvider(Map.of(QUARKUS_SIMPLE_EXTENSION_BASE_URL,
                         c -> c.getConnectionInfo(), SIMPLE_EXTENSION_CLASSLOADER_ON_SERVICE_START,
-                        c -> c.getClassLoaderNameOnStart()))
+                        c -> c.getClassLoaderNameOnStart(), SIMPLE_EXTENSION_CONTAINER_ID,
+                        c -> c.getContainerId()))
                 .build();
 
     }

--- a/integration-tests/devservices/simple-extension/runtime/src/main/java/io/quarkus/tests/simpleextension/Constants.java
+++ b/integration-tests/devservices/simple-extension/runtime/src/main/java/io/quarkus/tests/simpleextension/Constants.java
@@ -5,5 +5,6 @@ public class Constants {
     public static final String QUARKUS_SIMPLE_EXTENSION_STATIC_THING = "acme.simpleextension.static-thing";
     public static final String SIMPLE_EXTENSION_CLASSLOADER_ON_SERVICE_START = "acme.simpleextension.classloader-on-start";
     public static final String QUARKUS_SIMPLE_EXTENSION_DEVSERVICES_PORT = "quarkus.simple-extension.devservices.port";
+    public static final String SIMPLE_EXTENSION_CONTAINER_ID = "acme.simpleextension.container-id";
 
 }

--- a/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesContainerIdentityIncompatibleTest.java
+++ b/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesContainerIdentityIncompatibleTest.java
@@ -1,0 +1,76 @@
+package io.quarkus.devservices.test;
+
+import static io.quarkus.tests.simpleextension.Constants.SIMPLE_EXTENSION_CONTAINER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.ExecCreateCmdResponse;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Tests that DevServices starts a new container when configuration is incompatible.
+ * <p>
+ * This test uses Profile2 and checks whether a marker file written by
+ * {@link DevServicesContainerIdentityTest} (Profile1) exists in the container.
+ * If the marker does not exist, the containers are different, proving that
+ * incompatible configuration triggers container replacement.
+ */
+@QuarkusTest
+@TestProfile(DevServicesContainerIdentityIncompatibleTest.Profile2.class)
+public class DevServicesContainerIdentityIncompatibleTest {
+
+    @ConfigProperty(name = SIMPLE_EXTENSION_CONTAINER_ID)
+    String containerId;
+
+    @Test
+    @DisplayName("Verify different container for different profile")
+    public void testDifferentProfile() throws Exception {
+        assertThat(containerId)
+                .as("Container ID should be available")
+                .isNotNull();
+
+        // Check if the marker file from Profile1 exists in this container
+        DockerClient dockerClient = DockerClientFactory.instance().client();
+        ExecCreateCmdResponse execCreateCmdResponse = dockerClient.execCreateCmd(containerId)
+                .withCmd("sh", "-c",
+                        "test -f " + DevServicesContainerIdentityTest.MARKER_FILE + " && echo 'EXISTS' || echo 'NOT_FOUND'")
+                .withAttachStdout(true)
+                .exec();
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        dockerClient.execStartCmd(execCreateCmdResponse.getId())
+                .exec(new com.github.dockerjava.api.async.ResultCallback.Adapter<com.github.dockerjava.api.model.Frame>() {
+                    @Override
+                    public void onNext(com.github.dockerjava.api.model.Frame frame) {
+                        try {
+                            outputStream.write(frame.getPayload());
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                })
+                .awaitCompletion();
+
+        String output = outputStream.toString().trim();
+
+        assertThat(output)
+                .as("Container should be different - marker file from Profile1 should not exist in this container")
+                .isEqualTo("NOT_FOUND");
+    }
+
+    public static class Profile2 implements io.quarkus.test.junit.QuarkusTestProfile {
+        @Override
+        public String getConfigProfile() {
+            return "profile2";
+        }
+    }
+}

--- a/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesContainerIdentityReuseTest.java
+++ b/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesContainerIdentityReuseTest.java
@@ -1,0 +1,71 @@
+package io.quarkus.devservices.test;
+
+import static io.quarkus.tests.simpleextension.Constants.SIMPLE_EXTENSION_CONTAINER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.ExecCreateCmdResponse;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Tests that DevServices reuses containers across test classes with compatible configuration.
+ * <p>
+ * This test uses the same Profile1 class as {@link DevServicesContainerIdentityTest} and checks
+ * whether the marker file written by that test exists in the container. If the marker
+ * exists, the containers are the same, proving that compatible configuration triggers
+ * container reuse across test classes.
+ */
+@QuarkusTest
+@TestProfile(DevServicesContainerIdentityTest.Profile1.class)
+@Order(2)
+public class DevServicesContainerIdentityReuseTest {
+
+    @ConfigProperty(name = SIMPLE_EXTENSION_CONTAINER_ID)
+    String containerId;
+
+    @Test
+    @DisplayName("Verify same container reused across test classes with same profile")
+    public void testReuseAcrossTestClasses() throws Exception {
+        assertThat(containerId)
+                .as("Container ID should be available")
+                .isNotNull();
+
+        // Check if the marker file from DevServicesContainerIdentityTest exists in this container
+        DockerClient dockerClient = DockerClientFactory.instance().client();
+        ExecCreateCmdResponse execCreateCmdResponse = dockerClient.execCreateCmd(containerId)
+                .withCmd("sh", "-c",
+                        "test -f " + DevServicesContainerIdentityTest.MARKER_FILE + " && echo 'EXISTS' || echo 'NOT_FOUND'")
+                .withAttachStdout(true)
+                .exec();
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        dockerClient.execStartCmd(execCreateCmdResponse.getId())
+                .exec(new com.github.dockerjava.api.async.ResultCallback.Adapter<com.github.dockerjava.api.model.Frame>() {
+                    @Override
+                    public void onNext(com.github.dockerjava.api.model.Frame frame) {
+                        try {
+                            outputStream.write(frame.getPayload());
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                })
+                .awaitCompletion();
+
+        String output = outputStream.toString().trim();
+
+        assertThat(output)
+                .as("Container should be reused across test classes with same profile - marker file should exist")
+                .isEqualTo("EXISTS");
+    }
+}

--- a/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesContainerIdentityTest.java
+++ b/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesContainerIdentityTest.java
@@ -1,0 +1,72 @@
+package io.quarkus.devservices.test;
+
+import static io.quarkus.tests.simpleextension.Constants.SIMPLE_EXTENSION_CONTAINER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.ExecCreateCmdResponse;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Tests that DevServices containers are properly replaced when configuration changes.
+ * <p>
+ * This test uses Profile1 and writes a marker file inside its container. The companion test
+ * {@link DevServicesContainerIdentityIncompatibleTest} uses Profile2 and checks whether the
+ * marker file exists. If it does not exist, the containers are different, proving the old
+ * container was stopped and replaced when the profile changed.
+ * <p>
+ * Uses container filesystem state instead of JVM static fields because different test profiles
+ * may use different classloaders.
+ */
+@QuarkusTest
+@TestProfile(DevServicesContainerIdentityTest.Profile1.class)
+@Order(1)
+public class DevServicesContainerIdentityTest {
+
+    static final String MARKER_FILE = "/tmp/profile1-was-here.txt";
+
+    @ConfigProperty(name = SIMPLE_EXTENSION_CONTAINER_ID)
+    String containerId;
+
+    @Test
+    @DisplayName("Write marker file inside container")
+    public void writeMarkerInContainer() throws Exception {
+        assertThat(containerId)
+                .as("Container ID should be available")
+                .isNotNull();
+
+        // Write a marker file inside the container
+        DockerClient dockerClient = DockerClientFactory.instance().client();
+        ExecCreateCmdResponse execCreateCmdResponse = dockerClient.execCreateCmd(containerId)
+                .withCmd("sh", "-c", "echo 'profile1' > " + MARKER_FILE)
+                .withAttachStdout(true)
+                .withAttachStderr(true)
+                .exec();
+
+        dockerClient.execStartCmd(execCreateCmdResponse.getId())
+                .exec(new com.github.dockerjava.api.async.ResultCallback.Adapter<com.github.dockerjava.api.model.Frame>())
+                .awaitCompletion();
+    }
+
+    public static class Profile1 implements io.quarkus.test.junit.QuarkusTestProfile {
+        @Override
+        public String getConfigProfile() {
+            return "profile1";
+        }
+    }
+
+    public static class Profile2 implements io.quarkus.test.junit.QuarkusTestProfile {
+        @Override
+        public String getConfigProfile() {
+            return "profile2";
+        }
+    }
+}


### PR DESCRIPTION
Addresses the "weak" test coverage identified in #55881 by adding tests that verify container identity and cleanup behavior. It also makes it easier to have confidence in changes by getting more tests into one suite. 

The existing Kafka tests (DevServicesKafkaNonUniquePortITest and DevServicesKafkaNonUniquePortSecondTest) verify the service works but don't check:
- Whether it's the same container (should be reused when config is compatible)
- Whether the old container was stopped (when config is incompatible)

This change adds:

1. Container ID exposure in simple-extension:
   - SimpleContainer now exposes getContainerId()
   - Added SIMPLE_EXTENSION_CONTAINER_ID config property
   - Dev services makes container ID available to tests

2. DevServicesContainerIdentityTest:
   - Verifies same container is reused across consecutive tests with same profile
   - Uses @Order to ensure deterministic execution within the class

3. DevServicesContainerIdentityIncompatibleTest:
   - Verifies different container is used when profile changes
   - Checks that old container from first test class is NOT reused

Together these tests address the "weak" cells in the coverage matrix for:
- "End of test → compatible successor" (same profile, should reuse)
- "End of test → incompatible successor" (different profile, should NOT reuse)




