### PR TITLE
Qute: support multi-pipe CDATA delimiters

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -159,6 +159,16 @@ Unparsed Character Data::
 It is used to mark the content that should be rendered but _not parsed_.
 It starts with the sequence `{|`  and ends with the sequence `|}`: `{| <script>if(true){alert('Qute is cute!')};</script> |}`, and could be multi-line.
 +
+The number of `|` (pipe) characters in the opening delimiter can be increased to avoid conflicts with content that itself contains `|}`.
+The closing delimiter must use the same number of pipes as the opening delimiter.
+For example, `{||||` starts an unparsed block that only ends with `||||}`, making it safe to include `|}` in the content: `{|||| content with |} inside ||||}`.
++
+[NOTE]
+====
+Consecutive `|` characters immediately after `{|` are now counted as part of the opening delimiter.
+For example, `{||foo|}` was previously interpreted as single-pipe unparsed character data with content `|foo`, but is now interpreted as a double-pipe opening that requires `||}` to close.
+====
++
 [WARNING]
 ====
 Previously, unparsed character data could start with `{[` and end with `]}`. This syntax is now removed due to common collisions with constructs from other languages.

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
@@ -81,6 +81,7 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
     private final Deque<Scope> scopeStack;
     private int sectionBlockIdx;
     private boolean ignoreContent;
+    private int cdataPipeCount;
     private AtomicInteger expressionIdGenerator;
     private final List<Function<String, String>> contentFilters;
     private boolean hasLineSeparator;
@@ -331,19 +332,29 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
     }
 
     private void cdata(char character) {
-        if (character == END_DELIMITER && buffer.length() > 0
-                && isCdataEnd(buffer.charAt(buffer.length() - 1))) {
+        if (character == CDATA_START_DELIMITER && buffer.length() == 0) {
+            cdataPipeCount++;
+            return;
+        }
+        if (character == END_DELIMITER && buffer.length() >= cdataPipeCount
+                && isCdataEnd()) {
             // End of cdata
             state = State.TEXT;
-            buffer.deleteCharAt(buffer.length() - 1);
+            buffer.delete(buffer.length() - cdataPipeCount, buffer.length());
             flushText();
         } else {
             buffer.append(character);
         }
     }
 
-    private boolean isCdataEnd(char character) {
-        return character == CDATA_END_DELIMITER;
+    private boolean isCdataEnd() {
+        int start = buffer.length() - cdataPipeCount;
+        for (int i = start; i < buffer.length(); i++) {
+            if (buffer.charAt(i) != CDATA_END_DELIMITER) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private void tag(char character) {
@@ -380,6 +391,7 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
                 buffer.append(character);
                 state = State.COMMENT;
             } else if (character == CDATA_START_DELIMITER) {
+                cdataPipeCount = 1;
                 state = State.CDATA;
             } else {
                 buffer.append(character);

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
@@ -280,6 +280,20 @@ public class ParserTest {
                 + "|}").data("name", "world").render());
         assertEquals("Hello world <strong>", engine.parse("Hello {name} {|<strong>|}").data("name", "world").render());
         assertEquals("Hello {name} world", engine.parse("Hello{| {name} |}{name}").data("name", "world").render());
+
+        // Multi-pipe CDATA: 4 pipes
+        assertEquals("hello", engine.parse("{||||hello||||}").render());
+        // Multi-pipe CDATA: 3 pipes
+        assertEquals("text", engine.parse("{|||text|||}").render());
+        // Multi-pipe CDATA: content with |} inside is safe
+        assertEquals("hello |}world", engine.parse("{||||hello |}world||||}").render());
+        // Multi-pipe CDATA: content with ||} inside is safe
+        assertEquals("x |||}y", engine.parse("{||||x |||}y||||}").render());
+        // Multi-pipe CDATA alongside regular expressions
+        assertEquals("Hello world safe|}end",
+                engine.parse("Hello {name} {||||safe|}end||||}").data("name", "world").render());
+        // Multi-pipe CDATA: content with Qute expressions is not parsed
+        assertEquals("{name}", engine.parse("{|||{name}|||}").render());
     }
 
     @Test


### PR DESCRIPTION
- the number of pipe characters in the opening CDATA delimiter now determines how many are required in the closing delimiter
- this allows content containing |} to be safely wrapped, e.g. "{|||| content |} here ||||}"
- resolves #48889

@ia3andy It is not exactly what you're asking for (custom escape expressions), but it should solve the problem. WDYT?
