### PR TITLE
Make sure liquibase extensions don't fail on missing change logs

### DIFF
--- a/extensions/liquibase/liquibase-mongodb/deployment/pom.xml
+++ b/extensions/liquibase/liquibase-mongodb/deployment/pom.xml
@@ -31,6 +31,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jaxb-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/liquibase/liquibase-mongodb/deployment/src/main/java/io/quarkus/liquibase/mongodb/deployment/LiquibaseMongodbProcessor.java
+++ b/extensions/liquibase/liquibase-mongodb/deployment/src/main/java/io/quarkus/liquibase/mongodb/deployment/LiquibaseMongodbProcessor.java
@@ -2,12 +2,15 @@ package io.quarkus.liquibase.mongodb.deployment;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -22,6 +25,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -218,12 +222,14 @@ class LiquibaseMongodbProcessor {
 
         ChangeLogParameters changeLogParameters = new ChangeLogParameters();
         ChangeLogParserFactory changeLogParserFactory = ChangeLogParserFactory.getInstance();
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-
         LinkedHashSet<LogicalPhysicalAlias> allAliases = new LinkedHashSet<>();
-        try (var classLoaderResourceAccessor = new ClassLoaderResourceAccessor(classLoader)) {
+        try (var classLoaderResourceAccessor = new ClassLoaderResourceAccessor(
+                Thread.currentThread().getContextClassLoader())) {
             for (LiquibaseMongodbBuildTimeClientConfig buildConfig : liquibaseBuildConfig.clientConfigs().values()) {
-                String changeLog = buildConfig.changeLog();
+                String changeLog = resolveChangeLog(buildConfig.changeLog(), buildConfig.searchPath());
+                if (changeLog == null) {
+                    continue;
+                }
                 ChangeLogParser parser = changeLogParserFactory.getParser(changeLog, classLoaderResourceAccessor);
                 DatabaseChangeLog root = parser.parse(changeLog, changeLogParameters, classLoaderResourceAccessor);
                 if (root != null) {
@@ -355,16 +361,19 @@ class LiquibaseMongodbProcessor {
 
             Set<String> resources = new LinkedHashSet<>();
             for (LiquibaseMongodbBuildTimeClientConfig buildConfig : liquibaseBuildConfig.clientConfigs().values()) {
-                ChangeLogParser parser = changeLogParserFactory.getParser(buildConfig.changeLog(),
-                        classLoaderResourceAccessor);
-                DatabaseChangeLog changelog = parser.parse(buildConfig.changeLog(), changeLogParameters,
+                String changeLog = resolveChangeLog(buildConfig.changeLog(), buildConfig.searchPath());
+                if (changeLog == null) {
+                    LOGGER.debugf("Liquibase changeLog '%s' not found, skipping", buildConfig.changeLog());
+                    continue;
+                }
+                ChangeLogParser parser = changeLogParserFactory.getParser(changeLog, classLoaderResourceAccessor);
+                DatabaseChangeLog changelog = parser.parse(changeLog, changeLogParameters,
                         classLoaderResourceAccessor);
                 if (changelog != null) {
                     resources.addAll(LiquibaseChangeLogResourceDiscovery.scan(changelog).resourcePaths());
                 }
             }
             LOGGER.debugf("Liquibase changeLogs: %s", resources);
-
             return new ArrayList<>(resources);
 
         } catch (Exception ex) {
@@ -372,6 +381,48 @@ class LiquibaseMongodbProcessor {
             throw new IllegalStateException(
                     "Error while loading the liquibase changelogs: %s".formatted(ex.getMessage()), ex);
         }
+    }
+
+    /**
+     * Resolves the configured change log to the path that should be passed to the Liquibase parser,
+     * returning {@code null} if the resource cannot be found.
+     * <p>
+     * {@code filesystem:} paths are resolved against the file system (using search paths if configured),
+     * while classpath resources (with or without the {@code classpath:} prefix) are looked up on the
+     * runtime classpath via {@link QuarkusClassLoader#isResourcePresentAtRuntime(String)}.
+     *
+     * @param changeLog the configured change log path, possibly prefixed with {@code filesystem:} or {@code classpath:}
+     * @param oSearchPaths optional search paths checked for both {@code filesystem:} and unprefixed change logs
+     * @return the resolved path for the parser, or {@code null} if the change log was not found
+     */
+    private static String resolveChangeLog(String changeLog, Optional<List<String>> oSearchPaths) {
+        boolean filesystemOnly = changeLog.startsWith("filesystem:");
+
+        if (filesystemOnly) {
+            changeLog = changeLog.substring("filesystem:".length());
+        } else {
+            if (changeLog.startsWith("classpath:")) {
+                changeLog = changeLog.substring("classpath:".length());
+            }
+            if (QuarkusClassLoader.isResourcePresentAtRuntime(changeLog)) {
+                return changeLog;
+            }
+        }
+
+        if (oSearchPaths.isPresent()) {
+            for (String sp : oSearchPaths.get()) {
+                if (Files.exists(Path.of(sp).resolve(changeLog))) {
+                    return changeLog;
+                }
+            }
+        } else if (filesystemOnly) {
+            Path path = Path.of(changeLog);
+            if (Files.exists(path)) {
+                return path.getFileName().toString();
+            }
+        }
+
+        return null;
     }
 
 }

--- a/extensions/liquibase/liquibase-mongodb/deployment/src/test/java/io/quarkus/liquibase/mongodb/test/LiquibaseMongodbExtensionMissingChangeLogClasspathPrefixTest.java
+++ b/extensions/liquibase/liquibase-mongodb/deployment/src/test/java/io/quarkus/liquibase/mongodb/test/LiquibaseMongodbExtensionMissingChangeLogClasspathPrefixTest.java
@@ -1,0 +1,25 @@
+package io.quarkus.liquibase.mongodb.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Verifies that the build succeeds when a {@code classpath:}-prefixed change log
+ * is configured but the referenced resource does not exist.
+ */
+public class LiquibaseMongodbExtensionMissingChangeLogClasspathPrefixTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("missing-changelog-classpath-prefix.properties",
+                            "application.properties"));
+
+    @Test
+    @DisplayName("Build succeeds when classpath:-prefixed change log is missing")
+    public void buildSucceedsWithMissingClasspathPrefixedChangeLog() {
+    }
+}

--- a/extensions/liquibase/liquibase-mongodb/deployment/src/test/java/io/quarkus/liquibase/mongodb/test/LiquibaseMongodbExtensionMissingChangeLogFilesystemPrefixTest.java
+++ b/extensions/liquibase/liquibase-mongodb/deployment/src/test/java/io/quarkus/liquibase/mongodb/test/LiquibaseMongodbExtensionMissingChangeLogFilesystemPrefixTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.liquibase.mongodb.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Verifies that the build succeeds when a {@code filesystem:}-prefixed change log
+ * is configured but the referenced file does not exist.
+ */
+public class LiquibaseMongodbExtensionMissingChangeLogFilesystemPrefixTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("missing-changelog.properties",
+                            "application.properties"))
+            .overrideConfigKey("quarkus.liquibase-mongodb.change-log", "filesystem:/tmp/non-existent-changelog.xml");
+
+    @Test
+    @DisplayName("Build succeeds when filesystem:-prefixed change log is missing")
+    public void buildSucceedsWithMissingFilesystemPrefixedChangeLog() {
+    }
+}

--- a/extensions/liquibase/liquibase-mongodb/deployment/src/test/java/io/quarkus/liquibase/mongodb/test/LiquibaseMongodbExtensionMissingChangeLogTest.java
+++ b/extensions/liquibase/liquibase-mongodb/deployment/src/test/java/io/quarkus/liquibase/mongodb/test/LiquibaseMongodbExtensionMissingChangeLogTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.liquibase.mongodb.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Verifies that the build succeeds when the Liquibase MongoDB extension is present
+ * but no change log file exists (e.g. the dependency is on the classpath
+ * without being actively used).
+ */
+public class LiquibaseMongodbExtensionMissingChangeLogTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("missing-changelog.properties",
+                            "application.properties"));
+
+    @Test
+    @DisplayName("Build succeeds when no change log file is present")
+    public void buildSucceedsWithoutChangeLog() {
+    }
+}

--- a/extensions/liquibase/liquibase-mongodb/deployment/src/test/resources/missing-changelog-classpath-prefix.properties
+++ b/extensions/liquibase/liquibase-mongodb/deployment/src/test/resources/missing-changelog-classpath-prefix.properties
@@ -1,0 +1,3 @@
+quarkus.mongodb.devservices.enabled=false
+quarkus.mongodb.hosts=localhost:27017
+quarkus.liquibase-mongodb.change-log=classpath:db/non-existent-changeLog.xml

--- a/extensions/liquibase/liquibase-mongodb/deployment/src/test/resources/missing-changelog.properties
+++ b/extensions/liquibase/liquibase-mongodb/deployment/src/test/resources/missing-changelog.properties
@@ -1,0 +1,2 @@
+quarkus.mongodb.devservices.enabled=false
+quarkus.mongodb.hosts=localhost:27017

--- a/extensions/liquibase/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
+++ b/extensions/liquibase/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
@@ -3,7 +3,8 @@ package io.quarkus.liquibase.deployment;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -16,6 +17,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import javax.sql.DataSource;
@@ -36,6 +38,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.processor.DotNames;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -71,7 +74,6 @@ import io.quarkus.liquibase.runtime.LiquibaseRecorder;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.paths.PathFilter;
-import io.quarkus.runtime.util.StringUtil;
 import liquibase.change.DatabaseChangeProperty;
 import liquibase.changelog.ChangeLogParameters;
 import liquibase.changelog.DatabaseChangeLog;
@@ -267,25 +269,9 @@ class LiquibaseProcessor {
             liquibaseDataSources.add(liquibaseBuildConfig.datasources().get(dataSourceName));
         }
 
-        ChangeLogParameters changeLogParameters = new ChangeLogParameters();
-        ChangeLogParserFactory changeLogParserFactory = ChangeLogParserFactory.getInstance();
-
         LinkedHashSet<LogicalPhysicalAlias> allAliases = new LinkedHashSet<>();
-        for (LiquibaseDataSourceBuildTimeConfig liquibaseDataSourceConfig : liquibaseDataSources) {
-            Optional<List<String>> oSearchPaths = liquibaseDataSourceConfig.searchPath();
-            String changeLog = liquibaseDataSourceConfig.changeLog();
-            String parsedChangeLog = parseChangeLog(oSearchPaths, changeLog);
-
-            try (ResourceAccessor resourceAccessor = resolveResourceAccessor(oSearchPaths, changeLog)) {
-                ChangeLogParser parser = changeLogParserFactory.getParser(parsedChangeLog, resourceAccessor);
-                DatabaseChangeLog root = parser.parse(parsedChangeLog, changeLogParameters, resourceAccessor);
-                if (root != null) {
-                    allAliases.addAll(LiquibaseChangeLogResourceDiscovery.scan(root).logicalPhysicalAliases());
-                }
-            } catch (Exception ex) {
-                throw new IllegalStateException(ex);
-            }
-        }
+        forEachChangeLog(liquibaseDataSources, changelog -> allAliases.addAll(
+                LiquibaseChangeLogResourceDiscovery.scan(changelog).logicalPhysicalAliases()));
 
         byte[] mappingBytes = mergeLogicalPathMappingProperties(allAliases);
         if (mappingBytes != null) {
@@ -423,70 +409,119 @@ class LiquibaseProcessor {
             liquibaseDataSources.add(liquibaseBuildConfig.datasources().get(dataSourceName));
         }
 
-        ChangeLogParameters changeLogParameters = new ChangeLogParameters();
-        ChangeLogParserFactory changeLogParserFactory = ChangeLogParserFactory.getInstance();
         Set<String> resources = new LinkedHashSet<>();
-        for (LiquibaseDataSourceBuildTimeConfig liquibaseDataSourceConfig : liquibaseDataSources) {
-
-            Optional<List<String>> oSearchPaths = liquibaseDataSourceConfig.searchPath();
-            String changeLog = liquibaseDataSourceConfig.changeLog();
-            String parsedChangeLog = parseChangeLog(oSearchPaths, changeLog);
-
-            try (ResourceAccessor resourceAccessor = resolveResourceAccessor(oSearchPaths, changeLog)) {
-                ChangeLogParser parser = changeLogParserFactory.getParser(parsedChangeLog, resourceAccessor);
-                DatabaseChangeLog changelog = parser.parse(parsedChangeLog, changeLogParameters, resourceAccessor);
-                if (changelog != null) {
-                    resources.addAll(LiquibaseChangeLogResourceDiscovery.scan(changelog).resourcePaths());
-                }
-            } catch (Exception ex) {
-                throw new IllegalStateException(ex);
-            }
-        }
+        forEachChangeLog(liquibaseDataSources, changelog -> resources.addAll(
+                LiquibaseChangeLogResourceDiscovery.scan(changelog).resourcePaths()));
 
         LOGGER.debugf("Liquibase changeLogs: %s", resources);
         return new ArrayList<>(resources);
     }
 
-    private ResourceAccessor resolveResourceAccessor(Optional<List<String>> oSearchPaths, String changeLog)
-            throws FileNotFoundException {
-
-        CompositeResourceAccessor compositeResourceAccessor = new CompositeResourceAccessor();
-        compositeResourceAccessor
-                .addResourceAccessor(new ClassLoaderResourceAccessor(Thread.currentThread().getContextClassLoader()));
-
-        if (!changeLog.startsWith("filesystem:") && oSearchPaths.isEmpty()) {
-            return compositeResourceAccessor;
+    /**
+     * Resolves and parses the change log for each datasource configuration, passing each
+     * successfully parsed {@link DatabaseChangeLog} to the given consumer. Configurations
+     * whose change log cannot be found are silently skipped.
+     *
+     * @param configs the datasource build-time configurations to process
+     * @param consumer receives each successfully parsed {@link DatabaseChangeLog}
+     */
+    private static void forEachChangeLog(List<LiquibaseDataSourceBuildTimeConfig> configs,
+            Consumer<DatabaseChangeLog> consumer) {
+        ChangeLogParameters changeLogParameters = new ChangeLogParameters();
+        ChangeLogParserFactory changeLogParserFactory = ChangeLogParserFactory.getInstance();
+        try (var classpathAccessor = new ClassLoaderResourceAccessor(Thread.currentThread().getContextClassLoader())) {
+            for (LiquibaseDataSourceBuildTimeConfig config : configs) {
+                ResolvedChangeLog resolved = resolveChangeLog(config.changeLog(), config.searchPath(),
+                        classpathAccessor);
+                if (resolved == null) {
+                    LOGGER.debugf("Liquibase changeLog '%s' not found, skipping", config.changeLog());
+                    continue;
+                }
+                try (resolved) {
+                    ChangeLogParser parser = changeLogParserFactory.getParser(resolved.path(),
+                            resolved.resourceAccessor());
+                    DatabaseChangeLog changelog = parser.parse(resolved.path(), changeLogParameters,
+                            resolved.resourceAccessor());
+                    if (changelog != null) {
+                        consumer.accept(changelog);
+                    }
+                }
+            }
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
         }
-
-        if (oSearchPaths.isEmpty()) {
-            compositeResourceAccessor.addResourceAccessor(
-                    new DirectoryResourceAccessor(
-                            Paths.get(StringUtil.changePrefix(changeLog, "filesystem:", "")).getParent()));
-            return compositeResourceAccessor;
-        }
-
-        for (String searchPath : oSearchPaths.get()) {
-            compositeResourceAccessor.addResourceAccessor(new DirectoryResourceAccessor(Paths.get(searchPath)));
-        }
-
-        return compositeResourceAccessor;
     }
 
-    private String parseChangeLog(Optional<List<String>> oSearchPaths, String changeLog) {
+    /**
+     * A resolved change log with the path to pass to the Liquibase parser and the
+     * {@link ResourceAccessor} to use for reading it. Implements {@link AutoCloseable}
+     * so it can be used in try-with-resources; only closes the accessor when it owns it.
+     */
+    private record ResolvedChangeLog(String path, ResourceAccessor resourceAccessor, boolean ownsAccessor)
+            implements
+                AutoCloseable {
+        @Override
+        public void close() throws Exception {
+            if (ownsAccessor) {
+                resourceAccessor.close();
+            }
+        }
+    }
 
-        if (changeLog.startsWith("filesystem:") && oSearchPaths.isEmpty()) {
-            return Paths.get(StringUtil.changePrefix(changeLog, "filesystem:", "")).getFileName().toString();
+    /**
+     * Resolves the configured change log to the path and {@link ResourceAccessor} that should be
+     * passed to the Liquibase parser, returning {@code null} if the resource cannot be found.
+     * <p>
+     * {@code filesystem:} paths are resolved against the file system (using search paths if configured),
+     * while classpath resources (with or without the {@code classpath:} prefix) are looked up on the
+     * runtime classpath via {@link QuarkusClassLoader#isResourcePresentAtRuntime(String)}.
+     *
+     * @param changeLog the configured change log path, possibly prefixed with {@code filesystem:} or {@code classpath:}
+     * @param oSearchPaths optional search paths checked for both {@code filesystem:} and unprefixed change logs
+     * @param classpathAccessor shared classpath accessor reused for classpath-only change logs;
+     *        {@code filesystem:} and search-path cases create their own accessor
+     * @return the resolved change log, or {@code null} if the change log was not found
+     */
+    private static ResolvedChangeLog resolveChangeLog(String changeLog, Optional<List<String>> oSearchPaths,
+            ClassLoaderResourceAccessor classpathAccessor)
+            throws FileNotFoundException {
+        boolean filesystemOnly = changeLog.startsWith("filesystem:");
+
+        if (filesystemOnly) {
+            changeLog = changeLog.substring("filesystem:".length());
+        } else {
+            if (changeLog.startsWith("classpath:")) {
+                changeLog = changeLog.substring("classpath:".length());
+            }
+            if (QuarkusClassLoader.isResourcePresentAtRuntime(changeLog)) {
+                return new ResolvedChangeLog(changeLog, classpathAccessor, false);
+            }
         }
 
-        if (changeLog.startsWith("filesystem:")) {
-            return StringUtil.changePrefix(changeLog, "filesystem:", "");
+        if (oSearchPaths.isPresent()) {
+            for (String sp : oSearchPaths.get()) {
+                if (Files.exists(Path.of(sp).resolve(changeLog))) {
+                    CompositeResourceAccessor accessor = new CompositeResourceAccessor();
+                    accessor.addResourceAccessor(
+                            new ClassLoaderResourceAccessor(Thread.currentThread().getContextClassLoader()));
+                    for (String searchPath : oSearchPaths.get()) {
+                        accessor.addResourceAccessor(new DirectoryResourceAccessor(Path.of(searchPath)));
+                    }
+                    return new ResolvedChangeLog(changeLog, accessor, true);
+                }
+            }
+        } else if (filesystemOnly) {
+            Path path = Path.of(changeLog);
+            if (Files.exists(path)) {
+                CompositeResourceAccessor accessor = new CompositeResourceAccessor();
+                accessor.addResourceAccessor(
+                        new ClassLoaderResourceAccessor(Thread.currentThread().getContextClassLoader()));
+                accessor.addResourceAccessor(new DirectoryResourceAccessor(path.getParent()));
+                return new ResolvedChangeLog(path.getFileName().toString(), accessor, true);
+            }
         }
 
-        if (changeLog.startsWith("classpath:")) {
-            return StringUtil.changePrefix(changeLog, "classpath:", "");
-        }
-
-        return changeLog;
+        return null;
     }
 
 }

--- a/extensions/liquibase/liquibase/deployment/src/test/java/io/quarkus/liquibase/test/LiquibaseExtensionMigrateAtStartClasspathPrefixTest.java
+++ b/extensions/liquibase/liquibase/deployment/src/test/java/io/quarkus/liquibase/test/LiquibaseExtensionMigrateAtStartClasspathPrefixTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.liquibase.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.liquibase.LiquibaseFactory;
+import io.quarkus.test.QuarkusExtensionTest;
+import liquibase.Liquibase;
+import liquibase.changelog.ChangeSetStatus;
+
+/**
+ * Verifies that a {@code classpath:}-prefixed change log is resolved and
+ * applied correctly at startup.
+ */
+public class LiquibaseExtensionMigrateAtStartClasspathPrefixTest {
+
+    @Inject
+    LiquibaseFactory liquibaseFactory;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("db/changeLog.xml", "db/changeLog.xml")
+                    .addAsResource("classpath-prefix-config.properties", "application.properties"));
+
+    @Test
+    @DisplayName("Migrates at start with classpath:-prefixed change log")
+    public void testClasspathPrefixedChangeLog() throws Exception {
+        try (Liquibase liquibase = liquibaseFactory.createLiquibase()) {
+            List<ChangeSetStatus> status = liquibase.getChangeSetStatuses(liquibaseFactory.createContexts(),
+                    liquibaseFactory.createLabels());
+            assertNotNull(status);
+            assertEquals(1, status.size());
+            assertEquals("id-1", status.get(0).getChangeSet().getId());
+            assertFalse(status.get(0).getWillRun());
+        }
+    }
+}

--- a/extensions/liquibase/liquibase/deployment/src/test/java/io/quarkus/liquibase/test/LiquibaseExtensionMigrateAtStartFilesystemPrefixTest.java
+++ b/extensions/liquibase/liquibase/deployment/src/test/java/io/quarkus/liquibase/test/LiquibaseExtensionMigrateAtStartFilesystemPrefixTest.java
@@ -1,0 +1,81 @@
+package io.quarkus.liquibase.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.liquibase.LiquibaseFactory;
+import io.quarkus.test.QuarkusExtensionTest;
+import liquibase.Liquibase;
+import liquibase.changelog.ChangeSetStatus;
+
+/**
+ * Verifies that a {@code filesystem:}-prefixed change log is resolved and
+ * applied correctly at startup.
+ */
+public class LiquibaseExtensionMigrateAtStartFilesystemPrefixTest {
+
+    private static final Path CHANGELOG_FILE;
+
+    static {
+        try {
+            Path dir = Files.createTempDirectory("liquibase-test");
+            CHANGELOG_FILE = dir.resolve("changeLog.xml");
+            Files.writeString(CHANGELOG_FILE,
+                    """
+                            <?xml version="1.1" encoding="UTF-8" standalone="no"?>
+                            <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                                               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                               xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+                                <changeSet author="test" id="fs-1">
+                                    <createTable tableName="FS_TEST">
+                                        <column name="ID" type="VARCHAR(255)">
+                                            <constraints nullable="false"/>
+                                        </column>
+                                    </createTable>
+                                </changeSet>
+                            </databaseChangeLog>
+                            """);
+            CHANGELOG_FILE.toFile().deleteOnExit();
+            dir.toFile().deleteOnExit();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Inject
+    LiquibaseFactory liquibaseFactory;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("config-for-default-datasource-without-liquibase.properties",
+                            "application.properties"))
+            .overrideConfigKey("quarkus.liquibase.change-log", "filesystem:" + CHANGELOG_FILE.toAbsolutePath())
+            .overrideConfigKey("quarkus.liquibase.migrate-at-start", "true");
+
+    @Test
+    @DisplayName("Migrates at start with filesystem:-prefixed change log")
+    public void testFilesystemPrefixedChangeLog() throws Exception {
+        try (Liquibase liquibase = liquibaseFactory.createLiquibase()) {
+            List<ChangeSetStatus> status = liquibase.getChangeSetStatuses(liquibaseFactory.createContexts(),
+                    liquibaseFactory.createLabels());
+            assertNotNull(status);
+            assertEquals(1, status.size());
+            assertEquals("fs-1", status.get(0).getChangeSet().getId());
+            assertFalse(status.get(0).getWillRun());
+        }
+    }
+}

--- a/extensions/liquibase/liquibase/deployment/src/test/java/io/quarkus/liquibase/test/LiquibaseExtensionMissingChangeLogClasspathPrefixTest.java
+++ b/extensions/liquibase/liquibase/deployment/src/test/java/io/quarkus/liquibase/test/LiquibaseExtensionMissingChangeLogClasspathPrefixTest.java
@@ -1,0 +1,25 @@
+package io.quarkus.liquibase.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Verifies that the build succeeds when a {@code classpath:}-prefixed change log
+ * is configured but the referenced resource does not exist.
+ */
+public class LiquibaseExtensionMissingChangeLogClasspathPrefixTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("missing-changelog-classpath-prefix.properties",
+                            "application.properties"));
+
+    @Test
+    @DisplayName("Build succeeds when classpath:-prefixed change log is missing")
+    public void buildSucceedsWithMissingClasspathPrefixedChangeLog() {
+    }
+}

--- a/extensions/liquibase/liquibase/deployment/src/test/java/io/quarkus/liquibase/test/LiquibaseExtensionMissingChangeLogFilesystemPrefixTest.java
+++ b/extensions/liquibase/liquibase/deployment/src/test/java/io/quarkus/liquibase/test/LiquibaseExtensionMissingChangeLogFilesystemPrefixTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.liquibase.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Verifies that the build succeeds when a {@code filesystem:}-prefixed change log
+ * is configured but the referenced file does not exist.
+ */
+public class LiquibaseExtensionMissingChangeLogFilesystemPrefixTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("config-for-default-datasource-without-liquibase.properties",
+                            "application.properties"))
+            .overrideConfigKey("quarkus.liquibase.change-log", "filesystem:/tmp/non-existent-changelog.xml");
+
+    @Test
+    @DisplayName("Build succeeds when filesystem:-prefixed change log is missing")
+    public void buildSucceedsWithMissingFilesystemPrefixedChangeLog() {
+    }
+}

--- a/extensions/liquibase/liquibase/deployment/src/test/java/io/quarkus/liquibase/test/LiquibaseExtensionMissingChangeLogTest.java
+++ b/extensions/liquibase/liquibase/deployment/src/test/java/io/quarkus/liquibase/test/LiquibaseExtensionMissingChangeLogTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.liquibase.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Verifies that the build succeeds when the Liquibase extension is present
+ * but no change log file exists (e.g. the dependency is on the classpath
+ * without being actively used).
+ */
+public class LiquibaseExtensionMissingChangeLogTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("config-for-default-datasource-without-liquibase.properties",
+                            "application.properties"));
+
+    @Test
+    @DisplayName("Build succeeds when no change log file is present")
+    public void buildSucceedsWithoutChangeLog() {
+        // The build itself is the test — if we get here, the deployment
+        // processors handled the missing change log gracefully.
+    }
+}

--- a/extensions/liquibase/liquibase/deployment/src/test/resources/classpath-prefix-config.properties
+++ b/extensions/liquibase/liquibase/deployment/src/test/resources/classpath-prefix-config.properties
@@ -1,0 +1,6 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.username=sa
+quarkus.datasource.password=sa
+quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test-quarkus-classpath-prefix;DB_CLOSE_DELAY=-1
+quarkus.liquibase.migrate-at-start=true
+quarkus.liquibase.change-log=classpath:db/changeLog.xml

--- a/extensions/liquibase/liquibase/deployment/src/test/resources/missing-changelog-classpath-prefix.properties
+++ b/extensions/liquibase/liquibase/deployment/src/test/resources/missing-changelog-classpath-prefix.properties
@@ -1,0 +1,5 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.username=sa
+quarkus.datasource.password=sa
+quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test_quarkus;DB_CLOSE_DELAY=-1
+quarkus.liquibase.change-log=classpath:db/non-existent-changeLog.xml


### PR DESCRIPTION
Fixes #55875

We could possibly skip more work when a change log is missing but we'd need someone more familiar with Liquibase to weigh in on that.