### PR TITLE
Port Gradle extension plugin tests to Jackson 3

### DIFF
--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/TestUtils.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/TestUtils.java
@@ -18,10 +18,10 @@ import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 public class TestUtils {
 
@@ -131,9 +131,9 @@ public class TestUtils {
     }
 
     public static ObjectNode readExtensionFile(Path extensionFile) throws IOException {
-        YAMLFactory yf = new YAMLFactory();
-        ObjectMapper mapper = new ObjectMapper(yf)
-                .setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
+        ObjectMapper mapper = YAMLMapper.builder()
+                .propertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE)
+                .build();
         try (InputStream is = Files.newInputStream(extensionFile)) {
             return mapper.readValue(is, ObjectNode.class);
         } catch (IOException io) {

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
@@ -16,12 +16,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.quarkus.extension.gradle.QuarkusExtensionPlugin;
 import io.quarkus.extension.gradle.TestUtils;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 public class ExtensionDescriptorTaskTest {
 


### PR DESCRIPTION
The Jackson 2→3 migration (36107b96be0) updated the production code and version catalog but missed the test files. This was masked because Jackson 2 remained transitively on the classpath via quarkus-devtools-common until PR #55890 (CycloneDX 13.0.0) removed it.

This showed up in the CI for https://github.com/quarkusio/quarkus/pull/49026, and main is now also red (https://github.com/quarkusio/quarkus/actions/runs/31177832272/job/92867958715). I think https://github.com/quarkusio/quarkus/pull/55921 also shows the problem. 
