### PR TITLE
Make sure package-info.class isn't treated as a regular class during tree-shaking

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/JarTreeShakeBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/JarTreeShakeBuildItem.java
@@ -1,12 +1,15 @@
 package io.quarkus.deployment.pkg.builditem;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.commons.classloading.ClassLoaderHelper;
 import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.ResolvedDependency;
 
 /**
  * Build item that holds the results of dependency usage analysis for tree shaking.
@@ -42,6 +45,44 @@ public final class JarTreeShakeBuildItem extends SimpleBuildItem {
      */
     public Map<ArtifactKey, List<String>> getRemovedClasses() {
         return removedClasses;
+    }
+
+    /**
+     * Collects JAR entry paths of unreachable classes from a dependency into the given set.
+     * Handles multi-release JAR entries and preserves inner classes whose outer class is reachable.
+     *
+     * @param dep the dependency to scan
+     * @param removedEntries the set to add removed entry paths to
+     */
+    public void collectUnreachableEntries(ResolvedDependency dep, Set<String> removedEntries) throws IOException {
+        if (!classesShaken) {
+            return;
+        }
+        try (var pathTree = dep.getContentTree().open()) {
+            pathTree.walkRaw(visit -> {
+                String rel = visit.getRelativePath("/");
+                String classRel = rel;
+                if (rel.startsWith("META-INF/versions/")) {
+                    String afterVersions = rel.substring("META-INF/versions/".length());
+                    int slash = afterVersions.indexOf('/');
+                    if (slash > 0) {
+                        classRel = afterVersions.substring(slash + 1);
+                    } else {
+                        return;
+                    }
+                }
+                if (ClassLoaderHelper.isClassEntry(classRel)) {
+                    String className = classRel.substring(0, classRel.length() - 6).replace('/', '.');
+                    if (!reachableClassNames.contains(className)) {
+                        int dollarIdx = className.indexOf('$');
+                        if (dollarIdx < 0
+                                || !reachableClassNames.contains(className.substring(0, dollarIdx))) {
+                            removedEntries.add(rel);
+                        }
+                    }
+                }
+            });
+        }
     }
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractFastJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractFastJarBuilder.java
@@ -493,39 +493,8 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
                         }
                     }
                 }
-                // When tree shake level is CLASSES, add non-reachable classes to removal set.
-                // Use walkRaw to handle multi-release JARs: we need to add both base and
-                // versioned entry paths to the removal set for unreachable classes.
-                if (treeShakeResult != null
-                        && treeShakeResult.isClassesShaken()) {
-                    try (var pathTree = appDep.getContentTree().open()) {
-                        pathTree.walkRaw(visit -> {
-                            String rel = visit.getRelativePath("/");
-                            String classRel = rel;
-                            // For multi-release entries, extract the actual class path
-                            if (rel.startsWith("META-INF/versions/")) {
-                                String afterVersions = rel.substring("META-INF/versions/".length());
-                                int slash = afterVersions.indexOf('/');
-                                if (slash > 0) {
-                                    classRel = afterVersions.substring(slash + 1);
-                                } else {
-                                    return;
-                                }
-                            }
-                            if (classRel.endsWith(".class") && !classRel.equals("module-info.class")) {
-                                String className = classRel.substring(0, classRel.length() - 6).replace('/', '.');
-                                if (!treeShakeResult.getReachableClassNames().contains(className)) {
-                                    int dollarIdx = className.indexOf('$');
-                                    if (dollarIdx < 0
-                                            || !treeShakeResult.getReachableClassNames()
-                                                    .contains(className.substring(0, dollarIdx))) {
-                                        // Add the raw path (base or META-INF/versions/N/...) to removal set
-                                        removedFromThisArchive.add(rel);
-                                    }
-                                }
-                            }
-                        });
-                    }
+                if (treeShakeResult != null) {
+                    treeShakeResult.collectUnreachableEntries(appDep, removedFromThisArchive);
                 }
                 if (removedFromThisArchive.isEmpty()) {
                     // COPY_ATTRIBUTES triggers clonefile(2) on JDK 20+/macOS APFS, enabling

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
@@ -112,35 +112,8 @@ public abstract class AbstractLegacyThinJarBuilder<T extends BuildItem> extends 
                     if (transformedFromThisArchive != null && !transformedFromThisArchive.isEmpty()) {
                         removedEntries.addAll(transformedFromThisArchive);
                     }
-                    // When tree shake level is CLASSES, add non-reachable classes to removal set
-                    if (treeShakeResult != null
-                            && treeShakeResult.isClassesShaken()) {
-                        try (var pathTree = appDep.getContentTree().open()) {
-                            pathTree.walkRaw(visit -> {
-                                String rel = visit.getRelativePath("/");
-                                String classRel = rel;
-                                if (rel.startsWith("META-INF/versions/")) {
-                                    String afterVersions = rel.substring("META-INF/versions/".length());
-                                    int slash = afterVersions.indexOf('/');
-                                    if (slash > 0) {
-                                        classRel = afterVersions.substring(slash + 1);
-                                    } else {
-                                        return;
-                                    }
-                                }
-                                if (classRel.endsWith(".class") && !classRel.equals("module-info.class")) {
-                                    String className = classRel.substring(0, classRel.length() - 6).replace('/', '.');
-                                    if (!treeShakeResult.getReachableClassNames().contains(className)) {
-                                        int dollarIdx = className.indexOf('$');
-                                        if (dollarIdx < 0
-                                                || !treeShakeResult.getReachableClassNames()
-                                                        .contains(className.substring(0, dollarIdx))) {
-                                            removedEntries.add(rel);
-                                        }
-                                    }
-                                }
-                            });
-                        }
+                    if (treeShakeResult != null) {
+                        treeShakeResult.collectUnreachableEntries(appDep, removedEntries);
                     }
                     final String fileName;
                     if (removedEntries.isEmpty()) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.commons.classloading.ClassLoaderHelper;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
@@ -260,7 +261,7 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
                     // When tree shake level is CLASSES, skip non-reachable classes
                     // Skip filtering for multi-release version entries (META-INF/versions/)
                     if (treeShakeResult.isClassesShaken()
-                            && relativePath.endsWith(".class") && !relativePath.equals("module-info.class")
+                            && ClassLoaderHelper.isClassEntry(relativePath)
                             && !relativePath.startsWith("META-INF/versions/")) {
                         String className = relativePath.substring(0, relativePath.length() - 6).replace('/', '.');
                         if (!treeShakeResult.getReachableClassNames().contains(className)) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarTreeShakeInput.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarTreeShakeInput.java
@@ -19,6 +19,7 @@ import java.util.function.Supplier;
 import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.commons.classloading.ClassLoaderHelper;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassConditionBuildItem;
@@ -583,14 +584,8 @@ class JarTreeShakeInput implements AutoCloseable {
         return javaVersion;
     }
 
-    /**
-     * Returns {@code true} if the resource name represents a regular class file,
-     * excluding {@code module-info.class} and {@code package-info.class}.
-     */
     static boolean isClassEntry(String resourceName) {
-        return resourceName.endsWith(".class")
-                && !resourceName.equals("module-info.class")
-                && !resourceName.endsWith("package-info.class");
+        return ClassLoaderHelper.isClassEntry(resourceName);
     }
 
     /**

--- a/independent-projects/bootstrap/classloader-commons/src/main/java/io/quarkus/commons/classloading/ClassLoaderHelper.java
+++ b/independent-projects/bootstrap/classloader-commons/src/main/java/io/quarkus/commons/classloading/ClassLoaderHelper.java
@@ -43,4 +43,16 @@ public final class ClassLoaderHelper {
     public static boolean isInJdkPackage(String name) {
         return name.startsWith(JAVA) || name.startsWith(JDK_INTERNAL) || name.startsWith(SUN_MISC);
     }
+
+    /**
+     * Returns {@code true} if the resource name represents a regular class file,
+     * excluding {@code module-info.class} and {@code package-info.class}.
+     *
+     * @param resourceName the JAR entry path, e.g. {@code com/example/Foo.class}
+     */
+    public static boolean isClassEntry(String resourceName) {
+        return resourceName.endsWith(CLASS_SUFFIX)
+                && !resourceName.equals("module-info.class")
+                && !resourceName.endsWith("package-info.class");
+    }
 }

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/TreeShakeIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/TreeShakeIT.java
@@ -262,6 +262,12 @@ public class TreeShakeIT extends MojoTestBase {
         assertJarContains(libDir, "lib-loadclass-chain", "org/acme/loadchain/ChainProvider.class");
         assertJarNotContains(libDir, "lib-loadclass-chain", "org/acme/loadchain/UnusedChain.class");
 
+        // Package-info classes (must be preserved even though nothing references them in bytecode)
+        assertJarContains(libDir, "lib-package-info", "org/acme/pkginfo/package-info.class");
+        assertJarContains(libDir, "lib-package-info", "org/acme/pkginfo/PkgInfoService.class");
+        assertJarContains(libDir, "lib-package-info", "org/acme/pkginfo/PkgAnnotation.class");
+        assertJarNotContains(libDir, "lib-package-info", "org/acme/pkginfo/UnusedPkgInfo.class");
+
         // Transformed classes
         // In fast-jar, originals stay in lib JAR (transforms go to transformed-bytecode.jar).
         // In legacy-jar, transformed classes are moved to the runner JAR, so they're not in the lib JAR.
@@ -353,5 +359,7 @@ public class TreeShakeIT extends MojoTestBase {
         assertUberJarNotContains(uberJarFile, "org/acme/serialization/UnusedSerialization.class");
         assertUberJarContains(uberJarFile, "org/acme/loadchain/AlphaTarget.class");
         assertUberJarNotContains(uberJarFile, "org/acme/loadchain/UnusedChain.class");
+        assertUberJarContains(uberJarFile, "org/acme/pkginfo/package-info.class");
+        assertUberJarNotContains(uberJarFile, "org/acme/pkginfo/UnusedPkgInfo.class");
     }
 }

--- a/integration-tests/maven/src/test/resources-filtered/projects/tree-shake/app/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/tree-shake/app/pom.xml
@@ -140,6 +140,11 @@
             <artifactId>lib-loadclass-chain</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.acme.treeshake</groupId>
+            <artifactId>lib-package-info</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/integration-tests/maven/src/test/resources-filtered/projects/tree-shake/app/src/main/java/org/acme/app/TreeShakeResource.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/tree-shake/app/src/main/java/org/acme/app/TreeShakeResource.java
@@ -26,6 +26,7 @@ import org.acme.multirelease.MultiReleaseClass;
 import org.acme.serviceloader.ServiceInterface;
 import org.acme.throws_.ThrowingService;
 import org.acme.loadchain.ChainProvider;
+import org.acme.pkginfo.PkgInfoService;
 import org.acme.serialization.ResourceDeserializer;
 import org.acme.transform.TransformableClass;
 
@@ -166,5 +167,11 @@ public class TreeShakeResource {
     @Path("/loadclass-chain")
     public String loadclassChain() {
         return String.join(",", new ChainProvider().getLoaded());
+    }
+
+    @GET
+    @Path("/package-info")
+    public String packageInfo() {
+        return new PkgInfoService().describe();
     }
 }

--- a/integration-tests/maven/src/test/resources-filtered/projects/tree-shake/app/src/test/java/org/acme/app/TreeShakeCheck.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/tree-shake/app/src/test/java/org/acme/app/TreeShakeCheck.java
@@ -222,4 +222,14 @@ public class TreeShakeCheck {
         given().when().get("/tree-shake/loadclass-chain")
                 .then().statusCode(200).body(is("AlphaTarget,BetaTarget"));
     }
+
+    /**
+     * Verifies that {@code package-info.class} files are preserved by the tree shaker,
+     * so that package-level annotations remain accessible at runtime.
+     */
+    @Test
+    void testPackageInfo() {
+        given().when().get("/tree-shake/package-info")
+                .then().statusCode(200).body(is("tree-shake-test"));
+    }
 }

--- a/integration-tests/maven/src/test/resources-filtered/projects/tree-shake/libs/lib-package-info/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/tree-shake/libs/lib-package-info/pom.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme.treeshake</groupId>
+        <artifactId>tree-shake-libs-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>lib-package-info</artifactId>
+</project>

--- a/integration-tests/maven/src/test/resources-filtered/projects/tree-shake/libs/lib-package-info/src/main/java/org/acme/pkginfo/PkgAnnotation.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/tree-shake/libs/lib-package-info/src/main/java/org/acme/pkginfo/PkgAnnotation.java
@@ -1,0 +1,12 @@
+package org.acme.pkginfo;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PACKAGE)
+public @interface PkgAnnotation {
+    String value();
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/tree-shake/libs/lib-package-info/src/main/java/org/acme/pkginfo/PkgInfoService.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/tree-shake/libs/lib-package-info/src/main/java/org/acme/pkginfo/PkgInfoService.java
@@ -1,0 +1,9 @@
+package org.acme.pkginfo;
+
+public class PkgInfoService {
+    public String describe() {
+        Package pkg = PkgInfoService.class.getPackage();
+        PkgAnnotation anno = pkg.getAnnotation(PkgAnnotation.class);
+        return anno != null ? anno.value() : "missing";
+    }
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/tree-shake/libs/lib-package-info/src/main/java/org/acme/pkginfo/UnusedPkgInfo.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/tree-shake/libs/lib-package-info/src/main/java/org/acme/pkginfo/UnusedPkgInfo.java
@@ -1,0 +1,4 @@
+package org.acme.pkginfo;
+
+public class UnusedPkgInfo {
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/tree-shake/libs/lib-package-info/src/main/java/org/acme/pkginfo/package-info.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/tree-shake/libs/lib-package-info/src/main/java/org/acme/pkginfo/package-info.java
@@ -1,0 +1,2 @@
+@PkgAnnotation("tree-shake-test")
+package org.acme.pkginfo;

--- a/integration-tests/maven/src/test/resources-filtered/projects/tree-shake/libs/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/tree-shake/libs/pom.xml
@@ -45,6 +45,7 @@
         <module>lib-c</module>
         <module>lib-d</module>
         <module>lib-loadclass-chain</module>
+        <module>lib-package-info</module>
     </modules>
 
     <build>


### PR DESCRIPTION
Fixes #55912