### PR TITLE
Add test to verify containers are reused by databases, in no-profile case

### DIFF
--- a/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/JPAFunctionalityContainerReuseTest.java
+++ b/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/JPAFunctionalityContainerReuseTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.it.jpa.postgresql;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Creates a marker table to verify container reuse in JPAFunctionalitySecondTest.
+ */
+@QuarkusTest
+@Order(1)
+public class JPAFunctionalityContainerReuseTest {
+
+    @Inject
+    DataSource dataSource;
+
+    @Test
+    public void createMarkerForContainerReuseTest() throws SQLException {
+        try (Connection conn = dataSource.getConnection()) {
+            conn.createStatement().execute(
+                    "CREATE TABLE IF NOT EXISTS container_reuse_marker (id INT PRIMARY KEY, marker TEXT)");
+            conn.createStatement().execute(
+                    "INSERT INTO container_reuse_marker (id, marker) VALUES (1, 'test1') ON CONFLICT DO NOTHING");
+        }
+    }
+}

--- a/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/JPAFunctionalitySecondTest.java
+++ b/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/JPAFunctionalitySecondTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.it.jpa.postgresql;
+
+import static org.hamcrest.Matchers.is;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+/**
+ * Second test to verify container reuse behavior with PostgreSQL DevServices.
+ * Verifies that containers ARE reused across test classes (marker table exists).
+ * Must run after JPAFunctionalityTest.
+ */
+@QuarkusTest
+@Order(2)
+public class JPAFunctionalitySecondTest {
+
+    @Inject
+    DataSource dataSource;
+
+    @Test
+    public void base() {
+        RestAssured.when().get("/jpa/testfunctionality/base").then().body(is("OK"));
+    }
+
+    @Test
+    public void verifyContainerReused() throws SQLException {
+        // Check if the marker table from JPAFunctionalityTest exists
+        try (Connection conn = dataSource.getConnection()) {
+            try {
+                var rs = conn.createStatement().executeQuery("SELECT marker FROM container_reuse_marker WHERE id = 1");
+                if (!rs.next()) {
+                    throw new AssertionError("Marker table exists but is empty - container was reused but DB reset");
+                }
+                String marker = rs.getString("marker");
+                if (!"test1".equals(marker)) {
+                    throw new AssertionError("Expected marker 'test1' but found: " + marker);
+                }
+            } catch (SQLException e) {
+                throw new AssertionError("Marker table does not exist - container was not reused from JPAFunctionalityTest",
+                        e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
More work filling in gaps in #55881. This is related to https://github.com/quarkusio/quarkus/pull/55920, but the tests seem important enough I wanted some coverage in the db projects. 