### PR TITLE
OIDC: drop no-args constructors in OidcTenantConfig classes

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfig.java
@@ -8,10 +8,6 @@ import java.util.Optional;
 public abstract class OidcClientCommonConfig extends OidcCommonConfig
         implements io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig {
 
-    protected OidcClientCommonConfig() {
-
-    }
-
     protected OidcClientCommonConfig(io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig mapping) {
         super(mapping);
         this.tokenPath = mapping.tokenPath();
@@ -98,6 +94,9 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
     @Deprecated(since = "3.18", forRemoval = true)
     public static class Credentials implements io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials {
 
+        private Credentials() {
+        }
+
         /**
          * The client secret used by the `client_secret_basic` authentication method.
          * Must be set unless a secret is set in {@link #clientSecret} or {@link #jwt} client authentication is required.
@@ -178,6 +177,9 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
          *      "https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication">https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication</a>
          */
         public static class Secret implements io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Secret {
+
+            private Secret() {
+            }
 
             @Override
             public Optional<String> value() {
@@ -280,6 +282,9 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
          *      "https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication">https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication</a>
          */
         public static class Jwt implements io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Jwt {
+
+            private Jwt() {
+            }
 
             @Override
             public io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Jwt.Source source() {
@@ -612,6 +617,9 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
          */
         public static class Provider
                 implements io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Provider {
+
+            private Provider() {
+            }
 
             /**
              * The CredentialsProvider bean name, which should only be set if more than one CredentialsProvider is

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -7,10 +7,6 @@ import java.util.OptionalInt;
 
 public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime.config.OidcCommonConfig {
 
-    public OidcCommonConfig() {
-
-    }
-
     protected OidcCommonConfig(io.quarkus.oidc.common.runtime.config.OidcCommonConfig mapping) {
         this.authServerUrl = mapping.authServerUrl();
         this.discoveryPath = mapping.discoveryPath();
@@ -199,6 +195,9 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
      */
     @Deprecated(since = "3.18", forRemoval = true)
     public static class Tls implements io.quarkus.oidc.common.runtime.config.OidcCommonConfig.Tls {
+
+        private Tls() {
+        }
 
         /**
          * The name of the TLS configuration to use.
@@ -457,6 +456,9 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
      */
     @Deprecated(since = "3.18", forRemoval = true)
     public static class Proxy implements io.quarkus.oidc.common.runtime.config.OidcCommonConfig.Proxy {
+
+        private Proxy() {
+        }
 
         /**
          * The host name or IP address of the Proxy.<br/>

--- a/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/OidcCommonUtilsTest.java
+++ b/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/OidcCommonUtilsTest.java
@@ -16,6 +16,7 @@ import java.util.StringTokenizer;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.runtime.configuration.ConfigurationException;
+import io.smallrye.config.SmallRyeConfigBuilder;
 import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.ProxyOptions;
@@ -130,7 +131,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testProxyOptionsWithHostWithoutScheme() throws Exception {
-        OidcCommonConfig.Proxy config = new OidcCommonConfig.Proxy();
+        OidcCommonConfig.Proxy config = createDefaultConfig().proxy;
         config.host = Optional.of("localhost");
         config.port = 8080;
         config.username = Optional.of("user");
@@ -145,7 +146,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testProxyOptionsWithHostWithScheme() throws Exception {
-        OidcCommonConfig.Proxy config = new OidcCommonConfig.Proxy();
+        OidcCommonConfig.Proxy config = createDefaultConfig().proxy;
         config.host = Optional.of("http://localhost");
         config.port = 8080;
         config.username = Optional.of("user");
@@ -162,8 +163,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testJwtTokenWithScope() throws Exception {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.jwt.claims.put("scope", "read,write");
         PrivateKey key = KeyPairGenerator.getInstance("RSA").generateKeyPair().getPrivate();
@@ -176,8 +176,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testSignWithAudience() throws Exception {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.jwt.audience = Optional.of("https://server.example.com");
 
@@ -189,8 +188,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testSignWithAudienceRemoveTrailingSlash() throws Exception {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.jwt.audience = Optional.of("https://server.example.com/");
 
@@ -202,8 +200,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testSignWithAudienceKeepTrailingSlash() throws Exception {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.jwt.audience = Optional.of("https://server.example.com/");
         cfg.credentials.jwt.keepAudienceTrailingSlash = true;
@@ -216,8 +213,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testSecretAndClientSecretAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.secret = Optional.of("secret1");
         cfg.credentials.clientSecret.value = Optional.of("secret2");
@@ -229,8 +225,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testClientSecretValueAndJwtSecretAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.clientSecret.value = Optional.of("secret");
         cfg.credentials.jwt.secret = Optional.of("jwt-secret");
@@ -243,8 +238,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testSecretAndJwtSecretProviderAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.secret = Optional.of("secret");
         cfg.credentials.jwt.secretProvider.key = Optional.of("vault-jwt-secret");
@@ -257,8 +251,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testClientSecretValueAndJwtSecretProviderAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.clientSecret.value = Optional.of("secret");
         cfg.credentials.jwt.secretProvider.key = Optional.of("vault-jwt-secret");
@@ -271,8 +264,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testClientSecretProviderAndJwtSecretAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.clientSecret.provider.key = Optional.of("vault-key");
         cfg.credentials.jwt.secret = Optional.of("jwt-secret");
@@ -285,8 +277,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testClientSecretProviderAndJwtSecretProviderAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.clientSecret.provider.key = Optional.of("vault-key");
         cfg.credentials.jwt.secretProvider.key = Optional.of("vault-jwt-secret");
@@ -299,8 +290,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testClientSecretAndJwtKeyFileAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.clientSecret.value = Optional.of("secret");
         cfg.credentials.jwt.keyFile = Optional.of("privateKey.pem");
@@ -313,8 +303,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testClientSecretAndJwtKeyAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.secret = Optional.of("secret");
         cfg.credentials.jwt.key = Optional.of("pem-key-content");
@@ -327,8 +316,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testClientSecretAndJwtKeyStoreAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.clientSecret.value = Optional.of("secret");
         cfg.credentials.jwt.keyStoreFile = Optional.of("keystore.jks");
@@ -341,8 +329,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testClientSecretProviderAndJwtKeyFileAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.clientSecret.provider.key = Optional.of("vault-key");
         cfg.credentials.jwt.keyFile = Optional.of("privateKey.pem");
@@ -355,8 +342,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testJwtKeyAndKeyFileAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.jwt.key = Optional.of("pem-key-content");
         cfg.credentials.jwt.keyFile = Optional.of("privateKey.pem");
@@ -369,8 +355,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testJwtKeyAndKeyStoreAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.jwt.key = Optional.of("pem-key-content");
         cfg.credentials.jwt.keyStoreFile = Optional.of("keystore.jks");
@@ -383,8 +368,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testJwtKeyFileAndKeyStoreAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.jwt.keyFile = Optional.of("privateKey.pem");
         cfg.credentials.jwt.keyStoreFile = Optional.of("keystore.jks");
@@ -397,8 +381,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testAllThreeJwtKeyPropertiesAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.jwt.key = Optional.of("pem-key-content");
         cfg.credentials.jwt.keyFile = Optional.of("privateKey.pem");
@@ -411,8 +394,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testJwtSecretAndJwtKeyAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.jwt.secret = Optional.of("jwt-secret");
         cfg.credentials.jwt.key = Optional.of("pem-key-content");
@@ -425,8 +407,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testJwtSecretAndJwtKeyFileAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.jwt.secret = Optional.of("jwt-secret");
         cfg.credentials.jwt.keyFile = Optional.of("privateKey.pem");
@@ -439,8 +420,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testJwtSecretProviderAndJwtKeyStoreAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.jwt.secretProvider.key = Optional.of("vault-jwt-secret");
         cfg.credentials.jwt.keyStoreFile = Optional.of("keystore.jks");
@@ -453,8 +433,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testClientSecretAndJwtBearerAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.clientSecret.value = Optional.of("secret");
         cfg.credentials.jwt.source = OidcClientCommonConfig.Credentials.Jwt.Source.BEARER;
@@ -467,8 +446,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testClientSecretAndJwtSpiffeAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.secret = Optional.of("secret");
         cfg.credentials.jwt.source = OidcClientCommonConfig.Credentials.Jwt.Source.SPIFFE_JWT;
@@ -481,8 +459,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testJwtKeyFileAndJwtBearerAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.jwt.keyFile = Optional.of("privateKey.pem");
         cfg.credentials.jwt.source = OidcClientCommonConfig.Credentials.Jwt.Source.BEARER;
@@ -495,8 +472,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testJwtKeyStoreAndJwtSpiffeAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.jwt.keyStoreFile = Optional.of("keystore.jks");
         cfg.credentials.jwt.source = OidcClientCommonConfig.Credentials.Jwt.Source.SPIFFE_JWT;
@@ -509,8 +485,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testJwtSecretAndJwtBearerAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.jwt.secret = Optional.of("jwt-secret");
         cfg.credentials.jwt.source = OidcClientCommonConfig.Credentials.Jwt.Source.BEARER;
@@ -523,8 +498,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testJwtSecretProviderAndJwtSpiffeAreMutuallyExclusive() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.jwt.secretProvider.key = Optional.of("vault-jwt-secret");
         cfg.credentials.jwt.source = OidcClientCommonConfig.Credentials.Jwt.Source.SPIFFE_JWT;
@@ -537,8 +511,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testSingleClientSecretIsValid() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.clientSecret.value = Optional.of("secret");
         OidcCommonUtils.verifyCommonConfiguration(cfg, false, false);
@@ -546,8 +519,7 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testSingleJwtKeyFileIsValid() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.jwt.keyFile = Optional.of("privateKey.pem");
         OidcCommonUtils.verifyCommonConfiguration(cfg, false, false);
@@ -555,11 +527,20 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testSingleJwtSecretIsValid() {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
-        };
+        OidcClientCommonConfig cfg = createDefaultConfig();
         cfg.setClientId("client");
         cfg.credentials.jwt.secret = Optional.of("jwt-secret");
         OidcCommonUtils.verifyCommonConfiguration(cfg, false, false);
+    }
+
+    private static OidcClientCommonConfig createDefaultConfig() {
+        var mapping = new SmallRyeConfigBuilder()
+                .addDiscoveredConverters()
+                .withMapping(io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.class)
+                .build()
+                .getConfigMapping(io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.class);
+        return new OidcClientCommonConfig(mapping) {
+        };
     }
 
     public static JsonObject decodeJwtContent(String jwt) {

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomTenantConfigResolver.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomTenantConfigResolver.java
@@ -6,8 +6,8 @@ import org.eclipse.microprofile.config.ConfigProvider;
 
 import io.quarkus.oidc.OidcRequestContext;
 import io.quarkus.oidc.OidcTenantConfig;
-import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
 import io.quarkus.oidc.TenantConfigResolver;
+import io.quarkus.oidc.runtime.OidcTenantConfig.ApplicationType;
 import io.quarkus.oidc.runtime.OidcUtils;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
@@ -17,12 +17,13 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
     @Override
     public Uni<OidcTenantConfig> resolve(RoutingContext context, OidcRequestContext<OidcTenantConfig> requestContext) {
         if (context.request().path().endsWith("/tenant-config-resolver")) {
-            OidcTenantConfig config = new OidcTenantConfig();
-            config.setTenantId("tenant-config-resolver");
-            config.setAuthServerUrl(getIssuerUrl() + "/realms/quarkus");
-            config.setClientId("quarkus-web-app");
-            config.getCredentials().setSecret("secret");
-            config.setApplicationType(ApplicationType.WEB_APP);
+            OidcTenantConfig config = OidcTenantConfig.builder()
+                    .tenantId("tenant-config-resolver")
+                    .authServerUrl(getIssuerUrl() + "/realms/quarkus")
+                    .clientId("quarkus-web-app")
+                    .credentials("secret")
+                    .applicationType(ApplicationType.WEB_APP)
+                    .build();
             return Uni.createFrom().item(config);
         }
         context.remove(OidcUtils.TENANT_ID_ATTRIBUTE);

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -21,14 +21,6 @@ import io.quarkus.security.identity.SecurityIdentityAugmentor;
 
 public class OidcTenantConfig extends OidcClientCommonConfig implements io.quarkus.oidc.runtime.OidcTenantConfig {
 
-    /**
-     * @deprecated Use {@link #builder()} to create this config
-     */
-    @Deprecated(since = "3.18", forRemoval = true)
-    public OidcTenantConfig() {
-
-    }
-
     private OidcTenantConfig(io.quarkus.oidc.runtime.OidcTenantConfig mapping) {
         super(mapping);
         tenantId = mapping.tenantId();
@@ -179,6 +171,10 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      */
     @Deprecated(since = "3.18", forRemoval = true)
     public static class IntrospectionCredentials implements io.quarkus.oidc.runtime.OidcTenantConfig.IntrospectionCredentials {
+
+        private IntrospectionCredentials() {
+        }
+
         /**
          * Name
          */
@@ -289,6 +285,10 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      */
     @Deprecated(since = "3.18", forRemoval = true)
     public static class CertificateChain implements io.quarkus.oidc.runtime.OidcTenantConfig.CertificateChain {
+
+        private CertificateChain() {
+        }
+
         /**
          * Common name of the leaf certificate. It must be set if the {@link #trustStoreFile} does not have
          * this certificate imported.
@@ -459,6 +459,9 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     @Deprecated(since = "3.18", forRemoval = true)
     public static class Logout implements io.quarkus.oidc.runtime.OidcTenantConfig.Logout {
 
+        private Logout() {
+        }
+
         /**
          * The relative path of the logout endpoint at the application. If provided, the application is able to
          * initiate the
@@ -606,6 +609,10 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      */
     @Deprecated(since = "3.18", forRemoval = true)
     public static class Backchannel implements io.quarkus.oidc.runtime.OidcTenantConfig.Backchannel {
+
+        private Backchannel() {
+        }
+
         /**
          * The relative path of the Back-Channel Logout endpoint at the application.
          * It must start with the forward slash '/', for example, '/back-channel-logout'.
@@ -724,6 +731,10 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      */
     @Deprecated(since = "3.18", forRemoval = true)
     public static class Jwks implements io.quarkus.oidc.runtime.OidcTenantConfig.Jwks {
+
+        private Jwks() {
+        }
+
         /**
          * If JWK verification keys should be fetched at the moment a connection to the OIDC provider
          * is initialized.
@@ -838,6 +849,10 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      */
     @Deprecated(since = "3.18", forRemoval = true)
     public static class Frontchannel implements io.quarkus.oidc.runtime.OidcTenantConfig.Frontchannel {
+
+        private Frontchannel() {
+        }
+
         /**
          * The relative path of the Front-Channel Logout endpoint at the application.
          */
@@ -868,6 +883,9 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      */
     @Deprecated(since = "3.18", forRemoval = true)
     public static class TokenStateManager implements io.quarkus.oidc.runtime.OidcTenantConfig.TokenStateManager {
+
+        private TokenStateManager() {
+        }
 
         @Override
         public io.quarkus.oidc.runtime.OidcTenantConfig.TokenStateManager.Strategy strategy() {
@@ -1223,6 +1241,9 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     @Deprecated(since = "3.18", forRemoval = true)
     public static class Roles implements io.quarkus.oidc.runtime.OidcTenantConfig.Roles {
 
+        private Roles() {
+        }
+
         public static Roles fromClaimPath(List<String> path) {
             return fromClaimPathAndSeparator(path, null);
         }
@@ -1328,6 +1349,9 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      */
     @Deprecated(since = "3.18", forRemoval = true)
     public static class Authentication implements io.quarkus.oidc.runtime.OidcTenantConfig.Authentication {
+
+        private Authentication() {
+        }
 
         @Override
         public Optional<io.quarkus.oidc.runtime.OidcTenantConfig.Authentication.ResponseMode> responseMode() {
@@ -2182,6 +2206,9 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     @Deprecated(since = "3.18", forRemoval = true)
     public static class CodeGrant implements io.quarkus.oidc.runtime.OidcTenantConfig.CodeGrant {
 
+        private CodeGrant() {
+        }
+
         /**
          * Additional parameters, in addition to the required `code` and `redirect-uri` parameters,
          * which must be included to complete the authorization code grant request.
@@ -2254,6 +2281,9 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      */
     @Deprecated(since = "3.18", forRemoval = true)
     public static class Token implements io.quarkus.oidc.runtime.OidcTenantConfig.Token {
+
+        private Token() {
+        }
 
         public static Token fromIssuer(String issuer) {
             Token tokenClaims = new Token();
@@ -2809,6 +2839,9 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     @Deprecated(since = "3.18", forRemoval = true)
     public static class Binding implements io.quarkus.oidc.runtime.OidcTenantConfig.Binding {
 
+        private Binding() {
+        }
+
         /**
          * If a bearer access token must be bound to the client mTLS certificate.
          * It requires that JWT tokens must contain a confirmation `cnf` claim with a SHA256 certificate thumbprint
@@ -2833,6 +2866,9 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
 
     @Deprecated(since = "3.25", forRemoval = true)
     public static class ResourceMetadata implements io.quarkus.oidc.runtime.OidcTenantConfig.ResourceMetadata {
+
+        private ResourceMetadata() {
+        }
 
         public boolean enabled;
         public Optional<String> resource = Optional.empty();

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/KnownOidcProvidersTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/KnownOidcProvidersTest.java
@@ -9,9 +9,9 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.oidc.OidcTenantConfig;
-import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
-import io.quarkus.oidc.OidcTenantConfig.Authentication.ResponseMode;
-import io.quarkus.oidc.common.runtime.OidcClientCommonConfig.Credentials.Secret.Method;
+import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Secret.Method;
+import io.quarkus.oidc.runtime.OidcTenantConfig.ApplicationType;
+import io.quarkus.oidc.runtime.OidcTenantConfig.Authentication.ResponseMode;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Provider;
 import io.quarkus.oidc.runtime.providers.KnownOidcProviders;
 import io.smallrye.jwt.algorithm.SignatureAlgorithm;
@@ -20,12 +20,11 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testAcceptGitHubProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
+        OidcTenantConfig tenant = OidcTenantConfig.builder().build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.GITHUB));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.WEB_APP, config.getApplicationType().get());
+        assertEquals(ApplicationType.WEB_APP, config.applicationType().get());
         assertFalse(config.isDiscoveryEnabled().get());
         assertEquals("https://github.com/login/oauth", config.getAuthServerUrl().get());
         assertEquals("authorize", config.getAuthorizationPath().get());
@@ -41,26 +40,20 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testOverrideGitHubProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
-
-        tenant.setApplicationType(ApplicationType.HYBRID);
-        tenant.setDiscoveryEnabled(true);
-        tenant.setAuthServerUrl("http://localhost/wiremock");
-        tenant.setAuthorizationPath("authorization");
-        tenant.setTokenPath("tokens");
-        tenant.setUserInfoPath("userinfo");
-
-        tenant.authentication.setIdTokenRequired(true);
-        tenant.authentication.setUserInfoRequired(false);
-        tenant.token.setVerifyAccessTokenWithUserInfo(false);
-        tenant.authentication.setScopes(List.of("write"));
-        tenant.token.setPrincipalClaim("firstname");
-
+        OidcTenantConfig tenant = OidcTenantConfig.builder()
+                .applicationType(ApplicationType.HYBRID)
+                .discoveryEnabled(true)
+                .authServerUrl("http://localhost/wiremock")
+                .authorizationPath("authorization")
+                .tokenPath("tokens")
+                .userInfoPath("userinfo")
+                .authentication().idTokenRequired(true).userInfoRequired(false).scopes("write").end()
+                .token().verifyAccessTokenWithUserInfo(false).principalClaim("firstname").end()
+                .build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.GITHUB));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.HYBRID, config.getApplicationType().get());
+        assertEquals(ApplicationType.HYBRID, config.applicationType().get());
         assertTrue(config.isDiscoveryEnabled().get());
         assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
         assertEquals("authorization", config.getAuthorizationPath().get());
@@ -76,12 +69,11 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testAcceptTwitterProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
+        OidcTenantConfig tenant = OidcTenantConfig.builder().build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.TWITTER));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.WEB_APP, config.getApplicationType().get());
+        assertEquals(ApplicationType.WEB_APP, config.applicationType().get());
         assertFalse(config.isDiscoveryEnabled().get());
         assertEquals("https://api.twitter.com/2/oauth2", config.getAuthServerUrl().get());
         assertEquals("https://twitter.com/i/oauth2/authorize", config.getAuthorizationPath().get());
@@ -97,26 +89,20 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testOverrideTwitterProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
-
-        tenant.setApplicationType(ApplicationType.HYBRID);
-        tenant.setDiscoveryEnabled(true);
-        tenant.setAuthServerUrl("http://localhost/wiremock");
-        tenant.setAuthorizationPath("authorization");
-        tenant.setTokenPath("tokens");
-        tenant.setUserInfoPath("userinfo");
-
-        tenant.authentication.setIdTokenRequired(true);
-        tenant.authentication.setUserInfoRequired(false);
-        tenant.authentication.setAddOpenidScope(true);
-        tenant.authentication.setPkceRequired(false);
-        tenant.authentication.setScopes(List.of("write"));
-
+        OidcTenantConfig tenant = OidcTenantConfig.builder()
+                .applicationType(ApplicationType.HYBRID)
+                .discoveryEnabled(true)
+                .authServerUrl("http://localhost/wiremock")
+                .authorizationPath("authorization")
+                .tokenPath("tokens")
+                .userInfoPath("userinfo")
+                .authentication().idTokenRequired(true).userInfoRequired(false).addOpenidScope(true)
+                .pkceRequired(false).scopes("write").end()
+                .build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.TWITTER));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.HYBRID, config.getApplicationType().get());
+        assertEquals(ApplicationType.HYBRID, config.applicationType().get());
         assertTrue(config.isDiscoveryEnabled().get());
         assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
         assertEquals("authorization", config.getAuthorizationPath().get());
@@ -132,12 +118,11 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testAcceptMastodonProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
+        OidcTenantConfig tenant = OidcTenantConfig.builder().build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.MASTODON));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.WEB_APP, config.getApplicationType().get());
+        assertEquals(ApplicationType.WEB_APP, config.applicationType().get());
         assertFalse(config.isDiscoveryEnabled().get());
         assertEquals("https://mastodon.social", config.getAuthServerUrl().get());
         assertEquals("/oauth/authorize", config.getAuthorizationPath().get());
@@ -152,25 +137,20 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testOverrideMastodonProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
-
-        tenant.setApplicationType(ApplicationType.HYBRID);
-        tenant.setDiscoveryEnabled(true);
-        tenant.setAuthServerUrl("http://localhost/wiremock");
-        tenant.setAuthorizationPath("authorization");
-        tenant.setTokenPath("tokens");
-        tenant.setUserInfoPath("userinfo");
-
-        tenant.authentication.setIdTokenRequired(true);
-        tenant.authentication.setUserInfoRequired(false);
-        tenant.authentication.setAddOpenidScope(true);
-        tenant.authentication.setScopes(List.of("write"));
-
+        OidcTenantConfig tenant = OidcTenantConfig.builder()
+                .applicationType(ApplicationType.HYBRID)
+                .discoveryEnabled(true)
+                .authServerUrl("http://localhost/wiremock")
+                .authorizationPath("authorization")
+                .tokenPath("tokens")
+                .userInfoPath("userinfo")
+                .authentication().idTokenRequired(true).userInfoRequired(false).addOpenidScope(true)
+                .scopes("write").end()
+                .build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.MASTODON));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.HYBRID, config.getApplicationType().get());
+        assertEquals(ApplicationType.HYBRID, config.applicationType().get());
         assertTrue(config.isDiscoveryEnabled().get());
         assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
         assertEquals("authorization", config.getAuthorizationPath().get());
@@ -185,12 +165,11 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testAcceptXProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
+        OidcTenantConfig tenant = OidcTenantConfig.builder().build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.X));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.WEB_APP, config.getApplicationType().get());
+        assertEquals(ApplicationType.WEB_APP, config.applicationType().get());
         assertFalse(config.isDiscoveryEnabled().get());
         assertEquals("https://api.twitter.com/2/oauth2", config.getAuthServerUrl().get());
         assertEquals("https://twitter.com/i/oauth2/authorize", config.getAuthorizationPath().get());
@@ -206,26 +185,20 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testOverrideXProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
-
-        tenant.setApplicationType(ApplicationType.HYBRID);
-        tenant.setDiscoveryEnabled(true);
-        tenant.setAuthServerUrl("http://localhost/wiremock");
-        tenant.setAuthorizationPath("authorization");
-        tenant.setTokenPath("tokens");
-        tenant.setUserInfoPath("userinfo");
-
-        tenant.authentication.setIdTokenRequired(true);
-        tenant.authentication.setUserInfoRequired(false);
-        tenant.authentication.setAddOpenidScope(true);
-        tenant.authentication.setPkceRequired(false);
-        tenant.authentication.setScopes(List.of("write"));
-
+        OidcTenantConfig tenant = OidcTenantConfig.builder()
+                .applicationType(ApplicationType.HYBRID)
+                .discoveryEnabled(true)
+                .authServerUrl("http://localhost/wiremock")
+                .authorizationPath("authorization")
+                .tokenPath("tokens")
+                .userInfoPath("userinfo")
+                .authentication().idTokenRequired(true).userInfoRequired(false).addOpenidScope(true)
+                .pkceRequired(false).scopes("write").end()
+                .build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.X));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.HYBRID, config.getApplicationType().get());
+        assertEquals(ApplicationType.HYBRID, config.applicationType().get());
         assertTrue(config.isDiscoveryEnabled().get());
         assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
         assertEquals("authorization", config.getAuthorizationPath().get());
@@ -241,12 +214,11 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testAcceptFacebookProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
+        OidcTenantConfig tenant = OidcTenantConfig.builder().build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.FACEBOOK));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.WEB_APP, config.getApplicationType().get());
+        assertEquals(ApplicationType.WEB_APP, config.applicationType().get());
         assertFalse(config.isDiscoveryEnabled().get());
         assertEquals("https://www.facebook.com", config.getAuthServerUrl().get());
         assertEquals("https://facebook.com/dialog/oauth/", config.getAuthorizationPath().get());
@@ -259,23 +231,19 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testOverrideFacebookProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
-
-        tenant.setApplicationType(ApplicationType.HYBRID);
-        tenant.setDiscoveryEnabled(true);
-        tenant.setAuthServerUrl("http://localhost/wiremock");
-        tenant.setAuthorizationPath("authorization");
-        tenant.setJwksPath("jwks");
-        tenant.setTokenPath("tokens");
-
-        tenant.authentication.setScopes(List.of("write"));
-        tenant.authentication.setForceRedirectHttpsScheme(false);
-
+        OidcTenantConfig tenant = OidcTenantConfig.builder()
+                .applicationType(ApplicationType.HYBRID)
+                .discoveryEnabled(true)
+                .authServerUrl("http://localhost/wiremock")
+                .authorizationPath("authorization")
+                .jwksPath("jwks")
+                .tokenPath("tokens")
+                .authentication().scopes("write").forceRedirectHttpsScheme(false).end()
+                .build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.FACEBOOK));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.HYBRID, config.getApplicationType().get());
+        assertEquals(ApplicationType.HYBRID, config.applicationType().get());
         assertTrue(config.isDiscoveryEnabled().get());
         assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
         assertEquals("authorization", config.getAuthorizationPath().get());
@@ -288,12 +256,11 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testAcceptGoogleProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
+        OidcTenantConfig tenant = OidcTenantConfig.builder().build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.GOOGLE));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.WEB_APP, config.getApplicationType().get());
+        assertEquals(ApplicationType.WEB_APP, config.applicationType().get());
         assertEquals("https://accounts.google.com", config.getAuthServerUrl().get());
         assertEquals("name", config.getToken().getPrincipalClaim().get());
         assertEquals(List.of("openid", "email", "profile"), config.authentication.scopes.get());
@@ -302,19 +269,16 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testOverrideGoogleProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
-
-        tenant.setApplicationType(ApplicationType.HYBRID);
-        tenant.setAuthServerUrl("http://localhost/wiremock");
-        tenant.authentication.setScopes(List.of("write"));
-        tenant.token.setPrincipalClaim("firstname");
-        tenant.token.setVerifyAccessTokenWithUserInfo(false);
-
+        OidcTenantConfig tenant = OidcTenantConfig.builder()
+                .applicationType(ApplicationType.HYBRID)
+                .authServerUrl("http://localhost/wiremock")
+                .authentication().scopes("write").end()
+                .token().principalClaim("firstname").verifyAccessTokenWithUserInfo(false).end()
+                .build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.GOOGLE));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.HYBRID, config.getApplicationType().get());
+        assertEquals(ApplicationType.HYBRID, config.applicationType().get());
         assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
         assertEquals("firstname", config.getToken().getPrincipalClaim().get());
         assertEquals(List.of("write"), config.authentication.scopes.get());
@@ -323,12 +287,11 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testAcceptMicrosoftProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
+        OidcTenantConfig tenant = OidcTenantConfig.builder().build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.MICROSOFT));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.WEB_APP, config.getApplicationType().get());
+        assertEquals(ApplicationType.WEB_APP, config.applicationType().get());
         assertEquals("https://login.microsoftonline.com/common/v2.0", config.getAuthServerUrl().get());
         assertEquals(List.of("openid", "email", "profile"), config.authentication.scopes.get());
         assertEquals("any", config.getToken().getIssuer().get());
@@ -336,19 +299,16 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testOverrideMicrosoftProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
-
-        tenant.setApplicationType(ApplicationType.HYBRID);
-        tenant.setAuthServerUrl("http://localhost/wiremock");
-        tenant.getToken().setIssuer("http://localhost/wiremock");
-        tenant.authentication.setScopes(List.of("write"));
-        tenant.authentication.setForceRedirectHttpsScheme(false);
-
+        OidcTenantConfig tenant = OidcTenantConfig.builder()
+                .applicationType(ApplicationType.HYBRID)
+                .authServerUrl("http://localhost/wiremock")
+                .token().issuer("http://localhost/wiremock").end()
+                .authentication().scopes("write").forceRedirectHttpsScheme(false).end()
+                .build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.MICROSOFT));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.HYBRID, config.getApplicationType().get());
+        assertEquals(ApplicationType.HYBRID, config.applicationType().get());
         assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
         assertEquals(List.of("write"), config.authentication.scopes.get());
         assertEquals("http://localhost/wiremock", config.getToken().getIssuer().get());
@@ -357,16 +317,15 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testAcceptAppleProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
+        OidcTenantConfig tenant = OidcTenantConfig.builder().build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.APPLE));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.WEB_APP, config.getApplicationType().get());
+        assertEquals(ApplicationType.WEB_APP, config.applicationType().get());
         assertEquals("https://appleid.apple.com/", config.getAuthServerUrl().get());
         assertEquals(List.of("openid", "email", "name"), config.authentication.scopes.get());
-        assertEquals(ResponseMode.FORM_POST, config.authentication.responseMode.get());
-        assertEquals(Method.POST_JWT, config.credentials.clientSecret.method.get());
+        assertEquals(ResponseMode.FORM_POST, config.authentication().responseMode().get());
+        assertEquals(Method.POST_JWT, config.credentials().clientSecret().method().get());
         assertEquals("https://appleid.apple.com/", config.credentials.jwt.audience.get());
         assertEquals(SignatureAlgorithm.ES256.getAlgorithm(), config.credentials.jwt.signatureAlgorithm.get());
         assertTrue(config.authentication.forceRedirectHttpsScheme.get());
@@ -374,37 +333,33 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testOverrideAppleProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
-
-        tenant.setApplicationType(ApplicationType.HYBRID);
-        tenant.setAuthServerUrl("http://localhost/wiremock");
-        tenant.authentication.setScopes(List.of("write"));
-        tenant.authentication.setResponseMode(ResponseMode.QUERY);
-        tenant.credentials.clientSecret.setMethod(Method.POST);
-        tenant.credentials.jwt.setAudience("http://localhost/audience");
-        tenant.credentials.jwt.setSignatureAlgorithm(SignatureAlgorithm.ES256.getAlgorithm());
-
+        OidcTenantConfig tenant = OidcTenantConfig.builder()
+                .applicationType(ApplicationType.HYBRID)
+                .authServerUrl("http://localhost/wiremock")
+                .authentication().scopes("write").responseMode(ResponseMode.QUERY).end()
+                .credentials().clientSecret().method(Method.POST).end()
+                .jwt().audience("http://localhost/audience")
+                .signatureAlgorithm(SignatureAlgorithm.ES256.getAlgorithm()).end().end()
+                .build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.APPLE));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.HYBRID, config.getApplicationType().get());
+        assertEquals(ApplicationType.HYBRID, config.applicationType().get());
         assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
         assertEquals(List.of("write"), config.authentication.scopes.get());
-        assertEquals(ResponseMode.QUERY, config.authentication.responseMode.get());
-        assertEquals(Method.POST, config.credentials.clientSecret.method.get());
+        assertEquals(ResponseMode.QUERY, config.authentication().responseMode().get());
+        assertEquals(Method.POST, config.credentials().clientSecret().method().get());
         assertEquals("http://localhost/audience", config.credentials.jwt.audience.get());
         assertEquals(SignatureAlgorithm.ES256.getAlgorithm(), config.credentials.jwt.signatureAlgorithm.get());
     }
 
     @Test
     public void testAcceptSpotifyProperties() {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
+        OidcTenantConfig tenant = OidcTenantConfig.builder().build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.SPOTIFY));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.WEB_APP, config.getApplicationType().get());
+        assertEquals(ApplicationType.WEB_APP, config.applicationType().get());
         assertEquals("https://accounts.spotify.com", config.getAuthServerUrl().get());
         assertEquals(List.of("user-read-private", "user-read-email"), config.authentication.scopes.get());
         assertTrue(config.token.verifyAccessTokenWithUserInfo.get());
@@ -413,21 +368,17 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testOverrideSpotifyProperties() {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
-
-        tenant.setApplicationType(ApplicationType.HYBRID);
-        tenant.setAuthServerUrl("http://localhost/wiremock");
-        tenant.getToken().setIssuer("http://localhost/wiremock");
-        tenant.authentication.setScopes(List.of("write"));
-        tenant.authentication.setForceRedirectHttpsScheme(false);
-        tenant.token.setPrincipalClaim("firstname");
-        tenant.token.setVerifyAccessTokenWithUserInfo(false);
-
+        OidcTenantConfig tenant = OidcTenantConfig.builder()
+                .applicationType(ApplicationType.HYBRID)
+                .authServerUrl("http://localhost/wiremock")
+                .token().issuer("http://localhost/wiremock").principalClaim("firstname")
+                .verifyAccessTokenWithUserInfo(false).end()
+                .authentication().scopes("write").forceRedirectHttpsScheme(false).end()
+                .build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.SPOTIFY));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.HYBRID, config.getApplicationType().get());
+        assertEquals(ApplicationType.HYBRID, config.applicationType().get());
         assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
         assertEquals(List.of("write"), config.authentication.scopes.get());
         assertEquals("http://localhost/wiremock", config.getToken().getIssuer().get());
@@ -438,12 +389,11 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testAcceptStravaProperties() {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
+        OidcTenantConfig tenant = OidcTenantConfig.builder().build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.STRAVA));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.WEB_APP, config.getApplicationType().get());
+        assertEquals(ApplicationType.WEB_APP, config.applicationType().get());
 
         assertFalse(config.discoveryEnabled.get());
         assertEquals("https://www.strava.com/oauth", config.getAuthServerUrl().get());
@@ -453,83 +403,74 @@ public class KnownOidcProvidersTest {
         assertEquals(List.of("activity:read"), config.authentication.scopes.get());
         assertTrue(config.token.verifyAccessTokenWithUserInfo.get());
         assertFalse(config.getAuthentication().idTokenRequired.get());
-        assertEquals(Method.QUERY, config.credentials.clientSecret.method.get());
+        assertEquals(Method.QUERY, config.credentials().clientSecret().method().get());
         assertEquals("/strava", config.authentication.redirectPath.get());
         assertEquals(",", config.authentication.scopeSeparator.get());
     }
 
     @Test
     public void testOverrideStravaProperties() {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
-
-        tenant.setApplicationType(ApplicationType.HYBRID);
-        tenant.setAuthServerUrl("http://localhost/wiremock");
-        tenant.setAuthorizationPath("authorizations");
-        tenant.setTokenPath("tokens");
-        tenant.setUserInfoPath("users");
-
-        tenant.authentication.setScopes(List.of("write"));
-        tenant.token.setVerifyAccessTokenWithUserInfo(false);
-        tenant.credentials.clientSecret.setMethod(Method.BASIC);
-        tenant.authentication.setRedirectPath("/fitness-app");
-        tenant.authentication.setScopeSeparator(" ");
-
+        OidcTenantConfig tenant = OidcTenantConfig.builder()
+                .applicationType(ApplicationType.HYBRID)
+                .authServerUrl("http://localhost/wiremock")
+                .authorizationPath("authorizations")
+                .tokenPath("tokens")
+                .userInfoPath("users")
+                .authentication().scopes("write").redirectPath("/fitness-app").scopeSeparator(" ").end()
+                .token().verifyAccessTokenWithUserInfo(false).end()
+                .credentials().clientSecret().method(Method.BASIC).end().end()
+                .build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.STRAVA));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.HYBRID, config.getApplicationType().get());
+        assertEquals(ApplicationType.HYBRID, config.applicationType().get());
         assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
         assertEquals("authorizations", config.getAuthorizationPath().get());
         assertEquals("tokens", config.getTokenPath().get());
         assertEquals("users", config.getUserInfoPath().get());
         assertEquals(List.of("write"), config.authentication.scopes.get());
         assertFalse(config.token.verifyAccessTokenWithUserInfo.get());
-        assertEquals(Method.BASIC, config.credentials.clientSecret.method.get());
+        assertEquals(Method.BASIC, config.credentials().clientSecret().method().get());
         assertEquals("/fitness-app", config.authentication.redirectPath.get());
         assertEquals(" ", config.authentication.scopeSeparator.get());
     }
 
     @Test
     public void testAcceptTwitchProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
+        OidcTenantConfig tenant = OidcTenantConfig.builder().build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.TWITCH));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.WEB_APP, config.getApplicationType().get());
+        assertEquals(ApplicationType.WEB_APP, config.applicationType().get());
         assertEquals("https://id.twitch.tv/oauth2", config.getAuthServerUrl().get());
-        assertEquals(Method.POST, config.credentials.clientSecret.method.get());
+        assertEquals(Method.POST, config.credentials().clientSecret().method().get());
         assertTrue(config.authentication.forceRedirectHttpsScheme.get());
     }
 
     @Test
     public void testOverrideTwitchProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
-
-        tenant.setApplicationType(ApplicationType.HYBRID);
-        tenant.setAuthServerUrl("http://localhost/wiremock");
-        tenant.credentials.clientSecret.setMethod(Method.BASIC);
-        tenant.authentication.setForceRedirectHttpsScheme(false);
-
+        OidcTenantConfig tenant = OidcTenantConfig.builder()
+                .applicationType(ApplicationType.HYBRID)
+                .authServerUrl("http://localhost/wiremock")
+                .credentials().clientSecret().method(Method.BASIC).end().end()
+                .authentication().forceRedirectHttpsScheme(false).end()
+                .build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.FACEBOOK));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.HYBRID, config.getApplicationType().get());
+        assertEquals(ApplicationType.HYBRID, config.applicationType().get());
         assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
         assertFalse(config.getAuthentication().isForceRedirectHttpsScheme().get());
-        assertEquals(Method.BASIC, config.credentials.clientSecret.method.get());
+        assertEquals(Method.BASIC, config.credentials().clientSecret().method().get());
     }
 
     @Test
     public void testAcceptDiscordProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
+        OidcTenantConfig tenant = OidcTenantConfig.builder().build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.DISCORD));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.WEB_APP, config.getApplicationType().get());
+        assertEquals(ApplicationType.WEB_APP, config.applicationType().get());
         assertFalse(config.discoveryEnabled.get());
         assertEquals("https://discord.com/api/oauth2", config.getAuthServerUrl().get());
         assertEquals("authorize", config.getAuthorizationPath().get());
@@ -542,27 +483,24 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testOverrideDiscordProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
-
-        tenant.setApplicationType(ApplicationType.HYBRID);
-        tenant.setAuthServerUrl("http://localhost/wiremock");
-        tenant.credentials.clientSecret.setMethod(Method.BASIC);
-        tenant.authentication.setForceRedirectHttpsScheme(false);
-
+        OidcTenantConfig tenant = OidcTenantConfig.builder()
+                .applicationType(ApplicationType.HYBRID)
+                .authServerUrl("http://localhost/wiremock")
+                .credentials().clientSecret().method(Method.BASIC).end().end()
+                .authentication().forceRedirectHttpsScheme(false).end()
+                .build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.DISCORD));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.HYBRID, config.getApplicationType().get());
+        assertEquals(ApplicationType.HYBRID, config.applicationType().get());
         assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
         assertFalse(config.getAuthentication().isForceRedirectHttpsScheme().get());
-        assertEquals(Method.BASIC, config.credentials.clientSecret.method.get());
+        assertEquals(Method.BASIC, config.credentials().clientSecret().method().get());
     }
 
     @Test
     public void testAcceptLinkedInProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
+        OidcTenantConfig tenant = OidcTenantConfig.builder().build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.LINKEDIN));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
@@ -572,31 +510,28 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testOverrideLinkedInProperties() throws Exception {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
-
-        tenant.setApplicationType(ApplicationType.HYBRID);
-        tenant.setAuthServerUrl("http://localhost/wiremock");
-        tenant.credentials.clientSecret.setMethod(Method.BASIC);
-        tenant.authentication.setForceRedirectHttpsScheme(false);
-
+        OidcTenantConfig tenant = OidcTenantConfig.builder()
+                .applicationType(ApplicationType.HYBRID)
+                .authServerUrl("http://localhost/wiremock")
+                .credentials().clientSecret().method(Method.BASIC).end().end()
+                .authentication().forceRedirectHttpsScheme(false).end()
+                .build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.LINKEDIN));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.HYBRID, config.getApplicationType().get());
+        assertEquals(ApplicationType.HYBRID, config.applicationType().get());
         assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
         assertFalse(config.getAuthentication().isForceRedirectHttpsScheme().get());
-        assertEquals(Method.BASIC, config.credentials.clientSecret.method.get());
+        assertEquals(Method.BASIC, config.credentials().clientSecret().method().get());
     }
 
     @Test
     public void testAcceptSlackProperties() {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
+        OidcTenantConfig tenant = OidcTenantConfig.builder().build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.SLACK));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
-        assertEquals(ApplicationType.WEB_APP, config.getApplicationType().get());
+        assertEquals(ApplicationType.WEB_APP, config.applicationType().get());
         assertTrue(config.isDiscoveryEnabled().orElse(true));
         assertEquals("https://slack.com", config.getAuthServerUrl().get());
 
@@ -607,18 +542,18 @@ public class KnownOidcProvidersTest {
 
     @Test
     public void testOverrideSlackProperties() {
-        OidcTenantConfig tenant = new OidcTenantConfig();
-        tenant.setTenantId("PattiSmith");
-        tenant.setApplicationType(ApplicationType.SERVICE);
-        tenant.setDiscoveryEnabled(false);
-        tenant.setAuthServerUrl("https://private-slack.com");
-        tenant.getToken().setPrincipalClaim("I you my own principal");
-        tenant.getAuthentication().setForceRedirectHttpsScheme(false);
-        tenant.getAuthentication().setScopes(List.of("profile"));
+        OidcTenantConfig tenant = OidcTenantConfig.builder()
+                .tenantId("PattiSmith")
+                .applicationType(ApplicationType.SERVICE)
+                .discoveryEnabled(false)
+                .authServerUrl("https://private-slack.com")
+                .token().principalClaim("I you my own principal").end()
+                .authentication().forceRedirectHttpsScheme(false).scopes("profile").end()
+                .build();
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.SLACK));
 
         assertEquals("PattiSmith", config.getTenantId().get());
-        assertEquals(ApplicationType.SERVICE, config.getApplicationType().get());
+        assertEquals(ApplicationType.SERVICE, config.applicationType().get());
         assertFalse(config.isDiscoveryEnabled().orElse(true));
         assertEquals("https://private-slack.com", config.getAuthServerUrl().get());
 

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcProviderTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcProviderTest.java
@@ -43,7 +43,7 @@ public class OidcProviderTest {
         final String token = Jwt.issuer("http://keycloak/realm").jws().keyId("k1").sign(rsaJsonWebKey.getPrivateKey());
         final String newToken = replaceAlgorithm(token, "ES256");
         JsonWebKeySet jwkSet = new JsonWebKeySet("{\"keys\": [" + rsaJsonWebKey.toJson() + "]}");
-        OidcTenantConfig oidcConfig = new OidcTenantConfig();
+        OidcTenantConfig oidcConfig = OidcTenantConfig.builder().build();
 
         try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet)) {
             try {
@@ -76,7 +76,7 @@ public class OidcProviderTest {
 
         final String token = Jwt.issuer("http://keycloak/realm").sign(rsaJsonWebKey.getPrivateKey());
 
-        try (OidcProvider provider = new OidcProvider(null, new OidcTenantConfig(), jwkSet)) {
+        try (OidcProvider provider = new OidcProvider(null, OidcTenantConfig.builder().build(), jwkSet)) {
             TokenVerificationResult result = provider.verifyJwtToken(token, false, false, null);
             assertEquals("http://keycloak/realm", result.localVerificationResult().getString("iss"));
         }
@@ -91,7 +91,7 @@ public class OidcProviderTest {
 
         final String token = Jwt.issuer("http://keycloak/realm").sign(rsaJsonWebKey1.getPrivateKey());
 
-        try (OidcProvider provider = new OidcProvider(null, new OidcTenantConfig(), jwkSet)) {
+        try (OidcProvider provider = new OidcProvider(null, OidcTenantConfig.builder().build(), jwkSet)) {
             try {
                 provider.verifyJwtToken(token, false, false, null);
                 fail("InvalidJwtException expected");
@@ -109,8 +109,7 @@ public class OidcProviderTest {
                 "{\"keys\": [" + rsaJsonWebKey1.toJson() + "," + rsaJsonWebKey2.toJson() + "]}");
 
         final String token = Jwt.issuer("http://keycloak/realm").sign(rsaJsonWebKey2.getPrivateKey());
-        final OidcTenantConfig config = new OidcTenantConfig();
-        config.jwks.tryAll = true;
+        final OidcTenantConfig config = OidcTenantConfig.builder().jwks().tryAll(true).end().build();
 
         try (OidcProvider provider = new OidcProvider(null, config, jwkSet)) {
             TokenVerificationResult result = provider.verifyJwtToken(token, false, false, null);
@@ -127,8 +126,7 @@ public class OidcProviderTest {
                 "{\"keys\": [" + rsaJsonWebKey1.toJson() + "," + rsaJsonWebKey2.toJson() + "]}");
 
         final String token = Jwt.issuer("http://keycloak/realm").sign(rsaJsonWebKey3.getPrivateKey());
-        final OidcTenantConfig config = new OidcTenantConfig();
-        config.jwks.tryAll = true;
+        final OidcTenantConfig config = OidcTenantConfig.builder().jwks().tryAll(true).end().build();
 
         try (OidcProvider provider = new OidcProvider(null, config, jwkSet)) {
             try {
@@ -156,8 +154,7 @@ public class OidcProviderTest {
         rsaJsonWebKey.setKeyId("k1");
         JsonWebKeySet jwkSet = new JsonWebKeySet("{\"keys\": [" + rsaJsonWebKey.toJson() + "]}");
 
-        OidcTenantConfig oidcConfig = new OidcTenantConfig();
-        oidcConfig.token.subjectRequired = true;
+        OidcTenantConfig oidcConfig = OidcTenantConfig.builder().token().subjectRequired(true).end().build();
 
         final String tokenWithSub = Jwt.subject("subject").jws().keyId("k1").sign(rsaJsonWebKey.getPrivateKey());
 
@@ -183,8 +180,7 @@ public class OidcProviderTest {
         rsaJsonWebKey.setKeyId("k1");
         JsonWebKeySet jwkSet = new JsonWebKeySet("{\"keys\": [" + rsaJsonWebKey.toJson() + "]}");
 
-        OidcTenantConfig oidcConfig = new OidcTenantConfig();
-        oidcConfig.authentication.nonceRequired = true;
+        OidcTenantConfig oidcConfig = OidcTenantConfig.builder().authentication().nonceRequired(true).end().build();
 
         final String tokenWithNonce = Jwt.claim("nonce", "123456").jws().keyId("k1").sign(rsaJsonWebKey.getPrivateKey());
 
@@ -222,16 +218,14 @@ public class OidcProviderTest {
 
         JsonWebKeySet jwkSet = new JsonWebKeySet("{\"keys\": [" + rsaJsonWebKey.toJson() + "]}");
 
-        OidcTenantConfig oidcConfig = new OidcTenantConfig();
-        oidcConfig.token.issuedAtRequired = false;
+        OidcTenantConfig oidcConfig = OidcTenantConfig.builder().token().issuedAtRequired(false).end().build();
 
         try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet)) {
             TokenVerificationResult result = provider.verifyJwtToken(token, false, false, null);
             assertNull(result.localVerificationResult().getString(Claims.iat.name()));
         }
 
-        OidcTenantConfig oidcConfigRequireAge = new OidcTenantConfig();
-        oidcConfigRequireAge.token.issuedAtRequired = true;
+        OidcTenantConfig oidcConfigRequireAge = OidcTenantConfig.builder().token().issuedAtRequired(true).end().build();
 
         try (OidcProvider provider = new OidcProvider(null, oidcConfigRequireAge, jwkSet)) {
             try {
@@ -249,7 +243,7 @@ public class OidcProviderTest {
         rsaJsonWebKey.setKeyId("k1");
         JsonWebKeySet jwkSet = new JsonWebKeySet("{\"keys\": [" + rsaJsonWebKey.toJson() + "]}");
 
-        OidcTenantConfig oidcConfig = new OidcTenantConfig();
+        OidcTenantConfig oidcConfig = OidcTenantConfig.builder().build();
 
         String token = Jwt.claim("claim1", "claimValue1").claim("claim2", "claimValue2").jws().keyId("k1")
                 .sign(rsaJsonWebKey.getPrivateKey());

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcRecorderTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcRecorderTest.java
@@ -2,26 +2,23 @@ package io.quarkus.oidc.runtime;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Optional;
-
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.oidc.common.runtime.OidcCommonConfig.Proxy;
+import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 
 public class OidcRecorderTest {
 
     @Test
     public void testtoProxyOptionsWithHostCheckPresent() {
-        Proxy proxy = new Proxy();
-        proxy.host = Optional.of("server.example.com");
-        assertTrue(OidcCommonUtils.toProxyOptions(proxy, null).isPresent());
+        OidcTenantConfig config = OidcTenantConfig.builder().proxy("server.example.com", 80).build();
+        assertTrue(OidcCommonUtils.toProxyOptions(config.proxy(), null).isPresent());
     }
 
     @Test
     public void testtoProxyOptionsWithoutHostCheckNonPresent() {
-        Proxy proxy = new Proxy();
-        assertFalse(OidcCommonUtils.toProxyOptions(proxy, null).isPresent());
+        OidcTenantConfig config = OidcTenantConfig.builder().build();
+        assertFalse(OidcCommonUtils.toProxyOptions(config.proxy(), null).isPresent());
     }
 
 }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -54,8 +54,7 @@ public class OidcUtilsTest {
     @Test
     public void testGetSingleSessionCookie() throws Exception {
 
-        OidcTenantConfig oidcConfig = new OidcTenantConfig();
-        oidcConfig.setTenantId("test");
+        OidcTenantConfig oidcConfig = OidcTenantConfig.builder().tenantId("test").build();
         Map<String, Object> context = new HashMap<>();
         String sessionCookieValue = OidcUtils.getSessionCookie(context,
                 Map.of("q_session_test", new CookieImpl("q_session_test", "tokens")), oidcConfig);
@@ -69,8 +68,7 @@ public class OidcUtilsTest {
     @Test
     public void testGetMultipleSessionCookies() throws Exception {
 
-        OidcTenantConfig oidcConfig = new OidcTenantConfig();
-        oidcConfig.setTenantId("test");
+        OidcTenantConfig oidcConfig = OidcTenantConfig.builder().tenantId("test").build();
 
         char[] alphabet = "abcdefghijklmnopqrstuvwxyz".toCharArray();
 
@@ -103,21 +101,19 @@ public class OidcUtilsTest {
 
     @Test
     public void testCorrectTokenType() throws Exception {
-        OidcTenantConfig.Token tokenClaims = new OidcTenantConfig.Token();
-        tokenClaims.setTokenType("access_token");
+        OidcTenantConfig config = OidcTenantConfig.builder().token().tokenType("access_token").end().build();
         JsonObject json = new JsonObject();
         json.put("typ", "access_token");
-        OidcUtils.validatePrimaryJwtTokenType(tokenClaims, json);
+        OidcUtils.validatePrimaryJwtTokenType(config.token(), json);
     }
 
     @Test
     public void testWrongTokenType() throws Exception {
-        OidcTenantConfig.Token tokenClaims = new OidcTenantConfig.Token();
-        tokenClaims.setTokenType("access_token");
+        OidcTenantConfig config = OidcTenantConfig.builder().token().tokenType("access_token").end().build();
         JsonObject json = new JsonObject();
         json.put("typ", "refresh_token");
         try {
-            OidcUtils.validatePrimaryJwtTokenType(tokenClaims, json);
+            OidcUtils.validatePrimaryJwtTokenType(config.token(), json);
             fail("Exception expected: wrong token type");
         } catch (OIDCException ex) {
             // expected
@@ -126,10 +122,11 @@ public class OidcUtilsTest {
 
     @Test
     public void testKeycloakRefreshTokenType() throws Exception {
+        OidcTenantConfig config = OidcTenantConfig.builder().build();
         JsonObject json = new JsonObject();
         json.put("typ", "Refresh");
         try {
-            OidcUtils.validatePrimaryJwtTokenType(new OidcTenantConfig.Token(), json);
+            OidcUtils.validatePrimaryJwtTokenType(config.token(), json);
             fail("Exception expected: wrong token type");
         } catch (OIDCException ex) {
             // expected
@@ -289,31 +286,29 @@ public class OidcUtilsTest {
 
     @Test
     public void testEncodeScopesOpenidAdded() throws Exception {
-        OidcTenantConfig config = new OidcTenantConfig();
+        OidcTenantConfig config = OidcTenantConfig.builder().build();
         assertEquals("openid", OidcUtils.encodeScopes(config));
     }
 
     @Test
     public void testEncodeScopesOpenidNotAdded() throws Exception {
-        OidcTenantConfig config = new OidcTenantConfig();
-        config.authentication.setAddOpenidScope(false);
+        OidcTenantConfig config = OidcTenantConfig.builder().authentication().addOpenidScope(false).end().build();
         assertEquals("", OidcUtils.encodeScopes(config));
     }
 
     @Test
     public void testEncodeAllScopes() throws Exception {
-        OidcTenantConfig config = new OidcTenantConfig();
-        config.authentication.setScopes(List.of("a:1", "b:2"));
-        config.authentication.setExtraParams(Map.of("scope", "c,d"));
+        OidcTenantConfig config = OidcTenantConfig.builder()
+                .authentication().scopes(List.of("a:1", "b:2")).extraParams(Map.of("scope", "c,d")).end()
+                .build();
         assertEquals("openid+a%3A1+b%3A2+c+d", OidcUtils.encodeScopes(config));
     }
 
     @Test
     public void testEncodeAllScopesWithCustomSeparator() throws Exception {
-        OidcTenantConfig config = new OidcTenantConfig();
-        config.authentication.setScopeSeparator(",");
-        config.authentication.setScopes(List.of("a:1", "b:2"));
-        config.authentication.setExtraParams(Map.of("scope", "c,d"));
+        OidcTenantConfig config = OidcTenantConfig.builder()
+                .authentication().scopeSeparator(",").scopes(List.of("a:1", "b:2")).extraParams(Map.of("scope", "c,d")).end()
+                .build();
         assertEquals("openid%2Ca%3A1%2Cb%3A2%2Cc%2Cd", OidcUtils.encodeScopes(config));
     }
 

--- a/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -16,7 +16,6 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import io.quarkus.oidc.OidcRequestContext;
 import io.quarkus.oidc.OidcTenantConfig;
-import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
 import io.quarkus.oidc.TenantConfigResolver;
 import io.quarkus.oidc.client.registration.ClientMetadata;
 import io.quarkus.oidc.client.registration.OidcClientRegistration;
@@ -176,16 +175,16 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
     }
 
     private OidcTenantConfig createTenantConfig(String tenantId, ClientMetadata metadata) {
-        OidcTenantConfig oidcConfig = new OidcTenantConfig();
-        oidcConfig.setTenantId(tenantId);
-        oidcConfig.setAuthServerUrl(authServerUrl);
-        oidcConfig.setApplicationType(ApplicationType.WEB_APP);
-        oidcConfig.setClientName(metadata.getClientName());
-        oidcConfig.setClientId(metadata.getClientId());
-        oidcConfig.getCredentials().setSecret(metadata.getClientSecret());
         String redirectUri = metadata.getRedirectUris().get(0);
-        oidcConfig.getAuthentication().setRedirectPath(URI.create(redirectUri).getPath());
-        return oidcConfig;
+        return OidcTenantConfig.builder()
+                .tenantId(tenantId)
+                .authServerUrl(authServerUrl)
+                .applicationType(WEB_APP)
+                .clientName(metadata.getClientName())
+                .clientId(metadata.getClientId())
+                .credentials().secret(metadata.getClientSecret()).end()
+                .authentication().redirectPath(URI.create(redirectUri).getPath()).end()
+                .build();
     }
 
     protected static ClientMetadata createMetadata(String redirectUri, String clientName) {

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -10,8 +10,8 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import io.quarkus.oidc.OidcRequestContext;
 import io.quarkus.oidc.OidcTenantConfig;
-import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
 import io.quarkus.oidc.TenantConfigResolver;
+import io.quarkus.oidc.runtime.OidcTenantConfig.ApplicationType;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
@@ -22,18 +22,19 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
     @ConfigProperty(name = "quarkus.oidc.auth-server-url")
     String authServerUrl;
 
-    OidcTenantConfig config = new OidcTenantConfig();
+    OidcTenantConfig config;
 
     public CustomTenantConfigResolver() {
     }
 
     @PostConstruct
     public void initConfig() {
-        config.setTenantId("tenant-before-wrong-redirect");
-        config.setAuthServerUrl(authServerUrl);
-        config.setClientId("quarkus-app");
-        config.getCredentials().setSecret("secret");
-        config.setApplicationType(ApplicationType.WEB_APP);
+        config = OidcTenantConfig.authServerUrl(authServerUrl)
+                .tenantId("tenant-before-wrong-redirect")
+                .clientId("quarkus-app")
+                .credentials().secret("secret").end()
+                .applicationType(ApplicationType.WEB_APP)
+                .build();
     }
 
     @Override

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -1,7 +1,6 @@
 package io.quarkus.it.keycloak;
 
 import java.time.Duration;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -11,11 +10,10 @@ import org.eclipse.microprofile.config.ConfigProvider;
 
 import io.quarkus.oidc.OidcRequestContext;
 import io.quarkus.oidc.OidcTenantConfig;
-import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
-import io.quarkus.oidc.OidcTenantConfig.Roles.Source;
 import io.quarkus.oidc.TenantConfigResolver;
-import io.quarkus.oidc.common.runtime.OidcClientCommonConfig.Credentials;
-import io.quarkus.oidc.common.runtime.OidcClientCommonConfig.Credentials.Secret.Method;
+import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Secret.Method;
+import io.quarkus.oidc.runtime.OidcTenantConfig.ApplicationType;
+import io.quarkus.oidc.runtime.OidcTenantConfig.Roles.Source;
 import io.smallrye.jwt.algorithm.SignatureAlgorithm;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
@@ -44,18 +42,15 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                 String tenantId = path.split("/")[2];
 
                 if ("tenant-d".equals(tenantId)) {
-                    OidcTenantConfig config = new OidcTenantConfig();
-                    config.setTenantId("tenant-c");
-                    config.setAuthServerUrl(getIssuerUrl() + "/realms/quarkus-d");
-                    config.setClientId("quarkus-app-d");
-                    config.getCredentials().setSecret("secret");
-                    config.getToken().setIssuer(getIssuerUrl() + "/realms/quarkus-d");
-                    config.getAuthentication().setUserInfoRequired(true);
-                    config.setAllowUserInfoCache(false);
-                    return config;
+                    return OidcTenantConfig.authServerUrl(getIssuerUrl() + "/realms/quarkus-d")
+                            .tenantId("tenant-c")
+                            .clientId("quarkus-app-d")
+                            .credentials("secret")
+                            .token().issuer(getIssuerUrl() + "/realms/quarkus-d").end()
+                            .authentication().userInfoRequired(true).end()
+                            .allowUserInfoCache(false)
+                            .build();
                 } else if ("tenant-oidc".equals(tenantId) || context.normalizedPath().startsWith("/step-up-auth")) {
-                    OidcTenantConfig config = new OidcTenantConfig();
-                    config.setTenantId("tenant-oidc");
                     String uri = context.request().absoluteURI();
                     // authServerUri points to the JAX-RS `OidcResource`, root path is `/oidc`
                     final String authServerUri;
@@ -74,15 +69,16 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                             authServerUri = uri.replace("/tenant/tenant-oidc/api/user", "/oidc");
                         }
                     }
-                    config.setAuthServerUrl(authServerUri);
-                    config.setClientId("client");
-                    config.setAllowTokenIntrospectionCache(false);
                     // auto-discovery in Quarkus is enabled but the OIDC server returns an empty document, set the required endpoints in the config
-                    // try the path relative to the authServerUri
-                    config.setJwksPath("jwks");
-                    // try the absolute URI
-                    config.setIntrospectionPath(authServerUri + "/introspect");
-                    return config;
+                    return OidcTenantConfig.authServerUrl(authServerUri)
+                            .tenantId("tenant-oidc")
+                            .clientId("client")
+                            .allowTokenIntrospectionCache(false)
+                            // try the path relative to the authServerUri
+                            .jwksPath("jwks")
+                            // try the absolute URI
+                            .introspectionPath(authServerUri + "/introspect")
+                            .build();
                 } else if ("tenant-introspection-multiple-required-claims".equals(tenantId)) {
                     String uri = context.request().absoluteURI();
                     String authServerUri = uri.replace("/tenant-introspection/tenant-introspection-multiple-required-claims",
@@ -97,116 +93,118 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                             .token().requiredClaims("required_claim", Set.of("1", "2")).end()
                             .build();
                 } else if ("tenant-introspection-required-claims".equals(tenantId)) {
-
-                    OidcTenantConfig config = new OidcTenantConfig();
-                    config.setTenantId("tenant-introspection-required-claims");
-                    config.token.setRequiredClaims(Map.of("required_claim", Set.of("1")));
                     String uri = context.request().absoluteURI();
                     String authServerUri = uri.replace("/tenant-introspection/tenant-introspection-required-claims",
                             "/oidc");
-                    config.setAuthServerUrl(authServerUri);
-                    config.setDiscoveryEnabled(false);
-                    config.setClientId("client");
-                    config.setIntrospectionPath(authServerUri + "/introspect");
-                    config.setAllowTokenIntrospectionCache(false);
-                    return config;
+                    return OidcTenantConfig.builder()
+                            .tenantId("tenant-introspection-required-claims")
+                            .token().requiredClaims("required_claim", Set.of("1")).end()
+                            .authServerUrl(authServerUri)
+                            .discoveryEnabled(false)
+                            .clientId("client")
+                            .introspectionPath(authServerUri + "/introspect")
+                            .allowTokenIntrospectionCache(false)
+                            .build();
                 } else if ("tenant-oidc-no-discovery".equals(tenantId)) {
-                    OidcTenantConfig config = new OidcTenantConfig();
-                    config.setTenantId("tenant-oidc-no-discovery");
                     String uri = context.request().absoluteURI();
                     String authServerUri = uri.replace("/tenant/tenant-oidc-no-discovery/api/user", "/oidc");
-                    config.setAuthServerUrl(authServerUri);
-                    config.setDiscoveryEnabled(false);
-                    config.setJwksPath("jwks");
-                    config.setClientId("client");
-                    return config;
+                    return OidcTenantConfig.authServerUrl(authServerUri)
+                            .tenantId("tenant-oidc-no-discovery")
+                            .discoveryEnabled(false)
+                            .jwksPath("jwks")
+                            .clientId("client")
+                            .build();
                 } else if ("tenant-oidc-no-introspection".equals(tenantId)) {
-                    OidcTenantConfig config = new OidcTenantConfig();
-                    config.setTenantId("tenant-oidc-no-introspection");
                     String uri = context.request().absoluteURI();
                     String authServerUri = uri.replace("/tenant/tenant-oidc-no-introspection/api/user", "/oidc");
-                    config.setAuthServerUrl(authServerUri);
-                    config.token.setAllowJwtIntrospection(false);
-                    config.setClientId("client");
-                    return config;
+                    return OidcTenantConfig.builder()
+                            .tenantId("tenant-oidc-no-introspection")
+                            .authServerUrl(authServerUri)
+                            .token().allowJwtIntrospection(false).end()
+                            .clientId("client")
+                            .build();
                 } else if ("tenant-oidc-introspection-only".equals(tenantId)) {
-                    OidcTenantConfig config = new OidcTenantConfig();
-                    config.setTenantId(tenantId);
                     String uri = context.request().absoluteURI();
                     String authServerUri = uri.replace("/tenant/" + tenantId + "/api/user", "/oidc");
-                    config.setAuthServerUrl(authServerUri);
-                    config.setDiscoveryEnabled(false);
-                    config.authentication.setUserInfoRequired(true);
-                    config.token.setSubjectRequired(true);
-                    config.setIntrospectionPath("introspect");
-                    config.setUserInfoPath("userinfo");
-                    config.setClientId("client-introspection-only");
-                    config.setAllowTokenIntrospectionCache(false);
-                    config.setAllowUserInfoCache(false);
-                    Credentials creds = config.getCredentials();
-                    creds.clientSecret.setMethod(Credentials.Secret.Method.POST_JWT);
-                    creds.getJwt().setKeyFile("ecPrivateKey.pem");
-                    creds.getJwt().setSignatureAlgorithm(SignatureAlgorithm.ES256.getAlgorithm());
-                    return config;
+                    return OidcTenantConfig.authServerUrl(authServerUri)
+                            .tenantId(tenantId)
+                            .discoveryEnabled(false)
+                            .authentication().userInfoRequired(true).end()
+                            .token().subjectRequired(true).end()
+                            .introspectionPath("introspect")
+                            .userInfoPath("userinfo")
+                            .clientId("client-introspection-only")
+                            .allowTokenIntrospectionCache(false)
+                            .allowUserInfoCache(false)
+                            .credentials()
+                            .clientSecret().method(Method.POST_JWT).end()
+                            .jwt().keyFile("ecPrivateKey.pem")
+                            .signatureAlgorithm(SignatureAlgorithm.ES256.getAlgorithm())
+                            .endCredentials()
+                            .build();
                 } else if ("tenant-oidc-introspection-only-cache".equals(tenantId)) {
-                    OidcTenantConfig config = new OidcTenantConfig();
-                    config.setTenantId(tenantId);
                     String uri = context.request().absoluteURI();
                     String authServerUri = uri.replace("/tenant/" + tenantId + "/api/user", "/oidc");
-                    config.setAuthServerUrl(authServerUri);
-                    config.authentication.setUserInfoRequired(true);
-                    config.setUserInfoPath("userinfo");
-                    config.setClientId("client-introspection-only-cache");
-                    config.getIntrospectionCredentials().setName("bob");
-                    config.getIntrospectionCredentials().setSecret("bob_secret");
-                    config.getToken().setRequireJwtIntrospectionOnly(true);
-                    return config;
+                    return OidcTenantConfig.authServerUrl(authServerUri)
+                            .tenantId(tenantId)
+                            .authentication().userInfoRequired(true).end()
+                            .userInfoPath("userinfo")
+                            .clientId("client-introspection-only-cache")
+                            .introspectionCredentials().name("bob").secret("bob_secret").end()
+                            .token().requireJwtIntrospectionOnly(true).end()
+                            .build();
                 } else if ("tenant-oidc-no-opaque-token".equals(tenantId)) {
-                    OidcTenantConfig config = new OidcTenantConfig();
-                    config.setTenantId("tenant-oidc-no-opaque-token");
                     String uri = context.request().absoluteURI();
                     String authServerUri = uri.replace("/tenant-opaque/tenant-oidc-no-opaque-token/api/user", "/oidc");
-                    config.setAuthServerUrl(authServerUri);
-                    config.token.setAllowOpaqueTokenIntrospection(false);
-                    config.setClientId("client");
-                    return config;
+                    return OidcTenantConfig.authServerUrl(authServerUri)
+                            .tenantId("tenant-oidc-no-opaque-token")
+                            .token().allowOpaqueTokenIntrospection(false).end()
+                            .clientId("client")
+                            .build();
                 } else if ("tenant-web-app-refresh".equals(tenantId)) {
-                    OidcTenantConfig config = new OidcTenantConfig();
-                    config.setTenantId("tenant-web-app-refresh");
-                    config.setApplicationType(ApplicationType.WEB_APP);
-                    config.getToken().setRefreshExpired(true);
-                    config.getToken().setRefreshTokenTimeSkew(Duration.ofSeconds(3));
-                    config.setAuthServerUrl(getIssuerUrl() + "/realms/quarkus-webapp");
-                    config.setClientId("quarkus-app-webapp");
-                    config.getCredentials().getClientSecret().setValue(
-                            "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow");
-                    config.getCredentials().getClientSecret().setMethod(Method.POST);
-
                     // Let Keycloak issue a login challenge but use the test token endpoint
                     String uri = context.request().absoluteURI();
-                    String tokenUri = uri.replace("/tenant-refresh/tenant-web-app-refresh/api/user", "/oidc/token");
-                    config.setTokenPath(tokenUri);
-                    String jwksUri = uri.replace("/tenant-refresh/tenant-web-app-refresh/api/user", "/oidc/jwks");
-                    config.setJwksPath(jwksUri);
-                    String userInfoPath = uri.replace("/tenant-refresh/tenant-web-app-refresh/api/user", "/oidc/userinfo");
-                    config.setUserInfoPath(userInfoPath);
-                    config.getToken().setIssuer("any");
-                    config.tokenStateManager.setSplitTokens(true);
-                    config.tokenStateManager.setEncryptionRequired(false);
-                    config.getAuthentication().setSessionAgeExtension(Duration.ofMinutes(1));
-                    config.getAuthentication().setIdTokenRequired(false);
-                    return config;
+                    String tokenUri = uri.replace("/tenant-refresh/tenant-web-app-refresh/api/user",
+                            "/oidc/token");
+                    String jwksUri = uri.replace("/tenant-refresh/tenant-web-app-refresh/api/user",
+                            "/oidc/jwks");
+                    String userInfoPath = uri.replace("/tenant-refresh/tenant-web-app-refresh/api/user",
+                            "/oidc/userinfo");
+                    return OidcTenantConfig.builder()
+                            .tenantId("tenant-web-app-refresh")
+                            .applicationType(ApplicationType.WEB_APP)
+                            .authServerUrl(getIssuerUrl() + "/realms/quarkus-webapp")
+                            .clientId("quarkus-app-webapp")
+                            .credentials()
+                            .clientSecret()
+                            .value("AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow")
+                            .method(Method.POST)
+                            .end()
+                            .end()
+                            .tokenPath(tokenUri)
+                            .jwksPath(jwksUri)
+                            .userInfoPath(userInfoPath)
+                            .token()
+                            .refreshExpired(true)
+                            .refreshTokenTimeSkew(Duration.ofSeconds(3))
+                            .issuer("any")
+                            .end()
+                            .tokenStateManager().splitTokens(true).encryptionRequired(false).end()
+                            .authentication()
+                            .sessionAgeExtension(Duration.ofMinutes(1))
+                            .idTokenRequired(false)
+                            .end()
+                            .build();
                 } else if ("tenant-web-app-dynamic".equals(tenantId)) {
-                    OidcTenantConfig config = new OidcTenantConfig();
-                    config.setTenantId("tenant-web-app-dynamic");
-                    config.setAuthServerUrl(getIssuerUrl() + "/realms/quarkus-webapp");
-                    config.setClientId("quarkus-app-webapp");
-                    config.getCredentials().setSecret("secret");
-                    config.getAuthentication().setUserInfoRequired(true);
-                    config.getRoles().setSource(Source.userinfo);
-                    config.setAllowUserInfoCache(false);
-                    config.setApplicationType(ApplicationType.WEB_APP);
-                    return config;
+                    return OidcTenantConfig.authServerUrl(getIssuerUrl() + "/realms/quarkus-webapp")
+                            .tenantId("tenant-web-app-dynamic")
+                            .clientId("quarkus-app-webapp")
+                            .credentials("secret")
+                            .authentication().userInfoRequired(true).end()
+                            .roles().source(Source.userinfo).end()
+                            .allowUserInfoCache(false)
+                            .applicationType(ApplicationType.WEB_APP)
+                            .build();
                 }
                 return null;
             }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -109,11 +109,14 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
 
             return Uni.createFrom().item(config);
         } else if (path.endsWith("bearer-certificate-full-chain-root-only")) {
-            OidcTenantConfig config = new OidcTenantConfig();
-            config.setTenantId("bearer-certificate-full-chain-root-only");
-            config.getCertificateChain().setTrustStoreFile(Path.of("target/chain/truststore-rootcert.p12"));
-            config.getCertificateChain().setTrustStorePassword("storepassword");
-            config.getCertificateChain().setLeafCertificateName("www.quarkustest.com");
+            OidcTenantConfig config = OidcTenantConfig.builder()
+                    .tenantId("bearer-certificate-full-chain-root-only")
+                    .certificateChain()
+                    .trustStoreFile(Path.of("target/chain/truststore-rootcert.p12"))
+                    .trustStorePassword("storepassword")
+                    .leafCertificateName("www.quarkustest.com")
+                    .end()
+                    .build();
             return Uni.createFrom().item(config);
         }
 


### PR DESCRIPTION
- these constructors or their whole classes (or at least parent classes) were deprecated and marked for removal since 3.18
- users have full alternative in config builders and we need to do it if we want to rely on the config mapping interface
- setters and fields are still in place, I'll deal with it in follow-up in order to keep reviews easy to understand
- this change is intended for Quarkus 4 and should be documented in its migration guide https://github.com/quarkusio/quarkus/wiki/Migration-Guide-4.0
