### PR TITLE
[3.x] Bump smallrye-reactive-messaging.version from 4.36.0 to 4.37.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -59,7 +59,7 @@
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
         <smallrye-openssl.version>0.1.4</smallrye-openssl.version>
         <smallrye-mutiny-vertx-binding.version>3.23.0</smallrye-mutiny-vertx-binding.version>
-        <smallrye-reactive-messaging.version>4.36.0</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>4.37.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.7.10</smallrye-stork.version>
         <jakarta.activation.version>2.1.4</jakarta.activation.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ConnectorContextPropagationDecorator.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ConnectorContextPropagationDecorator.java
@@ -7,6 +7,7 @@ import java.util.concurrent.Executor;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.context.ThreadContext;
 import org.eclipse.microprofile.reactive.messaging.Message;
@@ -31,6 +32,15 @@ public class ConnectorContextPropagationDecorator implements PublisherDecorator,
                 .propagated(propagation.map(l -> l.toArray(String[]::new)).orElse(ThreadContext.NONE))
                 .cleared(ThreadContext.ALL_REMAINING)
                 .build();
+    }
+
+    @Override
+    public Multi<? extends Message<?>> decorate(Multi<? extends Message<?>> publisher, List<String> channelName,
+            Config config) {
+        if (config != null) {
+            return new ContextPropagationOperator<>(publisher, tc);
+        }
+        return publisher;
     }
 
     @Override


### PR DESCRIPTION
https://github.com/smallrye/smallrye-reactive-messaging/milestone/128?closed=1

https://github.com/smallrye/smallrye-reactive-messaging/pull/3454 -> introduces a small breaking change (a default method to implement) for beans implementing both `PublisherDecorator` and `SubscriberDecorator` at the same time.