### PR TITLE
Add a name-based syntax for datasource Dev Services volumes

### DIFF
--- a/docs/src/main/asciidoc/databases-dev-services.adoc
+++ b/docs/src/main/asciidoc/databases-dev-services.adoc
@@ -179,7 +179,35 @@ Mapping volumes from the Docker host's filesystem to the containers is handy to 
 Mapping volumes will only work in Dev Services with a container-based database like PostgreSQL.
 ====
 
-Dev Services volumes can be mapped to the filesystem or the classpath:
+Each volume is identified by a name of your choice, and is described by its `source`, `target`, `type` and `read-only` properties, modeled after the long syntax of Docker Compose volumes:
+
+[source,properties]
+----
+# Using a filesystem (bind) volume:
+quarkus.datasource.devservices.volumes."data".source=/path/from <1>
+quarkus.datasource.devservices.volumes."data".target=/container/to
+# Using a classpath volume:
+quarkus.datasource.devservices.volumes."init-script".type=classpath <2>
+quarkus.datasource.devservices.volumes."init-script".source=/file
+quarkus.datasource.devservices.volumes."init-script".target=/container/to
+# Using a read-only filesystem volume:
+quarkus.datasource.devservices.volumes."config".source=/path/to/config <3>
+quarkus.datasource.devservices.volumes."config".target=/container/config
+quarkus.datasource.devservices.volumes."config".read-only=true
+----
+
+<1> The volume type defaults to `bind`, mapping the file or folder "/path/from" from the local machine to "/container/to" in the container, with read and write permission.
+<2> The `classpath` type resolves the source from the project's classpath instead of the filesystem. Classpath volumes are read-only by default: the file or folder is copied into the container.
+<3> Set `read-only` to `true` on a `bind` volume to prevent the container from modifying the source.
+
+Because the volume name is the only thing encoded in the configuration key,
+the properties can also be provided as environment variables,
+for example `QUARKUS_DATASOURCE_DEVSERVICES_VOLUMES_DATA_SOURCE`.
+
+[NOTE]
+.Deprecated: mapping volumes by host location
+====
+Volumes can also be declared with the host location as the configuration key, with the container location as the value:
 
 [source,properties]
 ----
@@ -188,12 +216,15 @@ quarkus.datasource.devservices.volumes."/path/from"=/container/to <1>
 # Using a classpath volume:
 quarkus.datasource.devservices.volumes."classpath\:./file"=/container/to <2>
 ----
-<1> The file or folder "/path/from" from the local machine will be accessible at "/container/to" in the container.
-<2> When using classpath volumes, the location has to start with "classpath:". The file or folder "./file" from the project's classpath will be accessible at "/container/to" in the container.
 
-CAUTION: The colon character `:` needs to be escaped in `.properties` files as `\:`, or it will be interpreted as a key/value separator.
+<1> The file or folder "/path/from" from the local machine will be accessible at "/container/to" in the container, with read and write permission.
+<2> When using classpath volumes, the location has to start with "classpath:". The file or folder "./file" from the project's classpath will be accessible at "/container/to" in the container, with read permission only.
 
-IMPORTANT: when using a classpath volume, the container will only be granted read permission. On the other hand, when using a filesystem volume, the container will be granted read and write permission.
+This form is deprecated: the colon character `:` needs to be escaped in `.properties` files as `\:`, or it will be interpreted as a key/value separator,
+the access mode cannot be chosen,
+and characters like `.` or `:` in the key cannot be represented in an environment variable name.
+Both forms can be used together.
+====
 
 === Example of mapping volumes to persist the database data
 
@@ -202,7 +233,8 @@ Let's see an example using PostgreSQL where we'll map a file system volume to ke
 [source,properties]
 ----
 quarkus.datasource.db-kind=postgresql
-quarkus.datasource.devservices.volumes."/local/test/data"=/var/lib/postgresql/data
+quarkus.datasource.devservices.volumes."data".source=/local/test/data
+quarkus.datasource.devservices.volumes."data".target=/var/lib/postgresql/data
 ----
 
 The appropriate in-container location varies depending on the database vendor. For PostgreSQL is "/var/lib/postgresql/data", but for MySQL, you would need this configuration instead:
@@ -210,7 +242,8 @@ The appropriate in-container location varies depending on the database vendor. F
 [source,properties]
 ----
 quarkus.datasource.db-kind=mysql
-quarkus.datasource.devservices.volumes."/local/test/data"=/var/lib/mysql
+quarkus.datasource.devservices.volumes."data".source=/local/test/data
+quarkus.datasource.devservices.volumes."data".target=/var/lib/mysql
 ----
 
 When starting Dev Services (for example, in tests or in dev mode), you will see that the folder "/local/test/data" will be created at your file system and that will contain all the database data. When rerunning again the same Dev Services, this data will contain all the data you might have created beforehand.

--- a/extensions/datasource/common/src/main/java/io/quarkus/datasource/common/devservices/VolumeMount.java
+++ b/extensions/datasource/common/src/main/java/io/quarkus/datasource/common/devservices/VolumeMount.java
@@ -1,0 +1,37 @@
+package io.quarkus.datasource.common.devservices;
+
+import java.util.Objects;
+
+/**
+ * A volume mount to be applied to a Dev Service container.
+ * <p>
+ * This is the structured equivalent of the legacy {@code host-path=container-path} map form,
+ * allowing the mount type and access mode to be expressed explicitly.
+ */
+public record VolumeMount(Type type, String source, String target, boolean readOnly) {
+
+    public enum Type {
+        /**
+         * Bind mount of a host file system path.
+         */
+        BIND,
+        /**
+         * Mount of a resource resolved from the application classpath.
+         */
+        CLASSPATH
+    }
+
+    public VolumeMount {
+        Objects.requireNonNull(type, "type must not be null");
+        Objects.requireNonNull(source, "source must not be null");
+        Objects.requireNonNull(target, "target must not be null");
+    }
+
+    public static VolumeMount bind(String source, String target, boolean readOnly) {
+        return new VolumeMount(Type.BIND, source, target, readOnly);
+    }
+
+    public static VolumeMount classpath(String source, String target, boolean readOnly) {
+        return new VolumeMount(Type.CLASSPATH, source, target, readOnly);
+    }
+}

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceContainerConfig.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceContainerConfig.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 
+import io.quarkus.datasource.common.devservices.VolumeMount;
+
 public class DevServicesDatasourceContainerConfig {
 
     private final Optional<String> imageName;
@@ -20,7 +22,7 @@ public class DevServicesDatasourceContainerConfig {
     private final Optional<String> password;
     private final Optional<List<String>> initScriptPath;
     private final Optional<List<String>> initPrivilegedScriptPath;
-    private final Map<String, String> volumes;
+    private final List<VolumeMount> volumes;
     private final boolean reuse;
     private final boolean showLogs;
     private final String datasourceName;
@@ -37,7 +39,7 @@ public class DevServicesDatasourceContainerConfig {
             Optional<String> password,
             Optional<List<String>> initScriptPath,
             Optional<List<String>> initPrivilegedScriptPath,
-            Map<String, String> volumes,
+            List<VolumeMount> volumes,
             boolean reuse,
             boolean showLogs,
             String datasourceName,
@@ -53,7 +55,7 @@ public class DevServicesDatasourceContainerConfig {
         this.password = password;
         this.initScriptPath = initScriptPath;
         this.initPrivilegedScriptPath = initPrivilegedScriptPath;
-        this.volumes = volumes;
+        this.volumes = volumes != null ? volumes : Collections.emptyList();
         this.reuse = reuse;
         this.showLogs = showLogs;
         this.datasourceName = datasourceName;
@@ -108,7 +110,7 @@ public class DevServicesDatasourceContainerConfig {
         return showLogs;
     }
 
-    public Map<String, String> getVolumes() {
+    public List<VolumeMount> getVolumes() {
         return volumes;
     }
 

--- a/extensions/datasource/deployment/pom.xml
+++ b/extensions/datasource/deployment/pom.xml
@@ -49,6 +49,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devservices-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
@@ -148,6 +148,7 @@ public class DevServicesDatasourceProcessor {
             res.put(name + ".devservices.reuse", config.devservices().reuse());
             res.put(name + ".devservices.username", config.devservices().username());
             res.put(name + ".devservices.volumes", config.devservices().volumes());
+            res.put(name + ".devservices.named-volumes", config.devservices().namedVolumes());
             Optional<String> username = ConfigUtils.getFirstOptionalValue(
                     DataSourceUtil.dataSourcePropertyKeys(name, "username"), String.class);
             res.put(name + ".username", username);
@@ -407,7 +408,7 @@ public class DevServicesDatasourceProcessor {
                 dataSourceBuildTimeConfig.devservices().password(),
                 dataSourceBuildTimeConfig.devservices().initScriptPath(),
                 dataSourceBuildTimeConfig.devservices().initPrivilegedScriptPath(),
-                dataSourceBuildTimeConfig.devservices().volumes(),
+                DevServicesVolumes.toVolumeMounts(dataSourceBuildTimeConfig.devservices()),
                 dataSourceBuildTimeConfig.devservices().reuse(),
                 dataSourceBuildTimeConfig.devservices().showLogs(),
                 datasourceName,

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesVolumes.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesVolumes.java
@@ -1,0 +1,65 @@
+package io.quarkus.datasource.deployment.devservices;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.quarkus.datasource.common.devservices.VolumeMount;
+import io.quarkus.datasource.runtime.DevServicesBuildTimeConfig;
+
+final class DevServicesVolumes {
+
+    private static final String CLASSPATH = "classpath:";
+    private static final Set<String> VOLUME_PROPERTIES = Set.of("type", "source", "target", "read-only");
+
+    private DevServicesVolumes() {
+    }
+
+    static List<VolumeMount> toVolumeMounts(DevServicesBuildTimeConfig config) {
+        return toVolumeMounts(config.volumes(), config.namedVolumes());
+    }
+
+    static List<VolumeMount> toVolumeMounts(Map<String, String> legacyVolumes,
+            Map<String, ? extends DevServicesBuildTimeConfig.Volume> namedVolumes) {
+        List<VolumeMount> result = new ArrayList<>(legacyVolumes.size() + namedVolumes.size());
+        for (Map.Entry<String, String> volume : legacyVolumes.entrySet()) {
+            String hostLocation = volume.getKey();
+            if (isNamedVolumeProperty(hostLocation, namedVolumes.keySet())) {
+                continue;
+            }
+            if (hostLocation.startsWith(CLASSPATH)) {
+                result.add(VolumeMount.classpath(hostLocation.substring(CLASSPATH.length()), volume.getValue(), true));
+            } else {
+                result.add(VolumeMount.bind(hostLocation, volume.getValue(), false));
+            }
+        }
+        for (DevServicesBuildTimeConfig.Volume volume : namedVolumes.values()) {
+            VolumeMount.Type type = switch (volume.type()) {
+                case BIND -> VolumeMount.Type.BIND;
+                case CLASSPATH -> VolumeMount.Type.CLASSPATH;
+            };
+            boolean readOnly = volume.readOnly().orElse(type == VolumeMount.Type.CLASSPATH);
+            result.add(new VolumeMount(type, volume.source(), volume.target(), readOnly));
+        }
+        return result;
+    }
+
+    /**
+     * Both forms of {@code quarkus.datasource.devservices.volumes} share a prefix, and a {@code Map<String, String>}
+     * mapping collects every property under its prefix whatever the number of remaining key segments. The
+     * properties of a named volume are therefore also present in the legacy map, as {@code name.source} or
+     * {@code "name".source} entries, and must not be interpreted as host locations.
+     */
+    private static boolean isNamedVolumeProperty(String legacyKey, Set<String> volumeNames) {
+        int lastDot = legacyKey.lastIndexOf('.');
+        if (lastDot < 0 || !VOLUME_PROPERTIES.contains(legacyKey.substring(lastDot + 1))) {
+            return false;
+        }
+        String name = legacyKey.substring(0, lastDot);
+        if (name.length() > 1 && name.startsWith("\"") && name.endsWith("\"")) {
+            name = name.substring(1, name.length() - 1);
+        }
+        return volumeNames.contains(name);
+    }
+}

--- a/extensions/datasource/deployment/src/test/java/io/quarkus/datasource/deployment/devservices/DevServicesVolumesTest.java
+++ b/extensions/datasource/deployment/src/test/java/io/quarkus/datasource/deployment/devservices/DevServicesVolumesTest.java
@@ -1,0 +1,115 @@
+package io.quarkus.datasource.deployment.devservices;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.datasource.common.devservices.VolumeMount;
+import io.quarkus.datasource.runtime.DevServicesBuildTimeConfig;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.WithName;
+
+public class DevServicesVolumesTest {
+
+    /**
+     * The two forms of {@code quarkus.datasource.devservices.volumes} as they are declared in
+     * {@link DevServicesBuildTimeConfig}.
+     */
+    @ConfigMapping(prefix = "quarkus.datasource.devservices")
+    interface VolumesConfig {
+        Map<String, String> volumes();
+
+        @WithName("volumes")
+        Map<String, DevServicesBuildTimeConfig.Volume> namedVolumes();
+    }
+
+    @Test
+    void legacyFileSystemVolumeIsAReadWriteBindMount() {
+        assertThat(mounts(Map.of("quarkus.datasource.devservices.volumes.\"/host/data\"", "/container/data")))
+                .containsExactly(VolumeMount.bind("/host/data", "/container/data", false));
+    }
+
+    @Test
+    void legacyClasspathVolumeIsAReadOnlyClasspathMount() {
+        assertThat(mounts(Map.of("quarkus.datasource.devservices.volumes.\"classpath:init.sql\"", "/container/init.sql")))
+                .containsExactly(VolumeMount.classpath("init.sql", "/container/init.sql", true));
+    }
+
+    @Test
+    void namedVolumesAreConverted() {
+        List<VolumeMount> mounts = mounts(Map.of(
+                "quarkus.datasource.devservices.volumes.\"data\".source", "/host/data",
+                "quarkus.datasource.devservices.volumes.\"data\".target", "/container/data",
+                "quarkus.datasource.devservices.volumes.\"init\".type", "classpath",
+                "quarkus.datasource.devservices.volumes.\"init\".source", "init.sql",
+                "quarkus.datasource.devservices.volumes.\"init\".target", "/container/init.sql",
+                "quarkus.datasource.devservices.volumes.\"init\".read-only", "false"));
+
+        assertThat(mounts).containsExactlyInAnyOrder(
+                VolumeMount.bind("/host/data", "/container/data", false),
+                VolumeMount.classpath("init.sql", "/container/init.sql", false));
+    }
+
+    @Test
+    void readOnlyDefaultsToTrueForClasspathVolumesAndFalseForBindVolumes() {
+        List<VolumeMount> mounts = mounts(Map.of(
+                "quarkus.datasource.devservices.volumes.data.source", "/host/data",
+                "quarkus.datasource.devservices.volumes.data.target", "/container/data",
+                "quarkus.datasource.devservices.volumes.init.type", "classpath",
+                "quarkus.datasource.devservices.volumes.init.source", "init.sql",
+                "quarkus.datasource.devservices.volumes.init.target", "/container/init.sql"));
+
+        assertThat(mounts).containsExactlyInAnyOrder(
+                VolumeMount.bind("/host/data", "/container/data", false),
+                VolumeMount.classpath("init.sql", "/container/init.sql", true));
+    }
+
+    @Test
+    void namedVolumePropertiesCollectedByTheLegacyMapAreNotHostLocations() {
+        VolumesConfig config = config(Map.of(
+                "quarkus.datasource.devservices.volumes.\"/host/data\"", "/container/data",
+                "quarkus.datasource.devservices.volumes.\"init\".type", "classpath",
+                "quarkus.datasource.devservices.volumes.\"init\".source", "init.sql",
+                "quarkus.datasource.devservices.volumes.\"init\".target", "/container/init.sql",
+                "quarkus.datasource.devservices.volumes.config.source", "/host/config",
+                "quarkus.datasource.devservices.volumes.config.target", "/container/config"));
+
+        // a Map<String, String> collects every property under its prefix, whatever the number of remaining segments
+        assertThat(config.volumes()).containsOnlyKeys("/host/data", "\"init\".type", "\"init\".source", "\"init\".target",
+                "config.source", "config.target");
+        assertThat(config.namedVolumes()).containsOnlyKeys("init", "config");
+
+        assertThat(DevServicesVolumes.toVolumeMounts(config.volumes(), config.namedVolumes())).containsExactlyInAnyOrder(
+                VolumeMount.bind("/host/data", "/container/data", false),
+                VolumeMount.classpath("init.sql", "/container/init.sql", true),
+                VolumeMount.bind("/host/config", "/container/config", false));
+    }
+
+    @Test
+    void legacyKeysThatOnlyLookLikeVolumePropertiesAreKept() {
+        List<VolumeMount> mounts = mounts(Map.of(
+                "quarkus.datasource.devservices.volumes.\"/host/other.source\"", "/container/other",
+                "quarkus.datasource.devservices.volumes.\"init\".type", "classpath",
+                "quarkus.datasource.devservices.volumes.\"init\".source", "init.sql",
+                "quarkus.datasource.devservices.volumes.\"init\".target", "/container/init.sql"));
+
+        assertThat(mounts).contains(VolumeMount.bind("/host/other.source", "/container/other", false));
+    }
+
+    private static List<VolumeMount> mounts(Map<String, String> properties) {
+        VolumesConfig config = config(properties);
+        return DevServicesVolumes.toVolumeMounts(config.volumes(), config.namedVolumes());
+    }
+
+    private static VolumesConfig config(Map<String, String> properties) {
+        SmallRyeConfigBuilder builder = new SmallRyeConfigBuilder().withMapping(VolumesConfig.class);
+        properties.forEach(builder::withDefaultValue);
+        SmallRyeConfig config = builder.build();
+        return config.getConfigMapping(VolumesConfig.class);
+    }
+}

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
@@ -11,6 +11,7 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
 import io.smallrye.config.WithConverter;
 import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
 @ConfigGroup
 public interface DevServicesBuildTimeConfig {
@@ -114,7 +115,26 @@ public interface DevServicesBuildTimeConfig {
     Optional<List<@WithConverter(TrimmedStringConverter.class) String>> initPrivilegedScriptPath();
 
     /**
-     * The volumes to be mapped to the container.
+     * The volumes to be mapped to the container, keyed by an arbitrary name identifying the volume.
+     *
+     * Each volume is described by its `type`, `source`, `target` and `read-only` properties:
+     *
+     * [source,properties]
+     * ----
+     * quarkus.datasource.devservices.volumes."data".source=/path/from
+     * quarkus.datasource.devservices.volumes."data".target=/container/to
+     * ----
+     *
+     * This has no effect if the provider is not a container-based database, such as H2 or Derby.
+     *
+     * @asciidoclet
+     */
+    @WithName("volumes")
+    @ConfigDocMapKey("volume-name")
+    Map<String, Volume> namedVolumes();
+
+    /**
+     * The volumes to be mapped to the container, in the legacy `host-path=container-path` form.
      * <p>
      * The map key corresponds to the host location; the map value is the container location.
      * If the host location starts with "classpath:",
@@ -124,7 +144,12 @@ public interface DevServicesBuildTimeConfig {
      * potentially leading to data loss or modification in your file system.
      * <p>
      * This has no effect if the provider is not a container-based database, such as H2 or Derby.
+     *
+     * @deprecated Use the named form of {@code volumes} instead:
+     *             it does not encode the host location in the configuration key,
+     *             making it usable through environment variables, and allows selecting the access mode explicitly.
      */
+    @Deprecated
     @ConfigDocMapKey("host-path")
     Map<String, String> volumes();
 
@@ -160,5 +185,59 @@ public interface DevServicesBuildTimeConfig {
      */
     @WithDefault("false")
     boolean showLogs();
+
+    /**
+     * A volume to be mapped to the container.
+     */
+    @ConfigGroup
+    interface Volume {
+
+        /**
+         * The type of the volume.
+         *
+         * @asciidoclet
+         */
+        @WithDefault("bind")
+        Type type();
+
+        /**
+         * The source of the volume:
+         * a host file system path for `bind` volumes,
+         * or a resource path for `classpath` volumes.
+         *
+         * @asciidoclet
+         */
+        String source();
+
+        /**
+         * The container location the source is mounted to.
+         *
+         * @asciidoclet
+         */
+        String target();
+
+        /**
+         * Whether the volume is read-only.
+         *
+         * Defaults to `true` for `classpath` volumes and to `false` for `bind` volumes.
+         * Note that read-only `classpath` volumes are copied into the container,
+         * so changes to the source are not reflected in the container.
+         *
+         * @asciidoclet
+         */
+        @ConfigDocDefault("`true` for `classpath` volumes, `false` for `bind` volumes")
+        Optional<Boolean> readOnly();
+
+        enum Type {
+            /**
+             * Bind mount of a host file system path.
+             */
+            BIND,
+            /**
+             * Mount of a resource resolved from the application classpath.
+             */
+            CLASSPATH
+        }
+    }
 
 }

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/Volumes.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/Volumes.java
@@ -1,27 +1,27 @@
 package io.quarkus.devservices.common;
 
-import java.util.Map;
+import java.util.List;
 
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 
+import io.quarkus.datasource.common.devservices.VolumeMount;
+
 public final class Volumes {
 
-    private static final String CLASSPATH = "classpath:";
-    private static final String EMPTY = "";
-
     private Volumes() {
-
     }
 
-    public static void addVolumes(GenericContainer<?> container, Map<String, String> volumes) {
-        for (Map.Entry<String, String> volume : volumes.entrySet()) {
-            String hostLocation = volume.getKey();
-            if (volume.getKey().startsWith(CLASSPATH)) {
-                container.withClasspathResourceMapping(hostLocation.replaceFirst(CLASSPATH, EMPTY), volume.getValue(),
-                        BindMode.READ_ONLY);
-            } else {
-                container.withFileSystemBind(hostLocation, volume.getValue(), BindMode.READ_WRITE);
+    public static void addVolumes(GenericContainer<?> container, List<VolumeMount> volumes) {
+        for (VolumeMount volume : volumes) {
+            BindMode bindMode = volume.readOnly() ? BindMode.READ_ONLY : BindMode.READ_WRITE;
+            switch (volume.type()) {
+                case CLASSPATH:
+                    container.withClasspathResourceMapping(volume.source(), volume.target(), bindMode);
+                    break;
+                case BIND:
+                    container.withFileSystemBind(volume.source(), volume.target(), bindMode);
+                    break;
             }
         }
     }

--- a/extensions/devservices/common/src/test/java/io/quarkus/devservices/common/VolumesTest.java
+++ b/extensions/devservices/common/src/test/java/io/quarkus/devservices/common/VolumesTest.java
@@ -1,0 +1,71 @@
+package io.quarkus.devservices.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+import com.github.dockerjava.api.model.AccessMode;
+import com.github.dockerjava.api.model.Bind;
+
+import io.quarkus.datasource.common.devservices.VolumeMount;
+
+public class VolumesTest {
+
+    private static final DockerImageName IMAGE = DockerImageName.parse("alpine:3");
+
+    @Test
+    void bindMountCanBeReadWrite() {
+        GenericContainer<?> container = new GenericContainer<>(IMAGE);
+
+        Volumes.addVolumes(container, List.of(VolumeMount.bind("/host/data", "/container/data", false)));
+
+        assertThat(container.getBinds()).hasSize(1);
+        Bind bind = container.getBinds().get(0);
+        assertThat(bind.getPath()).isEqualTo("/host/data");
+        assertThat(bind.getVolume().getPath()).isEqualTo("/container/data");
+        assertThat(bind.getAccessMode()).isEqualTo(AccessMode.rw);
+    }
+
+    @Test
+    void bindMountCanBeReadOnly() {
+        GenericContainer<?> container = new GenericContainer<>(IMAGE);
+
+        Volumes.addVolumes(container, List.of(VolumeMount.bind("/host/config", "/container/config", true)));
+
+        assertThat(container.getBinds()).hasSize(1);
+        Bind bind = container.getBinds().get(0);
+        assertThat(bind.getAccessMode()).isEqualTo(AccessMode.ro);
+    }
+
+    @Test
+    void readOnlyClasspathMountIsCopiedIntoTheContainer() {
+        GenericContainer<?> container = new GenericContainer<>(IMAGE);
+
+        Volumes.addVolumes(container, List.of(VolumeMount.classpath("mount-test/init.sql", "/container/init.sql", true)));
+
+        // Testcontainers implements read-only classpath mappings as file copies, not binds
+        assertThat(container.getBinds()).isEmpty();
+        assertThat(container.getCopyToFileContainerPathMap()).containsValue("/container/init.sql");
+    }
+
+    @Test
+    void readWriteClasspathMountIsBoundFromTheResolvedResourcePath() {
+        GenericContainer<?> container = new GenericContainer<>(IMAGE);
+
+        Volumes.addVolumes(container, List.of(VolumeMount.classpath("mount-test/init.sql", "/container/init.sql", false)));
+
+        String resolvedPath = MountableFile.forClasspathResource("mount-test/init.sql").getResolvedPath();
+        assertThat(container.getBinds()).hasSize(1);
+        Bind bind = container.getBinds().get(0);
+        // compare as paths, not strings: on Windows the recorded bind uses backslashes
+        assertThat(Path.of(bind.getPath())).isEqualTo(Path.of(resolvedPath));
+        assertThat(bind.getVolume().getPath()).isEqualTo("/container/init.sql");
+        assertThat(bind.getAccessMode()).isEqualTo(AccessMode.rw);
+    }
+}

--- a/extensions/devservices/common/src/test/resources/mount-test/init.sql
+++ b/extensions/devservices/common/src/test/resources/mount-test/init.sql
@@ -1,0 +1,2 @@
+-- test resource for VolumesTest
+SELECT 1;

--- a/extensions/jdbc/jdbc-postgresql/deployment/src/test/java/io/quarkus/jdbc/postgresql/deployment/DevServicesPostgresqlDatasourceWithNamedVolumeTestCase.java
+++ b/extensions/jdbc/jdbc-postgresql/deployment/src/test/java/io/quarkus/jdbc/postgresql/deployment/DevServicesPostgresqlDatasourceWithNamedVolumeTestCase.java
@@ -1,0 +1,46 @@
+package io.quarkus.jdbc.postgresql.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.ResultSet;
+
+import javax.sql.DataSource;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class DevServicesPostgresqlDatasourceWithNamedVolumeTestCase {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .overrideConfigKey("quarkus.datasource.db-kind", "postgresql")
+            // The official postgres image will execute all the scripts in the folder "docker-entrypoint-initdb.d"
+            .overrideConfigKey("quarkus.datasource.devservices.volumes.\"init-script\".type", "classpath")
+            .overrideConfigKey("quarkus.datasource.devservices.volumes.\"init-script\".source", "/init-db.sql")
+            .overrideConfigKey("quarkus.datasource.devservices.volumes.\"init-script\".target",
+                    "/docker-entrypoint-initdb.d/init-db.sql");
+
+    @Inject
+    DataSource ds;
+
+    @Test
+    @DisplayName("Test if the named volume is applied successfully")
+    public void testDatasource() throws Exception {
+        int result = 0;
+        try (Connection con = ds.getConnection();
+                CallableStatement cs = con.prepareCall("SELECT my_func()");
+                ResultSet rs = cs.executeQuery()) {
+            if (rs.next()) {
+                result = rs.getInt(1);
+            }
+        }
+        assertEquals(100, result, "The init script should have been executed");
+    }
+}


### PR DESCRIPTION
The existing `quarkus.datasource.devservices.volumes` map encodes the host
location in the configuration key. As discussed in #36270, this makes the
property impossible to set through environment variables (map keys cannot
survive the env var name mangling — the original report was a corrupted
`QUARKUS_DATASOURCE_DEVSERVICES_VOLUMES_` variable on OpenShift Dev Spaces)
and forces `\:` escaping in properties files. It also gives no control over
the access mode: filesystem volumes are always read-write, classpath volumes
always read-only.

Following @yrodiere's review, volumes can now be declared under a name of
your choice, with explicit properties modeled after the long syntax of Docker
Compose volumes:

    quarkus.datasource.devservices.volumes."init-script".type=classpath
    quarkus.datasource.devservices.volumes."init-script".source=./init-db.sql
    quarkus.datasource.devservices.volumes."init-script".target=/docker-entrypoint-initdb.d/init-db.sql
    quarkus.datasource.devservices.volumes."init-script".read-only=true

Names rather than indices, so configuration split across files/profiles
composes without caring about contiguous indices. The properties can be set
through environment variables (`QUARKUS_DATASOURCE_DEVSERVICES_VOLUMES_INIT_SCRIPT_SOURCE`,
or `..._VOLUMES__INIT_SCRIPT__SOURCE` for the quoted key), need no escaping,
and make the type and access mode explicit.

Both forms share the `volumes` key. SmallRye Config maps the named properties
into the new `Map<String, Volume>`; since the legacy `Map<String, String>`
accepts any key, it also collects them as `"name".source`-style entries, which
are filtered out when both forms are merged into a single `List<VolumeMount>`
at config extraction time. The legacy host-path form keeps working and is now
documented as the deprecated alternative. The Dev Services container config
SPI carries that single list, so the database Dev Services processors and
`Volumes` have one code path; `VolumeMount` lives in `quarkus-datasource-common`
to keep the deployment SPI free of the testcontainers dependency.

Fixes #36270

Release note: Datasource Dev Services volumes can now be declared by name with
explicit `type`, `source`, `target` and `read-only` properties
(`quarkus.datasource.devservices.volumes."<name>".source`), following the long
syntax of Docker Compose volumes, which makes them configurable through
environment variables and allows choosing the access mode. The host-path map
form is deprecated.