### PR TITLE
Add configurable REST Data maximum page size

### DIFF
--- a/docs/src/main/asciidoc/quarkus-data-hibernate.adoc
+++ b/docs/src/main/asciidoc/quarkus-data-hibernate.adoc
@@ -1274,6 +1274,15 @@ may be requested.
 NOTE: Cursor-based pagination (`PageRequest.Mode.CURSOR_NEXT` / `CURSOR_PREVIOUS`) is not currently supported
 by this REST integration. Only offset-based pagination is available via query parameters.
 
+By default, the page size is not limited. You can configure the maximum page size accepted from a REST request:
+
+[source,properties]
+----
+quarkus.rest.data.page.max-size=100
+----
+
+Requests with a `size` greater than the configured maximum are rejected with an HTTP `400 Bad Request` response.
+
 === Page serialization
 
 When a REST endpoint returns a `jakarta.data.page.Page`, it is serialized as a JSON object with pagination

--- a/extensions/resteasy-reactive/rest-data-hibernate-json-types/deployment/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/deployment/RestDataHibernateProcessor.java
+++ b/extensions/resteasy-reactive/rest-data-hibernate-json-types/deployment/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/deployment/RestDataHibernateProcessor.java
@@ -21,8 +21,10 @@ import io.quarkus.resteasy.reactive.data.hibernate.runtime.JakartaDataObjectMapp
 import io.quarkus.resteasy.reactive.data.hibernate.runtime.LimitParamExtractor;
 import io.quarkus.resteasy.reactive.data.hibernate.runtime.OrderParamExtractor;
 import io.quarkus.resteasy.reactive.data.hibernate.runtime.PageRequestParamExtractor;
+import io.quarkus.resteasy.reactive.data.hibernate.runtime.RestDataHibernateConfig;
 import io.quarkus.resteasy.reactive.data.hibernate.runtime.SortParamExtractor;
 import io.quarkus.resteasy.reactive.server.spi.MethodScannerBuildItem;
+import io.quarkus.runtime.configuration.ConfigurationException;
 
 public class RestDataHibernateProcessor {
 
@@ -38,14 +40,18 @@ public class RestDataHibernateProcessor {
     }
 
     @BuildStep
-    MethodScannerBuildItem jakartaDataParamScanner() {
+    MethodScannerBuildItem jakartaDataParamScanner(RestDataHibernateConfig config) {
+        int maxPageSize = config.page().maxSize().orElse(Integer.MAX_VALUE);
+        if (maxPageSize <= 0) {
+            throw new ConfigurationException("quarkus.rest.data.page.max-size must be greater than 0");
+        }
         return new MethodScannerBuildItem(new MethodScanner() {
             @Override
             public ParameterExtractor handleCustomParameter(Type paramType, Map<DotName, AnnotationInstance> annotations,
                     boolean field, Map<String, Object> methodContext) {
                 DotName name = paramType.name();
                 if (name.equals(PAGE_REQUEST)) {
-                    return new PageRequestParamExtractor();
+                    return new PageRequestParamExtractor(maxPageSize);
                 }
                 if (name.equals(SORT)) {
                     return new SortParamExtractor();

--- a/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/runtime/PageRequestParamExtractor.java
+++ b/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/runtime/PageRequestParamExtractor.java
@@ -5,6 +5,8 @@ import jakarta.data.page.PageRequest;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
 
+import io.quarkus.runtime.annotations.RecordableConstructor;
+
 /**
  * Extracts a {@link PageRequest} from HTTP query parameters.
  * <ul>
@@ -17,6 +19,17 @@ public class PageRequestParamExtractor implements ParameterExtractor {
 
     private static final int DEFAULT_PAGE_NUMBER = 1;
     private static final int DEFAULT_PAGE_SIZE = 10;
+
+    private final int maxPageSize;
+
+    @RecordableConstructor
+    public PageRequestParamExtractor(int maxPageSize) {
+        this.maxPageSize = maxPageSize;
+    }
+
+    public int getMaxPageSize() {
+        return maxPageSize;
+    }
 
     @Override
     public Object extractParameter(ResteasyReactiveRequestContext context) {
@@ -32,6 +45,10 @@ public class PageRequestParamExtractor implements ParameterExtractor {
         String sizeStr = (String) context.getQueryParameter("size", true, false);
         if (sizeStr != null) {
             size = Integer.parseInt(sizeStr);
+        }
+        if (size > maxPageSize) {
+            throw new IllegalArgumentException(
+                    "Query parameter 'size' must not exceed the configured maximum of " + maxPageSize);
         }
 
         String requestTotalStr = (String) context.getQueryParameter("requestTotal", true, false);

--- a/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/runtime/RestDataHibernateConfig.java
+++ b/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/runtime/RestDataHibernateConfig.java
@@ -1,0 +1,25 @@
+package io.quarkus.resteasy.reactive.data.hibernate.runtime;
+
+import java.util.OptionalInt;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+
+@ConfigMapping(prefix = "quarkus.rest.data")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface RestDataHibernateConfig {
+
+    /**
+     * Page request configuration.
+     */
+    PageConfig page();
+
+    interface PageConfig {
+
+        /**
+         * The maximum page size accepted from a REST request. When not configured, the page size is not limited.
+         */
+        OptionalInt maxSize();
+    }
+}

--- a/integration-tests/rest-data-hibernate-json-types/src/main/resources/application.properties
+++ b/integration-tests/rest-data-hibernate-json-types/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 quarkus.datasource.db-kind=h2
+quarkus.rest.data.page.max-size=50
 # unclutter the logs
 quarkus.log.category."org.jboss.resteasy.reactive.server.handlers.ParameterHandler".level=OFF
 

--- a/integration-tests/rest-data-hibernate-json-types/src/test/java/io/quarkus/it/rest/data/hibernate/ParamExtractionTest.java
+++ b/integration-tests/rest-data-hibernate-json-types/src/test/java/io/quarkus/it/rest/data/hibernate/ParamExtractionTest.java
@@ -44,13 +44,32 @@ public class ParamExtractionTest {
     @Test
     public void testPageRequestPartialOverride() {
         given()
-                .queryParam("size", 50)
+                .queryParam("size", 40)
                 .when().get("/echo/page-request")
                 .then()
                 .statusCode(200)
                 .body("page", is(1))
-                .body("size", is(50))
+                .body("size", is(40))
                 .body("requestTotal", is(true));
+    }
+
+    @Test
+    public void testPageRequestSizeAtConfiguredMaximum() {
+        given()
+                .queryParam("size", 50)
+                .when().get("/echo/page-request")
+                .then()
+                .statusCode(200)
+                .body("size", is(50));
+    }
+
+    @Test
+    public void testPageRequestSizeAboveConfiguredMaximum() {
+        given()
+                .queryParam("size", 51)
+                .when().get("/echo/page-request")
+                .then()
+                .statusCode(400);
     }
 
     // --- Sort ---


### PR DESCRIPTION
REST clients can currently request an arbitrarily large page when a Jakarta Data `PageRequest` is populated from query parameters. This can cause excessive database work and memory consumption.

This change introduces the optional `quarkus.rest.data.page.max-size` configuration property. Requests exceeding the configured maximum are rejected with a `400 Bad Request` response. Page sizes remain unlimited when the property is not configured, preserving the existing behavior.

* Fixes #55937 