### PR TITLE
Add Dev Shell - a terminal TUI for Quarkus Dev Mode

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -204,6 +204,7 @@
         <!-- Check the compatibility matrix (https://github.com/opensearch-project/opensearch-testcontainers) before upgrading: -->
         <opensearch-testcontainers.version>2.1.3</opensearch-testcontainers.version>
         <com.dajudge.kindcontainer>2.0.0</com.dajudge.kindcontainer>
+        <tamboui.version>0.4.0</tamboui.version>
         <aesh.version>3.16.4</aesh.version>
         <aesh-readline.version>3.16.2</aesh-readline.version>
         <jline.version>4.2.1</jline.version> <!-- Keep in sync with dekorate -->
@@ -773,6 +774,21 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-devmcp-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-devshell</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-devshell-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-devshell-deployment-spi</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -6696,6 +6712,11 @@
                 <groupId>com.github.javaparser</groupId>
                 <artifactId>javaparser-core</artifactId>
                 <version>${javaparser.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>dev.tamboui</groupId>
+                <artifactId>tamboui-tui</artifactId>
+                <version>${tamboui.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.aesh</groupId>

--- a/core/deployment/src/main/java/io/quarkus/deployment/console/AeshConsole.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/AeshConsole.java
@@ -74,6 +74,7 @@ public class AeshConsole extends QuarkusConsole {
 
     private volatile boolean pauseOutput;
     private volatile boolean firstConsoleRun = true;
+    private volatile boolean passEscapeToDelegate;
     private DelegateConnection delegateConnection;
     private ReadlineConsole aeshConsole;
 
@@ -257,7 +258,7 @@ public class AeshConsole extends QuarkusConsole {
                     if (delegateConnection != null) {
                         //console mode
                         //just sent the input to the delegate
-                        if (keys.length == 1) {
+                        if (keys.length == 1 && !passEscapeToDelegate) {
                             for (var k : keys) {
                                 if (k == 27) { // escape key
                                     exitCliMode();
@@ -652,6 +653,47 @@ public class AeshConsole extends QuarkusConsole {
         connection.write(EXIT_ALTERNATE_SCREEN);
         pauseOutput = false;
         write(false, "");
+        deadlockSafeWrite();
+    }
+
+    /**
+     * Takes over the terminal for a full-screen TUI mode.
+     * Pauses log output, enters alternate screen buffer, and returns a
+     * {@link DelegateConnection} that the TUI can use for I/O.
+     * <p>
+     * Unlike CLI mode, ESC keys are forwarded to the delegate rather than
+     * triggering exit, allowing the TUI to use ESC for navigation.
+     * <p>
+     * Call {@link #releaseTerminal()} to restore normal console operation.
+     */
+    public DelegateConnection takeoverTerminal() {
+        pauseOutput = true;
+        passEscapeToDelegate = true;
+        delegateConnection = new DelegateConnection(connection);
+        connection.write(ALTERNATE_SCREEN_BUFFER);
+        return delegateConnection;
+    }
+
+    /**
+     * Releases the terminal after a TUI session.
+     * Exits alternate screen buffer, resumes log output, and clears the delegate.
+     */
+    public void releaseTerminal() {
+        if (delegateConnection == null) {
+            return;
+        }
+        passEscapeToDelegate = false;
+        delegateConnection.close();
+        delegateConnection = null;
+        connection.write("\033[0m");
+        connection.write("\033[?25h");
+        connection.enterRawMode();
+        connection.write(EXIT_ALTERNATE_SCREEN);
+        pauseOutput = false;
+        StringBuilder sb = new StringBuilder();
+        clearStatusMessages(sb);
+        printStatusAndPrompt(sb);
+        writeQueue.add(sb.toString());
         deadlockSafeWrite();
     }
 }

--- a/docs/src/main/asciidoc/dev-shell.adoc
+++ b/docs/src/main/asciidoc/dev-shell.adoc
@@ -1,0 +1,128 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+= Dev Shell
+include::_attributes.adoc[]
+:categories: core
+:summary: Dev Shell is a terminal-based user interface (TUI) for Quarkus Dev Mode, bringing the power of Dev UI directly to your terminal.
+:topics: dev-mode,dev-shell,tui,terminal
+
+Dev Shell is a terminal TUI for Quarkus Dev Mode.
+It provides an interactive, keyboard-driven interface for inspecting configuration,
+endpoints, continuous testing, dev services, and more — directly from your terminal.
+
+== Using Dev Shell
+
+=== In-process (pressing `t`)
+
+When running `quarkus dev` (or `mvn quarkus:dev`), press `t` to launch Dev Shell
+in the same terminal. The TUI takes over the screen using the alternate screen buffer,
+and pressing `q` or `ESC` on the main menu returns you to the log output.
+
+[source,shell]
+----
+$ mvn quarkus:dev
+...
+Press [t] for the Dev Shell, [h] for more options>
+----
+
+=== From another terminal
+
+Dev Shell can also connect to a running dev mode instance from a separate terminal.
+This is useful when you want to keep the log output visible while interacting with
+the Dev Shell.
+
+[source,shell]
+----
+$ java -cp <classpath> io.quarkus.devshell.deployment.DevShellCli --port 8080
+----
+
+Dev Shell connects via WebSocket to the same JSON-RPC endpoint that the
+browser-based Dev UI uses (`/q/dev-ui/json-rpc-ws`), so no additional server
+configuration is needed.
+
+== Screens
+
+Dev Shell includes the following built-in screens:
+
+Configuration::
+Browse all Quarkus configuration properties with phase indicators
+(build-time, build+run, runtime). Filter by name or value with `/`.
+
+Endpoints::
+View REST endpoints, static resources, and additional endpoints
+with HTTP method highlighting and tab-based grouping.
+
+Continuous Testing::
+Monitor test execution, start/stop testing, and run all or failed
+tests with keyboard shortcuts.
+
+Dev Services::
+Inspect running dev services including container details, port
+mappings, and injected configuration properties.
+
+== Navigation
+
+|===
+|Key |Action
+
+|`↑`/`↓` or `j`/`k`
+|Navigate lists
+
+|`Enter`
+|Open selected item
+
+|`Tab`
+|Switch tabs (where applicable)
+
+|`/`
+|Filter mode (Configuration screen)
+
+|`R`
+|Refresh data
+
+|`ESC`
+|Go back / exit filter
+
+|`q`
+|Quit Dev Shell
+|===
+
+== Configuration
+
+Dev Shell is enabled by default in dev mode. You can disable it or configure
+host access:
+
+[source,properties]
+----
+# Disable Dev Shell
+quarkus.devshell.enabled=false
+
+# Allow connections from additional hosts (localhost is always allowed)
+quarkus.devshell.allowed-hosts=192.168.1.100,my-dev-host.local
+----
+
+== Security
+
+By default, Dev Shell only accepts connections from localhost.
+This matches the Dev UI security model — both are dev-mode-only features
+that should not be exposed to untrusted networks.
+
+To allow connections from other hosts (e.g., from a container or VM),
+add them to `quarkus.devshell.allowed-hosts`.
+
+== Architecture
+
+Dev Shell connects to the running Quarkus application via the same
+WebSocket JSON-RPC endpoint used by the browser-based Dev UI.
+This means:
+
+* No additional server endpoints or ports are needed
+* Dev Shell sees the same data as Dev UI
+* It works with any Quarkus application that has Dev UI enabled
+* Multiple Dev Shell instances can connect simultaneously
+
+The TUI rendering uses https://tamboui.dev[TamboUI], a Java library
+for building terminal user interfaces.

--- a/extensions/agroal/deployment/pom.xml
+++ b/extensions/agroal/deployment/pom.xml
@@ -15,6 +15,10 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/devui/AgroalDevUIProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/devui/AgroalDevUIProcessor.java
@@ -10,6 +10,7 @@ import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.dev.spi.DevModeType;
 import io.quarkus.devjsonrpc.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
 import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
@@ -68,6 +69,12 @@ class AgroalDevUIProcessor {
             """;
 
     final record MoreDataResponse(String script) {
+    }
+
+    @BuildStep
+    ShellPageBuildItem createShellPage() {
+        return ShellPageBuildItem.withCustomPage("Agroal",
+                "io.quarkus.devshell.deployment.tui.pages.extensions.AgroalShellPage");
     }
 
 }

--- a/extensions/arc/deployment/pom.xml
+++ b/extensions/arc/deployment/pom.xml
@@ -27,6 +27,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/ArcDevUIProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/ArcDevUIProcessor.java
@@ -23,6 +23,7 @@ import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.devjsonrpc.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 
@@ -177,5 +178,11 @@ public class ArcDevUIProcessor {
     private static final String REMOVED_BEANS = "removedBeans";
     private static final String REMOVED_DECORATORS = "removedDecorators";
     private static final String REMOVED_INTERCEPTORS = "removedInterceptors";
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    ShellPageBuildItem createShellPage() {
+        return ShellPageBuildItem.withCustomPage("CDI (Arc)", 'a',
+                "io.quarkus.devshell.deployment.tui.pages.extensions.ArcShellPage");
+    }
 
 }

--- a/extensions/cache/deployment/pom.xml
+++ b/extensions/cache/deployment/pom.xml
@@ -57,6 +57,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http-deployment</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/devui/CacheDevUiProcessor.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/devui/CacheDevUiProcessor.java
@@ -5,6 +5,7 @@ import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devjsonrpc.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 
@@ -24,5 +25,11 @@ public class CacheDevUiProcessor {
     @BuildStep(onlyIf = IsLocalDevelopment.class)
     JsonRPCProvidersBuildItem createJsonRPCServiceForCache() {
         return new JsonRPCProvidersBuildItem(CacheJsonRPCService.class);
+    }
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    ShellPageBuildItem createShellPage() {
+        return ShellPageBuildItem.withCustomPage("Cache",
+                "io.quarkus.devshell.deployment.tui.pages.extensions.CacheShellPage");
     }
 }

--- a/extensions/datasource/deployment/pom.xml
+++ b/extensions/datasource/deployment/pom.xml
@@ -47,6 +47,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devservices-deployment</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devui/DevUIDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devui/DevUIDatasourceProcessor.java
@@ -9,6 +9,7 @@ import io.quarkus.datasource.runtime.dev.ui.DatasourceJsonRpcService;
 import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.devjsonrpc.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 
@@ -32,6 +33,12 @@ public class DevUIDatasourceProcessor {
     @BuildStep(onlyIf = IsLocalDevelopment.class)
     JsonRPCProvidersBuildItem registerJsonRpcBackend() {
         return new JsonRPCProvidersBuildItem(DatasourceJsonRpcService.class);
+    }
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    ShellPageBuildItem createShellPage() {
+        return ShellPageBuildItem.withCustomPage("Datasources", 'd',
+                "io.quarkus.devshell.deployment.tui.pages.extensions.DatasourceShellPage");
     }
 
 }

--- a/extensions/devshell/deployment-spi/pom.xml
+++ b/extensions/devshell/deployment-spi/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-devshell-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-devshell-deployment-spi</artifactId>
+    <name>Quarkus - Dev Shell - Deployment SPI</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/extensions/devshell/deployment-spi/src/main/java/io/quarkus/devshell/deployment/spi/ShellPageBuildItem.java
+++ b/extensions/devshell/deployment-spi/src/main/java/io/quarkus/devshell/deployment/spi/ShellPageBuildItem.java
@@ -1,0 +1,152 @@
+package io.quarkus.devshell.deployment.spi;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Map;
+import java.util.Optional;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.util.ArtifactInfoUtil;
+
+/**
+ * Build item for extensions to register pages in the Dev Shell TUI.
+ * This is the CLI equivalent of CardPageBuildItem for Dev UI.
+ * <p>
+ * Extensions can provide shell pages in two ways:
+ * <ol>
+ * <li>Implement {@code ShellPageProvider} as a CDI bean (recommended for simple pages)</li>
+ * <li>Provide a custom page class name (for advanced customization)</li>
+ * </ol>
+ * <p>
+ * When no explicit id is provided, the extension identifier is auto-detected
+ * from the calling class's Maven artifact, similar to Dev UI's CardPageBuildItem.
+ */
+public final class ShellPageBuildItem extends MultiBuildItem {
+
+    private final String title;
+    private final char shortcutKey;
+    private final String jsonRpcNamespace;
+    private final String providerClassName;
+    private final String customPageClassName;
+    private final Class<?> customPageClass;
+
+    private final Class<?> callerClass;
+    private String extensionIdentifier;
+
+    // ---- Factory methods WITHOUT explicit id (auto-detect from artifact) ----
+
+    public static ShellPageBuildItem withProvider(String title, Class<?> providerClass) {
+        return new ShellPageBuildItem(null, title, '\0', null, providerClass.getName(), null, null);
+    }
+
+    public static ShellPageBuildItem withProvider(String title, char shortcutKey, Class<?> providerClass) {
+        return new ShellPageBuildItem(null, title, shortcutKey, null, providerClass.getName(), null, null);
+    }
+
+    public static ShellPageBuildItem withCustomPage(String title, Class<?> pageClass) {
+        return new ShellPageBuildItem(null, title, '\0', null, null, pageClass.getName(), pageClass);
+    }
+
+    public static ShellPageBuildItem withCustomPage(String title, char shortcutKey, Class<?> pageClass) {
+        return new ShellPageBuildItem(null, title, shortcutKey, null, null, pageClass.getName(), pageClass);
+    }
+
+    public static ShellPageBuildItem withCustomPage(String title, String pageClassName) {
+        return new ShellPageBuildItem(null, title, '\0', null, null, pageClassName, null);
+    }
+
+    public static ShellPageBuildItem withCustomPage(String title, char shortcutKey, String pageClassName) {
+        return new ShellPageBuildItem(null, title, shortcutKey, null, null, pageClassName, null);
+    }
+
+    // ---- Factory methods WITH explicit id ----
+
+    public static ShellPageBuildItem withProvider(String id, String title, Class<?> providerClass) {
+        return new ShellPageBuildItem(id, title, '\0', null, providerClass.getName(), null, null);
+    }
+
+    public static ShellPageBuildItem withProvider(String id, String title, char shortcutKey, Class<?> providerClass) {
+        return new ShellPageBuildItem(id, title, shortcutKey, null, providerClass.getName(), null, null);
+    }
+
+    public static ShellPageBuildItem withCustomPage(String id, String title, Class<?> pageClass) {
+        return new ShellPageBuildItem(id, title, '\0', null, null, pageClass.getName(), pageClass);
+    }
+
+    public static ShellPageBuildItem withCustomPage(String id, String title, char shortcutKey, Class<?> pageClass) {
+        return new ShellPageBuildItem(id, title, shortcutKey, null, null, pageClass.getName(), pageClass);
+    }
+
+    private ShellPageBuildItem(String id, String title, char shortcutKey, String jsonRpcNamespace,
+            String providerClassName, String customPageClassName, Class<?> customPageClass) {
+        this.extensionIdentifier = id;
+        this.title = title;
+        this.shortcutKey = shortcutKey;
+        this.jsonRpcNamespace = jsonRpcNamespace;
+        this.providerClassName = providerClassName;
+        this.customPageClassName = customPageClassName;
+        this.customPageClass = customPageClass;
+
+        if (id == null) {
+            StackWalker stackWalker = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
+            Optional<StackWalker.StackFrame> stackFrame = stackWalker.walk(frames -> frames
+                    .filter(frame -> (!frame.getDeclaringClass().getPackageName()
+                            .startsWith("io.quarkus.devshell.deployment.spi")
+                            && !frame.getDeclaringClass().equals(MethodHandle.class)))
+                    .findFirst());
+
+            if (stackFrame.isPresent()) {
+                this.callerClass = stackFrame.get().getDeclaringClass();
+            } else {
+                throw new RuntimeException("Could not detect extension identifier automatically");
+            }
+        } else {
+            this.callerClass = null;
+        }
+    }
+
+    public String getId(CurateOutcomeBuildItem curateOutcomeBuildItem) {
+        if (this.extensionIdentifier == null && this.callerClass != null) {
+            Map.Entry<String, String> groupIdAndArtifactId = ArtifactInfoUtil.groupIdAndArtifactId(callerClass,
+                    curateOutcomeBuildItem);
+            String artifactId = groupIdAndArtifactId.getValue();
+            if (artifactId.endsWith("-deployment")) {
+                artifactId = artifactId.substring(0, artifactId.length() - "-deployment".length());
+            }
+            this.extensionIdentifier = artifactId;
+        }
+        return this.extensionIdentifier;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public char getShortcutKey() {
+        return shortcutKey;
+    }
+
+    public String getJsonRpcNamespace() {
+        return jsonRpcNamespace;
+    }
+
+    public String getProviderClassName() {
+        return providerClassName;
+    }
+
+    public String getPageClassName() {
+        return customPageClassName;
+    }
+
+    public Class<?> getPageClass() {
+        return customPageClass;
+    }
+
+    public boolean hasProvider() {
+        return providerClassName != null && !providerClassName.isEmpty();
+    }
+
+    public boolean hasCustomPage() {
+        return customPageClassName != null && !customPageClassName.isEmpty();
+    }
+}

--- a/extensions/devshell/deployment-spi/src/main/java/io/quarkus/devshell/deployment/spi/ShellPageData.java
+++ b/extensions/devshell/deployment-spi/src/main/java/io/quarkus/devshell/deployment/spi/ShellPageData.java
@@ -1,0 +1,138 @@
+package io.quarkus.devshell.deployment.spi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Data structure for shell page content.
+ * Providers return this to describe what should be displayed.
+ */
+public final class ShellPageData {
+
+    private final List<Section> sections;
+    private final String error;
+
+    private ShellPageData(List<Section> sections, String error) {
+        this.sections = sections;
+        this.error = error;
+    }
+
+    public List<Section> getSections() {
+        return sections;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public boolean hasError() {
+        return error != null && !error.isEmpty();
+    }
+
+    public boolean isEmpty() {
+        return sections.isEmpty();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static ShellPageData error(String message) {
+        return new ShellPageData(List.of(), message);
+    }
+
+    public static ShellPageData empty() {
+        return new ShellPageData(List.of(), null);
+    }
+
+    public static final class Section {
+
+        private final String title;
+        private final List<Item> items;
+
+        public Section(String title, List<Item> items) {
+            this.title = title;
+            this.items = items != null ? items : List.of();
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public List<Item> getItems() {
+            return items;
+        }
+    }
+
+    public static final class Item {
+
+        private final String label;
+        private final String value;
+        private final ShellPageProvider.ItemStyle style;
+
+        public Item(String label, String value) {
+            this(label, value, ShellPageProvider.ItemStyle.TEXT);
+        }
+
+        public Item(String label, String value, ShellPageProvider.ItemStyle style) {
+            this.label = label;
+            this.value = value;
+            this.style = style != null ? style : ShellPageProvider.ItemStyle.TEXT;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public ShellPageProvider.ItemStyle getStyle() {
+            return style;
+        }
+
+        public static Item header(String label) {
+            return new Item(label, null, ShellPageProvider.ItemStyle.HEADER);
+        }
+
+        public static Item text(String label, String value) {
+            return new Item(label, value, ShellPageProvider.ItemStyle.TEXT);
+        }
+
+        public static Item code(String label, String value) {
+            return new Item(label, value, ShellPageProvider.ItemStyle.CODE);
+        }
+
+        public static Item ok(String label, String value) {
+            return new Item(label, value, ShellPageProvider.ItemStyle.STATUS_OK);
+        }
+
+        public static Item warning(String label, String value) {
+            return new Item(label, value, ShellPageProvider.ItemStyle.STATUS_WARNING);
+        }
+
+        public static Item error(String label, String value) {
+            return new Item(label, value, ShellPageProvider.ItemStyle.STATUS_ERROR);
+        }
+    }
+
+    public static final class Builder {
+
+        private final List<Section> sections = new ArrayList<>();
+
+        public Builder addSection(String title, List<Item> items) {
+            sections.add(new Section(title, items));
+            return this;
+        }
+
+        public Builder addSection(Section section) {
+            sections.add(section);
+            return this;
+        }
+
+        public ShellPageData build() {
+            return new ShellPageData(List.copyOf(sections), null);
+        }
+    }
+}

--- a/extensions/devshell/deployment-spi/src/main/java/io/quarkus/devshell/deployment/spi/ShellPageProvider.java
+++ b/extensions/devshell/deployment-spi/src/main/java/io/quarkus/devshell/deployment/spi/ShellPageProvider.java
@@ -1,0 +1,56 @@
+package io.quarkus.devshell.deployment.spi;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Interface for extensions to provide shell page data.
+ * Extensions implement this as a CDI bean to define what data
+ * should be displayed in the Dev Shell TUI.
+ * <p>
+ * Example:
+ *
+ * <pre>
+ * &#64;ApplicationScoped
+ * public class MyExtensionShellProvider implements ShellPageProvider {
+ *     &#64;Inject
+ *     MyService service;
+ *
+ *     &#64;Override
+ *     public ShellPageData loadData() {
+ *         return ShellPageData.builder()
+ *                 .addSection("Status", List.of(
+ *                         ShellPageData.Item.ok("Active", String.valueOf(service.isActive()))))
+ *                 .build();
+ *     }
+ * }
+ * </pre>
+ */
+public interface ShellPageProvider {
+
+    ShellPageData loadData();
+
+    default List<PageAction> getActions() {
+        return List.of();
+    }
+
+    default String executeAction(String actionName, Map<String, Object> params) {
+        return null;
+    }
+
+    enum ItemStyle {
+        TEXT,
+        CODE,
+        STATUS_OK,
+        STATUS_WARNING,
+        STATUS_ERROR,
+        LINK,
+        HEADER
+    }
+
+    record PageAction(String name, String label, char shortcutKey) {
+        public PageAction(String name, char shortcutKey) {
+            this(name, name, shortcutKey);
+        }
+    }
+}

--- a/extensions/devshell/deployment/pom.xml
+++ b/extensions/devshell/deployment/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-devshell-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-devshell-deployment</artifactId>
+    <name>Quarkus - Dev Shell - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell-deployment-spi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devui-deployment</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- TamboUI TUI framework -->
+        <dependency>
+            <groupId>dev.tamboui</groupId>
+            <artifactId>tamboui-tui</artifactId>
+        </dependency>
+
+        <!-- Vert.x WebSocket client for JSON-RPC -->
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
+
+        <!-- Jackson for JSON parsing (not Vert.x JSON, which has classloading issues) -->
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${project.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/DevShellBuildTimeConfig.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/DevShellBuildTimeConfig.java
@@ -1,0 +1,28 @@
+package io.quarkus.devshell.deployment;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "quarkus.devshell")
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public interface DevShellBuildTimeConfig {
+
+    /**
+     * Whether Dev Shell is enabled in dev mode.
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+    /**
+     * Hosts allowed to connect to Dev Shell.
+     * By default, only localhost connections are accepted.
+     * Add additional hosts or IP addresses to this list to allow
+     * remote connections (e.g., from a container or VM).
+     */
+    Optional<List<String>> allowedHosts();
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/DevShellCli.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/DevShellCli.java
@@ -1,0 +1,95 @@
+package io.quarkus.devshell.deployment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.devshell.deployment.tui.RawTerminalBackend;
+import io.quarkus.devshell.deployment.tui.TerminalUI;
+import io.quarkus.devshell.deployment.tui.screens.MainMenuScreen;
+
+/**
+ * Standalone launcher for Dev Shell.
+ * Connects to a running Quarkus dev mode instance from a separate terminal.
+ * <p>
+ * Usage: java -cp ... io.quarkus.devshell.deployment.DevShellCli [options] [port]
+ */
+public class DevShellCli {
+
+    public static void main(String[] args) {
+        String host = "localhost";
+        int port = 8080;
+        String basePath = "/q/dev-ui/json-rpc-ws";
+        List<String> allowedHosts = new ArrayList<>();
+
+        for (int i = 0; i < args.length; i++) {
+            switch (args[i]) {
+                case "--host":
+                    if (i + 1 < args.length) {
+                        host = args[++i];
+                    }
+                    break;
+                case "--port":
+                case "-p":
+                    if (i + 1 < args.length) {
+                        port = Integer.parseInt(args[++i]);
+                    }
+                    break;
+                case "--allow-host":
+                    if (i + 1 < args.length) {
+                        allowedHosts.add(args[++i]);
+                    }
+                    break;
+                case "--help":
+                case "-h":
+                    printUsage();
+                    return;
+                default:
+                    try {
+                        port = Integer.parseInt(args[i]);
+                    } catch (NumberFormatException e) {
+                        System.err.println("Unknown argument: " + args[i]);
+                        printUsage();
+                        System.exit(1);
+                    }
+                    break;
+            }
+        }
+
+        System.out.println("Connecting to Quarkus Dev Mode at " + host + ":" + port + "...");
+
+        RawTerminalBackend backend = new RawTerminalBackend();
+        DevShellJsonRpcClient jsonRpcClient = new DevShellJsonRpcClient(host, port, basePath, allowedHosts);
+
+        try {
+            jsonRpcClient.connect();
+            System.out.println("Connected. Launching Dev Shell...");
+
+            backend.start();
+            backend.enterAlternateScreen();
+
+            TerminalUI tui = new TerminalUI(backend, jsonRpcClient);
+            tui.start(new MainMenuScreen());
+        } catch (SecurityException e) {
+            System.err.println(e.getMessage());
+            System.exit(1);
+        } catch (Exception e) {
+            System.err.println("Failed to connect: " + e.getMessage());
+            System.exit(1);
+        } finally {
+            backend.close();
+            jsonRpcClient.close();
+        }
+    }
+
+    private static void printUsage() {
+        System.out.println("Quarkus Dev Shell - Terminal UI for Dev Mode");
+        System.out.println();
+        System.out.println("Usage: dev-shell [options] [port]");
+        System.out.println();
+        System.out.println("Options:");
+        System.out.println("  --host <host>         Host to connect to (default: localhost)");
+        System.out.println("  --port, -p <port>     Port to connect to (default: 8080)");
+        System.out.println("  --allow-host <host>   Allow connecting to a non-localhost host");
+        System.out.println("  --help, -h            Show this help");
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/DevShellContext.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/DevShellContext.java
@@ -1,0 +1,63 @@
+package io.quarkus.devshell.deployment;
+
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.devshell.deployment.tui.screens.DependenciesScreen;
+import io.quarkus.devshell.deployment.tui.screens.ExtensionsListScreen;
+
+/**
+ * Holds build-time data collected by DevShellProcessor,
+ * accessible to TUI screens.
+ */
+public final class DevShellContext {
+
+    private static volatile List<ExtensionsListScreen.ExtensionInfo> extensionInfos = List.of();
+    private static volatile List<DependenciesScreen.DependencyInfo> dependencyInfos = List.of();
+    private static volatile Map<String, ShellPageInfo> shellPages = Map.of();
+    private static volatile Map<String, Map<String, Object>> buildTimeData = Map.of();
+
+    private DevShellContext() {
+    }
+
+    public static List<ExtensionsListScreen.ExtensionInfo> getExtensionInfos() {
+        return extensionInfos;
+    }
+
+    static void setExtensionInfos(List<ExtensionsListScreen.ExtensionInfo> infos) {
+        extensionInfos = infos;
+    }
+
+    public static List<DependenciesScreen.DependencyInfo> getDependencyInfos() {
+        return dependencyInfos;
+    }
+
+    static void setDependencyInfos(List<DependenciesScreen.DependencyInfo> infos) {
+        dependencyInfos = infos;
+    }
+
+    public static Map<String, ShellPageInfo> getShellPages() {
+        return shellPages;
+    }
+
+    static void setShellPages(Map<String, ShellPageInfo> pages) {
+        shellPages = pages;
+    }
+
+    public static Map<String, Map<String, Object>> getBuildTimeData() {
+        return buildTimeData;
+    }
+
+    public static Object getBuildTimeData(String namespace, String key) {
+        Map<String, Object> nsData = buildTimeData.get(namespace);
+        return nsData != null ? nsData.get(key) : null;
+    }
+
+    static void setBuildTimeData(Map<String, Map<String, Object>> data) {
+        buildTimeData = data;
+    }
+
+    public record ShellPageInfo(String id, String title, String customPageClassName, Class<?> customPageClass,
+            String providerClassName) {
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/DevShellJsonRpcClient.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/DevShellJsonRpcClient.java
@@ -1,0 +1,288 @@
+package io.quarkus.devshell.deployment;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import org.jboss.logging.Logger;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocket;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.http.WebSocketClientOptions;
+import io.vertx.core.http.WebSocketConnectOptions;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
+
+/**
+ * WebSocket client for the Dev UI JSON-RPC endpoint.
+ * Uses Jackson (not Vert.x JSON) to avoid classloading issues on the deployment CL.
+ */
+public class DevShellJsonRpcClient implements AutoCloseable {
+
+    private static final Logger log = Logger.getLogger(DevShellJsonRpcClient.class);
+    private static final int TIMEOUT_SECONDS = 10;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final Set<String> LOCALHOST_ADDRESSES = Set.of(
+            "localhost", "127.0.0.1", "::1", "0:0:0:0:0:0:0:1");
+
+    private final URI uri;
+    private final Vertx vertx;
+    private final AtomicInteger idCounter = new AtomicInteger(1);
+    private final ConcurrentHashMap<Integer, CompletableFuture<JsonNode>> pendingRequests = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, Consumer<JsonNode>> subscriptions = new ConcurrentHashMap<>();
+
+    private volatile WebSocketClient client;
+    private volatile WebSocket socket;
+    private volatile boolean connected;
+
+    DevShellJsonRpcClient(String host, int port, String path) {
+        this(host, port, path, List.of());
+    }
+
+    DevShellJsonRpcClient(String host, int port, String path, List<String> allowedHosts) {
+        validateHost(host, allowedHosts);
+        this.uri = URI.create("ws://" + host + ":" + port + path);
+        this.vertx = Vertx.vertx();
+    }
+
+    private static void validateHost(String host, List<String> allowedHosts) {
+        if (LOCALHOST_ADDRESSES.contains(host.toLowerCase())) {
+            return;
+        }
+        if (allowedHosts != null && allowedHosts.contains(host)) {
+            return;
+        }
+        try {
+            InetAddress addr = InetAddress.getByName(host);
+            if (addr.isLoopbackAddress()) {
+                return;
+            }
+        } catch (Exception e) {
+            // fall through to rejection
+        }
+        throw new SecurityException(
+                "Dev Shell only allows localhost connections by default. "
+                        + "To connect to '" + host + "', add it to quarkus.devshell.allowed-hosts");
+    }
+
+    public void connect() {
+        WebSocketClientOptions options = new WebSocketClientOptions()
+                .setDefaultHost(uri.getHost())
+                .setDefaultPort(uri.getPort())
+                .setMaxMessageSize(10 * 1024 * 1024);
+        client = vertx.createWebSocketClient(options);
+
+        try {
+            WebSocketConnectOptions connectOptions = new WebSocketConnectOptions()
+                    .setURI(uri.getPath());
+            socket = client.connect(connectOptions).toCompletionStage().toCompletableFuture()
+                    .get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            socket.textMessageHandler(this::handleResponse);
+
+            socket.exceptionHandler(t -> log.error("WebSocket error", t));
+            socket.closeHandler(v -> {
+                connected = false;
+                failAllPending("WebSocket closed");
+            });
+
+            connected = true;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to connect to Dev UI JSON-RPC at " + uri, e);
+        }
+    }
+
+    public JsonNode call(String namespace, String methodName) {
+        return call(namespace, methodName, MAPPER.createObjectNode());
+    }
+
+    public JsonNode call(String namespace, String methodName, ObjectNode params) {
+        int id = idCounter.getAndIncrement();
+        CompletableFuture<JsonNode> future = new CompletableFuture<>();
+        pendingRequests.put(id, future);
+
+        try {
+            ObjectNode request = MAPPER.createObjectNode()
+                    .put("jsonrpc", "2.0")
+                    .put("id", id)
+                    .put("method", namespace + "_" + methodName);
+            request.set("params", params);
+
+            socket.writeTextMessage(MAPPER.writeValueAsString(request));
+        } catch (Exception e) {
+            pendingRequests.remove(id);
+            throw new RuntimeException("Failed to send JSON-RPC request", e);
+        }
+
+        try {
+            return future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            pendingRequests.remove(id);
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            throw new RuntimeException(cause.getMessage(), cause);
+        }
+    }
+
+    public CompletableFuture<JsonNode> callAsync(String namespace, String methodName) {
+        return callAsync(namespace, methodName, MAPPER.createObjectNode());
+    }
+
+    public CompletableFuture<JsonNode> callAsync(String namespace, String methodName, ObjectNode params) {
+        int id = idCounter.getAndIncrement();
+        CompletableFuture<JsonNode> future = new CompletableFuture<>();
+        pendingRequests.put(id, future);
+
+        try {
+            ObjectNode request = MAPPER.createObjectNode()
+                    .put("jsonrpc", "2.0")
+                    .put("id", id)
+                    .put("method", namespace + "_" + methodName);
+            request.set("params", params);
+
+            socket.writeTextMessage(MAPPER.writeValueAsString(request));
+        } catch (Exception e) {
+            pendingRequests.remove(id);
+            future.completeExceptionally(e);
+        }
+        return future;
+    }
+
+    public int subscribe(String namespace, String methodName, Consumer<JsonNode> onMessage) {
+        return subscribe(namespace, methodName, MAPPER.createObjectNode(), onMessage);
+    }
+
+    public int subscribe(String namespace, String methodName, ObjectNode params, Consumer<JsonNode> onMessage) {
+        int id = idCounter.getAndIncrement();
+        subscriptions.put(id, onMessage);
+
+        CompletableFuture<JsonNode> ackFuture = new CompletableFuture<>();
+        pendingRequests.put(id, ackFuture);
+
+        try {
+            ObjectNode request = MAPPER.createObjectNode()
+                    .put("jsonrpc", "2.0")
+                    .put("id", id)
+                    .put("method", namespace + "_" + methodName);
+            request.set("params", params);
+
+            socket.writeTextMessage(MAPPER.writeValueAsString(request));
+        } catch (Exception e) {
+            subscriptions.remove(id);
+            pendingRequests.remove(id);
+            throw new RuntimeException("Subscribe failed", e);
+        }
+
+        try {
+            ackFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            subscriptions.remove(id);
+            pendingRequests.remove(id);
+            throw new RuntimeException("Subscribe failed: " + namespace + "_" + methodName, e);
+        }
+        return id;
+    }
+
+    public void unsubscribe(int subscriptionId) {
+        subscriptions.remove(subscriptionId);
+        if (connected && socket != null) {
+            try {
+                ObjectNode request = MAPPER.createObjectNode()
+                        .put("jsonrpc", "2.0")
+                        .put("id", subscriptionId)
+                        .put("method", "unsubscribe");
+                socket.writeTextMessage(MAPPER.writeValueAsString(request));
+            } catch (Exception e) {
+                log.debug("Failed to send unsubscribe", e);
+            }
+        }
+    }
+
+    public boolean isConnected() {
+        return connected;
+    }
+
+    private void handleResponse(String text) {
+        try {
+            JsonNode json = MAPPER.readTree(text);
+            int id = json.path("id").asInt(-1);
+
+            if (json.has("error")) {
+                CompletableFuture<JsonNode> future = pendingRequests.remove(id);
+                if (future != null) {
+                    JsonNode error = json.get("error");
+                    String errorMsg = error.path("message").asText("Unknown error");
+                    int idx = errorMsg.indexOf("failed:");
+                    if (idx >= 0) {
+                        errorMsg = errorMsg.substring(idx + 7).trim();
+                    }
+                    future.completeExceptionally(new RuntimeException(errorMsg));
+                }
+                return;
+            }
+
+            JsonNode result = json.get("result");
+            if (result == null) {
+                return;
+            }
+
+            String messageType = result.path("messageType").asText("Response");
+
+            switch (messageType) {
+                case "SubscriptionMessage":
+                    Consumer<JsonNode> handler = subscriptions.get(id);
+                    if (handler != null) {
+                        handler.accept(result.path("object"));
+                    }
+                    break;
+                case "Void":
+                    CompletableFuture<JsonNode> ackFuture = pendingRequests.remove(id);
+                    if (ackFuture != null) {
+                        ackFuture.complete(MAPPER.createObjectNode());
+                    }
+                    break;
+                default:
+                    CompletableFuture<JsonNode> future = pendingRequests.remove(id);
+                    if (future != null) {
+                        future.complete(result.path("object"));
+                    }
+                    break;
+            }
+        } catch (Exception e) {
+            log.error("Failed to parse JSON-RPC response", e);
+        }
+    }
+
+    private void failAllPending(String reason) {
+        RuntimeException ex = new RuntimeException(reason);
+        pendingRequests.values().forEach(f -> f.completeExceptionally(ex));
+        pendingRequests.clear();
+    }
+
+    @Override
+    public void close() {
+        connected = false;
+        failAllPending("Client closed");
+        subscriptions.clear();
+        if (socket != null) {
+            try {
+                socket.close().toCompletionStage().toCompletableFuture().get(3, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+        if (client != null) {
+            client.close();
+        }
+        if (vertx != null) {
+            vertx.close();
+        }
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/DevShellProcessor.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/DevShellProcessor.java
@@ -1,0 +1,151 @@
+package io.quarkus.devshell.deployment;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.annotations.Produce;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.builditem.ServiceStartBuildItem;
+import io.quarkus.deployment.console.AeshConsole;
+import io.quarkus.deployment.console.ConsoleCommand;
+import io.quarkus.deployment.console.ConsoleStateManager;
+import io.quarkus.deployment.console.DelegateConnection;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.dev.console.QuarkusConsole;
+import io.quarkus.dev.spi.DevModeType;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
+import io.quarkus.devshell.deployment.tui.DelegateConnectionBackend;
+import io.quarkus.devshell.deployment.tui.TerminalUI;
+import io.quarkus.devshell.deployment.tui.screens.DependenciesScreen;
+import io.quarkus.devshell.deployment.tui.screens.ExtensionsListScreen;
+import io.quarkus.devshell.deployment.tui.screens.MainMenuScreen;
+import io.quarkus.devui.deployment.ExtensionsBuildItem;
+import io.quarkus.devui.deployment.extension.Extension;
+import io.quarkus.devui.spi.buildtime.BuildTimeData;
+import io.quarkus.devui.spi.page.CardPageBuildItem;
+import io.quarkus.maven.dependency.ResolvedDependency;
+
+@BuildSteps(onlyIf = IsDevelopment.class)
+class DevShellProcessor {
+
+    private static final Logger log = Logger.getLogger(DevShellProcessor.class);
+    private static final String FEATURE = "devshell";
+
+    static volatile ConsoleStateManager.ConsoleContext shellContext;
+    static volatile List<String> allowedHosts;
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @Produce(ServiceStartBuildItem.class)
+    @BuildStep
+    void registerConsoleCommand(LaunchModeBuildItem launchModeBuildItem,
+            DevShellBuildTimeConfig config,
+            ExtensionsBuildItem extensionsBuildItem,
+            CurateOutcomeBuildItem curateOutcomeBuildItem,
+            List<ShellPageBuildItem> shellPages,
+            List<CardPageBuildItem> cardPages) {
+        if (!config.enabled()) {
+            return;
+        }
+        if (launchModeBuildItem.getDevModeType().orElse(null) != DevModeType.LOCAL) {
+            return;
+        }
+        if (!(QuarkusConsole.INSTANCE instanceof AeshConsole)) {
+            return;
+        }
+
+        allowedHosts = config.allowedHosts().orElse(List.of());
+
+        List<ExtensionsListScreen.ExtensionInfo> infos = new ArrayList<>();
+        for (Extension ext : extensionsBuildItem.getActiveExtensions()) {
+            infos.add(new ExtensionsListScreen.ExtensionInfo(
+                    ext.getNamespace(), ext.getName(), ext.getDescription(),
+                    ext.getKeywords(), true));
+        }
+        for (Extension ext : extensionsBuildItem.getInactiveExtensions()) {
+            infos.add(new ExtensionsListScreen.ExtensionInfo(
+                    ext.getNamespace(), ext.getName(), ext.getDescription(),
+                    ext.getKeywords(), false));
+        }
+        DevShellContext.setExtensionInfos(infos);
+
+        Map<String, DevShellContext.ShellPageInfo> pageMap = new HashMap<>();
+        for (ShellPageBuildItem page : shellPages) {
+            String id = page.getId(curateOutcomeBuildItem);
+            pageMap.put(id, new DevShellContext.ShellPageInfo(
+                    id, page.getTitle(),
+                    page.getPageClassName(), page.getPageClass(),
+                    page.getProviderClassName()));
+        }
+        DevShellContext.setShellPages(pageMap);
+
+        Map<String, Map<String, Object>> btData = new HashMap<>();
+        for (CardPageBuildItem card : cardPages) {
+            if (card.hasBuildTimeData()) {
+                String ns = card.getExtensionPathName(curateOutcomeBuildItem);
+                Map<String, Object> nsData = btData.computeIfAbsent(ns, k -> new HashMap<>());
+                for (Map.Entry<String, BuildTimeData> entry : card.getBuildTimeData().entrySet()) {
+                    nsData.put(entry.getKey(), entry.getValue().getContent());
+                }
+            }
+        }
+        DevShellContext.setBuildTimeData(btData);
+
+        List<DependenciesScreen.DependencyInfo> deps = new ArrayList<>();
+        for (ResolvedDependency dep : curateOutcomeBuildItem.getApplicationModel().getDependencies()) {
+            deps.add(new DependenciesScreen.DependencyInfo(
+                    dep.getGroupId(), dep.getArtifactId(), dep.getVersion(),
+                    dep.getScope() != null ? dep.getScope() : ""));
+        }
+        deps.sort((a, b) -> (a.groupId() + ":" + a.artifactId()).compareTo(b.groupId() + ":" + b.artifactId()));
+        DevShellContext.setDependencyInfos(deps);
+
+        if (shellContext == null) {
+            shellContext = ConsoleStateManager.INSTANCE.createContext("Dev Shell");
+        }
+        shellContext.reset(
+                new ConsoleCommand('t', "Open Dev Shell TUI", "for the Dev Shell", 100, null,
+                        DevShellProcessor::launchShell));
+    }
+
+    private static void launchShell() {
+        if (!(QuarkusConsole.INSTANCE instanceof AeshConsole aeshConsole)) {
+            return;
+        }
+
+        DelegateConnection delegate = aeshConsole.takeoverTerminal();
+        DelegateConnectionBackend backend = new DelegateConnectionBackend(delegate);
+
+        Thread tuiThread = new Thread(() -> {
+            DevShellJsonRpcClient jsonRpcClient = null;
+            try {
+                jsonRpcClient = new DevShellJsonRpcClient("localhost", 8080, "/q/dev-ui/json-rpc-ws",
+                        allowedHosts != null ? allowedHosts : List.of());
+                jsonRpcClient.connect();
+
+                TerminalUI tui = new TerminalUI(backend, jsonRpcClient);
+                tui.start(new MainMenuScreen());
+            } catch (Exception e) {
+                log.error("Dev Shell error", e);
+            } finally {
+                if (jsonRpcClient != null) {
+                    jsonRpcClient.close();
+                }
+                aeshConsole.releaseTerminal();
+            }
+        }, "Dev Shell TUI");
+        tuiThread.setDaemon(true);
+        tuiThread.start();
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/AnsiRenderer.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/AnsiRenderer.java
@@ -1,0 +1,85 @@
+package io.quarkus.devshell.deployment.tui;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * ANSI escape code utilities for terminal rendering.
+ */
+public final class AnsiRenderer {
+
+    private static final Pattern ANSI_PATTERN = Pattern
+            .compile("\033\\[(?:[0-9;]*[a-zA-Z]|\\][^\007]*\007|[()][A-Z0-9])");
+
+    private AnsiRenderer() {
+    }
+
+    public static String stripAnsi(String text) {
+        if (text == null) {
+            return "";
+        }
+        return ANSI_PATTERN.matcher(text).replaceAll("");
+    }
+
+    public static final String BOX_HORIZONTAL = "─";
+    public static final String BOX_VERTICAL = "│";
+    public static final String ARROW_RIGHT = "▶";
+
+    public static List<String> wrapText(String text, int maxWidth) {
+        List<String> lines = new ArrayList<>();
+        if (text == null || text.isEmpty()) {
+            return lines;
+        }
+
+        String[] paragraphs = text.split("\n");
+        for (String paragraph : paragraphs) {
+            if (paragraph.length() <= maxWidth) {
+                lines.add(paragraph);
+            } else {
+                String[] words = paragraph.split(" ");
+                StringBuilder currentLine = new StringBuilder();
+
+                for (String word : words) {
+                    if (currentLine.length() + word.length() + 1 <= maxWidth) {
+                        if (currentLine.length() > 0) {
+                            currentLine.append(" ");
+                        }
+                        currentLine.append(word);
+                    } else {
+                        if (currentLine.length() > 0) {
+                            lines.add(currentLine.toString());
+                            currentLine = new StringBuilder();
+                        }
+                        if (word.length() > maxWidth) {
+                            int start = 0;
+                            while (start < word.length()) {
+                                int end = Math.min(start + maxWidth, word.length());
+                                lines.add(word.substring(start, end));
+                                start = end;
+                            }
+                        } else {
+                            currentLine.append(word);
+                        }
+                    }
+                }
+
+                if (currentLine.length() > 0) {
+                    lines.add(currentLine.toString());
+                }
+            }
+        }
+
+        return lines;
+    }
+
+    public static String fixedWidth(String text, int width) {
+        if (text == null) {
+            text = "";
+        }
+        if (text.length() > width) {
+            return text.substring(0, width - 1) + "…";
+        }
+        return String.format("%-" + width + "s", text);
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/AnsiWriter.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/AnsiWriter.java
@@ -1,0 +1,180 @@
+package io.quarkus.devshell.deployment.tui;
+
+import java.util.Optional;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Modifier;
+import dev.tamboui.style.Style;
+
+/**
+ * Writes a TamboUI Buffer to a string of ANSI escape sequences.
+ * Uses only SGR codes compatible with aesh's Connection.write().
+ */
+final class AnsiWriter {
+
+    private static final char ESC = '';
+
+    private AnsiWriter() {
+    }
+
+    static String fullRender(Buffer buffer) {
+        StringBuilder sb = new StringBuilder(buffer.width() * buffer.height() * 4);
+        Rect area = buffer.area();
+        Style lastStyle = null;
+
+        for (int y = area.y(); y < area.y() + area.height(); y++) {
+            cursorTo(sb, y + 1, 1);
+            lastStyle = null;
+
+            for (int x = area.x(); x < area.x() + area.width(); x++) {
+                Cell cell = buffer.get(x, y);
+                Style style = cell.style();
+
+                if (!style.equals(lastStyle)) {
+                    appendStyle(sb, style);
+                    lastStyle = style;
+                }
+                sb.append(cell.symbol());
+            }
+        }
+        reset(sb);
+        return sb.toString();
+    }
+
+    static String diffRender(Buffer current, Buffer previous) {
+        StringBuilder sb = new StringBuilder(1024);
+        Rect area = current.area();
+        Style lastStyle = null;
+        int lastX = -2;
+        int lastY = -1;
+
+        for (int y = area.y(); y < area.y() + area.height(); y++) {
+            for (int x = area.x(); x < area.x() + area.width(); x++) {
+                Cell cell = current.get(x, y);
+                Cell prevCell = previous.get(x, y);
+
+                if (cellEquals(cell, prevCell)) {
+                    continue;
+                }
+
+                if (y != lastY || x != lastX + 1) {
+                    cursorTo(sb, y + 1, x + 1);
+                    lastStyle = null;
+                }
+                lastX = x;
+                lastY = y;
+
+                Style style = cell.style();
+                if (!style.equals(lastStyle)) {
+                    appendStyle(sb, style);
+                    lastStyle = style;
+                }
+                sb.append(cell.symbol());
+            }
+        }
+        if (sb.length() > 0) {
+            reset(sb);
+        }
+        return sb.toString();
+    }
+
+    private static boolean cellEquals(Cell a, Cell b) {
+        if (a == b) {
+            return true;
+        }
+        if (a == null || b == null) {
+            return false;
+        }
+        return a.symbol().equals(b.symbol()) && a.style().equals(b.style());
+    }
+
+    private static void appendStyle(StringBuilder sb, Style style) {
+        sb.append(ESC).append("[0");
+
+        Optional<Color> fg = style.fg();
+        if (fg.isPresent()) {
+            int code = colorToSgr(fg.get(), true);
+            if (code >= 0) {
+                sb.append(';').append(code);
+            }
+        }
+
+        Optional<Color> bg = style.bg();
+        if (bg.isPresent()) {
+            int code = colorToSgr(bg.get(), false);
+            if (code >= 0) {
+                sb.append(';').append(code);
+            }
+        }
+
+        var mods = style.effectiveModifiers();
+        if (mods.contains(Modifier.BOLD)) {
+            sb.append(";1");
+        }
+        if (mods.contains(Modifier.DIM)) {
+            sb.append(";2");
+        }
+        if (mods.contains(Modifier.ITALIC)) {
+            sb.append(";3");
+        }
+        if (mods.contains(Modifier.UNDERLINED)) {
+            sb.append(";4");
+        }
+        if (mods.contains(Modifier.REVERSED)) {
+            sb.append(";7");
+        }
+
+        sb.append('m');
+    }
+
+    private static int colorToSgr(Color color, boolean foreground) {
+        int base = foreground ? 30 : 40;
+
+        if (color == Color.BLACK)
+            return base;
+        if (color == Color.RED)
+            return base + 1;
+        if (color == Color.GREEN)
+            return base + 2;
+        if (color == Color.YELLOW)
+            return base + 3;
+        if (color == Color.BLUE)
+            return base + 4;
+        if (color == Color.MAGENTA)
+            return base + 5;
+        if (color == Color.CYAN)
+            return base + 6;
+        if (color == Color.WHITE)
+            return base + 7;
+
+        if (color == Color.GRAY || color == Color.DARK_GRAY)
+            return foreground ? 90 : 100;
+        if (color == Color.LIGHT_RED)
+            return foreground ? 91 : 101;
+        if (color == Color.LIGHT_GREEN)
+            return foreground ? 92 : 102;
+        if (color == Color.LIGHT_YELLOW)
+            return foreground ? 93 : 103;
+        if (color == Color.LIGHT_BLUE)
+            return foreground ? 94 : 104;
+        if (color == Color.LIGHT_MAGENTA)
+            return foreground ? 95 : 105;
+        if (color == Color.LIGHT_CYAN)
+            return foreground ? 96 : 106;
+        if (color == Color.BRIGHT_WHITE)
+            return foreground ? 97 : 107;
+
+        return -1;
+    }
+
+    private static void cursorTo(StringBuilder sb, int row, int col) {
+        sb.append(ESC).append('[').append(row).append(';').append(col).append('H');
+    }
+
+    private static void reset(StringBuilder sb) {
+        sb.append(ESC).append("[0m");
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/AppContext.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/AppContext.java
@@ -1,0 +1,69 @@
+package io.quarkus.devshell.deployment.tui;
+
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.devshell.deployment.DevShellContext;
+import io.quarkus.devshell.deployment.DevShellJsonRpcClient;
+import io.quarkus.devshell.deployment.tui.screens.ExtensionsListScreen;
+
+/**
+ * Context available to all screens, providing access to the JSON-RPC client,
+ * navigation, and terminal state.
+ */
+public class AppContext {
+
+    private final DevShellJsonRpcClient jsonRpcClient;
+    private final TerminalUI tui;
+    private volatile String statusText;
+
+    AppContext(DevShellJsonRpcClient jsonRpcClient, TerminalUI tui) {
+        this.jsonRpcClient = jsonRpcClient;
+        this.tui = tui;
+    }
+
+    public DevShellJsonRpcClient getJsonRpcClient() {
+        return jsonRpcClient;
+    }
+
+    public void navigateTo(Screen screen) {
+        tui.navigateTo(screen);
+    }
+
+    public void goBack() {
+        tui.goBack();
+    }
+
+    public void exit() {
+        tui.exit();
+    }
+
+    public int getWidth() {
+        return tui.getWidth();
+    }
+
+    public int getHeight() {
+        return tui.getHeight();
+    }
+
+    public void requestRedraw() {
+        tui.requestRedraw();
+    }
+
+    public void setStatus(String text) {
+        this.statusText = text;
+        tui.requestRedraw();
+    }
+
+    public String getStatus() {
+        return statusText;
+    }
+
+    public List<ExtensionsListScreen.ExtensionInfo> getExtensions() {
+        return DevShellContext.getExtensionInfos();
+    }
+
+    public Map<String, DevShellContext.ShellPageInfo> getShellPages() {
+        return DevShellContext.getShellPages();
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/DelegateConnectionBackend.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/DelegateConnectionBackend.java
@@ -1,0 +1,72 @@
+package io.quarkus.devshell.deployment.tui;
+
+import java.util.function.Consumer;
+
+import org.aesh.terminal.tty.Size;
+
+import io.quarkus.deployment.console.DelegateConnection;
+
+/**
+ * Terminal backend that wraps an aesh DelegateConnection.
+ * Used when Dev Shell runs in-process (pressing 't' in dev mode).
+ */
+public class DelegateConnectionBackend implements TerminalBackend {
+
+    private final DelegateConnection connection;
+
+    public DelegateConnectionBackend(DelegateConnection connection) {
+        this.connection = connection;
+    }
+
+    @Override
+    public void write(String output) {
+        connection.write(output);
+    }
+
+    @Override
+    public void setInputHandler(Consumer<int[]> handler) {
+        connection.setStdinHandler(handler);
+    }
+
+    @Override
+    public void setResizeHandler(Consumer<int[]> handler) {
+        connection.setSizeHandler(size -> handler.accept(new int[] { size.getWidth(), size.getHeight() }));
+    }
+
+    @Override
+    public int getWidth() {
+        Size size = connection.size();
+        return size != null ? size.getWidth() : 80;
+    }
+
+    @Override
+    public int getHeight() {
+        Size size = connection.size();
+        return size != null ? size.getHeight() : 24;
+    }
+
+    @Override
+    public void enterAlternateScreen() {
+        // handled by AeshConsole.takeoverTerminal()
+    }
+
+    @Override
+    public void exitAlternateScreen() {
+        // handled by AeshConsole.releaseTerminal()
+    }
+
+    @Override
+    public void hideCursor() {
+        connection.write("\033[?25l");
+    }
+
+    @Override
+    public void showCursor() {
+        connection.write("\033[?25h");
+    }
+
+    @Override
+    public void close() {
+        // lifecycle managed by AeshConsole
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/KeyCode.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/KeyCode.java
@@ -1,0 +1,87 @@
+package io.quarkus.devshell.deployment.tui;
+
+/**
+ * Key code constants and utilities for keyboard input handling.
+ */
+public final class KeyCode {
+
+    private KeyCode() {
+    }
+
+    public static final int ENTER = '\r';
+    public static final int NEWLINE = '\n';
+    public static final int ESCAPE = 27;
+    public static final int BACKSPACE = 127;
+    public static final int TAB = '\t';
+    public static final int SPACE = ' ';
+
+    public static final int UP = -1;
+    public static final int DOWN = -2;
+    public static final int RIGHT = -3;
+    public static final int LEFT = -4;
+    public static final int HOME = -5;
+    public static final int END = -6;
+    public static final int PAGE_UP = -7;
+    public static final int PAGE_DOWN = -8;
+    public static final int DELETE = -9;
+
+    public static final int CTRL_S = 19;
+
+    public static int parse(int[] keys) {
+        if (keys == null || keys.length == 0) {
+            return -100;
+        }
+
+        if (keys.length == 1) {
+            return keys[0];
+        }
+
+        if (keys.length >= 3 && keys[0] == ESCAPE && keys[1] == '[') {
+            return parseEscapeSequence(keys);
+        }
+
+        return keys[0];
+    }
+
+    private static int parseEscapeSequence(int[] keys) {
+        switch (keys[2]) {
+            case 'A':
+                return UP;
+            case 'B':
+                return DOWN;
+            case 'C':
+                return RIGHT;
+            case 'D':
+                return LEFT;
+            case 'H':
+                return HOME;
+            case 'F':
+                return END;
+            case '5':
+                if (keys.length >= 4 && keys[3] == '~')
+                    return PAGE_UP;
+                break;
+            case '6':
+                if (keys.length >= 4 && keys[3] == '~')
+                    return PAGE_DOWN;
+                break;
+            case '3':
+                if (keys.length >= 4 && keys[3] == '~')
+                    return DELETE;
+                break;
+            case '1':
+                if (keys.length >= 4 && keys[3] == '~')
+                    return HOME;
+                break;
+            case '4':
+                if (keys.length >= 4 && keys[3] == '~')
+                    return END;
+                break;
+        }
+        return keys[0];
+    }
+
+    public static boolean isPrintable(int key) {
+        return key >= 32 && key < 127;
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/RawTerminalBackend.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/RawTerminalBackend.java
@@ -1,0 +1,163 @@
+package io.quarkus.devshell.deployment.tui;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.util.function.Consumer;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Terminal backend using raw System.in/System.out with stty.
+ * Used for standalone Dev Shell sessions connecting from another terminal.
+ */
+public class RawTerminalBackend implements TerminalBackend {
+
+    private static final Logger log = Logger.getLogger(RawTerminalBackend.class);
+
+    private final InputStream in;
+    private final PrintStream out;
+    private volatile Consumer<int[]> inputHandler;
+    private volatile boolean running;
+    private Thread readerThread;
+    private String savedStty;
+
+    public RawTerminalBackend() {
+        this(System.in, System.out);
+    }
+
+    public RawTerminalBackend(InputStream in, PrintStream out) {
+        this.in = in;
+        this.out = out;
+    }
+
+    public void start() {
+        savedStty = stty("-g");
+        stty("raw -echo -icanon min 1");
+
+        running = true;
+        readerThread = new Thread(this::readLoop, "Dev Shell Input Reader");
+        readerThread.setDaemon(true);
+        readerThread.start();
+    }
+
+    private void readLoop() {
+        byte[] buf = new byte[64];
+        while (running) {
+            try {
+                int available = in.available();
+                if (available <= 0) {
+                    Thread.sleep(10);
+                    continue;
+                }
+                int n = in.read(buf, 0, Math.min(available, buf.length));
+                if (n <= 0) {
+                    break;
+                }
+                int[] keys = new int[n];
+                for (int i = 0; i < n; i++) {
+                    keys[i] = buf[i] & 0xFF;
+                }
+                Consumer<int[]> handler = inputHandler;
+                if (handler != null) {
+                    handler.accept(keys);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (IOException e) {
+                if (running) {
+                    log.debug("Input read error", e);
+                }
+                break;
+            }
+        }
+    }
+
+    @Override
+    public void write(String output) {
+        out.print(output);
+        out.flush();
+    }
+
+    @Override
+    public void setInputHandler(Consumer<int[]> handler) {
+        this.inputHandler = handler;
+    }
+
+    @Override
+    public void setResizeHandler(Consumer<int[]> handler) {
+        // SIGWINCH not easily captured in pure Java; size polled on render
+    }
+
+    @Override
+    public int getWidth() {
+        return queryTerminalSize()[0];
+    }
+
+    @Override
+    public int getHeight() {
+        return queryTerminalSize()[1];
+    }
+
+    @Override
+    public void enterAlternateScreen() {
+        write("\033[?1049h");
+    }
+
+    @Override
+    public void exitAlternateScreen() {
+        write("\033[?1049l");
+    }
+
+    @Override
+    public void hideCursor() {
+        write("\033[?25l");
+    }
+
+    @Override
+    public void showCursor() {
+        write("\033[?25h");
+    }
+
+    @Override
+    public void close() {
+        running = false;
+        if (readerThread != null) {
+            readerThread.interrupt();
+        }
+        showCursor();
+        exitAlternateScreen();
+        write("\033[0m");
+        if (savedStty != null) {
+            stty(savedStty);
+        }
+    }
+
+    private int[] queryTerminalSize() {
+        try {
+            String size = stty("size");
+            if (size != null && !size.isEmpty()) {
+                String[] parts = size.trim().split("\\s+");
+                if (parts.length == 2) {
+                    return new int[] { Integer.parseInt(parts[1]), Integer.parseInt(parts[0]) };
+                }
+            }
+        } catch (Exception e) {
+            // fall through
+        }
+        return new int[] { 80, 24 };
+    }
+
+    private static String stty(String args) {
+        try {
+            String[] cmd = { "/bin/sh", "-c", "stty " + args + " < /dev/tty" };
+            Process p = Runtime.getRuntime().exec(cmd);
+            String result = new String(p.getInputStream().readAllBytes()).trim();
+            p.waitFor();
+            return result;
+        } catch (Exception e) {
+            return "";
+        }
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/Screen.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/Screen.java
@@ -1,0 +1,34 @@
+package io.quarkus.devshell.deployment.tui;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+
+/**
+ * A full-screen TUI view. Screens are stacked: navigating to a new screen
+ * pushes it onto the stack, pressing Escape/back pops it.
+ */
+public interface Screen {
+
+    String getTitle();
+
+    default void onEnter(AppContext ctx) {
+    }
+
+    default void onLeave() {
+    }
+
+    void render(Rect area, Buffer buffer);
+
+    /**
+     * Handle a keyboard event.
+     *
+     * @return true if the key was consumed, false to let the shell handle it
+     */
+    boolean handleKey(int[] keys);
+
+    default void onResize(int width, int height) {
+    }
+
+    default void tick() {
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/TerminalBackend.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/TerminalBackend.java
@@ -1,0 +1,32 @@
+package io.quarkus.devshell.deployment.tui;
+
+import java.util.function.Consumer;
+
+/**
+ * Abstraction over the terminal I/O channel.
+ * Allows the TUI to run either in-process (via AeshConsole's DelegateConnection)
+ * or standalone from a separate terminal (via JLine).
+ */
+public interface TerminalBackend extends AutoCloseable {
+
+    void write(String output);
+
+    void setInputHandler(Consumer<int[]> handler);
+
+    void setResizeHandler(Consumer<int[]> handler);
+
+    int getWidth();
+
+    int getHeight();
+
+    void enterAlternateScreen();
+
+    void exitAlternateScreen();
+
+    void hideCursor();
+
+    void showCursor();
+
+    @Override
+    void close();
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/TerminalUI.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/TerminalUI.java
@@ -1,0 +1,271 @@
+package io.quarkus.devshell.deployment.tui;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.jboss.logging.Logger;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.text.Text;
+import dev.tamboui.widgets.paragraph.Paragraph;
+import io.quarkus.devshell.deployment.DevShellJsonRpcClient;
+import io.quarkus.devshell.deployment.tui.widgets.LogPanel;
+
+/**
+ * Main TUI controller. Manages the screen stack, rendering loop, and input handling.
+ * Uses TamboUI for rendering to an in-memory Buffer, then writes the buffer's
+ * ANSI output via the {@link TerminalBackend}.
+ */
+public class TerminalUI {
+
+    private static final Logger log = Logger.getLogger(TerminalUI.class);
+
+    private final TerminalBackend backend;
+    private final DevShellJsonRpcClient jsonRpcClient;
+    private final Deque<Screen> screenStack = new ArrayDeque<>();
+    private final LinkedBlockingQueue<int[]> inputQueue = new LinkedBlockingQueue<>();
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private final AtomicBoolean redrawRequested = new AtomicBoolean(true);
+    private final AppContext appContext;
+    private volatile int width;
+    private volatile int height;
+    private Buffer previousBuffer;
+    private LogPanel logPanel;
+    private boolean logPanelVisible = false;
+    private static final int LOG_PANEL_HEIGHT = 8;
+
+    public TerminalUI(TerminalBackend backend, DevShellJsonRpcClient jsonRpcClient) {
+        this.backend = backend;
+        this.jsonRpcClient = jsonRpcClient;
+        this.width = backend.getWidth();
+        this.height = backend.getHeight();
+        this.appContext = new AppContext(jsonRpcClient, this);
+    }
+
+    public void start(Screen initialScreen) {
+        running.set(true);
+
+        backend.setInputHandler(keys -> {
+            if (keys != null) {
+                inputQueue.offer(keys);
+            }
+        });
+
+        backend.setResizeHandler(size -> {
+            if (size != null && size.length == 2) {
+                this.width = size[0];
+                this.height = size[1];
+                Screen current = screenStack.peek();
+                if (current != null) {
+                    int effectiveHeight = logPanelVisible ? height - LOG_PANEL_HEIGHT - 1 : height - 1;
+                    current.onResize(width, effectiveHeight);
+                }
+                previousBuffer = null;
+                requestRedraw();
+            }
+        });
+
+        navigateTo(initialScreen);
+        backend.hideCursor();
+
+        while (running.get()) {
+            try {
+                int[] keys = inputQueue.poll(100, TimeUnit.MILLISECONDS);
+                if (keys != null) {
+                    handleInput(keys);
+                }
+
+                Screen current = screenStack.peek();
+                if (current != null) {
+                    current.tick();
+                }
+
+                if (redrawRequested.compareAndSet(true, false)) {
+                    render();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (Exception e) {
+                log.error("Error in TUI loop", e);
+            }
+        }
+
+        backend.showCursor();
+        backend.write("\033[0m\033[2J\033[H");
+    }
+
+    private void handleInput(int[] keys) {
+        if (keys.length == 1 && keys[0] == -1) {
+            exit();
+            return;
+        }
+
+        // Let log panel handle tab switching keys before screens
+        if (logPanelVisible && logPanel != null) {
+            int parsedKey = KeyCode.parse(keys);
+            if (logPanel.handleKey(parsedKey)) {
+                requestRedraw();
+                return;
+            }
+        }
+
+        Screen current = screenStack.peek();
+        if (current != null && current.handleKey(keys)) {
+            requestRedraw();
+            return;
+        }
+
+        if (keys.length == 1) {
+            int k = keys[0];
+            if (k == 'l' || k == 'L') {
+                toggleLogPanel();
+            } else if (k == 27) { // ESC
+                goBack();
+            } else if (k == 'q' || k == 'Q') {
+                if (screenStack.size() <= 1) {
+                    exit();
+                } else {
+                    goBack();
+                }
+            }
+        }
+    }
+
+    private void render() {
+        if (width <= 0 || height <= 0) {
+            return;
+        }
+        Screen current = screenStack.peek();
+        if (current == null) {
+            return;
+        }
+
+        Rect fullArea = new Rect(0, 0, width, height);
+        Buffer buffer = Buffer.empty(fullArea);
+
+        if (logPanelVisible && logPanel != null) {
+            var areas = Layout.vertical()
+                    .constraints(Constraint.fill(), Constraint.length(LOG_PANEL_HEIGHT), Constraint.length(1))
+                    .split(fullArea);
+            current.render(areas.get(0), buffer);
+            logPanel.render(areas.get(1), buffer);
+            renderStatusBar(areas.get(2), buffer, current);
+        } else {
+            var areas = Layout.vertical()
+                    .constraints(Constraint.fill(), Constraint.length(1))
+                    .split(fullArea);
+            current.render(areas.get(0), buffer);
+            renderStatusBar(areas.get(1), buffer, current);
+        }
+
+        String output;
+        if (previousBuffer == null) {
+            output = "\033[2J" + AnsiWriter.fullRender(buffer);
+        } else {
+            output = AnsiWriter.diffRender(buffer, previousBuffer);
+        }
+        if (!output.isEmpty()) {
+            backend.write(output);
+        }
+        previousBuffer = buffer;
+    }
+
+    private void renderStatusBar(Rect area, Buffer buffer, Screen current) {
+        Style statusStyle = Style.EMPTY.onBlue().white();
+        Style boldStatus = statusStyle.bold();
+
+        buffer.fill(area, new Cell(" ", statusStyle));
+
+        Span logSpan;
+        if (logPanelVisible && logPanel != null) {
+            String tabName = logPanel.getActiveTab() == 0 ? "Server" : "Testing";
+            String streamInfo = logPanel.isStreaming() ? " live" : "";
+            logSpan = Span.styled("  [L] " + tabName + streamInfo, statusStyle);
+        } else {
+            logSpan = Span.styled("  [L] Logs", statusStyle);
+        }
+
+        Line statusLine = Line.from(
+                Span.styled(" Dev Shell", boldStatus),
+                Span.styled(" | ", statusStyle),
+                Span.styled(current.getTitle(), statusStyle),
+                Span.styled(" | ", statusStyle),
+                Span.styled("ESC: back  q: quit", statusStyle),
+                logSpan);
+
+        Paragraph statusParagraph = Paragraph.builder()
+                .text(Text.from(statusLine))
+                .style(statusStyle)
+                .build();
+        statusParagraph.render(area, buffer);
+    }
+
+    void navigateTo(Screen screen) {
+        screen.onEnter(appContext);
+        screenStack.push(screen);
+        previousBuffer = null;
+        requestRedraw();
+    }
+
+    void goBack() {
+        if (screenStack.size() <= 1) {
+            exit();
+            return;
+        }
+        Screen removed = screenStack.pop();
+        if (removed != null) {
+            removed.onLeave();
+        }
+        previousBuffer = null;
+        requestRedraw();
+    }
+
+    void exit() {
+        running.set(false);
+        if (logPanel != null) {
+            logPanel.stop();
+        }
+        while (!screenStack.isEmpty()) {
+            screenStack.pop().onLeave();
+        }
+    }
+
+    private void toggleLogPanel() {
+        logPanelVisible = !logPanelVisible;
+        if (logPanelVisible) {
+            if (logPanel == null) {
+                logPanel = new LogPanel();
+                logPanel.start(appContext);
+            }
+        }
+        Screen current = screenStack.peek();
+        if (current != null) {
+            int effectiveHeight = logPanelVisible ? height - LOG_PANEL_HEIGHT - 1 : height - 1;
+            current.onResize(width, effectiveHeight);
+        }
+        requestRedraw();
+    }
+
+    void requestRedraw() {
+        redrawRequested.set(true);
+    }
+
+    int getWidth() {
+        return width;
+    }
+
+    int getHeight() {
+        return height;
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/BaseExtensionPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/BaseExtensionPage.java
@@ -1,0 +1,301 @@
+package io.quarkus.devshell.deployment.tui.pages;
+
+import java.util.concurrent.CompletableFuture;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import io.quarkus.devshell.deployment.DevShellContext;
+import io.quarkus.devshell.deployment.tui.AppContext;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
+
+public abstract class BaseExtensionPage implements ExtensionPage {
+
+    protected static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final Style TAB_ACTIVE = Style.EMPTY.bold().reversed();
+    private static final Style TAB_INACTIVE = Style.EMPTY.gray();
+    private static final Style LOADING_STYLE = Style.EMPTY.yellow();
+    private static final Style ERROR_STYLE = Style.EMPTY.red();
+    protected static final Style FOOTER_STYLE = Style.EMPTY.gray();
+    protected static final Style HEADER_STYLE = Style.EMPTY.cyan().bold();
+    protected static final Style LABEL_STYLE = Style.EMPTY.cyan();
+    protected static final Style VALUE_STYLE = Style.EMPTY.white();
+    protected static final Style DIM_STYLE = Style.EMPTY.gray();
+
+    protected final String namespace;
+    protected final String displayName;
+    protected AppContext ctx;
+    protected volatile boolean loading = false;
+    protected volatile String errorMessage;
+    protected boolean initialized = false;
+
+    private String[] tabNames;
+    private int activeTabIndex = 0;
+
+    protected BaseExtensionPage(String namespace, String displayName) {
+        this.namespace = namespace;
+        this.displayName = displayName;
+    }
+
+    @Override
+    public String getNamespace() {
+        return namespace;
+    }
+
+    @Override
+    public String getTitle() {
+        return displayName;
+    }
+
+    @Override
+    public void onEnter(AppContext ctx) {
+        this.ctx = ctx;
+        if (!initialized) {
+            initialized = true;
+            loadDataAsync();
+        }
+    }
+
+    @Override
+    public void onLeave() {
+    }
+
+    @Override
+    public void render(Rect area, Buffer buffer) {
+        if (loading) {
+            buffer.setString(area.x() + 2, area.y() + 1, "Loading...", LOADING_STYLE);
+            return;
+        }
+        if (errorMessage != null) {
+            buffer.setString(area.x() + 2, area.y() + 1, "Error: " + truncate(errorMessage, area.width() - 10),
+                    ERROR_STYLE);
+            return;
+        }
+
+        if (tabNames != null && tabNames.length > 1) {
+            var areas = Layout.vertical()
+                    .constraints(Constraint.length(2), Constraint.fill(), Constraint.length(1))
+                    .split(area);
+            renderTabBar(areas.get(0), buffer);
+            renderPanel(areas.get(1), buffer);
+            renderFooterBar(areas.get(2), buffer);
+        } else {
+            var areas = Layout.vertical()
+                    .constraints(Constraint.fill(), Constraint.length(1))
+                    .split(area);
+            renderPanel(areas.get(0), buffer);
+            renderFooterBar(areas.get(1), buffer);
+        }
+    }
+
+    @Override
+    public boolean handleKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+
+        if (tabNames != null && tabNames.length > 1) {
+            if (key == KeyCode.TAB) {
+                activeTabIndex = (activeTabIndex + 1) % tabNames.length;
+                onTabChanged(activeTabIndex);
+                ctx.requestRedraw();
+                return true;
+            }
+            if (key >= '1' && key <= '9') {
+                int idx = key - '1';
+                if (idx < tabNames.length) {
+                    activeTabIndex = idx;
+                    onTabChanged(activeTabIndex);
+                    ctx.requestRedraw();
+                    return true;
+                }
+            }
+        }
+
+        if (key == 'r' || key == 'R') {
+            loadDataAsync();
+            return true;
+        }
+
+        return handlePanelKey(keys);
+    }
+
+    @Override
+    public void initPanel(AppContext ctx) {
+        if (!initialized) {
+            this.ctx = ctx;
+            initialized = true;
+            loadDataAsync();
+        }
+    }
+
+    @Override
+    public void reset() {
+        initialized = false;
+        loading = false;
+        errorMessage = null;
+    }
+
+    // --- Tab support ---
+
+    protected void setTabs(String... names) {
+        this.tabNames = names;
+        if (activeTabIndex >= names.length) {
+            activeTabIndex = 0;
+        }
+    }
+
+    protected int getActiveTab() {
+        return activeTabIndex;
+    }
+
+    protected String getActiveTabName() {
+        if (tabNames != null && activeTabIndex < tabNames.length) {
+            return tabNames[activeTabIndex];
+        }
+        return null;
+    }
+
+    protected void onTabChanged(int newTab) {
+    }
+
+    private void renderTabBar(Rect area, Buffer buffer) {
+        int col = area.x() + 1;
+        for (int i = 0; i < tabNames.length; i++) {
+            String label = " " + tabNames[i] + " ";
+            buffer.setString(col, area.y(), label, i == activeTabIndex ? TAB_ACTIVE : TAB_INACTIVE);
+            col += label.length() + 1;
+        }
+    }
+
+    // --- Data loading ---
+
+    protected void loadDataAsync() {
+        loading = true;
+        errorMessage = null;
+        if (ctx != null) {
+            ctx.requestRedraw();
+        }
+        CompletableFuture.runAsync(() -> {
+            try {
+                loadData();
+                loading = false;
+            } catch (Exception e) {
+                loading = false;
+                errorMessage = extractErrorMessage(e);
+            }
+            if (ctx != null) {
+                ctx.requestRedraw();
+            }
+        });
+    }
+
+    private String extractErrorMessage(Exception e) {
+        String msg = e.getMessage();
+        if (msg == null) {
+            return e.getClass().getSimpleName();
+        }
+        // Strip internal JSON-RPC method names (namespace_method format)
+        if (msg.contains("failed:")) {
+            String detail = msg.substring(msg.indexOf("failed:") + 7).trim();
+            if (!detail.isEmpty()) {
+                return detail;
+            }
+        }
+        // Strip "JSON-RPC error NNNN: " prefix
+        if (msg.startsWith("JSON-RPC error ")) {
+            int colonIdx = msg.indexOf(':', 15);
+            if (colonIdx > 0 && colonIdx < msg.length() - 1) {
+                return msg.substring(colonIdx + 1).trim();
+            }
+        }
+        return msg;
+    }
+
+    // --- JSON-RPC helpers ---
+
+    protected JsonNode rpcCall(String method) {
+        return ctx.getJsonRpcClient().call(namespace, method);
+    }
+
+    protected JsonNode rpcCall(String method, ObjectNode params) {
+        return ctx.getJsonRpcClient().call(namespace, method, params);
+    }
+
+    protected CompletableFuture<JsonNode> rpcCallAsync(String method) {
+        return ctx.getJsonRpcClient().callAsync(namespace, method);
+    }
+
+    protected ObjectNode createParams() {
+        return MAPPER.createObjectNode();
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <T> T getBuildTimeData(String key) {
+        return (T) DevShellContext.getBuildTimeData(namespace, key);
+    }
+
+    protected JsonNode getBuildTimeDataAsJson(String key) {
+        Object data = DevShellContext.getBuildTimeData(namespace, key);
+        if (data == null) {
+            return MAPPER.nullNode();
+        }
+        return MAPPER.valueToTree(data);
+    }
+
+    // --- Rendering helpers ---
+
+    protected void renderFooterBar(Rect area, Buffer buffer) {
+        String tabHint = (tabNames != null && tabNames.length > 1) ? "[Tab] Switch  " : "";
+        String footer = " " + tabHint + getFooterText() + "  [R] Refresh  [ESC] Back";
+        buffer.setString(area.x(), area.y(), truncate(footer, area.width()), FOOTER_STYLE);
+    }
+
+    protected String getFooterText() {
+        return "";
+    }
+
+    protected void renderLoading(Buffer buffer, int x, int y) {
+        buffer.setString(x, y, "Loading...", LOADING_STYLE);
+    }
+
+    protected void renderError(Buffer buffer, int x, int y, int maxWidth) {
+        if (errorMessage != null) {
+            buffer.setString(x, y, truncate("Error: " + errorMessage, maxWidth), ERROR_STYLE);
+        }
+    }
+
+    protected static String truncate(String text, int maxLen) {
+        if (text == null)
+            return "";
+        if (maxLen <= 0)
+            return "";
+        if (text.length() <= maxLen)
+            return text;
+        return text.substring(0, maxLen - 1) + "…";
+    }
+
+    // --- Panel rendering (for embedding in ExtensionsListScreen detail view) ---
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        if (loading) {
+            buffer.setString(area.x(), area.y(), "Loading...", LOADING_STYLE);
+            return;
+        }
+        if (errorMessage != null) {
+            buffer.setString(area.x(), area.y(), truncate(errorMessage, area.width()), ERROR_STYLE);
+            return;
+        }
+        buffer.setString(area.x(), area.y(), "Press Enter to view details", FOOTER_STYLE);
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        return false;
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/ConfigurationPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/ConfigurationPage.java
@@ -1,0 +1,151 @@
+package io.quarkus.devshell.deployment.tui.pages;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import tools.jackson.databind.JsonNode;
+
+public class ConfigurationPage extends BaseExtensionPage {
+
+    private static final Style PHASE_BUILD = Style.EMPTY.red();
+    private static final Style PHASE_BUILD_RUN = Style.EMPTY.yellow();
+    private static final Style PHASE_RUN = Style.EMPTY.green();
+    private static final Style SELECTED = Style.EMPTY.onCyan().black().bold();
+
+    private List<ConfigEntry> allEntries = List.of();
+    private int selectedIndex = 0;
+    private int scrollOffset = 0;
+
+    public ConfigurationPage() {
+        super("devui-configuration", "Configuration");
+        setTabs("All", "Changed", "Build Time", "Runtime");
+    }
+
+    @Override
+    public void loadData() {
+        JsonNode result = rpcCall("getAllConfiguration");
+        List<ConfigEntry> entries = new ArrayList<>();
+        JsonNode arr = result.isArray() ? result : result.path("_array");
+        if (arr.isArray()) {
+            for (JsonNode item : arr) {
+                String value = "";
+                JsonNode cv = item.path("configValue");
+                if (cv.isObject()) {
+                    value = cv.path("value").asText("");
+                } else if (cv.isTextual()) {
+                    value = cv.asText("");
+                }
+                entries.add(new ConfigEntry(
+                        item.path("name").asText(""),
+                        value,
+                        item.path("defaultValue").asText(""),
+                        item.path("configPhase").asText("")));
+            }
+        }
+        allEntries = entries;
+    }
+
+    private List<ConfigEntry> getFilteredEntries() {
+        return switch (getActiveTab()) {
+            case 1 -> allEntries.stream()
+                    .filter(e -> !e.value.isEmpty() && !e.value.equals(e.defaultValue))
+                    .toList();
+            case 2 -> allEntries.stream()
+                    .filter(e -> "BUILD_TIME".equals(e.phase) || "BUILD_AND_RUN_TIME_FIXED".equals(e.phase))
+                    .toList();
+            case 3 -> allEntries.stream()
+                    .filter(e -> "RUN_TIME".equals(e.phase))
+                    .toList();
+            default -> allEntries;
+        };
+    }
+
+    @Override
+    protected void onTabChanged(int newTab) {
+        selectedIndex = 0;
+        scrollOffset = 0;
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        List<ConfigEntry> entries = getFilteredEntries();
+        int visibleRows = area.height();
+
+        if (selectedIndex < scrollOffset) {
+            scrollOffset = selectedIndex;
+        } else if (selectedIndex >= scrollOffset + visibleRows) {
+            scrollOffset = selectedIndex - visibleRows + 1;
+        }
+
+        for (int i = 0; i < visibleRows && (scrollOffset + i) < entries.size(); i++) {
+            int idx = scrollOffset + i;
+            ConfigEntry entry = entries.get(idx);
+            boolean selected = idx == selectedIndex;
+
+            if (selected) {
+                buffer.fill(new Rect(area.x(), area.y() + i, area.width(), 1), new Cell(" ", SELECTED));
+            }
+
+            Style phaseStyle = switch (entry.phase) {
+                case "BUILD_TIME" -> PHASE_BUILD;
+                case "BUILD_AND_RUN_TIME_FIXED" -> PHASE_BUILD_RUN;
+                default -> PHASE_RUN;
+            };
+
+            int x = area.x();
+            buffer.setString(x, area.y() + i, " * ", selected ? SELECTED : phaseStyle);
+            x += 3;
+
+            int nameWidth = area.width() / 2;
+            buffer.setString(x, area.y() + i, truncate(entry.name, nameWidth), selected ? SELECTED : VALUE_STYLE);
+            x += nameWidth;
+
+            String value = entry.value.isEmpty() ? "(not set)" : entry.value;
+            buffer.setString(x, area.y() + i, truncate(value, area.width() - x + area.x()),
+                    selected ? SELECTED : DIM_STYLE);
+        }
+
+        if (entries.isEmpty()) {
+            buffer.setString(area.x() + 2, area.y() + 1, "No configuration properties found", DIM_STYLE);
+        }
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        List<ConfigEntry> entries = getFilteredEntries();
+
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                if (selectedIndex < entries.size() - 1) {
+                    selectedIndex++;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                if (selectedIndex > 0) {
+                    selectedIndex--;
+                    ctx.requestRedraw();
+                }
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    protected String getFooterText() {
+        List<ConfigEntry> entries = getFilteredEntries();
+        return entries.size() + "/" + allEntries.size() + " properties";
+    }
+
+    private record ConfigEntry(String name, String value, String defaultValue, String phase) {
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/ExtensionPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/ExtensionPage.java
@@ -1,0 +1,21 @@
+package io.quarkus.devshell.deployment.tui.pages;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import io.quarkus.devshell.deployment.tui.AppContext;
+import io.quarkus.devshell.deployment.tui.Screen;
+
+public interface ExtensionPage extends Screen {
+
+    String getNamespace();
+
+    void loadData();
+
+    void renderPanel(Rect area, Buffer buffer);
+
+    boolean handlePanelKey(int[] keys);
+
+    void initPanel(AppContext ctx);
+
+    void reset();
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/ExtensionPageFactory.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/ExtensionPageFactory.java
@@ -1,0 +1,127 @@
+package io.quarkus.devshell.deployment.tui.pages;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.devshell.deployment.DevShellContext;
+import io.quarkus.devshell.deployment.tui.AppContext;
+import io.quarkus.devshell.deployment.tui.Screen;
+import io.quarkus.devshell.deployment.tui.pages.extensions.AgroalShellPage;
+import io.quarkus.devshell.deployment.tui.pages.extensions.ArcShellPage;
+import io.quarkus.devshell.deployment.tui.pages.extensions.CacheShellPage;
+import io.quarkus.devshell.deployment.tui.pages.extensions.DatasourceShellPage;
+import io.quarkus.devshell.deployment.tui.pages.extensions.FaultToleranceShellPage;
+import io.quarkus.devshell.deployment.tui.pages.extensions.FlywayShellPage;
+import io.quarkus.devshell.deployment.tui.pages.extensions.GraphQLShellPage;
+import io.quarkus.devshell.deployment.tui.pages.extensions.GrpcShellPage;
+import io.quarkus.devshell.deployment.tui.pages.extensions.HealthShellPage;
+import io.quarkus.devshell.deployment.tui.pages.extensions.HibernateOrmShellPage;
+import io.quarkus.devshell.deployment.tui.pages.extensions.InfoShellPage;
+import io.quarkus.devshell.deployment.tui.pages.extensions.KafkaShellPage;
+import io.quarkus.devshell.deployment.tui.pages.extensions.LiquibaseShellPage;
+import io.quarkus.devshell.deployment.tui.pages.extensions.MicrometerShellPage;
+import io.quarkus.devshell.deployment.tui.pages.extensions.OpenApiShellPage;
+import io.quarkus.devshell.deployment.tui.pages.extensions.ReactiveMessagingShellPage;
+import io.quarkus.devshell.deployment.tui.pages.extensions.RestEndpointsShellPage;
+import io.quarkus.devshell.deployment.tui.pages.extensions.SchedulerShellPage;
+import io.quarkus.devshell.deployment.tui.pages.extensions.WebDependencyLocatorShellPage;
+import io.quarkus.devshell.deployment.tui.screens.ExtensionsListScreen;
+
+public final class ExtensionPageFactory {
+
+    private static final Logger log = Logger.getLogger(ExtensionPageFactory.class);
+
+    private static final Map<String, Function<ExtensionsListScreen.ExtensionInfo, ExtensionPage>> PAGE_REGISTRY;
+
+    static {
+        var map = new HashMap<String, Function<ExtensionsListScreen.ExtensionInfo, ExtensionPage>>();
+        map.put("quarkus-arc", ext -> new ArcShellPage());
+        map.put("quarkus-agroal", ext -> new AgroalShellPage());
+        map.put("quarkus-cache", ext -> new CacheShellPage());
+        map.put("quarkus-datasource", ext -> new DatasourceShellPage());
+        map.put("quarkus-flyway", ext -> new FlywayShellPage());
+        map.put("quarkus-grpc", ext -> new GrpcShellPage());
+        map.put("quarkus-hibernate-orm", ext -> new HibernateOrmShellPage());
+        map.put("quarkus-info", ext -> new InfoShellPage());
+        map.put("quarkus-kafka-client", ext -> new KafkaShellPage());
+        map.put("quarkus-liquibase", ext -> new LiquibaseShellPage());
+        map.put("quarkus-micrometer", ext -> new MicrometerShellPage());
+        map.put("quarkus-rest", ext -> new RestEndpointsShellPage());
+        map.put("quarkus-resteasy-reactive", ext -> new RestEndpointsShellPage());
+        map.put("quarkus-scheduler", ext -> new SchedulerShellPage());
+        map.put("quarkus-smallrye-fault-tolerance", ext -> new FaultToleranceShellPage());
+        map.put("quarkus-smallrye-graphql", ext -> new GraphQLShellPage());
+        map.put("quarkus-smallrye-health", ext -> new HealthShellPage());
+        map.put("quarkus-smallrye-openapi", ext -> new OpenApiShellPage());
+        map.put("quarkus-messaging", ext -> new ReactiveMessagingShellPage());
+        map.put("quarkus-web-dependency-locator", ext -> new WebDependencyLocatorShellPage());
+        PAGE_REGISTRY = Map.copyOf(map);
+    }
+
+    private ExtensionPageFactory() {
+    }
+
+    public static Screen createPage(ExtensionsListScreen.ExtensionInfo ext, AppContext ctx) {
+        String namespace = ext.namespace();
+        if (namespace == null || namespace.isEmpty()) {
+            return new GenericExtensionPage(ext);
+        }
+
+        // SPI-registered pages take priority over the hardcoded registry
+        DevShellContext.ShellPageInfo spiPage = DevShellContext.getShellPages().get(namespace);
+        if (spiPage != null) {
+            Screen page = createFromSpi(spiPage, ext);
+            if (page != null) {
+                log.debugf("Created SPI-registered shell page for %s", namespace);
+                return page;
+            }
+        }
+
+        // Fall back to hardcoded built-in pages
+        Function<ExtensionsListScreen.ExtensionInfo, ExtensionPage> factory = PAGE_REGISTRY.get(namespace);
+        if (factory != null) {
+            ExtensionPage page = factory.apply(ext);
+            log.debugf("Created built-in shell page for %s", namespace);
+            return page;
+        }
+
+        log.debugf("No shell page for %s, using generic", namespace);
+        return new GenericExtensionPage(ext);
+    }
+
+    private static Screen createFromSpi(DevShellContext.ShellPageInfo info, ExtensionsListScreen.ExtensionInfo ext) {
+        // Custom page class (direct class reference available)
+        if (info.customPageClass() != null) {
+            try {
+                return (Screen) info.customPageClass().getDeclaredConstructor().newInstance();
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException
+                    | NoSuchMethodException e) {
+                log.warnf("Failed to instantiate custom shell page %s: %s",
+                        info.customPageClass().getName(), e.getMessage());
+            }
+        }
+
+        // Custom page class (by name, for cross-classloader cases)
+        if (info.customPageClassName() != null && !info.customPageClassName().isEmpty() && info.customPageClass() == null) {
+            try {
+                Class<?> pageClass = Thread.currentThread().getContextClassLoader().loadClass(info.customPageClassName());
+                return (Screen) pageClass.getDeclaredConstructor().newInstance();
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+                    | InvocationTargetException | NoSuchMethodException e) {
+                log.warnf("Failed to load custom shell page class %s: %s",
+                        info.customPageClassName(), e.getMessage());
+            }
+        }
+
+        // Provider-based page (uses JSON-RPC to fetch data from the extension's namespace)
+        if (info.providerClassName() != null && !info.providerClassName().isEmpty()) {
+            return new ProviderBasedPage(ext, info.id());
+        }
+
+        return null;
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/GenericExtensionPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/GenericExtensionPage.java
@@ -1,0 +1,61 @@
+package io.quarkus.devshell.deployment.tui.pages;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import io.quarkus.devshell.deployment.tui.screens.ExtensionsListScreen;
+
+public class GenericExtensionPage extends BaseExtensionPage {
+
+    private final ExtensionsListScreen.ExtensionInfo extensionInfo;
+
+    public GenericExtensionPage(ExtensionsListScreen.ExtensionInfo ext) {
+        super(ext.namespace(), ext.name());
+        this.extensionInfo = ext;
+    }
+
+    @Override
+    public void loadData() {
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        int x = area.x() + 2;
+        int y = area.y() + 1;
+
+        buffer.setString(x, y, extensionInfo.name(), HEADER_STYLE);
+        y += 2;
+
+        buffer.setString(x, y, "Namespace:", LABEL_STYLE);
+        buffer.setString(x + 11, y, extensionInfo.namespace(), DIM_STYLE);
+        y += 1;
+
+        buffer.setString(x, y, "Status:", LABEL_STYLE);
+        buffer.setString(x + 11, y, extensionInfo.active() ? "Active" : "Inactive",
+                extensionInfo.active() ? Style.EMPTY.green() : Style.EMPTY.gray());
+        y += 2;
+
+        if (extensionInfo.description() != null && !extensionInfo.description().isEmpty()) {
+            buffer.setString(x, y, "Description:", LABEL_STYLE);
+            y += 1;
+            String desc = truncate(extensionInfo.description(), area.width() - x - 2);
+            buffer.setString(x, y, desc, VALUE_STYLE);
+            y += 2;
+        }
+
+        if (extensionInfo.keywords() != null && !extensionInfo.keywords().isEmpty()) {
+            buffer.setString(x, y, "Keywords:", LABEL_STYLE);
+            y += 1;
+            buffer.setString(x, y, truncate(String.join(", ", extensionInfo.keywords()), area.width() - x - 2),
+                    DIM_STYLE);
+            y += 2;
+        }
+
+        buffer.setString(x, y, "No custom shell page available for this extension.", DIM_STYLE);
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        return false;
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/ProviderBasedPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/ProviderBasedPage.java
@@ -1,0 +1,148 @@
+package io.quarkus.devshell.deployment.tui.pages;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.screens.ExtensionsListScreen;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * Renders data for extensions that expose a generic JSON-RPC data endpoint.
+ * Falls back to showing extension info when no data is available.
+ */
+public class ProviderBasedPage extends BaseExtensionPage {
+
+    private final ExtensionsListScreen.ExtensionInfo extensionInfo;
+    private final List<Section> sections = new ArrayList<>();
+    private int scrollOffset = 0;
+
+    public ProviderBasedPage(ExtensionsListScreen.ExtensionInfo ext, String jsonRpcNamespace) {
+        super(jsonRpcNamespace != null ? jsonRpcNamespace : ext.namespace(), ext.name());
+        this.extensionInfo = ext;
+    }
+
+    @Override
+    public void loadData() {
+        sections.clear();
+        try {
+            JsonNode result = rpcCall("getAll");
+            parseSections(result);
+        } catch (Exception e) {
+            // Extension may not have a getAll method, that's OK
+        }
+    }
+
+    private void parseSections(JsonNode result) {
+        if (result == null) {
+            return;
+        }
+        if (result.isArray()) {
+            Section section = new Section("Data");
+            for (JsonNode item : result) {
+                if (item.isObject()) {
+                    item.properties().forEach(field -> section.items.add(
+                            new Item(field.getKey(), field.getValue().asText(""))));
+                } else {
+                    section.items.add(new Item("", item.asText("")));
+                }
+            }
+            if (!section.items.isEmpty()) {
+                sections.add(section);
+            }
+        } else if (result.isObject()) {
+            Section section = new Section("Data");
+            result.properties().forEach(field -> {
+                JsonNode value = field.getValue();
+                if (value.isObject() || value.isArray()) {
+                    section.items.add(new Item(field.getKey(), value.toString()));
+                } else {
+                    section.items.add(new Item(field.getKey(), value.asText("")));
+                }
+            });
+            if (!section.items.isEmpty()) {
+                sections.add(section);
+            }
+        }
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        int x = area.x() + 1;
+        int y = area.y();
+        int maxWidth = area.width() - 2;
+
+        if (sections.isEmpty()) {
+            buffer.setString(x, y, extensionInfo.name(), HEADER_STYLE);
+            y += 2;
+            buffer.setString(x, y, "Namespace: " + extensionInfo.namespace(), DIM_STYLE);
+            y += 1;
+            buffer.setString(x, y, extensionInfo.active() ? "Active" : "Inactive",
+                    extensionInfo.active() ? Style.EMPTY.green() : DIM_STYLE);
+            if (extensionInfo.description() != null && !extensionInfo.description().isEmpty()) {
+                y += 2;
+                buffer.setString(x, y, truncate(extensionInfo.description(), maxWidth), VALUE_STYLE);
+            }
+            return;
+        }
+
+        int row = y - scrollOffset;
+        for (Section section : sections) {
+            if (row >= y && row < area.y() + area.height() - 1) {
+                buffer.setString(x, row, section.title, HEADER_STYLE);
+            }
+            row++;
+
+            for (Item item : section.items) {
+                if (row >= y && row < area.y() + area.height() - 1) {
+                    if (item.label.isEmpty()) {
+                        buffer.setString(x + 1, row, truncate(item.value, maxWidth - 1), VALUE_STYLE);
+                    } else {
+                        String label = item.label + ": ";
+                        buffer.setString(x + 1, row, label, LABEL_STYLE);
+                        buffer.setString(x + 1 + label.length(), row,
+                                truncate(item.value, maxWidth - label.length() - 1), VALUE_STYLE);
+                    }
+                }
+                row++;
+            }
+            row++;
+        }
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                scrollOffset++;
+                ctx.requestRedraw();
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                if (scrollOffset > 0) {
+                    scrollOffset--;
+                    ctx.requestRedraw();
+                }
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static class Section {
+        final String title;
+        final List<Item> items = new ArrayList<>();
+
+        Section(String title) {
+            this.title = title;
+        }
+    }
+
+    private record Item(String label, String value) {
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/AgroalShellPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/AgroalShellPage.java
@@ -1,0 +1,155 @@
+package io.quarkus.devshell.deployment.tui.pages.extensions;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.pages.BaseExtensionPage;
+import io.quarkus.devshell.deployment.tui.widgets.KeyValuePanel;
+import io.quarkus.devshell.deployment.tui.widgets.ListView;
+import tools.jackson.databind.JsonNode;
+
+public class AgroalShellPage extends BaseExtensionPage {
+
+    private final ListView<DatasourceInfo> listView = new ListView<>(ds -> ds.name);
+    private final List<DatasourceInfo> datasources = new ArrayList<>();
+
+    public AgroalShellPage() {
+        super("quarkus-agroal", "Agroal Connection Pools");
+    }
+
+    @Override
+    public void loadData() {
+        JsonNode result = rpcCall("getDataSources");
+        datasources.clear();
+
+        if (result.isArray()) {
+            for (JsonNode ds : result) {
+                String name = ds.path("name").asText("default");
+                String jdbcUrl = ds.path("jdbcUrl").asText("");
+                int poolSize = ds.path("poolSize").asInt(ds.path("maxSize").asInt(0));
+                int activeCount = ds.path("activeCount").asInt(0);
+                int availableCount = ds.path("availableCount").asInt(0);
+                datasources.add(new DatasourceInfo(name, jdbcUrl, poolSize, activeCount, availableCount, ds));
+            }
+        } else if (result.isObject()) {
+            Iterator<Map.Entry<String, JsonNode>> fields = result.properties().iterator();
+            while (fields.hasNext()) {
+                Map.Entry<String, JsonNode> entry = fields.next();
+                JsonNode ds = entry.getValue();
+                String jdbcUrl = ds.path("jdbcUrl").asText("");
+                int poolSize = ds.path("poolSize").asInt(ds.path("maxSize").asInt(0));
+                int activeCount = ds.path("activeCount").asInt(0);
+                int availableCount = ds.path("availableCount").asInt(0);
+                datasources.add(
+                        new DatasourceInfo(entry.getKey(), jdbcUrl, poolSize, activeCount, availableCount, ds));
+            }
+        }
+        listView.setItems(datasources);
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        if (datasources.isEmpty()) {
+            buffer.setString(area.x() + 1, area.y(), "No Agroal datasources found", DIM_STYLE);
+            return;
+        }
+
+        var areas = Layout.horizontal()
+                .constraints(Constraint.percentage(35), Constraint.percentage(65))
+                .split(area);
+
+        // Datasource list
+        Rect listArea = areas.get(0);
+        listView.setVisibleRows(listArea.height());
+        listView.setWidth(listArea.width() - 1);
+        listView.render(buffer, listArea.y(), listArea.x() + 1);
+
+        // Detail panel
+        Rect detailArea = areas.get(1);
+        int x = detailArea.x() + 1;
+        int y = detailArea.y();
+        int w = detailArea.width() - 2;
+
+        DatasourceInfo selected = listView.getSelectedItem();
+        if (selected != null) {
+            KeyValuePanel detail = new KeyValuePanel(selected.name);
+            detail.addIfPresent("JDBC URL", selected.jdbcUrl);
+            detail.add("Pool Size", String.valueOf(selected.poolSize));
+            detail.add("Active", String.valueOf(selected.activeCount));
+            detail.add("Available", String.valueOf(selected.availableCount));
+
+            // Add any extra fields from the raw JSON
+            if (selected.raw.isObject()) {
+                Iterator<Map.Entry<String, JsonNode>> fields = selected.raw.properties().iterator();
+                while (fields.hasNext()) {
+                    Map.Entry<String, JsonNode> field = fields.next();
+                    String key = field.getKey();
+                    if (!"name".equals(key) && !"jdbcUrl".equals(key)
+                            && !"poolSize".equals(key) && !"maxSize".equals(key)
+                            && !"activeCount".equals(key) && !"availableCount".equals(key)) {
+                        detail.addIfPresent(key, field.getValue().asText(""));
+                    }
+                }
+            }
+            detail.render(buffer, y, x, w);
+        }
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                listView.moveDown();
+                ctx.requestRedraw();
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                listView.moveUp();
+                ctx.requestRedraw();
+                return true;
+            case KeyCode.PAGE_DOWN:
+                listView.pageDown();
+                ctx.requestRedraw();
+                return true;
+            case KeyCode.PAGE_UP:
+                listView.pageUp();
+                ctx.requestRedraw();
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    protected String getFooterText() {
+        return "[j/k] Navigate";
+    }
+
+    private static class DatasourceInfo {
+        final String name;
+        final String jdbcUrl;
+        final int poolSize;
+        final int activeCount;
+        final int availableCount;
+        final JsonNode raw;
+
+        DatasourceInfo(String name, String jdbcUrl, int poolSize, int activeCount, int availableCount,
+                JsonNode raw) {
+            this.name = name;
+            this.jdbcUrl = jdbcUrl;
+            this.poolSize = poolSize;
+            this.activeCount = activeCount;
+            this.availableCount = availableCount;
+            this.raw = raw;
+        }
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/ArcShellPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/ArcShellPage.java
@@ -1,0 +1,182 @@
+package io.quarkus.devshell.deployment.tui.pages.extensions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.pages.BaseExtensionPage;
+import io.quarkus.devshell.deployment.tui.widgets.TableView;
+import tools.jackson.databind.JsonNode;
+
+public class ArcShellPage extends BaseExtensionPage {
+
+    private final TableView<BeanInfo> beansTable = new TableView<>();
+    private final TableView<ObserverInfo> observersTable = new TableView<>();
+    private final TableView<BeanInfo> removedTable = new TableView<>();
+
+    private final List<BeanInfo> beans = new ArrayList<>();
+    private final List<ObserverInfo> observers = new ArrayList<>();
+    private final List<BeanInfo> removedBeans = new ArrayList<>();
+
+    public ArcShellPage() {
+        super("quarkus-arc", "ArC CDI");
+        setTabs("Beans", "Observers", "Removed");
+
+        beansTable.addColumn("Bean Class", b -> b.beanClass, 30);
+        beansTable.addColumn("Scope", b -> b.scope, 15);
+        beansTable.addColumn("Kind", b -> b.kind, 12);
+
+        observersTable.addColumn("Observer Class", o -> o.declaringClass, 30);
+        observersTable.addColumn("Observed Type", o -> o.observedType, 25);
+        observersTable.addColumn("Priority", o -> String.valueOf(o.priority), 10);
+
+        removedTable.addColumn("Bean Class", b -> b.beanClass, 30);
+        removedTable.addColumn("Scope", b -> b.scope, 15);
+        removedTable.addColumn("Kind", b -> b.kind, 12);
+    }
+
+    @Override
+    public void loadData() {
+        // Beans (build-time data)
+        JsonNode beansResult = getBuildTimeDataAsJson("beans");
+        beans.clear();
+        if (beansResult.isArray()) {
+            for (JsonNode b : beansResult) {
+                beans.add(new BeanInfo(
+                        b.path("beanClass").asText(b.path("providerType").path("name").asText("")),
+                        b.path("scope").asText(b.path("scope").path("simpleName").asText("")),
+                        b.path("kind").asText("")));
+            }
+        }
+        beansTable.setItems(beans);
+
+        // Observers (build-time data)
+        JsonNode observersResult = getBuildTimeDataAsJson("observers");
+        observers.clear();
+        if (observersResult.isArray()) {
+            for (JsonNode o : observersResult) {
+                observers.add(new ObserverInfo(
+                        o.path("declaringClass").asText(o.path("declaringClass").path("simpleName").asText("")),
+                        o.path("observedType").asText(o.path("observedType").path("name").asText("")),
+                        o.path("priority").asInt(0)));
+            }
+        }
+        observersTable.setItems(observers);
+
+        // Removed beans (build-time data)
+        JsonNode removedResult = getBuildTimeDataAsJson("removedBeans");
+        removedBeans.clear();
+        if (removedResult.isArray()) {
+            for (JsonNode b : removedResult) {
+                removedBeans.add(new BeanInfo(
+                        b.path("beanClass").asText(b.path("providerType").path("name").asText("")),
+                        b.path("scope").asText(b.path("scope").path("simpleName").asText("")),
+                        b.path("kind").asText("")));
+            }
+        }
+        removedTable.setItems(removedBeans);
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        int x = area.x() + 1;
+        int y = area.y();
+        int w = area.width() - 2;
+        int h = area.height() - 1;
+
+        switch (getActiveTab()) {
+            case 0:
+                buffer.setString(x, y, beans.size() + " beans", DIM_STYLE);
+                beansTable.setVisibleRows(h - 3);
+                beansTable.setWidth(w);
+                beansTable.render(buffer, y + 1, x);
+                break;
+            case 1:
+                buffer.setString(x, y, observers.size() + " observers", DIM_STYLE);
+                observersTable.setVisibleRows(h - 3);
+                observersTable.setWidth(w);
+                observersTable.render(buffer, y + 1, x);
+                break;
+            case 2:
+                buffer.setString(x, y, removedBeans.size() + " removed beans", DIM_STYLE);
+                removedTable.setVisibleRows(h - 3);
+                removedTable.setWidth(w);
+                removedTable.render(buffer, y + 1, x);
+                break;
+        }
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                activeTable().moveDown();
+                ctx.requestRedraw();
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                activeTable().moveUp();
+                ctx.requestRedraw();
+                return true;
+            case KeyCode.PAGE_DOWN:
+                activeTable().pageDown();
+                ctx.requestRedraw();
+                return true;
+            case KeyCode.PAGE_UP:
+                activeTable().pageUp();
+                ctx.requestRedraw();
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private TableView<?> activeTable() {
+        switch (getActiveTab()) {
+            case 1:
+                return observersTable;
+            case 2:
+                return removedTable;
+            default:
+                return beansTable;
+        }
+    }
+
+    @Override
+    protected void onTabChanged(int newTab) {
+        // Tables keep their own scroll state, nothing extra needed
+    }
+
+    @Override
+    protected String getFooterText() {
+        return "[j/k] Navigate";
+    }
+
+    private static class BeanInfo {
+        final String beanClass;
+        final String scope;
+        final String kind;
+
+        BeanInfo(String beanClass, String scope, String kind) {
+            this.beanClass = beanClass;
+            this.scope = scope;
+            this.kind = kind;
+        }
+    }
+
+    private static class ObserverInfo {
+        final String declaringClass;
+        final String observedType;
+        final int priority;
+
+        ObserverInfo(String declaringClass, String observedType, int priority) {
+            this.declaringClass = declaringClass;
+            this.observedType = observedType;
+            this.priority = priority;
+        }
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/CacheShellPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/CacheShellPage.java
@@ -1,0 +1,141 @@
+package io.quarkus.devshell.deployment.tui.pages.extensions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.pages.BaseExtensionPage;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
+
+public class CacheShellPage extends BaseExtensionPage {
+
+    private static final Style SELECTED = Style.EMPTY.onCyan().black().bold();
+
+    private List<CacheEntry> caches = List.of();
+    private int selectedIndex = 0;
+    private int scrollOffset = 0;
+
+    public CacheShellPage() {
+        super("quarkus-cache", "Cache");
+    }
+
+    @Override
+    public void loadData() {
+        JsonNode result = rpcCall("getAll");
+        List<CacheEntry> entries = new ArrayList<>();
+        JsonNode arr = result.isArray() ? result : result.path("_array");
+        if (arr.isArray()) {
+            for (JsonNode item : arr) {
+                entries.add(new CacheEntry(
+                        item.path("name").asText(""),
+                        item.path("size").asLong(0)));
+            }
+        }
+        caches = entries;
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        if (caches.isEmpty()) {
+            buffer.setString(area.x() + 1, area.y(), "No caches found", DIM_STYLE);
+            return;
+        }
+
+        int visibleRows = area.height();
+        if (selectedIndex < scrollOffset) {
+            scrollOffset = selectedIndex;
+        } else if (selectedIndex >= scrollOffset + visibleRows) {
+            scrollOffset = selectedIndex - visibleRows + 1;
+        }
+
+        for (int i = 0; i < visibleRows && (scrollOffset + i) < caches.size(); i++) {
+            int idx = scrollOffset + i;
+            CacheEntry entry = caches.get(idx);
+            boolean selected = idx == selectedIndex;
+
+            if (selected) {
+                buffer.fill(new Rect(area.x(), area.y() + i, area.width(), 1), new Cell(" ", SELECTED));
+            }
+
+            int x = area.x() + 1;
+            buffer.setString(x, area.y() + i, truncate(entry.name, 40), selected ? SELECTED : VALUE_STYLE);
+            x += 41;
+
+            String size = "size: " + entry.size;
+            buffer.setString(x, area.y() + i, size, selected ? SELECTED : DIM_STYLE);
+        }
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                if (selectedIndex < caches.size() - 1) {
+                    selectedIndex++;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                if (selectedIndex > 0) {
+                    selectedIndex--;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case 'c':
+            case 'C':
+                clearSelected();
+                return true;
+            case 'a':
+            case 'A':
+                clearAll();
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private void clearSelected() {
+        if (caches.isEmpty())
+            return;
+        CacheEntry entry = caches.get(selectedIndex);
+        try {
+            ObjectNode params = createParams();
+            params.put("name", entry.name);
+            rpcCall("clear", params);
+            loadDataAsync();
+        } catch (Exception e) {
+            errorMessage = e.getMessage();
+            ctx.requestRedraw();
+        }
+    }
+
+    private void clearAll() {
+        try {
+            for (CacheEntry entry : caches) {
+                ObjectNode params = createParams();
+                params.put("name", entry.name);
+                rpcCall("clear", params);
+            }
+            loadDataAsync();
+        } catch (Exception e) {
+            errorMessage = e.getMessage();
+            ctx.requestRedraw();
+        }
+    }
+
+    @Override
+    protected String getFooterText() {
+        return "[j/k] Navigate  [C] Clear  [A] Clear All  " + caches.size() + " caches";
+    }
+
+    private record CacheEntry(String name, long size) {
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/DatasourceShellPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/DatasourceShellPage.java
@@ -1,0 +1,97 @@
+package io.quarkus.devshell.deployment.tui.pages.extensions;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.pages.BaseExtensionPage;
+import io.quarkus.devshell.deployment.tui.widgets.KeyValuePanel;
+import tools.jackson.databind.JsonNode;
+
+public class DatasourceShellPage extends BaseExtensionPage {
+
+    private final List<KeyValuePanel> panels = new ArrayList<>();
+    private int scrollOffset = 0;
+
+    public DatasourceShellPage() {
+        super("quarkus-datasource", "Datasources");
+    }
+
+    @Override
+    public void loadData() {
+        JsonNode result = getBuildTimeDataAsJson("datasources");
+        panels.clear();
+
+        if (result.isArray()) {
+            for (JsonNode ds : result) {
+                String name = ds.path("name").asText("default");
+                KeyValuePanel panel = new KeyValuePanel(name);
+                panel.addIfPresent("JDBC URL", ds.path("jdbcUrl").asText(""));
+                panel.addIfPresent("DB Kind", ds.path("dbKind").asText(""));
+                panel.addIfPresent("Username", ds.path("username").asText(""));
+                panel.addIfPresent("Driver", ds.path("driver").asText(""));
+                panels.add(panel);
+            }
+        } else if (result.isObject()) {
+            Iterator<Map.Entry<String, JsonNode>> fields = result.properties().iterator();
+            while (fields.hasNext()) {
+                Map.Entry<String, JsonNode> entry = fields.next();
+                KeyValuePanel panel = new KeyValuePanel(entry.getKey());
+                JsonNode ds = entry.getValue();
+                if (ds.isObject()) {
+                    Iterator<Map.Entry<String, JsonNode>> props = ds.properties().iterator();
+                    while (props.hasNext()) {
+                        Map.Entry<String, JsonNode> prop = props.next();
+                        panel.add(prop.getKey(), prop.getValue().asText(""));
+                    }
+                } else {
+                    panel.add(entry.getKey(), ds.asText(""));
+                }
+                panels.add(panel);
+            }
+        }
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        if (panels.isEmpty()) {
+            buffer.setString(area.x() + 1, area.y(), "No datasources configured", DIM_STYLE);
+            return;
+        }
+        int row = area.y() - scrollOffset;
+        for (KeyValuePanel panel : panels) {
+            row = panel.render(buffer, row, area.x() + 1, area.width() - 2);
+            row++;
+        }
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                scrollOffset++;
+                ctx.requestRedraw();
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                if (scrollOffset > 0) {
+                    scrollOffset--;
+                    ctx.requestRedraw();
+                }
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    protected String getFooterText() {
+        return "[j/k] Scroll";
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/FaultToleranceShellPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/FaultToleranceShellPage.java
@@ -1,0 +1,130 @@
+package io.quarkus.devshell.deployment.tui.pages.extensions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.pages.BaseExtensionPage;
+import tools.jackson.databind.JsonNode;
+
+public class FaultToleranceShellPage extends BaseExtensionPage {
+
+    private static final Style SELECTED = Style.EMPTY.onCyan().black().bold();
+    private static final Style STRATEGY_STYLE = Style.EMPTY.yellow();
+
+    private List<GuardedMethod> methods = List.of();
+    private int selectedIndex = 0;
+    private int scrollOffset = 0;
+
+    public FaultToleranceShellPage() {
+        super("quarkus-smallrye-fault-tolerance", "Fault Tolerance");
+    }
+
+    @Override
+    public void loadData() {
+        JsonNode result = rpcCall("getGuardedMethods");
+        List<GuardedMethod> entries = new ArrayList<>();
+        JsonNode arr = result.isArray() ? result : result.path("_array");
+        if (arr.isArray()) {
+            for (JsonNode item : arr) {
+                List<String> strategies = new ArrayList<>();
+                JsonNode strats = item.path("strategies");
+                if (strats.isArray()) {
+                    for (JsonNode s : strats) {
+                        strategies.add(s.asText(""));
+                    }
+                } else {
+                    // Try common individual strategy fields
+                    for (String name : List.of("circuitBreaker", "retry", "timeout", "bulkhead", "fallback",
+                            "rateLimit")) {
+                        if (item.path(name).asBoolean(false) || item.has(name + "Config")) {
+                            strategies.add(name);
+                        }
+                    }
+                }
+                entries.add(new GuardedMethod(
+                        item.path("method").asText(item.path("name").asText("")),
+                        item.path("beanClass").asText(item.path("clazz").asText("")),
+                        strategies));
+            }
+        }
+        methods = entries;
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        if (methods.isEmpty()) {
+            buffer.setString(area.x() + 1, area.y(), "No guarded methods found", DIM_STYLE);
+            return;
+        }
+
+        int visibleRows = area.height();
+        if (selectedIndex < scrollOffset) {
+            scrollOffset = selectedIndex;
+        } else if (selectedIndex >= scrollOffset + visibleRows) {
+            scrollOffset = selectedIndex - visibleRows + 1;
+        }
+
+        for (int i = 0; i < visibleRows && (scrollOffset + i) < methods.size(); i++) {
+            int idx = scrollOffset + i;
+            GuardedMethod entry = methods.get(idx);
+            boolean selected = idx == selectedIndex;
+
+            if (selected) {
+                buffer.fill(new Rect(area.x(), area.y() + i, area.width(), 1), new Cell(" ", SELECTED));
+            }
+
+            int x = area.x() + 1;
+            String methodName = entry.beanClass.isEmpty() ? entry.method
+                    : shortClassName(entry.beanClass) + "." + entry.method;
+            buffer.setString(x, area.y() + i, truncate(methodName, 45), selected ? SELECTED : VALUE_STYLE);
+            x += 46;
+
+            if (!entry.strategies.isEmpty()) {
+                String strats = String.join(", ", entry.strategies);
+                buffer.setString(x, area.y() + i, truncate(strats, area.width() - x + area.x()),
+                        selected ? SELECTED : STRATEGY_STYLE);
+            }
+        }
+    }
+
+    private String shortClassName(String fqcn) {
+        int dot = fqcn.lastIndexOf('.');
+        return dot >= 0 ? fqcn.substring(dot + 1) : fqcn;
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                if (selectedIndex < methods.size() - 1) {
+                    selectedIndex++;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                if (selectedIndex > 0) {
+                    selectedIndex--;
+                    ctx.requestRedraw();
+                }
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    protected String getFooterText() {
+        return "[j/k] Navigate  " + methods.size() + " guarded methods";
+    }
+
+    private record GuardedMethod(String method, String beanClass, List<String> strategies) {
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/FlywayShellPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/FlywayShellPage.java
@@ -1,0 +1,183 @@
+package io.quarkus.devshell.deployment.tui.pages.extensions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.pages.BaseExtensionPage;
+import tools.jackson.databind.JsonNode;
+
+public class FlywayShellPage extends BaseExtensionPage {
+
+    private static final Style SELECTED = Style.EMPTY.onCyan().black().bold();
+    private static final Style SUCCESS_STYLE = Style.EMPTY.green();
+    private static final Style PENDING_STYLE = Style.EMPTY.yellow();
+
+    private List<DatasourceEntry> datasources = List.of();
+    private List<MigrationEntry> migrations = List.of();
+    private int selectedIndex = 0;
+    private int scrollOffset = 0;
+
+    public FlywayShellPage() {
+        super("quarkus-flyway", "Flyway");
+        setTabs("Info", "Migrations");
+    }
+
+    @Override
+    public void loadData() {
+        JsonNode result = rpcCall("getDatasources");
+        List<DatasourceEntry> ds = new ArrayList<>();
+        List<MigrationEntry> migs = new ArrayList<>();
+
+        JsonNode arr = result.isArray() ? result : result.path("_array");
+        if (arr.isArray()) {
+            for (JsonNode item : arr) {
+                String name = item.path("name").asText(item.path("datasource").asText("default"));
+                ds.add(new DatasourceEntry(name,
+                        item.path("currentVersion").asText(""),
+                        item.path("schemaVersion").asText("")));
+
+                JsonNode migsNode = item.path("migrations");
+                if (migsNode.isArray()) {
+                    for (JsonNode mig : migsNode) {
+                        migs.add(new MigrationEntry(
+                                name,
+                                mig.path("version").asText(""),
+                                mig.path("description").asText(""),
+                                mig.path("state").asText(mig.path("status").asText(""))));
+                    }
+                }
+            }
+        }
+        datasources = ds;
+        migrations = migs;
+    }
+
+    @Override
+    protected void onTabChanged(int newTab) {
+        selectedIndex = 0;
+        scrollOffset = 0;
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        if (getActiveTab() == 0) {
+            renderInfo(area, buffer);
+        } else {
+            renderMigrations(area, buffer);
+        }
+    }
+
+    private void renderInfo(Rect area, Buffer buffer) {
+        if (datasources.isEmpty()) {
+            buffer.setString(area.x() + 1, area.y(), "No datasources found", DIM_STYLE);
+            return;
+        }
+
+        int row = area.y();
+        for (int i = 0; i < datasources.size() && row < area.y() + area.height(); i++) {
+            DatasourceEntry ds = datasources.get(i);
+            buffer.setString(area.x() + 1, row, ds.name, HEADER_STYLE);
+            row++;
+            if (row < area.y() + area.height()) {
+                buffer.setString(area.x() + 3, row, "Version: " + ds.currentVersion, VALUE_STYLE);
+                row++;
+            }
+            if (row < area.y() + area.height() && !ds.schemaVersion.isEmpty()) {
+                buffer.setString(area.x() + 3, row, "Schema:  " + ds.schemaVersion, DIM_STYLE);
+                row++;
+            }
+            row++;
+        }
+    }
+
+    private void renderMigrations(Rect area, Buffer buffer) {
+        if (migrations.isEmpty()) {
+            buffer.setString(area.x() + 1, area.y(), "No migrations found", DIM_STYLE);
+            return;
+        }
+
+        int visibleRows = area.height();
+        if (selectedIndex < scrollOffset) {
+            scrollOffset = selectedIndex;
+        } else if (selectedIndex >= scrollOffset + visibleRows) {
+            scrollOffset = selectedIndex - visibleRows + 1;
+        }
+
+        for (int i = 0; i < visibleRows && (scrollOffset + i) < migrations.size(); i++) {
+            int idx = scrollOffset + i;
+            MigrationEntry entry = migrations.get(idx);
+            boolean selected = idx == selectedIndex;
+
+            if (selected) {
+                buffer.fill(new Rect(area.x(), area.y() + i, area.width(), 1), new Cell(" ", SELECTED));
+            }
+
+            boolean success = "SUCCESS".equalsIgnoreCase(entry.state) || "APPLIED".equalsIgnoreCase(entry.state);
+            int x = area.x() + 1;
+            buffer.setString(x, area.y() + i, truncate(entry.version, 10), selected ? SELECTED : LABEL_STYLE);
+            x += 11;
+            buffer.setString(x, area.y() + i, truncate(entry.description, 35), selected ? SELECTED : VALUE_STYLE);
+            x += 36;
+            buffer.setString(x, area.y() + i, truncate(entry.state, 12),
+                    selected ? SELECTED : (success ? SUCCESS_STYLE : PENDING_STYLE));
+        }
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                if (getActiveTab() == 1 && selectedIndex < migrations.size() - 1) {
+                    selectedIndex++;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                if (getActiveTab() == 1 && selectedIndex > 0) {
+                    selectedIndex--;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case 'm':
+            case 'M':
+                doAction("migrate");
+                return true;
+            case 'c':
+            case 'C':
+                doAction("clean");
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private void doAction(String method) {
+        try {
+            rpcCall(method);
+            loadDataAsync();
+        } catch (Exception e) {
+            errorMessage = e.getMessage();
+            ctx.requestRedraw();
+        }
+    }
+
+    @Override
+    protected String getFooterText() {
+        return "[M] Migrate  [C] Clean  [j/k] Navigate";
+    }
+
+    private record DatasourceEntry(String name, String currentVersion, String schemaVersion) {
+    }
+
+    private record MigrationEntry(String datasource, String version, String description, String state) {
+    }
+
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/GraphQLShellPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/GraphQLShellPage.java
@@ -1,0 +1,161 @@
+package io.quarkus.devshell.deployment.tui.pages.extensions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.pages.BaseExtensionPage;
+import tools.jackson.databind.JsonNode;
+
+public class GraphQLShellPage extends BaseExtensionPage {
+
+    private static final Style SELECTED = Style.EMPTY.onCyan().black().bold();
+    private static final Pattern TYPE_PATTERN = Pattern.compile("^\\s*(?:type|input|enum|interface|union|scalar)\\s+(\\w+)");
+
+    private List<String> schemaLines = List.of();
+    private List<String> typeNames = List.of();
+    private int selectedIndex = 0;
+    private int scrollOffset = 0;
+
+    public GraphQLShellPage() {
+        super("quarkus-smallrye-graphql", "GraphQL");
+        setTabs("Schema", "Types");
+    }
+
+    @Override
+    public void loadData() {
+        JsonNode result = rpcCall("getGraphQLSchema");
+        String schema = result.isTextual() ? result.asText("") : result.path("_value").asText("");
+
+        List<String> lines = new ArrayList<>();
+        List<String> types = new ArrayList<>();
+        if (!schema.isEmpty()) {
+            for (String line : schema.split("\n")) {
+                lines.add(line);
+                Matcher m = TYPE_PATTERN.matcher(line);
+                if (m.find()) {
+                    types.add(m.group(1));
+                }
+            }
+        }
+        schemaLines = lines;
+        typeNames = types;
+    }
+
+    @Override
+    protected void onTabChanged(int newTab) {
+        selectedIndex = 0;
+        scrollOffset = 0;
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        if (getActiveTab() == 0) {
+            renderSchema(area, buffer);
+        } else {
+            renderTypes(area, buffer);
+        }
+    }
+
+    private void renderSchema(Rect area, Buffer buffer) {
+        if (schemaLines.isEmpty()) {
+            buffer.setString(area.x() + 1, area.y(), "No schema available", DIM_STYLE);
+            return;
+        }
+
+        int visibleRows = area.height();
+        if (scrollOffset > schemaLines.size() - visibleRows) {
+            scrollOffset = Math.max(0, schemaLines.size() - visibleRows);
+        }
+
+        for (int i = 0; i < visibleRows && (scrollOffset + i) < schemaLines.size(); i++) {
+            int idx = scrollOffset + i;
+            String line = schemaLines.get(idx);
+            buffer.setString(area.x() + 1, area.y() + i, truncate(line, area.width() - 2), VALUE_STYLE);
+        }
+    }
+
+    private void renderTypes(Rect area, Buffer buffer) {
+        if (typeNames.isEmpty()) {
+            buffer.setString(area.x() + 1, area.y(), "No types found", DIM_STYLE);
+            return;
+        }
+
+        int visibleRows = area.height();
+        if (selectedIndex < scrollOffset) {
+            scrollOffset = selectedIndex;
+        } else if (selectedIndex >= scrollOffset + visibleRows) {
+            scrollOffset = selectedIndex - visibleRows + 1;
+        }
+
+        for (int i = 0; i < visibleRows && (scrollOffset + i) < typeNames.size(); i++) {
+            int idx = scrollOffset + i;
+            boolean selected = idx == selectedIndex;
+            if (selected) {
+                buffer.fill(new Rect(area.x(), area.y() + i, area.width(), 1), new Cell(" ", SELECTED));
+            }
+            buffer.setString(area.x() + 2, area.y() + i, truncate(typeNames.get(idx), area.width() - 3),
+                    selected ? SELECTED : VALUE_STYLE);
+        }
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        if (getActiveTab() == 0) {
+            // Schema tab: scroll only
+            switch (key) {
+                case 'j':
+                case KeyCode.DOWN:
+                    if (scrollOffset < schemaLines.size() - 1) {
+                        scrollOffset++;
+                        ctx.requestRedraw();
+                    }
+                    return true;
+                case 'k':
+                case KeyCode.UP:
+                    if (scrollOffset > 0) {
+                        scrollOffset--;
+                        ctx.requestRedraw();
+                    }
+                    return true;
+                default:
+                    return false;
+            }
+        } else {
+            // Types tab: selection
+            switch (key) {
+                case 'j':
+                case KeyCode.DOWN:
+                    if (selectedIndex < typeNames.size() - 1) {
+                        selectedIndex++;
+                        ctx.requestRedraw();
+                    }
+                    return true;
+                case 'k':
+                case KeyCode.UP:
+                    if (selectedIndex > 0) {
+                        selectedIndex--;
+                        ctx.requestRedraw();
+                    }
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+
+    @Override
+    protected String getFooterText() {
+        if (getActiveTab() == 0) {
+            return "[j/k] Scroll  " + schemaLines.size() + " lines";
+        }
+        return "[j/k] Navigate  " + typeNames.size() + " types";
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/GrpcShellPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/GrpcShellPage.java
@@ -1,0 +1,135 @@
+package io.quarkus.devshell.deployment.tui.pages.extensions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.pages.BaseExtensionPage;
+import io.quarkus.devshell.deployment.tui.widgets.ListView;
+import tools.jackson.databind.JsonNode;
+
+public class GrpcShellPage extends BaseExtensionPage {
+
+    private final ListView<GrpcService> listView = new ListView<>(s -> s.name);
+    private final List<GrpcService> services = new ArrayList<>();
+
+    public GrpcShellPage() {
+        super("quarkus-grpc", "gRPC Services");
+    }
+
+    @Override
+    public void loadData() {
+        JsonNode result = rpcCall("getGrpcServices");
+        services.clear();
+
+        if (result.isArray()) {
+            for (JsonNode svc : result) {
+                String name = svc.path("name").asText(svc.path("serviceName").asText(""));
+                String status = svc.path("status").asText("");
+                List<String> methods = new ArrayList<>();
+                JsonNode methodsNode = svc.path("methods");
+                if (methodsNode.isArray()) {
+                    for (JsonNode m : methodsNode) {
+                        methods.add(m.asText(m.path("name").asText("")));
+                    }
+                }
+                services.add(new GrpcService(name, status, methods));
+            }
+        }
+        listView.setItems(services);
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        if (services.isEmpty()) {
+            buffer.setString(area.x() + 1, area.y(), "No gRPC services found", DIM_STYLE);
+            return;
+        }
+
+        var areas = Layout.horizontal()
+                .constraints(Constraint.percentage(40), Constraint.percentage(60))
+                .split(area);
+
+        // Service list
+        Rect listArea = areas.get(0);
+        listView.setVisibleRows(listArea.height());
+        listView.setWidth(listArea.width() - 1);
+        listView.render(buffer, listArea.y(), listArea.x() + 1);
+
+        // Detail panel
+        Rect detailArea = areas.get(1);
+        int x = detailArea.x() + 1;
+        int y = detailArea.y();
+        int w = detailArea.width() - 2;
+
+        GrpcService selected = listView.getSelectedItem();
+        if (selected != null) {
+            buffer.setString(x, y, selected.name, HEADER_STYLE);
+            y++;
+            if (!selected.status.isEmpty()) {
+                buffer.setString(x, y, "Status: ", LABEL_STYLE);
+                buffer.setString(x + 8, y, selected.status, VALUE_STYLE);
+                y++;
+            }
+            y++;
+            if (!selected.methods.isEmpty()) {
+                buffer.setString(x, y, "Methods:", LABEL_STYLE);
+                y++;
+                for (String method : selected.methods) {
+                    if (y >= detailArea.y() + detailArea.height())
+                        break;
+                    buffer.setString(x + 1, y, "- " + truncate(method, w - 3), VALUE_STYLE);
+                    y++;
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                listView.moveDown();
+                ctx.requestRedraw();
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                listView.moveUp();
+                ctx.requestRedraw();
+                return true;
+            case KeyCode.PAGE_DOWN:
+                listView.pageDown();
+                ctx.requestRedraw();
+                return true;
+            case KeyCode.PAGE_UP:
+                listView.pageUp();
+                ctx.requestRedraw();
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    protected String getFooterText() {
+        return "[j/k] Navigate";
+    }
+
+    private static class GrpcService {
+        final String name;
+        final String status;
+        final List<String> methods;
+
+        GrpcService(String name, String status, List<String> methods) {
+            this.name = name;
+            this.status = status;
+            this.methods = methods;
+        }
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/HealthShellPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/HealthShellPage.java
@@ -1,0 +1,156 @@
+package io.quarkus.devshell.deployment.tui.pages.extensions;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.pages.BaseExtensionPage;
+import tools.jackson.databind.JsonNode;
+
+public class HealthShellPage extends BaseExtensionPage {
+
+    private static final Style UP_STYLE = Style.EMPTY.green();
+    private static final Style DOWN_STYLE = Style.EMPTY.red();
+    private static final Style SELECTED_STYLE = Style.EMPTY.reversed();
+
+    private String overallStatus = "";
+    private final List<HealthCheck> checks = new ArrayList<>();
+    private int selectedIndex = 0;
+    private int scrollOffset = 0;
+
+    public HealthShellPage() {
+        super("quarkus-smallrye-health", "Health");
+    }
+
+    @Override
+    public void loadData() {
+        JsonNode result = rpcCall("getHealth");
+        overallStatus = result.path("status").asText("UNKNOWN");
+        checks.clear();
+
+        JsonNode checksNode = result.path("checks");
+        if (checksNode.isArray()) {
+            for (JsonNode check : checksNode) {
+                String name = check.path("name").asText("");
+                String status = check.path("status").asText("UNKNOWN");
+                JsonNode data = check.path("data");
+                checks.add(new HealthCheck(name, status, data));
+            }
+        }
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        int x = area.x() + 1;
+        int y = area.y();
+        int w = area.width() - 2;
+
+        // Overall status
+        Style statusStyle = "UP".equals(overallStatus) ? UP_STYLE : DOWN_STYLE;
+        buffer.setString(x, y, "Overall: ", LABEL_STYLE);
+        buffer.setString(x + 9, y, overallStatus, statusStyle);
+        y += 2;
+
+        if (checks.isEmpty()) {
+            buffer.setString(x, y, "No health checks found", DIM_STYLE);
+            return;
+        }
+
+        // Checks list
+        int visibleRows = Math.min(checks.size(), area.height() - 4);
+        for (int i = 0; i < visibleRows; i++) {
+            int idx = scrollOffset + i;
+            if (idx >= checks.size())
+                break;
+
+            HealthCheck check = checks.get(idx);
+            boolean selected = idx == selectedIndex;
+            String icon = "UP".equals(check.status) ? "+ " : "x ";
+            Style iconStyle = "UP".equals(check.status) ? UP_STYLE : DOWN_STYLE;
+
+            if (selected) {
+                buffer.fill(new Rect(x, y + i, w, 1), new Cell(" ", SELECTED_STYLE));
+            }
+
+            buffer.setString(x, y + i, icon, iconStyle);
+            buffer.setString(x + 2, y + i, truncate(check.name, w - 2),
+                    selected ? SELECTED_STYLE : VALUE_STYLE);
+        }
+
+        // Detail for selected check
+        if (selectedIndex >= 0 && selectedIndex < checks.size()) {
+            int detailY = y + visibleRows + 1;
+            HealthCheck selected = checks.get(selectedIndex);
+            buffer.setString(x, detailY, "─".repeat(w), DIM_STYLE);
+            detailY++;
+            buffer.setString(x, detailY, selected.name, HEADER_STYLE);
+            detailY++;
+            buffer.setString(x, detailY, "Status: ", LABEL_STYLE);
+            Style st = "UP".equals(selected.status) ? UP_STYLE : DOWN_STYLE;
+            buffer.setString(x + 8, detailY, selected.status, st);
+            detailY++;
+
+            if (selected.data != null && selected.data.isObject()) {
+                Iterator<Map.Entry<String, JsonNode>> fields = selected.data.properties().iterator();
+                while (fields.hasNext() && detailY < area.y() + area.height()) {
+                    Map.Entry<String, JsonNode> field = fields.next();
+                    String label = field.getKey() + ": ";
+                    buffer.setString(x, detailY, label, LABEL_STYLE);
+                    buffer.setString(x + label.length(), detailY,
+                            truncate(field.getValue().asText(""), w - label.length()), VALUE_STYLE);
+                    detailY++;
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                if (selectedIndex < checks.size() - 1) {
+                    selectedIndex++;
+                    if (selectedIndex >= scrollOffset + 10)
+                        scrollOffset++;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                if (selectedIndex > 0) {
+                    selectedIndex--;
+                    if (selectedIndex < scrollOffset)
+                        scrollOffset = selectedIndex;
+                    ctx.requestRedraw();
+                }
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    protected String getFooterText() {
+        return "[j/k] Navigate";
+    }
+
+    private static class HealthCheck {
+        final String name;
+        final String status;
+        final JsonNode data;
+
+        HealthCheck(String name, String status, JsonNode data) {
+            this.name = name;
+            this.status = status;
+            this.data = data;
+        }
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/HibernateOrmShellPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/HibernateOrmShellPage.java
@@ -1,0 +1,147 @@
+package io.quarkus.devshell.deployment.tui.pages.extensions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.pages.BaseExtensionPage;
+import io.quarkus.devshell.deployment.tui.widgets.KeyValuePanel;
+import io.quarkus.devshell.deployment.tui.widgets.ListView;
+import tools.jackson.databind.JsonNode;
+
+public class HibernateOrmShellPage extends BaseExtensionPage {
+
+    private int persistenceUnits = 0;
+    private int entityTypes = 0;
+    private int namedQueries = 0;
+
+    private final ListView<String> puListView = new ListView<>(name -> name);
+    private final ListView<String> entityListView = new ListView<>(name -> name);
+    private final List<String> puNames = new ArrayList<>();
+    private final List<String> entityNames = new ArrayList<>();
+
+    public HibernateOrmShellPage() {
+        super("quarkus-hibernate-orm", "Hibernate ORM");
+        setTabs("Info", "Persistence Units", "Entities");
+    }
+
+    @Override
+    public void loadData() {
+        JsonNode puResult = rpcCall("getNumberOfPersistenceUnits");
+        persistenceUnits = puResult.asInt(0);
+
+        JsonNode entityResult = rpcCall("getNumberOfEntityTypes");
+        entityTypes = entityResult.asInt(0);
+
+        JsonNode queryResult = rpcCall("getNumberOfNamedQueries");
+        namedQueries = queryResult.asInt(0);
+
+        // Try to get detailed lists if available
+        puNames.clear();
+        try {
+            JsonNode puList = rpcCall("getPersistenceUnits");
+            if (puList.isArray()) {
+                for (JsonNode pu : puList) {
+                    puNames.add(pu.path("name").asText(pu.asText("")));
+                }
+            }
+        } catch (Exception ignored) {
+            // Method may not exist, just show counts
+        }
+        puListView.setItems(puNames);
+
+        entityNames.clear();
+        try {
+            JsonNode entityList = rpcCall("getEntityTypes");
+            if (entityList.isArray()) {
+                for (JsonNode e : entityList) {
+                    entityNames.add(e.path("name").asText(e.path("className").asText(e.asText(""))));
+                }
+            }
+        } catch (Exception ignored) {
+            // Method may not exist, just show counts
+        }
+        entityListView.setItems(entityNames);
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        int x = area.x() + 1;
+        int y = area.y();
+        int w = area.width() - 2;
+        int h = area.height();
+
+        switch (getActiveTab()) {
+            case 0:
+                KeyValuePanel info = new KeyValuePanel("Hibernate ORM Summary");
+                info.add("Persistence Units", String.valueOf(persistenceUnits));
+                info.add("Entity Types", String.valueOf(entityTypes));
+                info.add("Named Queries", String.valueOf(namedQueries));
+                info.render(buffer, y, x, w);
+                break;
+            case 1:
+                if (puNames.isEmpty()) {
+                    buffer.setString(x, y, persistenceUnits + " persistence unit(s)", DIM_STYLE);
+                } else {
+                    buffer.setString(x, y, puNames.size() + " persistence units", DIM_STYLE);
+                    puListView.setVisibleRows(h - 2);
+                    puListView.setWidth(w);
+                    puListView.render(buffer, y + 1, x);
+                }
+                break;
+            case 2:
+                if (entityNames.isEmpty()) {
+                    buffer.setString(x, y, entityTypes + " entity type(s)", DIM_STYLE);
+                } else {
+                    buffer.setString(x, y, entityNames.size() + " entities", DIM_STYLE);
+                    entityListView.setVisibleRows(h - 2);
+                    entityListView.setWidth(w);
+                    entityListView.render(buffer, y + 1, x);
+                }
+                break;
+        }
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                activeList().moveDown();
+                ctx.requestRedraw();
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                activeList().moveUp();
+                ctx.requestRedraw();
+                return true;
+            case KeyCode.PAGE_DOWN:
+                activeList().pageDown();
+                ctx.requestRedraw();
+                return true;
+            case KeyCode.PAGE_UP:
+                activeList().pageUp();
+                ctx.requestRedraw();
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private ListView<String> activeList() {
+        return getActiveTab() == 2 ? entityListView : puListView;
+    }
+
+    @Override
+    protected void onTabChanged(int newTab) {
+        // Lists keep their own scroll state
+    }
+
+    @Override
+    protected String getFooterText() {
+        return "[j/k] Navigate";
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/InfoShellPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/InfoShellPage.java
@@ -1,0 +1,87 @@
+package io.quarkus.devshell.deployment.tui.pages.extensions;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.pages.BaseExtensionPage;
+import io.quarkus.devshell.deployment.tui.widgets.KeyValuePanel;
+import tools.jackson.databind.JsonNode;
+
+public class InfoShellPage extends BaseExtensionPage {
+
+    private final List<KeyValuePanel> panels = new ArrayList<>();
+    private int scrollOffset = 0;
+
+    public InfoShellPage() {
+        super("quarkus-info", "Info");
+    }
+
+    @Override
+    public void loadData() {
+        JsonNode result = rpcCall("getApplicationAndEnvironmentInfo");
+        panels.clear();
+
+        if (result.isObject()) {
+            Iterator<Map.Entry<String, JsonNode>> sections = result.properties().iterator();
+            while (sections.hasNext()) {
+                Map.Entry<String, JsonNode> section = sections.next();
+                KeyValuePanel panel = new KeyValuePanel(section.getKey());
+                JsonNode value = section.getValue();
+                if (value.isObject()) {
+                    Iterator<Map.Entry<String, JsonNode>> fields = value.properties().iterator();
+                    while (fields.hasNext()) {
+                        Map.Entry<String, JsonNode> field = fields.next();
+                        panel.add(field.getKey(), field.getValue().asText(""));
+                    }
+                } else {
+                    panel.add(section.getKey(), value.asText(""));
+                }
+                panels.add(panel);
+            }
+        }
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        if (panels.isEmpty()) {
+            buffer.setString(area.x() + 1, area.y(), "No info available", DIM_STYLE);
+            return;
+        }
+        int row = area.y() - scrollOffset;
+        for (KeyValuePanel panel : panels) {
+            row = panel.render(buffer, row, area.x() + 1, area.width() - 2);
+            row++;
+        }
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                scrollOffset++;
+                ctx.requestRedraw();
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                if (scrollOffset > 0) {
+                    scrollOffset--;
+                    ctx.requestRedraw();
+                }
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    protected String getFooterText() {
+        return "[j/k] Scroll";
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/KafkaShellPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/KafkaShellPage.java
@@ -1,0 +1,116 @@
+package io.quarkus.devshell.deployment.tui.pages.extensions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.pages.BaseExtensionPage;
+import tools.jackson.databind.JsonNode;
+
+public class KafkaShellPage extends BaseExtensionPage {
+
+    private static final Style SELECTED = Style.EMPTY.onCyan().black().bold();
+
+    private List<String> topics = List.of();
+    private List<String> consumerGroups = List.of();
+    private int selectedIndex = 0;
+    private int scrollOffset = 0;
+
+    public KafkaShellPage() {
+        super("quarkus-kafka-client", "Kafka");
+        setTabs("Topics", "Consumer Groups");
+    }
+
+    @Override
+    public void loadData() {
+        JsonNode result = rpcCall("getInfo");
+        List<String> t = new ArrayList<>();
+        List<String> cg = new ArrayList<>();
+
+        JsonNode topicsNode = result.path("topics");
+        if (topicsNode.isArray()) {
+            for (JsonNode item : topicsNode) {
+                t.add(item.isObject() ? item.path("name").asText(item.toString()) : item.asText(""));
+            }
+        }
+
+        JsonNode groupsNode = result.path("consumerGroups");
+        if (groupsNode.isArray()) {
+            for (JsonNode item : groupsNode) {
+                cg.add(item.isObject() ? item.path("groupId").asText(item.toString()) : item.asText(""));
+            }
+        }
+
+        topics = t;
+        consumerGroups = cg;
+    }
+
+    @Override
+    protected void onTabChanged(int newTab) {
+        selectedIndex = 0;
+        scrollOffset = 0;
+    }
+
+    private List<String> currentList() {
+        return getActiveTab() == 0 ? topics : consumerGroups;
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        List<String> items = currentList();
+        if (items.isEmpty()) {
+            buffer.setString(area.x() + 1, area.y(), "No " + getActiveTabName() + " found", DIM_STYLE);
+            return;
+        }
+
+        int visibleRows = area.height();
+        if (selectedIndex < scrollOffset) {
+            scrollOffset = selectedIndex;
+        } else if (selectedIndex >= scrollOffset + visibleRows) {
+            scrollOffset = selectedIndex - visibleRows + 1;
+        }
+
+        for (int i = 0; i < visibleRows && (scrollOffset + i) < items.size(); i++) {
+            int idx = scrollOffset + i;
+            boolean selected = idx == selectedIndex;
+            if (selected) {
+                buffer.fill(new Rect(area.x(), area.y() + i, area.width(), 1), new Cell(" ", SELECTED));
+            }
+            buffer.setString(area.x() + 2, area.y() + i, truncate(items.get(idx), area.width() - 3),
+                    selected ? SELECTED : VALUE_STYLE);
+        }
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        List<String> items = currentList();
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                if (selectedIndex < items.size() - 1) {
+                    selectedIndex++;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                if (selectedIndex > 0) {
+                    selectedIndex--;
+                    ctx.requestRedraw();
+                }
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    protected String getFooterText() {
+        return "[j/k] Navigate  " + currentList().size() + " items";
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/LiquibaseShellPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/LiquibaseShellPage.java
@@ -1,0 +1,124 @@
+package io.quarkus.devshell.deployment.tui.pages.extensions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.pages.BaseExtensionPage;
+import tools.jackson.databind.JsonNode;
+
+public class LiquibaseShellPage extends BaseExtensionPage {
+
+    private static final Style SELECTED = Style.EMPTY.onCyan().black().bold();
+    private static final Style SUCCESS_STYLE = Style.EMPTY.green();
+    private static final Style PENDING_STYLE = Style.EMPTY.yellow();
+
+    private List<DatasourceEntry> datasources = List.of();
+    private int selectedIndex = 0;
+    private int scrollOffset = 0;
+
+    public LiquibaseShellPage() {
+        super("quarkus-liquibase", "Liquibase");
+    }
+
+    @Override
+    public void loadData() {
+        JsonNode result = rpcCall("getLiquibaseFactories");
+        List<DatasourceEntry> entries = new ArrayList<>();
+        JsonNode arr = result.isArray() ? result : result.path("_array");
+        if (arr.isArray()) {
+            for (JsonNode item : arr) {
+                String name = item.path("name").asText(item.path("datasource").asText("default"));
+                String status = item.path("status").asText(item.path("state").asText(""));
+                int changesets = item.path("changeSetsCount").asInt(
+                        item.path("changesets").isArray() ? item.path("changesets").size() : 0);
+                entries.add(new DatasourceEntry(name, status, changesets));
+            }
+        }
+        datasources = entries;
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        if (datasources.isEmpty()) {
+            buffer.setString(area.x() + 1, area.y(), "No datasources found", DIM_STYLE);
+            return;
+        }
+
+        int visibleRows = area.height();
+        if (selectedIndex < scrollOffset) {
+            scrollOffset = selectedIndex;
+        } else if (selectedIndex >= scrollOffset + visibleRows) {
+            scrollOffset = selectedIndex - visibleRows + 1;
+        }
+
+        for (int i = 0; i < visibleRows && (scrollOffset + i) < datasources.size(); i++) {
+            int idx = scrollOffset + i;
+            DatasourceEntry entry = datasources.get(idx);
+            boolean selected = idx == selectedIndex;
+
+            if (selected) {
+                buffer.fill(new Rect(area.x(), area.y() + i, area.width(), 1), new Cell(" ", SELECTED));
+            }
+
+            boolean upToDate = "up-to-date".equalsIgnoreCase(entry.status)
+                    || "EXECUTED".equalsIgnoreCase(entry.status);
+            int x = area.x() + 1;
+            buffer.setString(x, area.y() + i, truncate(entry.name, 25), selected ? SELECTED : VALUE_STYLE);
+            x += 26;
+
+            String statusText = entry.status.isEmpty() ? entry.changesets + " changesets" : entry.status;
+            buffer.setString(x, area.y() + i, truncate(statusText, area.width() - x + area.x()),
+                    selected ? SELECTED : (upToDate ? SUCCESS_STYLE : PENDING_STYLE));
+        }
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                if (selectedIndex < datasources.size() - 1) {
+                    selectedIndex++;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                if (selectedIndex > 0) {
+                    selectedIndex--;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case 'u':
+            case 'U':
+                doUpdate();
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private void doUpdate() {
+        try {
+            rpcCall("migrate");
+            loadDataAsync();
+        } catch (Exception e) {
+            errorMessage = e.getMessage();
+            ctx.requestRedraw();
+        }
+    }
+
+    @Override
+    protected String getFooterText() {
+        return "[j/k] Navigate  [U] Update  " + datasources.size() + " datasources";
+    }
+
+    private record DatasourceEntry(String name, String status, int changesets) {
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/MicrometerShellPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/MicrometerShellPage.java
@@ -1,0 +1,97 @@
+package io.quarkus.devshell.deployment.tui.pages.extensions;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.pages.BaseExtensionPage;
+
+public class MicrometerShellPage extends BaseExtensionPage {
+
+    private final List<String> lines = new ArrayList<>();
+    private int scrollOffset = 0;
+
+    public MicrometerShellPage() {
+        super("quarkus-micrometer", "Micrometer Metrics");
+    }
+
+    @Override
+    public void loadData() {
+        lines.clear();
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("http://localhost:8080/q/metrics"))
+                    .header("Accept", "application/json")
+                    .GET()
+                    .build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            for (String line : response.body().split("\n", -1)) {
+                lines.add(line);
+            }
+        } catch (Exception e) {
+            lines.add("Failed to fetch metrics: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        if (lines.isEmpty()) {
+            buffer.setString(area.x() + 1, area.y(), "No metrics available", DIM_STYLE);
+            return;
+        }
+
+        int x = area.x() + 1;
+        int w = area.width() - 2;
+        int visibleRows = area.height();
+
+        for (int i = 0; i < visibleRows; i++) {
+            int lineIdx = scrollOffset + i;
+            if (lineIdx >= lines.size())
+                break;
+            buffer.setString(x, area.y() + i, truncate(lines.get(lineIdx), w), VALUE_STYLE);
+        }
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                if (scrollOffset < lines.size() - 1) {
+                    scrollOffset++;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                if (scrollOffset > 0) {
+                    scrollOffset--;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case KeyCode.PAGE_DOWN:
+                scrollOffset = Math.min(scrollOffset + 20, Math.max(0, lines.size() - 1));
+                ctx.requestRedraw();
+                return true;
+            case KeyCode.PAGE_UP:
+                scrollOffset = Math.max(scrollOffset - 20, 0);
+                ctx.requestRedraw();
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    protected String getFooterText() {
+        return "[j/k] Scroll";
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/OpenApiShellPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/OpenApiShellPage.java
@@ -1,0 +1,102 @@
+package io.quarkus.devshell.deployment.tui.pages.extensions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.pages.BaseExtensionPage;
+import tools.jackson.databind.JsonNode;
+
+public class OpenApiShellPage extends BaseExtensionPage {
+
+    private final List<String> lines = new ArrayList<>();
+    private int scrollOffset = 0;
+
+    public OpenApiShellPage() {
+        super("quarkus-smallrye-openapi", "OpenAPI");
+    }
+
+    @Override
+    public void loadData() {
+        JsonNode result = rpcCall("getOpenAPISchema");
+        lines.clear();
+
+        String text = result.asText("");
+        if (text.isEmpty() && result.isObject()) {
+            text = result.toPrettyString();
+        }
+        for (String line : text.split("\n", -1)) {
+            lines.add(line);
+        }
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        if (lines.isEmpty()) {
+            buffer.setString(area.x() + 1, area.y(), "No OpenAPI document available", DIM_STYLE);
+            return;
+        }
+
+        int x = area.x() + 1;
+        int w = area.width() - 2;
+        int visibleRows = area.height();
+        int lineNumWidth = String.valueOf(lines.size()).length() + 1;
+
+        for (int i = 0; i < visibleRows; i++) {
+            int lineIdx = scrollOffset + i;
+            if (lineIdx >= lines.size())
+                break;
+
+            String lineNum = String.format("%" + lineNumWidth + "d ", lineIdx + 1);
+            buffer.setString(x, area.y() + i, lineNum, DIM_STYLE);
+            buffer.setString(x + lineNum.length(), area.y() + i,
+                    truncate(lines.get(lineIdx), w - lineNum.length()), VALUE_STYLE);
+        }
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                if (scrollOffset < lines.size() - 1) {
+                    scrollOffset++;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                if (scrollOffset > 0) {
+                    scrollOffset--;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case KeyCode.PAGE_DOWN:
+                scrollOffset = Math.min(lines.size() - 1, scrollOffset + 20);
+                ctx.requestRedraw();
+                return true;
+            case KeyCode.PAGE_UP:
+                scrollOffset = Math.max(0, scrollOffset - 20);
+                ctx.requestRedraw();
+                return true;
+            case KeyCode.HOME:
+                scrollOffset = 0;
+                ctx.requestRedraw();
+                return true;
+            case KeyCode.END:
+                scrollOffset = Math.max(0, lines.size() - 1);
+                ctx.requestRedraw();
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    protected String getFooterText() {
+        return "[j/k] Scroll  [PgUp/PgDn] Page";
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/ReactiveMessagingShellPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/ReactiveMessagingShellPage.java
@@ -1,0 +1,119 @@
+package io.quarkus.devshell.deployment.tui.pages.extensions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.pages.BaseExtensionPage;
+import tools.jackson.databind.JsonNode;
+
+public class ReactiveMessagingShellPage extends BaseExtensionPage {
+
+    private static final Style SELECTED = Style.EMPTY.onCyan().black().bold();
+    private static final Style CONNECTOR_STYLE = Style.EMPTY.yellow();
+
+    private List<ChannelEntry> channels = List.of();
+    private int selectedIndex = 0;
+    private int scrollOffset = 0;
+
+    public ReactiveMessagingShellPage() {
+        super("quarkus-messaging", "Reactive Messaging");
+    }
+
+    @Override
+    public void loadData() {
+        JsonNode result = rpcCall("getInfo");
+        List<ChannelEntry> entries = new ArrayList<>();
+
+        JsonNode channelsNode = result.path("channels");
+        if (!channelsNode.isArray()) {
+            channelsNode = result.isArray() ? result : result.path("_array");
+        }
+        if (channelsNode.isArray()) {
+            for (JsonNode item : channelsNode) {
+                entries.add(new ChannelEntry(
+                        item.path("name").asText(""),
+                        item.path("connector").asText(""),
+                        item.path("type").asText(""),
+                        item.path("publisher").asText(""),
+                        item.path("consumer").asText("")));
+            }
+        }
+        channels = entries;
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        if (channels.isEmpty()) {
+            buffer.setString(area.x() + 1, area.y(), "No channels found", DIM_STYLE);
+            return;
+        }
+
+        int visibleRows = area.height();
+        if (selectedIndex < scrollOffset) {
+            scrollOffset = selectedIndex;
+        } else if (selectedIndex >= scrollOffset + visibleRows) {
+            scrollOffset = selectedIndex - visibleRows + 1;
+        }
+
+        for (int i = 0; i < visibleRows && (scrollOffset + i) < channels.size(); i++) {
+            int idx = scrollOffset + i;
+            ChannelEntry entry = channels.get(idx);
+            boolean selected = idx == selectedIndex;
+
+            if (selected) {
+                buffer.fill(new Rect(area.x(), area.y() + i, area.width(), 1), new Cell(" ", SELECTED));
+            }
+
+            int x = area.x() + 1;
+            buffer.setString(x, area.y() + i, truncate(entry.name, 30), selected ? SELECTED : VALUE_STYLE);
+            x += 31;
+
+            if (!entry.connector.isEmpty()) {
+                String conn = "[" + entry.connector + "]";
+                buffer.setString(x, area.y() + i, truncate(conn, 20), selected ? SELECTED : CONNECTOR_STYLE);
+                x += 21;
+            }
+
+            if (!entry.type.isEmpty()) {
+                buffer.setString(x, area.y() + i, truncate(entry.type, area.width() - x + area.x()),
+                        selected ? SELECTED : DIM_STYLE);
+            }
+        }
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                if (selectedIndex < channels.size() - 1) {
+                    selectedIndex++;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                if (selectedIndex > 0) {
+                    selectedIndex--;
+                    ctx.requestRedraw();
+                }
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    protected String getFooterText() {
+        return "[j/k] Navigate  " + channels.size() + " channels";
+    }
+
+    private record ChannelEntry(String name, String connector, String type, String publisher, String consumer) {
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/RestEndpointsShellPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/RestEndpointsShellPage.java
@@ -1,0 +1,118 @@
+package io.quarkus.devshell.deployment.tui.pages.extensions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.pages.BaseExtensionPage;
+import tools.jackson.databind.JsonNode;
+
+public class RestEndpointsShellPage extends BaseExtensionPage {
+
+    private static final Style SELECTED = Style.EMPTY.onCyan().black().bold();
+    private static final Style GET_STYLE = Style.EMPTY.green().bold();
+    private static final Style POST_STYLE = Style.EMPTY.yellow().bold();
+    private static final Style PUT_STYLE = Style.EMPTY.blue().bold();
+    private static final Style DELETE_STYLE = Style.EMPTY.red().bold();
+
+    private List<EndpointEntry> endpoints = List.of();
+    private int selectedIndex = 0;
+    private int scrollOffset = 0;
+
+    public RestEndpointsShellPage() {
+        super("devui-endpoints", "REST Endpoints");
+    }
+
+    @Override
+    public void loadData() {
+        JsonNode result = rpcCall("getAllEndpoints");
+        List<EndpointEntry> entries = new ArrayList<>();
+        JsonNode arr = result.isArray() ? result : result.path("_array");
+        if (arr.isArray()) {
+            for (JsonNode item : arr) {
+                entries.add(new EndpointEntry(
+                        item.path("httpMethod").asText("GET").toUpperCase(),
+                        item.path("uri").asText(""),
+                        item.path("javaMethod").asText("")));
+            }
+        }
+        endpoints = entries;
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        if (endpoints.isEmpty()) {
+            buffer.setString(area.x() + 1, area.y(), "No endpoints found", DIM_STYLE);
+            return;
+        }
+
+        int visibleRows = area.height();
+        if (selectedIndex < scrollOffset) {
+            scrollOffset = selectedIndex;
+        } else if (selectedIndex >= scrollOffset + visibleRows) {
+            scrollOffset = selectedIndex - visibleRows + 1;
+        }
+
+        for (int i = 0; i < visibleRows && (scrollOffset + i) < endpoints.size(); i++) {
+            int idx = scrollOffset + i;
+            EndpointEntry entry = endpoints.get(idx);
+            boolean selected = idx == selectedIndex;
+
+            if (selected) {
+                buffer.fill(new Rect(area.x(), area.y() + i, area.width(), 1), new Cell(" ", SELECTED));
+            }
+
+            int x = area.x() + 1;
+            String method = String.format("%-7s", entry.method);
+            Style methodStyle = selected ? SELECTED : methodColor(entry.method);
+            buffer.setString(x, area.y() + i, method, methodStyle);
+            x += 8;
+            buffer.setString(x, area.y() + i, truncate(entry.uri, area.width() - x + area.x() - 1),
+                    selected ? SELECTED : VALUE_STYLE);
+        }
+    }
+
+    private Style methodColor(String method) {
+        return switch (method) {
+            case "POST" -> POST_STYLE;
+            case "PUT" -> PUT_STYLE;
+            case "DELETE" -> DELETE_STYLE;
+            default -> GET_STYLE;
+        };
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                if (selectedIndex < endpoints.size() - 1) {
+                    selectedIndex++;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                if (selectedIndex > 0) {
+                    selectedIndex--;
+                    ctx.requestRedraw();
+                }
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    protected String getFooterText() {
+        return "[j/k] Navigate  " + endpoints.size() + " endpoints";
+    }
+
+    private record EndpointEntry(String method, String uri, String javaMethod) {
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/SchedulerShellPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/SchedulerShellPage.java
@@ -1,0 +1,161 @@
+package io.quarkus.devshell.deployment.tui.pages.extensions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.pages.BaseExtensionPage;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
+
+public class SchedulerShellPage extends BaseExtensionPage {
+
+    private static final Style SELECTED = Style.EMPTY.onCyan().black().bold();
+    private static final Style RUNNING_STYLE = Style.EMPTY.green();
+    private static final Style PAUSED_STYLE = Style.EMPTY.yellow();
+
+    private List<ScheduleEntry> schedules = List.of();
+    private int selectedIndex = 0;
+    private int scrollOffset = 0;
+
+    public SchedulerShellPage() {
+        super("quarkus-scheduler", "Scheduler");
+    }
+
+    @Override
+    public void loadData() {
+        JsonNode result = rpcCall("getData");
+        List<ScheduleEntry> entries = new ArrayList<>();
+        JsonNode arr = result.isArray() ? result : result.path("schedulerData");
+        if (!arr.isArray()) {
+            arr = result.path("_array");
+        }
+        if (arr.isArray()) {
+            for (JsonNode item : arr) {
+                entries.add(new ScheduleEntry(
+                        item.path("identity").asText(item.path("triggerDescription").asText("")),
+                        item.path("cron").asText(item.path("every").asText("")),
+                        item.path("methodDescription").asText(""),
+                        item.path("running").asBoolean(!item.path("paused").asBoolean(false))));
+            }
+        }
+        schedules = entries;
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        if (schedules.isEmpty()) {
+            buffer.setString(area.x() + 1, area.y(), "No scheduled jobs found", DIM_STYLE);
+            return;
+        }
+
+        int visibleRows = area.height();
+        if (selectedIndex < scrollOffset) {
+            scrollOffset = selectedIndex;
+        } else if (selectedIndex >= scrollOffset + visibleRows) {
+            scrollOffset = selectedIndex - visibleRows + 1;
+        }
+
+        for (int i = 0; i < visibleRows && (scrollOffset + i) < schedules.size(); i++) {
+            int idx = scrollOffset + i;
+            ScheduleEntry entry = schedules.get(idx);
+            boolean selected = idx == selectedIndex;
+
+            if (selected) {
+                buffer.fill(new Rect(area.x(), area.y() + i, area.width(), 1), new Cell(" ", SELECTED));
+            }
+
+            int x = area.x() + 1;
+            String status = entry.running ? "* " : "| ";
+            buffer.setString(x, area.y() + i, status, selected ? SELECTED : (entry.running ? RUNNING_STYLE : PAUSED_STYLE));
+            x += 2;
+
+            buffer.setString(x, area.y() + i, truncate(entry.identity, 30), selected ? SELECTED : VALUE_STYLE);
+            x += 31;
+
+            buffer.setString(x, area.y() + i, truncate(entry.schedule, 20), selected ? SELECTED : DIM_STYLE);
+            x += 21;
+
+            if (!entry.description.isEmpty()) {
+                buffer.setString(x, area.y() + i, truncate(entry.description, area.width() - x + area.x()),
+                        selected ? SELECTED : DIM_STYLE);
+            }
+        }
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                if (selectedIndex < schedules.size() - 1) {
+                    selectedIndex++;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                if (selectedIndex > 0) {
+                    selectedIndex--;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case KeyCode.ENTER:
+                togglePause();
+                return true;
+            case 't':
+            case 'T':
+                triggerJob();
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private void togglePause() {
+        if (schedules.isEmpty())
+            return;
+        ScheduleEntry entry = schedules.get(selectedIndex);
+        try {
+            ObjectNode params = createParams();
+            params.put("identity", entry.identity);
+            if (entry.running) {
+                rpcCall("pauseJob", params);
+            } else {
+                rpcCall("resumeJob", params);
+            }
+            loadDataAsync();
+        } catch (Exception e) {
+            errorMessage = e.getMessage();
+            ctx.requestRedraw();
+        }
+    }
+
+    private void triggerJob() {
+        if (schedules.isEmpty())
+            return;
+        ScheduleEntry entry = schedules.get(selectedIndex);
+        try {
+            ObjectNode params = createParams();
+            params.put("identity", entry.identity);
+            rpcCall("executeJob", params);
+            loadDataAsync();
+        } catch (Exception e) {
+            errorMessage = e.getMessage();
+            ctx.requestRedraw();
+        }
+    }
+
+    @Override
+    protected String getFooterText() {
+        return "[j/k] Navigate  [Enter] Pause/Resume  [T] Trigger  " + schedules.size() + " jobs";
+    }
+
+    private record ScheduleEntry(String identity, String schedule, String description, boolean running) {
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/WebDependencyLocatorShellPage.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/pages/extensions/WebDependencyLocatorShellPage.java
@@ -1,0 +1,100 @@
+package io.quarkus.devshell.deployment.tui.pages.extensions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.pages.BaseExtensionPage;
+import io.quarkus.devshell.deployment.tui.widgets.TableView;
+import tools.jackson.databind.JsonNode;
+
+public class WebDependencyLocatorShellPage extends BaseExtensionPage {
+
+    private final TableView<WebDep> tableView = new TableView<>();
+    private final List<WebDep> deps = new ArrayList<>();
+
+    public WebDependencyLocatorShellPage() {
+        super("quarkus-web-dependency-locator", "Web Dependencies");
+        tableView.addColumn("Name", d -> d.name, 20);
+        tableView.addColumn("Version", d -> d.version, 15);
+    }
+
+    @Override
+    public void loadData() {
+        JsonNode result = getBuildTimeDataAsJson("webDependencyLibraries");
+        deps.clear();
+
+        if (result.isArray()) {
+            for (JsonNode dep : result) {
+                String name = dep.path("name").asText(dep.asText(""));
+                String version = dep.path("version").asText("");
+                deps.add(new WebDep(name, version));
+            }
+        } else if (result.isObject()) {
+            var fields = result.properties().iterator();
+            while (fields.hasNext()) {
+                var entry = fields.next();
+                deps.add(new WebDep(entry.getKey(), entry.getValue().asText("")));
+            }
+        }
+
+        tableView.setItems(deps);
+    }
+
+    @Override
+    public void renderPanel(Rect area, Buffer buffer) {
+        if (deps.isEmpty()) {
+            buffer.setString(area.x() + 1, area.y(), "No web dependencies found", DIM_STYLE);
+            return;
+        }
+
+        buffer.setString(area.x() + 1, area.y(), deps.size() + " dependencies", DIM_STYLE);
+        tableView.setVisibleRows(area.height() - 3);
+        tableView.setWidth(area.width() - 2);
+        tableView.render(buffer, area.y() + 1, area.x() + 1);
+    }
+
+    @Override
+    public boolean handlePanelKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                tableView.moveDown();
+                ctx.requestRedraw();
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                tableView.moveUp();
+                ctx.requestRedraw();
+                return true;
+            case KeyCode.PAGE_DOWN:
+                tableView.pageDown();
+                ctx.requestRedraw();
+                return true;
+            case KeyCode.PAGE_UP:
+                tableView.pageUp();
+                ctx.requestRedraw();
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    protected String getFooterText() {
+        return "[j/k] Navigate";
+    }
+
+    private static class WebDep {
+        final String name;
+        final String version;
+
+        WebDep(String name, String version) {
+            this.name = name;
+            this.version = version;
+        }
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/BuildMetricsScreen.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/BuildMetricsScreen.java
@@ -1,0 +1,210 @@
+package io.quarkus.devshell.deployment.tui.screens;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import io.quarkus.devshell.deployment.tui.AppContext;
+import io.quarkus.devshell.deployment.tui.Screen;
+import tools.jackson.databind.JsonNode;
+
+public class BuildMetricsScreen implements Screen {
+
+    private static final Style DIM = Style.EMPTY.gray();
+    private static final Style NORMAL = Style.EMPTY.white();
+    private static final Style SELECTED = Style.EMPTY.onCyan().black().bold();
+    private static final Style HEADER = Style.EMPTY.cyan().bold();
+    private static final Style GREEN = Style.EMPTY.green();
+
+    private AppContext ctx;
+    private volatile boolean loading = true;
+    private volatile String errorMessage;
+    private volatile long totalDuration;
+    private volatile int threadCount;
+    private volatile List<BuildStep> steps = List.of();
+    private int selectedIndex = 0;
+    private int scrollOffset = 0;
+
+    @Override
+    public String getTitle() {
+        return "Build Metrics";
+    }
+
+    @Override
+    public void onEnter(AppContext ctx) {
+        this.ctx = ctx;
+        loadDataAsync();
+    }
+
+    private void loadDataAsync() {
+        loading = true;
+        ctx.requestRedraw();
+
+        CompletableFuture.runAsync(() -> {
+            try {
+                JsonNode result = ctx.getJsonRpcClient().call("devui-build-metrics", "getBuildMetrics");
+                parseBuildMetrics(result);
+                loading = false;
+            } catch (Exception e) {
+                errorMessage = e.getMessage();
+                loading = false;
+            }
+            ctx.requestRedraw();
+        });
+    }
+
+    private void parseBuildMetrics(JsonNode result) {
+        totalDuration = result.path("duration").asLong(0);
+        threadCount = result.path("numberOfThreads").asInt(0);
+
+        List<BuildStep> list = new ArrayList<>();
+        JsonNode items = result.path("records");
+        if (items.isArray()) {
+            for (JsonNode item : items) {
+                list.add(new BuildStep(
+                        item.path("stepId").asText(item.path("name").asText("")),
+                        item.path("duration").asLong(0),
+                        item.path("thread").asText("")));
+            }
+        }
+        list.sort((a, b) -> Long.compare(b.duration, a.duration));
+        steps = list;
+    }
+
+    @Override
+    public void render(Rect area, Buffer buffer) {
+        if (loading) {
+            buffer.setString(area.x() + 2, area.y() + 1, "Loading build metrics...", Style.EMPTY.yellow());
+            return;
+        }
+        if (errorMessage != null) {
+            buffer.setString(area.x() + 2, area.y() + 1, "Error: " + errorMessage, Style.EMPTY.red());
+            return;
+        }
+
+        var areas = Layout.vertical()
+                .constraints(Constraint.length(2), Constraint.fill(), Constraint.length(1))
+                .split(area);
+
+        renderSummary(areas.get(0), buffer);
+        renderSteps(areas.get(1), buffer);
+        renderFooter(areas.get(2), buffer);
+    }
+
+    private void renderSummary(Rect area, Buffer buffer) {
+        buffer.setLine(area.x(), area.y(), Line.from(
+                Span.styled(" Build duration: ", DIM),
+                Span.styled(formatDuration(totalDuration), GREEN),
+                Span.styled("  Threads: ", DIM),
+                Span.styled(String.valueOf(threadCount), NORMAL),
+                Span.styled("  Steps: ", DIM),
+                Span.styled(String.valueOf(steps.size()), NORMAL)));
+
+        buffer.setLine(area.x(), area.y() + 1, Line.from(
+                Span.styled(" Step", HEADER),
+                Span.styled(" ".repeat(Math.max(1, area.width() / 2 - 10)), Style.EMPTY),
+                Span.styled("Duration", HEADER),
+                Span.styled("    Thread", HEADER)));
+    }
+
+    private void renderSteps(Rect area, Buffer buffer) {
+        int visibleRows = area.height();
+        if (selectedIndex < scrollOffset) {
+            scrollOffset = selectedIndex;
+        } else if (selectedIndex >= scrollOffset + visibleRows) {
+            scrollOffset = selectedIndex - visibleRows + 1;
+        }
+
+        int nameWidth = area.width() / 2;
+
+        for (int i = 0; i < visibleRows && (scrollOffset + i) < steps.size(); i++) {
+            int idx = scrollOffset + i;
+            BuildStep step = steps.get(idx);
+            boolean selected = idx == selectedIndex;
+            Style rowStyle = selected ? SELECTED : NORMAL;
+
+            if (selected) {
+                buffer.fill(new Rect(area.x(), area.y() + i, area.width(), 1), new Cell(" ", SELECTED));
+            }
+
+            String name = truncate(step.name, nameWidth);
+            buffer.setString(area.x() + 1, area.y() + i, name, rowStyle);
+            buffer.setString(area.x() + nameWidth + 1, area.y() + i,
+                    String.format("%8s", formatDuration(step.duration)), selected ? SELECTED : GREEN);
+            buffer.setString(area.x() + nameWidth + 12, area.y() + i,
+                    truncate(step.thread, 20), selected ? SELECTED : DIM);
+        }
+    }
+
+    private void renderFooter(Rect area, Buffer buffer) {
+        buffer.setLine(area.x(), area.y(), Line.from(
+                Span.styled(" R", Style.EMPTY.cyan()), Span.styled(" Refresh  ", DIM),
+                Span.styled("ESC", Style.EMPTY.cyan()), Span.styled(" Back", DIM)));
+    }
+
+    @Override
+    public boolean handleKey(int[] keys) {
+        if (keys.length == 1) {
+            switch (keys[0]) {
+                case 'j':
+                    return moveDown();
+                case 'k':
+                    return moveUp();
+                case 'r':
+                case 'R':
+                    loadDataAsync();
+                    return true;
+            }
+        }
+        if (keys.length == 3 && keys[0] == 27 && keys[1] == '[') {
+            if (keys[2] == 'A')
+                return moveUp();
+            if (keys[2] == 'B')
+                return moveDown();
+        }
+        return false;
+    }
+
+    private boolean moveUp() {
+        if (selectedIndex > 0) {
+            selectedIndex--;
+            ctx.requestRedraw();
+            return true;
+        }
+        return false;
+    }
+
+    private boolean moveDown() {
+        if (selectedIndex < steps.size() - 1) {
+            selectedIndex++;
+            ctx.requestRedraw();
+            return true;
+        }
+        return false;
+    }
+
+    private static String formatDuration(long ms) {
+        if (ms < 1000)
+            return ms + "ms";
+        return String.format("%.1fs", ms / 1000.0);
+    }
+
+    private static String truncate(String s, int maxLen) {
+        if (s == null || maxLen <= 0)
+            return "";
+        if (s.length() <= maxLen)
+            return s;
+        return s.substring(0, maxLen - 1) + "~";
+    }
+
+    private record BuildStep(String name, long duration, String thread) {
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/ConfigDetailScreen.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/ConfigDetailScreen.java
@@ -1,0 +1,412 @@
+package io.quarkus.devshell.deployment.tui.screens;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import io.quarkus.devshell.deployment.tui.AppContext;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.Screen;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
+
+public class ConfigDetailScreen implements Screen {
+
+    private static final Style LABEL = Style.EMPTY.cyan();
+    private static final Style VALUE = Style.EMPTY.white();
+    private static final Style VALUE_SET = Style.EMPTY.green();
+    private static final Style VALUE_UNSET = Style.EMPTY.gray();
+    private static final Style DIM = Style.EMPTY.gray();
+    private static final Style WARN = Style.EMPTY.yellow();
+    private static final Style ERROR = Style.EMPTY.red();
+    private static final Style EDIT_STYLE = Style.EMPTY.onWhite().black();
+
+    private enum Mode {
+        VIEW,
+        EDIT,
+        DELETE_CONFIRM
+    }
+
+    private final ConfigurationScreen.ConfigItem item;
+    private AppContext ctx;
+    private Mode mode = Mode.VIEW;
+
+    private String editBuffer = "";
+    private int cursorPos = 0;
+    private String statusMessage;
+    private Style statusStyle = DIM;
+
+    private int descriptionScrollOffset = 0;
+    private List<String> wrappedDescription = List.of();
+
+    public ConfigDetailScreen(ConfigurationScreen.ConfigItem item) {
+        this.item = item;
+    }
+
+    @Override
+    public String getTitle() {
+        return "Config: " + item.name();
+    }
+
+    @Override
+    public void onEnter(AppContext ctx) {
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void render(Rect area, Buffer buffer) {
+        var areas = Layout.vertical()
+                .constraints(Constraint.length(8), Constraint.fill(), Constraint.length(1))
+                .split(area);
+
+        renderProperties(areas.get(0), buffer);
+        renderDescription(areas.get(1), buffer);
+        renderFooter(areas.get(2), buffer);
+    }
+
+    private void renderProperties(Rect area, Buffer buffer) {
+        int x = area.x() + 2;
+        int y = area.y();
+
+        buffer.setString(x, y, "Name:", LABEL);
+        buffer.setString(x + 14, y, item.name(), VALUE);
+        y++;
+
+        buffer.setString(x, y, "Value:", LABEL);
+        if (mode == Mode.EDIT) {
+            String display = editBuffer + " ";
+            buffer.setString(x + 14, y, display, EDIT_STYLE);
+            if (cursorPos < display.length()) {
+                buffer.setString(x + 14 + cursorPos, y, String.valueOf(display.charAt(cursorPos)),
+                        Style.EMPTY.onCyan().black());
+            }
+        } else {
+            if (item.value().isEmpty()) {
+                buffer.setString(x + 14, y, "(not set)", VALUE_UNSET);
+            } else {
+                buffer.setString(x + 14, y, item.value(), VALUE_SET);
+            }
+        }
+        y++;
+
+        buffer.setString(x, y, "Default:", LABEL);
+        String defaultVal = item.defaultValue().isEmpty() ? "(none)" : item.defaultValue();
+        buffer.setString(x + 14, y, defaultVal, DIM);
+        y++;
+
+        buffer.setString(x, y, "Phase:", LABEL);
+        String phaseLabel = formatPhase(item.configPhase());
+        Style phaseStyle = phaseStyle(item.configPhase());
+        buffer.setString(x + 14, y, phaseLabel, phaseStyle);
+        String phaseDesc = phaseDescription(item.configPhase());
+        buffer.setString(x + 14 + phaseLabel.length() + 2, y, phaseDesc, DIM);
+        y++;
+
+        if (!item.sourceName().isEmpty()) {
+            buffer.setString(x, y, "Source:", LABEL);
+            buffer.setString(x + 14, y, item.sourceName(), DIM);
+            y++;
+        }
+
+        if (mode == Mode.DELETE_CONFIRM) {
+            y++;
+            buffer.setString(x, y, "Delete this property? (Y/N)", WARN);
+        }
+
+        if (statusMessage != null) {
+            y++;
+            buffer.setString(x, y, statusMessage, statusStyle);
+        }
+    }
+
+    private void renderDescription(Rect area, Buffer buffer) {
+        int x = area.x() + 2;
+        int y = area.y();
+        int width = area.width() - 4;
+
+        buffer.setString(x, y, "Description:", LABEL);
+        y++;
+
+        String desc = item.description();
+        if (desc == null || desc.isEmpty()) {
+            buffer.setString(x, y, "(no description available)", DIM);
+            return;
+        }
+
+        wrappedDescription = wrapText(desc, Math.max(1, width));
+        int visibleRows = area.height() - 1;
+
+        for (int i = 0; i < visibleRows && (descriptionScrollOffset + i) < wrappedDescription.size(); i++) {
+            buffer.setString(x, y + i, wrappedDescription.get(descriptionScrollOffset + i), VALUE);
+        }
+
+        if (wrappedDescription.size() > visibleRows) {
+            int pct = (int) ((descriptionScrollOffset + visibleRows) * 100.0 / wrappedDescription.size());
+            buffer.setString(area.x() + area.width() - 5, area.y() + area.height() - 1,
+                    Math.min(pct, 100) + "%", DIM);
+        }
+    }
+
+    private void renderFooter(Rect area, Buffer buffer) {
+        if (mode == Mode.EDIT) {
+            buffer.setLine(area.x(), area.y(), Line.from(
+                    Span.styled(" Enter", Style.EMPTY.cyan()), Span.styled(" Save  ", DIM),
+                    Span.styled("ESC", Style.EMPTY.cyan()), Span.styled(" Cancel", DIM)));
+        } else if (mode == Mode.DELETE_CONFIRM) {
+            buffer.setLine(area.x(), area.y(), Line.from(
+                    Span.styled(" Y", Style.EMPTY.cyan()), Span.styled(" Confirm  ", DIM),
+                    Span.styled("N", Style.EMPTY.cyan()), Span.styled(" Cancel", DIM)));
+        } else {
+            buffer.setLine(area.x(), area.y(), Line.from(
+                    Span.styled(" E", Style.EMPTY.cyan()), Span.styled(" Edit  ", DIM),
+                    Span.styled("D", Style.EMPTY.cyan()), Span.styled(" Delete  ", DIM),
+                    Span.styled("R", Style.EMPTY.cyan()), Span.styled(" Refresh  ", DIM),
+                    Span.styled("j/k", Style.EMPTY.cyan()), Span.styled(" Scroll  ", DIM),
+                    Span.styled("ESC", Style.EMPTY.cyan()), Span.styled(" Back", DIM)));
+        }
+    }
+
+    @Override
+    public boolean handleKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+
+        switch (mode) {
+            case EDIT:
+                return handleEditKey(key);
+            case DELETE_CONFIRM:
+                return handleDeleteConfirmKey(key);
+            default:
+                return handleViewKey(key);
+        }
+    }
+
+    private boolean handleViewKey(int key) {
+        switch (key) {
+            case 'e':
+            case 'E':
+                mode = Mode.EDIT;
+                editBuffer = item.value();
+                cursorPos = editBuffer.length();
+                statusMessage = null;
+                ctx.requestRedraw();
+                return true;
+            case 'd':
+            case 'D':
+                mode = Mode.DELETE_CONFIRM;
+                statusMessage = null;
+                ctx.requestRedraw();
+                return true;
+            case 'r':
+            case 'R':
+                statusMessage = null;
+                ctx.requestRedraw();
+                return true;
+            case 'j':
+            case KeyCode.DOWN:
+                return scrollDown();
+            case 'k':
+            case KeyCode.UP:
+                return scrollUp();
+            case KeyCode.ESCAPE:
+                return false;
+        }
+        return false;
+    }
+
+    private boolean handleEditKey(int key) {
+        switch (key) {
+            case KeyCode.ENTER:
+            case KeyCode.NEWLINE:
+                saveProperty();
+                return true;
+            case KeyCode.ESCAPE:
+                mode = Mode.VIEW;
+                ctx.requestRedraw();
+                return true;
+            case KeyCode.BACKSPACE:
+            case 8:
+                if (cursorPos > 0) {
+                    editBuffer = editBuffer.substring(0, cursorPos - 1) + editBuffer.substring(cursorPos);
+                    cursorPos--;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case KeyCode.LEFT:
+                if (cursorPos > 0) {
+                    cursorPos--;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case KeyCode.RIGHT:
+                if (cursorPos < editBuffer.length()) {
+                    cursorPos++;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case KeyCode.HOME:
+                cursorPos = 0;
+                ctx.requestRedraw();
+                return true;
+            case KeyCode.END:
+                cursorPos = editBuffer.length();
+                ctx.requestRedraw();
+                return true;
+            default:
+                if (KeyCode.isPrintable(key)) {
+                    editBuffer = editBuffer.substring(0, cursorPos) + (char) key + editBuffer.substring(cursorPos);
+                    cursorPos++;
+                    ctx.requestRedraw();
+                }
+                return true;
+        }
+    }
+
+    private boolean handleDeleteConfirmKey(int key) {
+        switch (key) {
+            case 'y':
+            case 'Y':
+                deleteProperty();
+                return true;
+            case 'n':
+            case 'N':
+            case KeyCode.ESCAPE:
+                mode = Mode.VIEW;
+                ctx.requestRedraw();
+                return true;
+        }
+        return true;
+    }
+
+    private void saveProperty() {
+        mode = Mode.VIEW;
+        statusMessage = "Saving...";
+        statusStyle = WARN;
+        ctx.requestRedraw();
+
+        CompletableFuture.runAsync(() -> {
+            try {
+                ObjectMapper mapper = new ObjectMapper();
+                ObjectNode params = mapper.createObjectNode();
+                params.put("name", item.name());
+                params.put("value", editBuffer);
+                ctx.getJsonRpcClient().call("devui-configuration", "updateProperty", params);
+
+                String phaseHint = "";
+                if ("BUILD_TIME".equals(item.configPhase())) {
+                    phaseHint = " (rebuild required for build-time property)";
+                } else if ("BUILD_AND_RUN_TIME_FIXED".equals(item.configPhase())) {
+                    phaseHint = " (restart required for build+run-time property)";
+                }
+                statusMessage = "Saved successfully" + phaseHint;
+                statusStyle = VALUE_SET;
+            } catch (Exception e) {
+                statusMessage = "Save failed: " + e.getMessage();
+                statusStyle = ERROR;
+            }
+            ctx.requestRedraw();
+        });
+    }
+
+    private void deleteProperty() {
+        mode = Mode.VIEW;
+        statusMessage = "Deleting...";
+        statusStyle = WARN;
+        ctx.requestRedraw();
+
+        CompletableFuture.runAsync(() -> {
+            try {
+                ObjectMapper mapper = new ObjectMapper();
+                ObjectNode params = mapper.createObjectNode();
+                params.put("name", item.name());
+                ctx.getJsonRpcClient().call("devui-configuration", "removeProperty", params);
+                statusMessage = "Property removed";
+                statusStyle = VALUE_SET;
+            } catch (Exception e) {
+                statusMessage = "Delete failed: " + e.getMessage();
+                statusStyle = ERROR;
+            }
+            ctx.requestRedraw();
+        });
+    }
+
+    private boolean scrollUp() {
+        if (descriptionScrollOffset > 0) {
+            descriptionScrollOffset--;
+            ctx.requestRedraw();
+            return true;
+        }
+        return true;
+    }
+
+    private boolean scrollDown() {
+        if (descriptionScrollOffset < wrappedDescription.size() - 1) {
+            descriptionScrollOffset++;
+            ctx.requestRedraw();
+            return true;
+        }
+        return true;
+    }
+
+    private static String formatPhase(String phase) {
+        return switch (phase) {
+            case "BUILD_TIME" -> "BUILD_TIME";
+            case "BUILD_AND_RUN_TIME_FIXED" -> "BUILD+RUN";
+            case "RUN_TIME" -> "RUN_TIME";
+            default -> phase;
+        };
+    }
+
+    private static String phaseDescription(String phase) {
+        return switch (phase) {
+            case "BUILD_TIME" -> "Fixed at build time, requires rebuild";
+            case "BUILD_AND_RUN_TIME_FIXED" -> "Set at build time, requires restart";
+            case "RUN_TIME" -> "Can be changed at runtime";
+            default -> "";
+        };
+    }
+
+    private static Style phaseStyle(String phase) {
+        return switch (phase) {
+            case "BUILD_TIME" -> Style.EMPTY.red();
+            case "BUILD_AND_RUN_TIME_FIXED" -> Style.EMPTY.yellow();
+            case "RUN_TIME" -> Style.EMPTY.green();
+            default -> Style.EMPTY.white();
+        };
+    }
+
+    private static List<String> wrapText(String text, int width) {
+        List<String> lines = new ArrayList<>();
+        if (text == null || text.isEmpty() || width <= 0) {
+            return lines;
+        }
+        for (String paragraph : text.split("\n")) {
+            if (paragraph.isEmpty()) {
+                lines.add("");
+                continue;
+            }
+            String[] words = paragraph.split(" ");
+            StringBuilder current = new StringBuilder();
+            for (String word : words) {
+                if (current.length() + word.length() + 1 > width && current.length() > 0) {
+                    lines.add(current.toString());
+                    current = new StringBuilder();
+                }
+                if (current.length() > 0) {
+                    current.append(' ');
+                }
+                current.append(word);
+            }
+            if (current.length() > 0) {
+                lines.add(current.toString());
+            }
+        }
+        return lines;
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/ConfigurationScreen.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/ConfigurationScreen.java
@@ -1,0 +1,303 @@
+package io.quarkus.devshell.deployment.tui.screens;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import io.quarkus.devshell.deployment.tui.AppContext;
+import io.quarkus.devshell.deployment.tui.Screen;
+import tools.jackson.databind.JsonNode;
+
+public class ConfigurationScreen implements Screen {
+
+    private static final Style PHASE_BUILD = Style.EMPTY.red();
+    private static final Style PHASE_BUILD_RUN = Style.EMPTY.yellow();
+    private static final Style PHASE_RUN = Style.EMPTY.green();
+    private static final Style DIM = Style.EMPTY.gray();
+    private static final Style SELECTED = Style.EMPTY.onCyan().black().bold();
+    private static final Style NORMAL = Style.EMPTY.white();
+
+    private AppContext ctx;
+    private volatile List<ConfigItem> items = List.of();
+    private volatile List<ConfigItem> filteredItems = List.of();
+    private volatile boolean loading = true;
+    private volatile String errorMessage;
+    private int selectedIndex = 0;
+    private int scrollOffset = 0;
+    private String filter = "";
+    private boolean filterMode = false;
+
+    @Override
+    public String getTitle() {
+        return "Configuration";
+    }
+
+    @Override
+    public void onEnter(AppContext ctx) {
+        this.ctx = ctx;
+        loadDataAsync();
+    }
+
+    private void loadDataAsync() {
+        loading = true;
+        errorMessage = null;
+        ctx.requestRedraw();
+
+        CompletableFuture.runAsync(() -> {
+            try {
+                JsonNode result = ctx.getJsonRpcClient().call("devui-configuration", "getAllConfiguration");
+                items = parseConfig(result);
+                applyFilter();
+                loading = false;
+            } catch (Exception e) {
+                errorMessage = e.getMessage();
+                items = List.of();
+                filteredItems = List.of();
+                loading = false;
+            }
+            ctx.requestRedraw();
+        });
+    }
+
+    private List<ConfigItem> parseConfig(JsonNode result) {
+        List<ConfigItem> list = new ArrayList<>();
+        JsonNode arr = result.isArray() ? result : result.path("_array");
+        if (!arr.isArray()) {
+            return list;
+        }
+
+        for (JsonNode item : arr) {
+            String currentValue = "";
+            String sourceName = "";
+            JsonNode cv = item.path("configValue");
+            if (cv.isObject()) {
+                currentValue = cv.path("value").asText("");
+                sourceName = cv.path("sourceName").asText("");
+            } else if (cv.isTextual()) {
+                currentValue = cv.asText("");
+            }
+
+            list.add(new ConfigItem(
+                    item.path("name").asText(""),
+                    item.path("description").asText(""),
+                    item.path("defaultValue").asText(""),
+                    currentValue,
+                    item.path("configPhase").asText(""),
+                    sourceName));
+        }
+        return list;
+    }
+
+    private void applyFilter() {
+        if (filter.isEmpty()) {
+            filteredItems = new ArrayList<>(items);
+        } else {
+            String lowerFilter = filter.toLowerCase();
+            filteredItems = items.stream()
+                    .filter(i -> i.name.toLowerCase().contains(lowerFilter)
+                            || i.value.toLowerCase().contains(lowerFilter))
+                    .toList();
+        }
+        selectedIndex = Math.min(selectedIndex, Math.max(0, filteredItems.size() - 1));
+    }
+
+    @Override
+    public void render(Rect area, Buffer buffer) {
+        if (loading) {
+            buffer.setString(area.x() + 2, area.y() + 1, "Loading configuration...", Style.EMPTY.yellow());
+            return;
+        }
+        if (errorMessage != null) {
+            buffer.setString(area.x() + 2, area.y() + 1, "Error: " + errorMessage, Style.EMPTY.red());
+            return;
+        }
+
+        var areas = Layout.vertical()
+                .constraints(Constraint.length(1), Constraint.length(1), Constraint.fill(), Constraint.length(1))
+                .split(area);
+
+        renderLegend(areas.get(0), buffer);
+        renderFilterBar(areas.get(1), buffer);
+        renderTable(areas.get(2), buffer);
+        renderFooter(areas.get(3), buffer);
+    }
+
+    private void renderLegend(Rect area, Buffer buffer) {
+        buffer.setLine(area.x(), area.y(), Line.from(
+                Span.styled(" * ", PHASE_BUILD), Span.styled("BUILD ", DIM),
+                Span.styled(" * ", PHASE_BUILD_RUN), Span.styled("BUILD+RUN ", DIM),
+                Span.styled(" * ", PHASE_RUN), Span.styled("RUN ", DIM),
+                Span.styled("  " + filteredItems.size() + "/" + items.size() + " properties", DIM)));
+    }
+
+    private void renderFilterBar(Rect area, Buffer buffer) {
+        if (filterMode) {
+            buffer.setLine(area.x(), area.y(), Line.from(
+                    Span.styled(" Filter: ", Style.EMPTY.yellow()),
+                    Span.styled(filter + "_", NORMAL)));
+        } else if (!filter.isEmpty()) {
+            buffer.setLine(area.x(), area.y(), Line.from(
+                    Span.styled(" Filter: ", DIM),
+                    Span.styled(filter, NORMAL),
+                    Span.styled("  (/ to edit, Esc to clear)", DIM)));
+        }
+    }
+
+    private void renderTable(Rect area, Buffer buffer) {
+        int visibleRows = area.height();
+        if (selectedIndex < scrollOffset) {
+            scrollOffset = selectedIndex;
+        } else if (selectedIndex >= scrollOffset + visibleRows) {
+            scrollOffset = selectedIndex - visibleRows + 1;
+        }
+
+        for (int i = 0; i < visibleRows && (scrollOffset + i) < filteredItems.size(); i++) {
+            int idx = scrollOffset + i;
+            ConfigItem item = filteredItems.get(idx);
+            boolean selected = idx == selectedIndex;
+            Style rowStyle = selected ? SELECTED : NORMAL;
+
+            if (selected) {
+                buffer.fill(new Rect(area.x(), area.y() + i, area.width(), 1), new Cell(" ", SELECTED));
+            }
+
+            Style phaseStyle = switch (item.configPhase) {
+                case "BUILD_TIME" -> PHASE_BUILD;
+                case "BUILD_AND_RUN_TIME_FIXED" -> PHASE_BUILD_RUN;
+                default -> PHASE_RUN;
+            };
+
+            int x = area.x();
+            buffer.setString(x, area.y() + i, " * ", selected ? rowStyle : phaseStyle);
+            x += 3;
+
+            int nameWidth = area.width() / 2;
+            String name = truncate(item.name, nameWidth);
+            buffer.setString(x, area.y() + i, name, rowStyle);
+            x += nameWidth;
+
+            String value = item.value.isEmpty() ? "(not set)" : item.value;
+            value = truncate(value, area.width() - x + area.x());
+            buffer.setString(x, area.y() + i, value, selected ? rowStyle : DIM);
+        }
+    }
+
+    private void renderFooter(Rect area, Buffer buffer) {
+        buffer.setLine(area.x(), area.y(), Line.from(
+                Span.styled(" Enter", Style.EMPTY.cyan()), Span.styled(" Details  ", DIM),
+                Span.styled("/", Style.EMPTY.cyan()), Span.styled(" Filter  ", DIM),
+                Span.styled("R", Style.EMPTY.cyan()), Span.styled(" Refresh  ", DIM),
+                Span.styled("ESC", Style.EMPTY.cyan()), Span.styled(" Back", DIM)));
+    }
+
+    @Override
+    public boolean handleKey(int[] keys) {
+        if (loading) {
+            return false;
+        }
+        if (filterMode) {
+            return handleFilterKey(keys);
+        }
+
+        if (keys.length == 1) {
+            switch (keys[0]) {
+                case 'j':
+                    return moveDown();
+                case 'k':
+                    return moveUp();
+                case '/':
+                    filterMode = true;
+                    ctx.requestRedraw();
+                    return true;
+                case '\r':
+                case '\n':
+                    if (!filteredItems.isEmpty()) {
+                        ctx.navigateTo(new ConfigDetailScreen(filteredItems.get(selectedIndex)));
+                    }
+                    return true;
+                case 'r':
+                case 'R':
+                    loadDataAsync();
+                    return true;
+            }
+        }
+        if (keys.length == 3 && keys[0] == 27 && keys[1] == '[') {
+            if (keys[2] == 'A')
+                return moveUp();
+            if (keys[2] == 'B')
+                return moveDown();
+        }
+        return false;
+    }
+
+    private boolean handleFilterKey(int[] keys) {
+        if (keys.length == 1) {
+            int k = keys[0];
+            if (k == 27) {
+                filterMode = false;
+                filter = "";
+                applyFilter();
+                ctx.requestRedraw();
+                return true;
+            }
+            if (k == '\r' || k == '\n') {
+                filterMode = false;
+                ctx.requestRedraw();
+                return true;
+            }
+            if (k == 127 || k == 8) {
+                if (!filter.isEmpty()) {
+                    filter = filter.substring(0, filter.length() - 1);
+                    applyFilter();
+                    ctx.requestRedraw();
+                }
+                return true;
+            }
+            if (k >= 32 && k < 127) {
+                filter += (char) k;
+                applyFilter();
+                ctx.requestRedraw();
+                return true;
+            }
+        }
+        return true;
+    }
+
+    private boolean moveUp() {
+        if (selectedIndex > 0) {
+            selectedIndex--;
+            ctx.requestRedraw();
+            return true;
+        }
+        return false;
+    }
+
+    private boolean moveDown() {
+        if (selectedIndex < filteredItems.size() - 1) {
+            selectedIndex++;
+            ctx.requestRedraw();
+            return true;
+        }
+        return false;
+    }
+
+    private static String truncate(String s, int maxLen) {
+        if (s == null || maxLen <= 0)
+            return "";
+        if (s.length() <= maxLen)
+            return s;
+        return s.substring(0, maxLen - 1) + "~";
+    }
+
+    record ConfigItem(String name, String description, String defaultValue, String value, String configPhase,
+            String sourceName) {
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/ContinuousTestingScreen.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/ContinuousTestingScreen.java
@@ -1,0 +1,178 @@
+package io.quarkus.devshell.deployment.tui.screens;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import io.quarkus.devshell.deployment.tui.AppContext;
+import io.quarkus.devshell.deployment.tui.Screen;
+import tools.jackson.databind.JsonNode;
+
+public class ContinuousTestingScreen implements Screen {
+
+    private static final Style GREEN = Style.EMPTY.green();
+    private static final Style RED = Style.EMPTY.red();
+    private static final Style YELLOW = Style.EMPTY.yellow();
+    private static final Style DIM = Style.EMPTY.gray();
+    private static final Style NORMAL = Style.EMPTY.white();
+    private static final String NAMESPACE = "devui-continuous-testing";
+
+    private AppContext ctx;
+    private boolean running;
+    private boolean inProgress;
+    private long passed;
+    private long failed;
+    private long skipped;
+    private String statusMessage = "Loading...";
+
+    @Override
+    public String getTitle() {
+        return "Continuous Testing";
+    }
+
+    @Override
+    public void onEnter(AppContext ctx) {
+        this.ctx = ctx;
+        loadState();
+    }
+
+    private void loadState() {
+        try {
+            JsonNode result = ctx.getJsonRpcClient().call(NAMESPACE, "currentState");
+            parseState(result);
+        } catch (Exception e) {
+            statusMessage = "Continuous testing not available";
+        }
+    }
+
+    private void parseState(JsonNode state) {
+        JsonNode config = state.path("config");
+        running = config.path("enabled").asBoolean(false);
+        inProgress = state.path("inProgress").asBoolean(false);
+
+        JsonNode result = state.path("result");
+        JsonNode counts = result.path("counts");
+        passed = counts.path("passed").asLong(0);
+        failed = counts.path("failed").asLong(0);
+        skipped = counts.path("skipped").asLong(0);
+
+        statusMessage = running ? "Running" : "Stopped";
+    }
+
+    @Override
+    public void render(Rect area, Buffer buffer) {
+        var areas = Layout.vertical()
+                .constraints(Constraint.length(3), Constraint.fill(), Constraint.length(1))
+                .split(area);
+
+        renderStatus(areas.get(0), buffer);
+        renderResults(areas.get(1), buffer);
+        renderFooter(areas.get(2), buffer);
+    }
+
+    private void renderStatus(Rect area, Buffer buffer) {
+        Style statusColor = running ? GREEN : RED;
+        String statusIcon = running ? "*" : "o";
+
+        buffer.setLine(area.x() + 1, area.y(), Line.from(
+                Span.styled(statusIcon + " ", statusColor),
+                Span.styled(statusMessage, statusColor.bold())));
+
+        if (inProgress) {
+            buffer.setString(area.x() + 1, area.y() + 1, ">> Testing in progress...", YELLOW);
+        }
+
+        buffer.setLine(area.x() + 1, area.y() + 2, Line.from(
+                Span.styled("+ ", GREEN), Span.styled(passed + " passed  ", NORMAL),
+                Span.styled("x ", RED), Span.styled(failed + " failed  ", NORMAL),
+                Span.styled("- ", YELLOW), Span.styled(skipped + " skipped", NORMAL)));
+    }
+
+    private void renderResults(Rect area, Buffer buffer) {
+        if (!running) {
+            buffer.setString(area.x() + 2, area.y() + 1, "Press [S] to start continuous testing", DIM);
+            return;
+        }
+
+        long total = passed + failed + skipped;
+        if (total == 0) {
+            buffer.setString(area.x() + 2, area.y() + 1, "No test results yet", DIM);
+            return;
+        }
+
+        int barWidth = Math.max(1, area.width() - 4);
+        int passedWidth = total > 0 ? (int) (passed * barWidth / total) : 0;
+        int failedWidth = total > 0 ? (int) (failed * barWidth / total) : 0;
+        int skippedWidth = barWidth - passedWidth - failedWidth;
+
+        int x = area.x() + 2;
+        int y = area.y() + 1;
+        for (int i = 0; i < passedWidth; i++) {
+            buffer.set(x + i, y, new Cell("#", GREEN));
+        }
+        for (int i = 0; i < failedWidth; i++) {
+            buffer.set(x + passedWidth + i, y, new Cell("#", RED));
+        }
+        for (int i = 0; i < skippedWidth; i++) {
+            buffer.set(x + passedWidth + failedWidth + i, y, new Cell(".", YELLOW));
+        }
+    }
+
+    private void renderFooter(Rect area, Buffer buffer) {
+        if (running) {
+            buffer.setLine(area.x(), area.y(), Line.from(
+                    Span.styled(" S", Style.EMPTY.cyan()), Span.styled(" Stop  ", DIM),
+                    Span.styled("A", Style.EMPTY.cyan()), Span.styled(" Run All  ", DIM),
+                    Span.styled("F", Style.EMPTY.cyan()), Span.styled(" Run Failed  ", DIM),
+                    Span.styled("R", Style.EMPTY.cyan()), Span.styled(" Refresh  ", DIM),
+                    Span.styled("ESC", Style.EMPTY.cyan()), Span.styled(" Back", DIM)));
+        } else {
+            buffer.setLine(area.x(), area.y(), Line.from(
+                    Span.styled(" S", Style.EMPTY.cyan()), Span.styled(" Start  ", DIM),
+                    Span.styled("R", Style.EMPTY.cyan()), Span.styled(" Refresh  ", DIM),
+                    Span.styled("ESC", Style.EMPTY.cyan()), Span.styled(" Back", DIM)));
+        }
+    }
+
+    @Override
+    public boolean handleKey(int[] keys) {
+        if (keys.length != 1)
+            return false;
+        switch (keys[0]) {
+            case 's':
+            case 'S':
+                invokeAction(running ? "stop" : "start");
+                return true;
+            case 'a':
+            case 'A':
+                if (running)
+                    invokeAction("runAll");
+                return true;
+            case 'f':
+            case 'F':
+                if (running)
+                    invokeAction("runFailed");
+                return true;
+            case 'r':
+            case 'R':
+                loadState();
+                ctx.requestRedraw();
+                return true;
+        }
+        return false;
+    }
+
+    private void invokeAction(String action) {
+        try {
+            ctx.getJsonRpcClient().call(NAMESPACE, action);
+        } catch (Exception e) {
+            statusMessage = "Action failed: " + e.getMessage();
+        }
+        loadState();
+        ctx.requestRedraw();
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/DependenciesScreen.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/DependenciesScreen.java
@@ -1,0 +1,140 @@
+package io.quarkus.devshell.deployment.tui.screens;
+
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import io.quarkus.devshell.deployment.DevShellContext;
+import io.quarkus.devshell.deployment.tui.AppContext;
+import io.quarkus.devshell.deployment.tui.Screen;
+
+public class DependenciesScreen implements Screen {
+
+    private static final Style DIM = Style.EMPTY.gray();
+    private static final Style NORMAL = Style.EMPTY.white();
+    private static final Style SELECTED = Style.EMPTY.onCyan().black().bold();
+    private static final Style GREEN = Style.EMPTY.green();
+    private static final Style CYAN = Style.EMPTY.cyan();
+
+    private AppContext ctx;
+    private List<DependencyInfo> deps = List.of();
+    private int selectedIndex = 0;
+    private int scrollOffset = 0;
+
+    @Override
+    public String getTitle() {
+        return "Dependencies";
+    }
+
+    @Override
+    public void onEnter(AppContext ctx) {
+        this.ctx = ctx;
+        deps = DevShellContext.getDependencyInfos();
+    }
+
+    @Override
+    public void render(Rect area, Buffer buffer) {
+        var areas = Layout.vertical()
+                .constraints(Constraint.length(1), Constraint.fill(), Constraint.length(1))
+                .split(area);
+
+        buffer.setLine(areas.get(0).x(), areas.get(0).y(), Line.from(
+                Span.styled(" " + deps.size() + " dependencies", DIM)));
+
+        renderList(areas.get(1), buffer);
+        renderFooter(areas.get(2), buffer);
+    }
+
+    private void renderList(Rect area, Buffer buffer) {
+        int visibleRows = area.height();
+        if (selectedIndex < scrollOffset) {
+            scrollOffset = selectedIndex;
+        } else if (selectedIndex >= scrollOffset + visibleRows) {
+            scrollOffset = selectedIndex - visibleRows + 1;
+        }
+
+        for (int i = 0; i < visibleRows && (scrollOffset + i) < deps.size(); i++) {
+            int idx = scrollOffset + i;
+            DependencyInfo dep = deps.get(idx);
+            boolean selected = idx == selectedIndex;
+
+            if (selected) {
+                buffer.fill(new Rect(area.x(), area.y() + i, area.width(), 1), new Cell(" ", SELECTED));
+            }
+
+            Style aStyle = selected ? SELECTED : NORMAL;
+            Style vStyle = selected ? SELECTED : GREEN;
+            Style sStyle = selected ? SELECTED : CYAN;
+
+            int x = area.x() + 1;
+            String groupArt = dep.groupId + ":" + dep.artifactId;
+            int nameWidth = area.width() * 2 / 3;
+            buffer.setString(x, area.y() + i, truncate(groupArt, nameWidth), aStyle);
+            x += nameWidth + 1;
+            buffer.setString(x, area.y() + i, truncate(dep.version, 15), vStyle);
+            x += 16;
+            if (!dep.scope.isEmpty()) {
+                buffer.setString(x, area.y() + i, dep.scope, sStyle);
+            }
+        }
+    }
+
+    private void renderFooter(Rect area, Buffer buffer) {
+        buffer.setLine(area.x(), area.y(), Line.from(
+                Span.styled(" ESC", Style.EMPTY.cyan()), Span.styled(" Back", DIM)));
+    }
+
+    @Override
+    public boolean handleKey(int[] keys) {
+        if (keys.length == 1) {
+            switch (keys[0]) {
+                case 'j':
+                    return moveDown();
+                case 'k':
+                    return moveUp();
+            }
+        }
+        if (keys.length == 3 && keys[0] == 27 && keys[1] == '[') {
+            if (keys[2] == 'A')
+                return moveUp();
+            if (keys[2] == 'B')
+                return moveDown();
+        }
+        return false;
+    }
+
+    private boolean moveUp() {
+        if (selectedIndex > 0) {
+            selectedIndex--;
+            ctx.requestRedraw();
+            return true;
+        }
+        return false;
+    }
+
+    private boolean moveDown() {
+        if (selectedIndex < deps.size() - 1) {
+            selectedIndex++;
+            ctx.requestRedraw();
+            return true;
+        }
+        return false;
+    }
+
+    private static String truncate(String s, int maxLen) {
+        if (s == null || maxLen <= 0)
+            return "";
+        if (s.length() <= maxLen)
+            return s;
+        return s.substring(0, maxLen - 1) + "~";
+    }
+
+    public record DependencyInfo(String groupId, String artifactId, String version, String scope) {
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/DevServicesScreen.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/DevServicesScreen.java
@@ -1,0 +1,228 @@
+package io.quarkus.devshell.deployment.tui.screens;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.text.Text;
+import dev.tamboui.widgets.block.Block;
+import dev.tamboui.widgets.block.Borders;
+import dev.tamboui.widgets.paragraph.Paragraph;
+import io.quarkus.devshell.deployment.tui.AppContext;
+import io.quarkus.devshell.deployment.tui.Screen;
+import tools.jackson.databind.JsonNode;
+
+public class DevServicesScreen implements Screen {
+
+    private static final Style GREEN = Style.EMPTY.green();
+    private static final Style YELLOW = Style.EMPTY.yellow();
+    private static final Style DIM = Style.EMPTY.gray();
+    private static final Style NORMAL = Style.EMPTY.white();
+    private static final Style SELECTED = Style.EMPTY.onCyan().black().bold();
+    private static final Style LABEL = Style.EMPTY.cyan();
+
+    private AppContext ctx;
+    private List<DevService> services = List.of();
+    private int selectedIndex = 0;
+
+    @Override
+    public String getTitle() {
+        return "Dev Services";
+    }
+
+    @Override
+    public void onEnter(AppContext ctx) {
+        this.ctx = ctx;
+        loadData();
+    }
+
+    private void loadData() {
+        try {
+            JsonNode result = ctx.getJsonRpcClient().call("devui-dev-services", "getDevServices");
+            services = parseServices(result);
+        } catch (Exception e) {
+            services = List.of();
+        }
+    }
+
+    private List<DevService> parseServices(JsonNode result) {
+        List<DevService> list = new ArrayList<>();
+        JsonNode arr = result.isArray() ? result : null;
+        if (arr == null) {
+            return list;
+        }
+
+        for (JsonNode ds : arr) {
+            list.add(new DevService(
+                    ds.path("name").asText(""),
+                    ds.path("description").asText(""),
+                    ds.path("containerInfo"),
+                    ds.path("configs")));
+        }
+        return list;
+    }
+
+    @Override
+    public void render(Rect area, Buffer buffer) {
+        if (services.isEmpty()) {
+            Paragraph p = Paragraph.builder()
+                    .text(Text.from(Line.from(Span.styled(" No dev services running", DIM))))
+                    .build();
+            p.render(area, buffer);
+            return;
+        }
+
+        var areas = Layout.horizontal()
+                .constraints(Constraint.percentage(35), Constraint.percentage(65))
+                .split(area);
+
+        renderServiceList(areas.get(0), buffer);
+        renderServiceDetail(areas.get(1), buffer);
+    }
+
+    private void renderServiceList(Rect area, Buffer buffer) {
+        Block listBlock = Block.builder()
+                .title(" Services (" + services.size() + ") ")
+                .borders(Borders.ALL)
+                .build();
+        Rect inner = listBlock.inner(area);
+        listBlock.render(area, buffer);
+
+        for (int i = 0; i < services.size() && i < inner.height(); i++) {
+            DevService svc = services.get(i);
+            boolean selected = i == selectedIndex;
+            boolean hasContainer = svc.containerInfo != null && !svc.containerInfo.isMissingNode();
+
+            if (selected) {
+                buffer.fill(new Rect(inner.x(), inner.y() + i, inner.width(), 1), new Cell(" ", SELECTED));
+            }
+
+            Style iconStyle = selected ? SELECTED : (hasContainer ? GREEN : YELLOW);
+            String icon = hasContainer ? "# " : "o ";
+            buffer.setString(inner.x(), inner.y() + i, icon, iconStyle);
+            buffer.setString(inner.x() + 2, inner.y() + i,
+                    truncate(svc.name, inner.width() - 2), selected ? SELECTED : NORMAL);
+        }
+    }
+
+    private void renderServiceDetail(Rect area, Buffer buffer) {
+        if (selectedIndex >= services.size())
+            return;
+        DevService svc = services.get(selectedIndex);
+
+        Block detailBlock = Block.builder()
+                .title(" " + svc.name + " ")
+                .borders(Borders.ALL)
+                .build();
+        Rect inner = detailBlock.inner(area);
+        detailBlock.render(area, buffer);
+
+        int y = inner.y();
+
+        if (!svc.description.isEmpty()) {
+            buffer.setString(inner.x(), y++, svc.description, NORMAL);
+            y++;
+        }
+
+        if (svc.containerInfo != null && !svc.containerInfo.isMissingNode()) {
+            buffer.setString(inner.x(), y++, "Container", LABEL.bold());
+            renderField(buffer, inner.x(), y++, "Image", svc.containerInfo.path("imageName").asText(""), inner.width());
+            renderField(buffer, inner.x(), y++, "ID",
+                    truncate(svc.containerInfo.path("id").asText(""), 12), inner.width());
+            renderField(buffer, inner.x(), y++, "Status", svc.containerInfo.path("status").asText(""), inner.width());
+
+            JsonNode ports = svc.containerInfo.path("exposedPorts");
+            if (ports.isArray() && ports.size() > 0) {
+                StringBuilder portStr = new StringBuilder();
+                for (int i = 0; i < ports.size(); i++) {
+                    JsonNode p = ports.get(i);
+                    if (i > 0)
+                        portStr.append(", ");
+                    portStr.append(p.path("publicPort").asInt(0))
+                            .append("->").append(p.path("privatePort").asInt(0))
+                            .append("/").append(p.path("type").asText("tcp"));
+                }
+                renderField(buffer, inner.x(), y++, "Ports", portStr.toString(), inner.width());
+            }
+            y++;
+        }
+
+        if (svc.configs != null && !svc.configs.isMissingNode() && svc.configs.isObject()) {
+            buffer.setString(inner.x(), y++, "Configuration", LABEL.bold());
+            Iterator<String> fields = svc.configs.propertyNames().iterator();
+            while (fields.hasNext() && y < inner.y() + inner.height()) {
+                String key = fields.next();
+                String value = svc.configs.path(key).asText("");
+                buffer.setString(inner.x(), y, truncate(key, inner.width() / 2), LABEL);
+                buffer.setString(inner.x() + inner.width() / 2, y, truncate(value, inner.width() / 2), DIM);
+                y++;
+            }
+        }
+    }
+
+    private void renderField(Buffer buffer, int x, int y, String label, String value, int maxWidth) {
+        buffer.setString(x, y, "  " + label + ": ", LABEL);
+        buffer.setString(x + label.length() + 4, y, truncate(value, maxWidth - label.length() - 4), NORMAL);
+    }
+
+    @Override
+    public boolean handleKey(int[] keys) {
+        if (keys.length == 1) {
+            switch (keys[0]) {
+                case 'j':
+                    return moveDown();
+                case 'k':
+                    return moveUp();
+                case 'r':
+                case 'R':
+                    loadData();
+                    ctx.requestRedraw();
+                    return true;
+            }
+        }
+        if (keys.length == 3 && keys[0] == 27 && keys[1] == '[') {
+            if (keys[2] == 'A')
+                return moveUp();
+            if (keys[2] == 'B')
+                return moveDown();
+        }
+        return false;
+    }
+
+    private boolean moveUp() {
+        if (selectedIndex > 0) {
+            selectedIndex--;
+            ctx.requestRedraw();
+            return true;
+        }
+        return false;
+    }
+
+    private boolean moveDown() {
+        if (selectedIndex < services.size() - 1) {
+            selectedIndex++;
+            ctx.requestRedraw();
+            return true;
+        }
+        return false;
+    }
+
+    private static String truncate(String s, int maxLen) {
+        if (maxLen <= 0)
+            return "";
+        if (s.length() <= maxLen)
+            return s;
+        return s.substring(0, maxLen - 1) + "~";
+    }
+
+    private record DevService(String name, String description, JsonNode containerInfo, JsonNode configs) {
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/EndpointDetailScreen.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/EndpointDetailScreen.java
@@ -1,0 +1,134 @@
+package io.quarkus.devshell.deployment.tui.screens;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import io.quarkus.devshell.deployment.tui.AppContext;
+import io.quarkus.devshell.deployment.tui.Screen;
+
+public class EndpointDetailScreen implements Screen {
+
+    private static final Style LABEL = Style.EMPTY.cyan();
+    private static final Style VALUE = Style.EMPTY.white();
+    private static final Style DIM = Style.EMPTY.gray();
+
+    private final EndpointsScreen.EndpointItem item;
+
+    private String httpMethod = "";
+    private String consumes = "";
+    private String produces = "";
+    private String javaMethod = "";
+
+    public EndpointDetailScreen(EndpointsScreen.EndpointItem item) {
+        this.item = item;
+        parseDescription(item.description());
+    }
+
+    private void parseDescription(String description) {
+        if (description == null || description.isEmpty()) {
+            httpMethod = "GET";
+            return;
+        }
+
+        // Format: "GET (consumes:application/json) (produces:text/html) (java:com.example.Resource#method)"
+        int firstSpace = description.indexOf(' ');
+        int firstParen = description.indexOf('(');
+        int end = firstSpace > 0 ? firstSpace : (firstParen > 0 ? firstParen : description.length());
+        String method = description.substring(0, Math.min(end, 10)).toUpperCase();
+        if (method.matches("GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS")) {
+            httpMethod = method;
+        } else {
+            httpMethod = "GET";
+        }
+
+        consumes = extractField(description, "consumes:");
+        produces = extractField(description, "produces:");
+        javaMethod = extractField(description, "java:");
+    }
+
+    private static String extractField(String description, String prefix) {
+        int start = description.indexOf(prefix);
+        if (start < 0) {
+            return "";
+        }
+        start += prefix.length();
+        int end = description.indexOf(')', start);
+        if (end < 0) {
+            end = description.length();
+        }
+        return description.substring(start, end).trim();
+    }
+
+    @Override
+    public String getTitle() {
+        return "Endpoint: " + item.uri();
+    }
+
+    @Override
+    public void onEnter(AppContext ctx) {
+    }
+
+    @Override
+    public void render(Rect area, Buffer buffer) {
+        var areas = Layout.vertical()
+                .constraints(Constraint.fill(), Constraint.length(1))
+                .split(area);
+
+        renderDetails(areas.get(0), buffer);
+        renderFooter(areas.get(1), buffer);
+    }
+
+    private void renderDetails(Rect area, Buffer buffer) {
+        int x = area.x() + 2;
+        int y = area.y() + 1;
+
+        buffer.setString(x, y, "Path:", LABEL);
+        buffer.setString(x + 14, y, item.uri(), VALUE);
+        y += 2;
+
+        buffer.setString(x, y, "Method:", LABEL);
+        buffer.setString(x + 14, y, httpMethod, methodStyle(httpMethod));
+        y += 2;
+
+        if (!consumes.isEmpty()) {
+            buffer.setString(x, y, "Consumes:", LABEL);
+            buffer.setString(x + 14, y, consumes, VALUE);
+            y += 2;
+        }
+
+        if (!produces.isEmpty()) {
+            buffer.setString(x, y, "Produces:", LABEL);
+            buffer.setString(x + 14, y, produces, VALUE);
+            y += 2;
+        }
+
+        if (!javaMethod.isEmpty()) {
+            buffer.setString(x, y, "Java Method:", LABEL);
+            buffer.setString(x + 14, y, javaMethod, VALUE);
+        }
+    }
+
+    private void renderFooter(Rect area, Buffer buffer) {
+        buffer.setLine(area.x(), area.y(), Line.from(
+                Span.styled(" ESC", Style.EMPTY.cyan()), Span.styled(" Back", DIM)));
+    }
+
+    private static Style methodStyle(String method) {
+        return switch (method) {
+            case "GET" -> Style.EMPTY.green().bold();
+            case "POST" -> Style.EMPTY.yellow().bold();
+            case "PUT" -> Style.EMPTY.blue().bold();
+            case "DELETE" -> Style.EMPTY.red().bold();
+            default -> Style.EMPTY.magenta().bold();
+        };
+    }
+
+    @Override
+    public boolean handleKey(int[] keys) {
+        return false;
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/EndpointsScreen.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/EndpointsScreen.java
@@ -1,0 +1,242 @@
+package io.quarkus.devshell.deployment.tui.screens;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import io.quarkus.devshell.deployment.tui.AppContext;
+import io.quarkus.devshell.deployment.tui.Screen;
+import tools.jackson.databind.JsonNode;
+
+public class EndpointsScreen implements Screen {
+
+    private static final Style METHOD_GET = Style.EMPTY.green().bold();
+    private static final Style METHOD_POST = Style.EMPTY.yellow().bold();
+    private static final Style METHOD_PUT = Style.EMPTY.blue().bold();
+    private static final Style METHOD_DELETE = Style.EMPTY.red().bold();
+    private static final Style METHOD_OTHER = Style.EMPTY.magenta().bold();
+    private static final Style DIM = Style.EMPTY.gray();
+    private static final Style SELECTED = Style.EMPTY.onCyan().black().bold();
+    private static final Style NORMAL = Style.EMPTY.white();
+    private static final Style TAB_ACTIVE = Style.EMPTY.cyan().bold();
+    private static final Style TAB_INACTIVE = Style.EMPTY.gray();
+
+    private AppContext ctx;
+    private final List<EndpointItem> restEndpoints = new ArrayList<>();
+    private final List<EndpointItem> staticResources = new ArrayList<>();
+    private final List<EndpointItem> additionalEndpoints = new ArrayList<>();
+    private int activeTab = 0;
+    private int selectedIndex = 0;
+    private int scrollOffset = 0;
+
+    @Override
+    public String getTitle() {
+        return "Endpoints";
+    }
+
+    @Override
+    public void onEnter(AppContext ctx) {
+        this.ctx = ctx;
+        loadData();
+    }
+
+    private void loadData() {
+        restEndpoints.clear();
+        staticResources.clear();
+        additionalEndpoints.clear();
+
+        try {
+            JsonNode result = ctx.getJsonRpcClient().call("devui-endpoints", "getAllEndpoints");
+            parseEndpoints(result);
+        } catch (Exception e) {
+            // no endpoint data available
+        }
+    }
+
+    private void parseEndpoints(JsonNode result) {
+        addEndpoints(result, "Resource Endpoints", restEndpoints);
+        addEndpoints(result, "Servlet mappings", restEndpoints);
+        addEndpoints(result, "Static resources", staticResources);
+        addEndpoints(result, "Additional endpoints", additionalEndpoints);
+    }
+
+    private void addEndpoints(JsonNode result, String key, List<EndpointItem> target) {
+        JsonNode arr = result.path(key);
+        if (arr.isArray()) {
+            for (JsonNode ep : arr) {
+                target.add(new EndpointItem(
+                        ep.path("uri").asText(""),
+                        ep.path("description").asText("")));
+            }
+        }
+    }
+
+    private List<EndpointItem> activeList() {
+        return switch (activeTab) {
+            case 1 -> staticResources;
+            case 2 -> additionalEndpoints;
+            default -> restEndpoints;
+        };
+    }
+
+    @Override
+    public void render(Rect area, Buffer buffer) {
+        var areas = Layout.vertical()
+                .constraints(Constraint.length(1), Constraint.fill(), Constraint.length(1))
+                .split(area);
+
+        renderTabs(areas.get(0), buffer);
+        renderList(areas.get(1), buffer);
+        renderFooter(areas.get(2), buffer);
+    }
+
+    private void renderTabs(Rect area, Buffer buffer) {
+        buffer.setLine(area.x(), area.y(), Line.from(
+                Span.styled(" REST", activeTab == 0 ? TAB_ACTIVE : TAB_INACTIVE),
+                Span.styled(" (" + restEndpoints.size() + ") ", activeTab == 0 ? TAB_ACTIVE : TAB_INACTIVE),
+                Span.styled("| Static", activeTab == 1 ? TAB_ACTIVE : TAB_INACTIVE),
+                Span.styled(" (" + staticResources.size() + ") ", activeTab == 1 ? TAB_ACTIVE : TAB_INACTIVE),
+                Span.styled("| Additional", activeTab == 2 ? TAB_ACTIVE : TAB_INACTIVE),
+                Span.styled(" (" + additionalEndpoints.size() + ") ", activeTab == 2 ? TAB_ACTIVE : TAB_INACTIVE)));
+    }
+
+    private void renderList(Rect area, Buffer buffer) {
+        List<EndpointItem> list = activeList();
+        int visibleRows = area.height();
+
+        if (selectedIndex < scrollOffset) {
+            scrollOffset = selectedIndex;
+        } else if (selectedIndex >= scrollOffset + visibleRows) {
+            scrollOffset = selectedIndex - visibleRows + 1;
+        }
+
+        for (int i = 0; i < visibleRows && (scrollOffset + i) < list.size(); i++) {
+            int idx = scrollOffset + i;
+            EndpointItem item = list.get(idx);
+            boolean selected = idx == selectedIndex;
+
+            if (selected) {
+                buffer.fill(new Rect(area.x(), area.y() + i, area.width(), 1), new Cell(" ", SELECTED));
+            }
+
+            int x = area.x() + 1;
+            if (activeTab == 0) {
+                String method = extractMethod(item.description);
+                Style methodStyle = methodColor(method);
+                String paddedMethod = String.format("%-7s", method);
+                buffer.setString(x, area.y() + i, paddedMethod, selected ? SELECTED : methodStyle);
+                x += 8;
+            }
+
+            Style pathStyle = selected ? SELECTED : NORMAL;
+            buffer.setString(x, area.y() + i, truncate(item.uri, area.width() - (x - area.x())), pathStyle);
+        }
+
+        if (list.isEmpty()) {
+            buffer.setString(area.x() + 2, area.y() + 1, "No endpoints found", DIM);
+        }
+    }
+
+    private void renderFooter(Rect area, Buffer buffer) {
+        buffer.setLine(area.x(), area.y(), Line.from(
+                Span.styled(" Enter", Style.EMPTY.cyan()), Span.styled(" Details  ", DIM),
+                Span.styled("Tab", Style.EMPTY.cyan()), Span.styled(" Switch  ", DIM),
+                Span.styled("R", Style.EMPTY.cyan()), Span.styled(" Refresh  ", DIM),
+                Span.styled("ESC", Style.EMPTY.cyan()), Span.styled(" Back", DIM)));
+    }
+
+    @Override
+    public boolean handleKey(int[] keys) {
+        if (keys.length == 1) {
+            switch (keys[0]) {
+                case '\t':
+                    activeTab = (activeTab + 1) % 3;
+                    selectedIndex = 0;
+                    scrollOffset = 0;
+                    ctx.requestRedraw();
+                    return true;
+                case '\r':
+                case '\n':
+                    List<EndpointItem> list = activeList();
+                    if (!list.isEmpty() && selectedIndex < list.size()) {
+                        ctx.navigateTo(new EndpointDetailScreen(list.get(selectedIndex)));
+                    }
+                    return true;
+                case 'j':
+                    return moveDown();
+                case 'k':
+                    return moveUp();
+                case 'r':
+                case 'R':
+                    loadData();
+                    ctx.requestRedraw();
+                    return true;
+            }
+        }
+        if (keys.length == 3 && keys[0] == 27 && keys[1] == '[') {
+            if (keys[2] == 'A')
+                return moveUp();
+            if (keys[2] == 'B')
+                return moveDown();
+        }
+        return false;
+    }
+
+    private boolean moveUp() {
+        if (selectedIndex > 0) {
+            selectedIndex--;
+            ctx.requestRedraw();
+            return true;
+        }
+        return false;
+    }
+
+    private boolean moveDown() {
+        if (selectedIndex < activeList().size() - 1) {
+            selectedIndex++;
+            ctx.requestRedraw();
+            return true;
+        }
+        return false;
+    }
+
+    private static String extractMethod(String description) {
+        if (description == null || description.isEmpty())
+            return "GET";
+        int space = description.indexOf(' ');
+        int paren = description.indexOf('(');
+        int end = space > 0 ? space : (paren > 0 ? paren : description.length());
+        String method = description.substring(0, Math.min(end, 10)).toUpperCase();
+        if (method.matches("GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS"))
+            return method;
+        return "GET";
+    }
+
+    private static Style methodColor(String method) {
+        return switch (method) {
+            case "GET" -> METHOD_GET;
+            case "POST" -> METHOD_POST;
+            case "PUT" -> METHOD_PUT;
+            case "DELETE" -> METHOD_DELETE;
+            default -> METHOD_OTHER;
+        };
+    }
+
+    private static String truncate(String s, int maxLen) {
+        if (maxLen <= 0)
+            return "";
+        if (s.length() <= maxLen)
+            return s;
+        return s.substring(0, maxLen - 1) + "~";
+    }
+
+    record EndpointItem(String uri, String description) {
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/ExtensionsListScreen.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/ExtensionsListScreen.java
@@ -1,0 +1,200 @@
+package io.quarkus.devshell.deployment.tui.screens;
+
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.text.Text;
+import dev.tamboui.widgets.block.Block;
+import dev.tamboui.widgets.block.Borders;
+import dev.tamboui.widgets.paragraph.Paragraph;
+import io.quarkus.devshell.deployment.tui.AppContext;
+import io.quarkus.devshell.deployment.tui.Screen;
+import io.quarkus.devshell.deployment.tui.pages.ExtensionPageFactory;
+
+public class ExtensionsListScreen implements Screen {
+
+    private static final Style ACTIVE = Style.EMPTY.green();
+    private static final Style INACTIVE = Style.EMPTY.gray();
+    private static final Style NORMAL = Style.EMPTY.white();
+    private static final Style SELECTED = Style.EMPTY.onCyan().black().bold();
+    private static final Style HEADER = Style.EMPTY.cyan().bold();
+    private static final Style DIM = Style.EMPTY.gray();
+
+    private final List<ExtensionInfo> extensions;
+    private int selectedIndex = 0;
+    private int scrollOffset = 0;
+    private AppContext ctx;
+
+    public ExtensionsListScreen(List<ExtensionInfo> extensions) {
+        this.extensions = extensions;
+    }
+
+    @Override
+    public String getTitle() {
+        return "Extensions";
+    }
+
+    @Override
+    public void onEnter(AppContext ctx) {
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void render(Rect area, Buffer buffer) {
+        long activeCount = extensions.stream().filter(ExtensionInfo::active).count();
+        long inactiveCount = extensions.size() - activeCount;
+
+        var areas = Layout.horizontal()
+                .constraints(Constraint.percentage(40), Constraint.percentage(60))
+                .split(area);
+
+        renderExtensionList(areas.get(0), buffer, activeCount, inactiveCount);
+        renderExtensionDetail(areas.get(1), buffer);
+    }
+
+    private void renderExtensionList(Rect area, Buffer buffer, long activeCount, long inactiveCount) {
+        Block listBlock = Block.builder()
+                .title(" Extensions (" + activeCount + " active, " + inactiveCount + " inactive) ")
+                .borders(Borders.ALL)
+                .build();
+        Rect inner = listBlock.inner(area);
+        listBlock.render(area, buffer);
+
+        int visibleRows = inner.height();
+        if (selectedIndex < scrollOffset) {
+            scrollOffset = selectedIndex;
+        } else if (selectedIndex >= scrollOffset + visibleRows) {
+            scrollOffset = selectedIndex - visibleRows + 1;
+        }
+
+        for (int i = 0; i < visibleRows && (scrollOffset + i) < extensions.size(); i++) {
+            int idx = scrollOffset + i;
+            ExtensionInfo ext = extensions.get(idx);
+            boolean selected = idx == selectedIndex;
+
+            if (selected) {
+                buffer.fill(new Rect(inner.x(), inner.y() + i, inner.width(), 1), new Cell(" ", SELECTED));
+            }
+
+            String icon = ext.active ? "* " : "o ";
+            Style iconStyle = selected ? SELECTED : (ext.active ? ACTIVE : INACTIVE);
+            buffer.setString(inner.x(), inner.y() + i, icon, iconStyle);
+            buffer.setString(inner.x() + 2, inner.y() + i,
+                    truncate(ext.name, inner.width() - 2), selected ? SELECTED : NORMAL);
+        }
+    }
+
+    private void renderExtensionDetail(Rect area, Buffer buffer) {
+        if (selectedIndex >= extensions.size()) {
+            return;
+        }
+        ExtensionInfo ext = extensions.get(selectedIndex);
+
+        Block detailBlock = Block.builder()
+                .title(" " + ext.name + " ")
+                .borders(Borders.ALL)
+                .build();
+        Rect inner = detailBlock.inner(area);
+        detailBlock.render(area, buffer);
+
+        int y = inner.y();
+
+        Style statusStyle = ext.active ? ACTIVE : INACTIVE;
+        buffer.setString(inner.x(), y, ext.active ? "* Active" : "o Inactive", statusStyle);
+        y += 2;
+
+        buffer.setString(inner.x(), y, "Namespace:", HEADER);
+        buffer.setString(inner.x() + 11, y, ext.namespace, DIM);
+        y += 2;
+
+        if (ext.description != null && !ext.description.isEmpty()) {
+            Paragraph desc = Paragraph.builder()
+                    .text(Text.from(Line.from(Span.styled(ext.description, NORMAL))))
+                    .build();
+            Rect descArea = new Rect(inner.x(), y, inner.width(), Math.min(3, inner.height() - (y - inner.y())));
+            desc.render(descArea, buffer);
+            y += 4;
+        }
+
+        if (ext.keywords != null && !ext.keywords.isEmpty()) {
+            buffer.setString(inner.x(), y, "Keywords:", HEADER);
+            y++;
+            buffer.setString(inner.x(), y, truncate(String.join(", ", ext.keywords), inner.width()), DIM);
+            y += 2;
+        }
+
+        buffer.setString(inner.x(), y, "Press Enter to explore", DIM);
+    }
+
+    @Override
+    public boolean handleKey(int[] keys) {
+        if (keys.length == 1) {
+            switch (keys[0]) {
+                case 'j':
+                    return moveDown();
+                case 'k':
+                    return moveUp();
+                case '\r':
+                case '\n':
+                    if (selectedIndex < extensions.size()) {
+                        ExtensionInfo ext = extensions.get(selectedIndex);
+                        Screen page = ExtensionPageFactory.createPage(ext, ctx);
+                        if (page != null) {
+                            ctx.navigateTo(page);
+                        }
+                    }
+                    return true;
+            }
+        }
+        if (keys.length == 3 && keys[0] == 27 && keys[1] == '[') {
+            if (keys[2] == 'A')
+                return moveUp();
+            if (keys[2] == 'B')
+                return moveDown();
+        }
+        return false;
+    }
+
+    private boolean moveUp() {
+        if (selectedIndex > 0) {
+            selectedIndex--;
+            ctx.requestRedraw();
+            return true;
+        }
+        return false;
+    }
+
+    private boolean moveDown() {
+        if (selectedIndex < extensions.size() - 1) {
+            selectedIndex++;
+            ctx.requestRedraw();
+            return true;
+        }
+        return false;
+    }
+
+    private static String truncate(String s, int maxLen) {
+        if (s == null || maxLen <= 0)
+            return "";
+        if (s.length() <= maxLen)
+            return s;
+        return s.substring(0, maxLen - 1) + "~";
+    }
+
+    public record ExtensionInfo(String namespace, String name, String description, List<String> keywords,
+            boolean active) {
+        public ExtensionInfo {
+            namespace = namespace != null ? namespace : "";
+            name = name != null ? name : "";
+            description = description != null ? description : "";
+            keywords = keywords != null ? keywords : List.of();
+        }
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/MainMenuScreen.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/MainMenuScreen.java
@@ -1,0 +1,167 @@
+package io.quarkus.devshell.deployment.tui.screens;
+
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.text.Text;
+import dev.tamboui.widgets.block.Block;
+import dev.tamboui.widgets.block.Borders;
+import dev.tamboui.widgets.paragraph.Paragraph;
+import io.quarkus.devshell.deployment.DevShellContext;
+import io.quarkus.devshell.deployment.tui.AppContext;
+import io.quarkus.devshell.deployment.tui.Screen;
+
+public class MainMenuScreen implements Screen {
+
+    private static final Style SELECTED_STYLE = Style.EMPTY.onCyan().black().bold();
+    private static final Style NORMAL_STYLE = Style.EMPTY.white();
+    private static final Style HEADER_STYLE = Style.EMPTY.cyan().bold();
+    private static final Style DIM_STYLE = Style.EMPTY.gray();
+
+    private final List<MenuItem> menuItems = List.of(
+            new MenuItem("Extensions", "View loaded extensions and their status"),
+            new MenuItem("Configuration", "View and search application configuration properties"),
+            new MenuItem("Endpoints", "Browse HTTP endpoints, static resources and routes"),
+            new MenuItem("Continuous Testing", "Monitor and control continuous test execution"),
+            new MenuItem("Dev Services", "View running dev services and container details"),
+            new MenuItem("Build Metrics", "Build time statistics and step timings"),
+            new MenuItem("Dependencies", "Application dependency tree"),
+            new MenuItem("Readme", "View project README.md file"),
+            new MenuItem("Workspace", "Project workspace overview"));
+
+    private int selectedIndex = 0;
+    private AppContext ctx;
+
+    @Override
+    public String getTitle() {
+        return "Main Menu";
+    }
+
+    @Override
+    public void onEnter(AppContext ctx) {
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void render(Rect area, Buffer buffer) {
+        var areas = Layout.horizontal()
+                .constraints(Constraint.percentage(40), Constraint.percentage(60))
+                .split(area);
+
+        renderMenuList(areas.get(0), buffer);
+        renderDescription(areas.get(1), buffer);
+    }
+
+    private void renderMenuList(Rect area, Buffer buffer) {
+        Block menuBlock = Block.builder()
+                .title(" Menu ")
+                .borders(Borders.ALL)
+                .build();
+
+        Rect inner = menuBlock.inner(area);
+        menuBlock.render(area, buffer);
+
+        for (int i = 0; i < menuItems.size() && i < inner.height(); i++) {
+            MenuItem item = menuItems.get(i);
+            Style style = i == selectedIndex ? SELECTED_STYLE : NORMAL_STYLE;
+            String prefix = i == selectedIndex ? " > " : "   ";
+            String text = prefix + item.title;
+
+            if (i == selectedIndex) {
+                buffer.fill(new Rect(inner.x(), inner.y() + i, inner.width(), 1), new Cell(" ", SELECTED_STYLE));
+            }
+
+            buffer.setString(inner.x(), inner.y() + i, text, style);
+        }
+    }
+
+    private void renderDescription(Rect area, Buffer buffer) {
+        MenuItem selected = menuItems.get(selectedIndex);
+
+        Block descBlock = Block.builder()
+                .title(" " + selected.title + " ")
+                .borders(Borders.ALL)
+                .build();
+
+        Rect inner = descBlock.inner(area);
+        descBlock.render(area, buffer);
+
+        Paragraph desc = Paragraph.builder()
+                .text(Text.from(
+                        Line.from(Span.styled(selected.description, NORMAL_STYLE)),
+                        Line.from(),
+                        Line.from(Span.styled("Press Enter to open, ESC to quit", DIM_STYLE))))
+                .build();
+        desc.render(inner, buffer);
+    }
+
+    @Override
+    public boolean handleKey(int[] keys) {
+        if (keys.length == 1) {
+            switch (keys[0]) {
+                case 'k':
+                    moveUp();
+                    return true;
+                case 'j':
+                    moveDown();
+                    return true;
+                case '\r':
+                case '\n':
+                    openSelected();
+                    return true;
+            }
+        }
+        if (keys.length == 3 && keys[0] == 27 && keys[1] == '[') {
+            if (keys[2] == 'A') {
+                moveUp();
+                return true;
+            } else if (keys[2] == 'B') {
+                moveDown();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void moveUp() {
+        if (selectedIndex > 0) {
+            selectedIndex--;
+            ctx.requestRedraw();
+        }
+    }
+
+    private void moveDown() {
+        if (selectedIndex < menuItems.size() - 1) {
+            selectedIndex++;
+            ctx.requestRedraw();
+        }
+    }
+
+    private void openSelected() {
+        Screen screen = switch (selectedIndex) {
+            case 0 -> new ExtensionsListScreen(DevShellContext.getExtensionInfos());
+            case 1 -> new ConfigurationScreen();
+            case 2 -> new EndpointsScreen();
+            case 3 -> new ContinuousTestingScreen();
+            case 4 -> new DevServicesScreen();
+            case 5 -> new BuildMetricsScreen();
+            case 6 -> new DependenciesScreen();
+            case 7 -> new ReadmeScreen();
+            case 8 -> new WorkspaceScreen();
+            default -> null;
+        };
+        if (screen != null) {
+            ctx.navigateTo(screen);
+        }
+    }
+
+    private record MenuItem(String title, String description) {
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/ReadmeScreen.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/ReadmeScreen.java
@@ -1,0 +1,226 @@
+package io.quarkus.devshell.deployment.tui.screens;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import io.quarkus.devshell.deployment.tui.AppContext;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.Screen;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
+
+public class ReadmeScreen implements Screen {
+
+    private static final Style HEADING1 = Style.EMPTY.cyan().bold();
+    private static final Style HEADING2 = Style.EMPTY.cyan();
+    private static final Style HEADING3 = Style.EMPTY.white().bold();
+    private static final Style NORMAL = Style.EMPTY.white();
+    private static final Style DIM = Style.EMPTY.gray();
+    private static final Style BLOCKQUOTE = Style.EMPTY.gray();
+    private static final Style RULE = Style.EMPTY.gray();
+    private static final Style YELLOW = Style.EMPTY.yellow();
+
+    private AppContext ctx;
+    private volatile boolean loading = true;
+    private volatile String errorMessage;
+    private List<String> lines = List.of();
+    private int scrollOffset = 0;
+
+    @Override
+    public String getTitle() {
+        return "README";
+    }
+
+    @Override
+    public void onEnter(AppContext ctx) {
+        this.ctx = ctx;
+        loadDataAsync();
+    }
+
+    private void loadDataAsync() {
+        loading = true;
+        errorMessage = null;
+        ctx.requestRedraw();
+
+        CompletableFuture.runAsync(() -> {
+            try {
+                JsonNode result = ctx.getJsonRpcClient().call("devui-workspace", "getWorkspaceItems");
+                JsonNode arr = result.isArray() ? result : result.path("items");
+
+                String readmePath = null;
+                if (arr.isArray()) {
+                    for (JsonNode item : arr) {
+                        String name = item.path("name").asText(item.path("fileName").asText(""));
+                        if ("README.md".equalsIgnoreCase(name)) {
+                            readmePath = item.path("path").asText(item.path("filePath").asText(""));
+                            break;
+                        }
+                    }
+                }
+
+                if (readmePath == null || readmePath.isEmpty()) {
+                    errorMessage = "No README.md found in workspace";
+                    loading = false;
+                    ctx.requestRedraw();
+                    return;
+                }
+
+                ObjectMapper mapper = new ObjectMapper();
+                ObjectNode params = mapper.createObjectNode();
+                params.put("path", readmePath);
+                JsonNode content = ctx.getJsonRpcClient().call("devui-workspace", "getWorkspaceItemContent", params);
+
+                boolean isBinary = content.path("isBinary").asBoolean(false);
+                if (isBinary) {
+                    errorMessage = "README.md appears to be a binary file";
+                    loading = false;
+                    ctx.requestRedraw();
+                    return;
+                }
+
+                String text = content.path("content").asText("");
+                if (text.isEmpty()) {
+                    errorMessage = "README.md is empty";
+                } else {
+                    lines = List.of(text.split("\n", -1));
+                }
+                loading = false;
+            } catch (Exception e) {
+                errorMessage = e.getMessage();
+                loading = false;
+            }
+            ctx.requestRedraw();
+        });
+    }
+
+    @Override
+    public void render(Rect area, Buffer buffer) {
+        if (loading) {
+            buffer.setString(area.x() + 2, area.y() + 1, "Loading README.md...", YELLOW);
+            return;
+        }
+        if (errorMessage != null) {
+            buffer.setString(area.x() + 2, area.y() + 1, errorMessage, Style.EMPTY.red());
+            return;
+        }
+
+        var areas = Layout.vertical()
+                .constraints(Constraint.fill(), Constraint.length(1))
+                .split(area);
+
+        renderContent(areas.get(0), buffer);
+        renderFooter(areas.get(1), buffer);
+    }
+
+    private void renderContent(Rect area, Buffer buffer) {
+        int visibleRows = area.height();
+        int width = area.width() - 2;
+
+        for (int i = 0; i < visibleRows && (scrollOffset + i) < lines.size(); i++) {
+            String line = lines.get(scrollOffset + i);
+            int y = area.y() + i;
+            int x = area.x() + 1;
+
+            renderMarkdownLine(buffer, x, y, line, width);
+        }
+
+        if (lines.size() > visibleRows) {
+            int pct = (int) ((scrollOffset + visibleRows) * 100.0 / lines.size());
+            buffer.setString(area.x() + area.width() - 5, area.y() + area.height() - 1,
+                    Math.min(pct, 100) + "%", DIM);
+        }
+    }
+
+    private void renderMarkdownLine(Buffer buffer, int x, int y, String line, int width) {
+        if (line.startsWith("### ")) {
+            buffer.setString(x, y, truncate(line.substring(4), width), HEADING3);
+        } else if (line.startsWith("## ")) {
+            buffer.setString(x, y, truncate(line.substring(3), width), HEADING2);
+        } else if (line.startsWith("# ")) {
+            buffer.setString(x, y, truncate(line.substring(2), width), HEADING1);
+        } else if (line.startsWith("- ") || line.startsWith("* ")) {
+            buffer.setString(x, y, "• " + truncate(line.substring(2), width - 2), NORMAL);
+        } else if (line.startsWith("> ")) {
+            buffer.setString(x, y, "│ " + truncate(line.substring(2), width - 2), BLOCKQUOTE);
+        } else if (line.matches("^[-*_]{3,}$")) {
+            String rule = "─".repeat(Math.max(1, Math.min(width, 40)));
+            buffer.setString(x, y, rule, RULE);
+        } else {
+            String cleaned = line.replace("`", "");
+            buffer.setString(x, y, truncate(cleaned, width), NORMAL);
+        }
+    }
+
+    private void renderFooter(Rect area, Buffer buffer) {
+        buffer.setLine(area.x(), area.y(), Line.from(
+                Span.styled(" j/k", Style.EMPTY.cyan()), Span.styled(" Scroll  ", DIM),
+                Span.styled("PgUp/PgDn", Style.EMPTY.cyan()), Span.styled(" Page  ", DIM),
+                Span.styled("Home/End", Style.EMPTY.cyan()), Span.styled(" Jump  ", DIM),
+                Span.styled("R", Style.EMPTY.cyan()), Span.styled(" Refresh  ", DIM),
+                Span.styled("ESC", Style.EMPTY.cyan()), Span.styled(" Back", DIM)));
+    }
+
+    @Override
+    public boolean handleKey(int[] keys) {
+        if (loading) {
+            return false;
+        }
+
+        int key = KeyCode.parse(keys);
+
+        switch (key) {
+            case 'j':
+            case KeyCode.DOWN:
+                if (scrollOffset < lines.size() - 1) {
+                    scrollOffset++;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case 'k':
+            case KeyCode.UP:
+                if (scrollOffset > 0) {
+                    scrollOffset--;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case KeyCode.PAGE_DOWN:
+                scrollOffset = Math.min(scrollOffset + 20, Math.max(0, lines.size() - 1));
+                ctx.requestRedraw();
+                return true;
+            case KeyCode.PAGE_UP:
+                scrollOffset = Math.max(scrollOffset - 20, 0);
+                ctx.requestRedraw();
+                return true;
+            case KeyCode.HOME:
+                scrollOffset = 0;
+                ctx.requestRedraw();
+                return true;
+            case KeyCode.END:
+                scrollOffset = Math.max(0, lines.size() - 1);
+                ctx.requestRedraw();
+                return true;
+            case 'r':
+            case 'R':
+                loadDataAsync();
+                return true;
+        }
+
+        return false;
+    }
+
+    private static String truncate(String s, int maxLen) {
+        if (s == null || maxLen <= 0)
+            return "";
+        if (s.length() <= maxLen)
+            return s;
+        return s.substring(0, maxLen - 1) + "~";
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/WorkspaceScreen.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/screens/WorkspaceScreen.java
@@ -1,0 +1,504 @@
+package io.quarkus.devshell.deployment.tui.screens;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import io.quarkus.devshell.deployment.tui.AppContext;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+import io.quarkus.devshell.deployment.tui.Screen;
+import io.quarkus.devshell.deployment.tui.widgets.TreeView;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
+
+public class WorkspaceScreen implements Screen {
+
+    private static final Style DIM = Style.EMPTY.gray();
+    private static final Style NORMAL = Style.EMPTY.white();
+    private static final Style CYAN = Style.EMPTY.cyan();
+    private static final Style YELLOW = Style.EMPTY.yellow();
+
+    private AppContext ctx;
+    private volatile boolean loading = true;
+    private volatile String errorMessage;
+
+    private final List<WorkspaceItem> items = new ArrayList<>();
+    private final TreeView<WorkspaceItem> treeView;
+
+    private String selectedFilePath;
+    private volatile String selectedFileContent;
+    private volatile boolean loadingContent;
+    private int contentScrollOffset = 0;
+
+    private boolean editMode = false;
+    private List<StringBuilder> editLines;
+    private int cursorRow = 0;
+    private int cursorCol = 0;
+    private boolean modified = false;
+
+    public WorkspaceScreen() {
+        this.treeView = new TreeView<>(item -> item.name, item -> item.name);
+    }
+
+    @Override
+    public String getTitle() {
+        return "Workspace";
+    }
+
+    @Override
+    public void onEnter(AppContext ctx) {
+        this.ctx = ctx;
+        loadDataAsync();
+    }
+
+    private void loadDataAsync() {
+        loading = true;
+        ctx.requestRedraw();
+
+        CompletableFuture.runAsync(() -> {
+            try {
+                JsonNode result = ctx.getJsonRpcClient().call("devui-workspace", "getWorkspaceItems");
+                items.clear();
+                JsonNode arr = result.isArray() ? result : result.path("items");
+                if (arr.isArray()) {
+                    for (JsonNode item : arr) {
+                        String name = item.path("name").asText(item.path("fileName").asText(""));
+                        String path = item.path("path").asText(item.path("filePath").asText(""));
+                        if (!name.isEmpty()) {
+                            items.add(new WorkspaceItem(name, path));
+                        }
+                    }
+                }
+                treeView.setItems(items);
+                treeView.expandAll();
+                loading = false;
+            } catch (Exception e) {
+                errorMessage = e.getMessage();
+                loading = false;
+            }
+            ctx.requestRedraw();
+        });
+    }
+
+    private void loadFileContent(String path) {
+        if (path == null) {
+            return;
+        }
+        loadingContent = true;
+        selectedFilePath = path;
+        selectedFileContent = null;
+        contentScrollOffset = 0;
+        ctx.requestRedraw();
+
+        CompletableFuture.runAsync(() -> {
+            try {
+                ObjectNode params = new ObjectMapper().createObjectNode();
+                params.put("path", path);
+                JsonNode result = ctx.getJsonRpcClient().call("devui-workspace", "getWorkspaceItemContent", params);
+
+                boolean isBinary = result.path("isBinary").asBoolean(false);
+                if (isBinary) {
+                    selectedFileContent = "[Binary file]";
+                } else {
+                    String content = result.path("content").asText("");
+                    selectedFileContent = content.isEmpty() ? "(empty)" : content;
+                }
+                loadingContent = false;
+            } catch (Exception e) {
+                selectedFileContent = "Error: " + e.getMessage();
+                loadingContent = false;
+            }
+            ctx.requestRedraw();
+        });
+    }
+
+    @Override
+    public void render(Rect area, Buffer buffer) {
+        if (loading) {
+            buffer.setString(area.x() + 2, area.y() + 1, "Loading workspace...", YELLOW);
+            return;
+        }
+        if (errorMessage != null) {
+            buffer.setString(area.x() + 2, area.y() + 1, "Error: " + errorMessage, Style.EMPTY.red());
+            return;
+        }
+        if (items.isEmpty()) {
+            buffer.setString(area.x() + 2, area.y() + 1, "No workspace items found", DIM);
+            return;
+        }
+
+        int treeWidth = Math.min(50, area.width() / 2);
+        int contentWidth = area.width() - treeWidth - 1;
+
+        buffer.setString(area.x(), area.y(), " Files (" + items.size() + ")", CYAN.bold());
+
+        treeView.setVisibleRows(area.height() - 3);
+        treeView.setWidth(treeWidth - 1);
+        treeView.render(buffer, area.y() + 1, area.x());
+
+        for (int row = area.y() + 1; row < area.y() + area.height() - 1; row++) {
+            buffer.setString(area.x() + treeWidth, row, "|", DIM);
+        }
+
+        renderContentPanel(buffer, area.x() + treeWidth + 1, area.y(), contentWidth, area.height());
+
+        renderFooter(buffer, area.x(), area.y() + area.height() - 1, area.width());
+    }
+
+    private void renderContentPanel(Buffer buffer, int startCol, int startRow, int width, int height) {
+        if (editMode) {
+            renderEditPanel(buffer, startCol, startRow, width, height);
+            return;
+        }
+
+        TreeView.TreeNode<WorkspaceItem> selected = treeView.getSelectedNode();
+
+        if (selected == null || selected.isDirectory) {
+            buffer.setString(startCol + 1, startRow + 1, "Select a file to preview", DIM);
+            return;
+        }
+
+        buffer.setString(startCol + 1, startRow, selected.name, CYAN.bold());
+
+        if (loadingContent) {
+            buffer.setString(startCol + 1, startRow + 2, "Loading...", YELLOW);
+            return;
+        }
+
+        if (selectedFileContent == null) {
+            buffer.setString(startCol + 1, startRow + 2, "Press Enter to load file content", DIM);
+            return;
+        }
+
+        String[] lines = selectedFileContent.split("\n", -1);
+        int contentHeight = height - 3;
+        int endLine = Math.min(contentScrollOffset + contentHeight, lines.length);
+
+        for (int i = contentScrollOffset; i < endLine; i++) {
+            int row = startRow + 2 + (i - contentScrollOffset);
+            String lineNum = String.format("%3d ", i + 1);
+            buffer.setString(startCol, row, lineNum, DIM);
+
+            String line = lines[i];
+            if (line.length() > width - 5) {
+                line = line.substring(0, width - 8) + "...";
+            }
+            buffer.setString(startCol + 4, row, line, NORMAL);
+        }
+
+        if (lines.length > contentHeight) {
+            int pct = (int) ((contentScrollOffset + contentHeight) * 100.0 / lines.length);
+            buffer.setString(startCol + width - 5, startRow + height - 2, Math.min(pct, 100) + "%", DIM);
+        }
+    }
+
+    private void renderEditPanel(Buffer buffer, int startCol, int startRow, int width, int height) {
+        // Header: filename with [EDIT] tag and optional [MODIFIED] tag
+        String fileName = selectedFilePath;
+        int lastSlash = fileName.lastIndexOf('/');
+        if (lastSlash >= 0) {
+            fileName = fileName.substring(lastSlash + 1);
+        }
+        int col = startCol + 1;
+        col += buffer.setString(col, startRow, fileName, CYAN.bold());
+        col += buffer.setString(col, startRow, " [EDIT]", CYAN);
+        if (modified) {
+            buffer.setString(col, startRow, " [MODIFIED]", YELLOW);
+        }
+
+        // Cursor position indicator
+        String posInfo = "Ln " + (cursorRow + 1) + ", Col " + (cursorCol + 1);
+        buffer.setString(startCol + width - posInfo.length() - 1, startRow, posInfo, DIM);
+
+        // Auto-scroll to keep cursor visible
+        int contentHeight = height - 3;
+        if (cursorRow < contentScrollOffset) {
+            contentScrollOffset = cursorRow;
+        } else if (cursorRow >= contentScrollOffset + contentHeight) {
+            contentScrollOffset = cursorRow - contentHeight + 1;
+        }
+
+        int endLine = Math.min(contentScrollOffset + contentHeight, editLines.size());
+
+        for (int i = contentScrollOffset; i < endLine; i++) {
+            int row = startRow + 2 + (i - contentScrollOffset);
+            String lineNum = String.format("%3d ", i + 1);
+            buffer.setString(startCol, row, lineNum, DIM);
+
+            StringBuilder lineBuilder = editLines.get(i);
+            String line = lineBuilder.toString();
+            int maxLineWidth = width - 5;
+
+            if (i == cursorRow) {
+                // Render line with cursor
+                String beforeCursor = line.substring(0, Math.min(cursorCol, line.length()));
+                if (beforeCursor.length() > maxLineWidth - 1) {
+                    // Cursor is beyond visible area, truncate from left
+                    beforeCursor = beforeCursor.substring(beforeCursor.length() - maxLineWidth + 1);
+                }
+                int x = startCol + 4;
+                x += buffer.setString(x, row, beforeCursor, NORMAL);
+
+                // Render cursor character with reversed style
+                String cursorChar = cursorCol < line.length()
+                        ? String.valueOf(line.charAt(cursorCol))
+                        : " ";
+                x += buffer.setString(x, row, cursorChar, NORMAL.reversed());
+
+                // Render after cursor
+                if (cursorCol < line.length()) {
+                    String afterCursor = line.substring(cursorCol + 1);
+                    int remaining = maxLineWidth - (beforeCursor.length() + 1);
+                    if (afterCursor.length() > remaining) {
+                        afterCursor = afterCursor.substring(0, Math.max(0, remaining - 3)) + "...";
+                    }
+                    buffer.setString(x, row, afterCursor, NORMAL);
+                }
+            } else {
+                if (line.length() > maxLineWidth) {
+                    line = line.substring(0, maxLineWidth - 3) + "...";
+                }
+                buffer.setString(startCol + 4, row, line, NORMAL);
+            }
+        }
+
+        if (editLines.size() > contentHeight) {
+            int pct = (int) ((contentScrollOffset + contentHeight) * 100.0 / editLines.size());
+            buffer.setString(startCol + width - 5, startRow + height - 2, Math.min(pct, 100) + "%", DIM);
+        }
+    }
+
+    private void renderFooter(Buffer buffer, int x, int y, int width) {
+        if (editMode) {
+            buffer.setString(x, y, " Ctrl+S: Save  ESC: Cancel  Tab: 4 spaces", DIM);
+        } else {
+            String footer = " Enter: Preview  E: Expand  C: Collapse  [/]: Scroll content  R: Refresh";
+            if (selectedFileContent != null && !"[Binary file]".equals(selectedFileContent)) {
+                footer += "  W: Edit";
+            }
+            footer += "  ESC: Back";
+            buffer.setString(x, y, footer, DIM);
+        }
+    }
+
+    @Override
+    public boolean handleKey(int[] keys) {
+        if (editMode) {
+            return handleEditKey(keys);
+        }
+
+        if (loading) {
+            return false;
+        }
+
+        int key = KeyCode.parse(keys);
+
+        if (treeView.handleKey(key)) {
+            TreeView.TreeNode<WorkspaceItem> selected = treeView.getSelectedNode();
+            if (selected != null && !selected.isDirectory) {
+                if (selected.data != null && !selected.data.path.equals(selectedFilePath)) {
+                    selectedFileContent = null;
+                    contentScrollOffset = 0;
+                }
+            }
+            ctx.requestRedraw();
+            return true;
+        }
+
+        switch (key) {
+            case KeyCode.ENTER:
+                TreeView.TreeNode<WorkspaceItem> selected = treeView.getSelectedNode();
+                if (selected != null && !selected.isDirectory && selected.data != null) {
+                    loadFileContent(selected.data.path);
+                }
+                return true;
+            case 'e':
+            case 'E':
+                treeView.expandAll();
+                ctx.requestRedraw();
+                return true;
+            case 'c':
+            case 'C':
+                treeView.collapseAll();
+                ctx.requestRedraw();
+                return true;
+            case '[':
+                if (selectedFileContent != null && contentScrollOffset > 0) {
+                    contentScrollOffset--;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case ']':
+                if (selectedFileContent != null) {
+                    contentScrollOffset++;
+                    ctx.requestRedraw();
+                }
+                return true;
+            case 'r':
+            case 'R':
+                loadDataAsync();
+                return true;
+            case 'w':
+            case 'W':
+                if (selectedFileContent != null && !"[Binary file]".equals(selectedFileContent)) {
+                    enterEditMode();
+                }
+                return true;
+        }
+
+        return false;
+    }
+
+    private void enterEditMode() {
+        String[] lines = selectedFileContent.split("\n", -1);
+        editLines = new ArrayList<>();
+        for (String line : lines) {
+            editLines.add(new StringBuilder(line));
+        }
+        editMode = true;
+        modified = false;
+        cursorRow = 0;
+        cursorCol = 0;
+        ctx.requestRedraw();
+    }
+
+    private boolean handleEditKey(int[] keys) {
+        int key = KeyCode.parse(keys);
+
+        switch (key) {
+            case KeyCode.ESCAPE:
+                editMode = false;
+                editLines = null;
+                break;
+            case KeyCode.CTRL_S:
+                saveEditedContent();
+                break;
+            case KeyCode.ENTER:
+                splitLineAtCursor();
+                modified = true;
+                break;
+            case KeyCode.BACKSPACE:
+                handleBackspace();
+                break;
+            case KeyCode.DELETE:
+                handleDelete();
+                break;
+            case KeyCode.TAB:
+                editLines.get(cursorRow).insert(cursorCol, "    ");
+                cursorCol += 4;
+                modified = true;
+                break;
+            case KeyCode.UP:
+                if (cursorRow > 0) {
+                    cursorRow--;
+                    cursorCol = Math.min(cursorCol, editLines.get(cursorRow).length());
+                }
+                break;
+            case KeyCode.DOWN:
+                if (cursorRow < editLines.size() - 1) {
+                    cursorRow++;
+                    cursorCol = Math.min(cursorCol, editLines.get(cursorRow).length());
+                }
+                break;
+            case KeyCode.LEFT:
+                if (cursorCol > 0) {
+                    cursorCol--;
+                } else if (cursorRow > 0) {
+                    cursorRow--;
+                    cursorCol = editLines.get(cursorRow).length();
+                }
+                break;
+            case KeyCode.RIGHT:
+                if (cursorCol < editLines.get(cursorRow).length()) {
+                    cursorCol++;
+                } else if (cursorRow < editLines.size() - 1) {
+                    cursorRow++;
+                    cursorCol = 0;
+                }
+                break;
+            case KeyCode.HOME:
+                cursorCol = 0;
+                break;
+            case KeyCode.END:
+                cursorCol = editLines.get(cursorRow).length();
+                break;
+            case KeyCode.PAGE_UP:
+                cursorRow = Math.max(0, cursorRow - 20);
+                cursorCol = Math.min(cursorCol, editLines.get(cursorRow).length());
+                break;
+            case KeyCode.PAGE_DOWN:
+                cursorRow = Math.min(editLines.size() - 1, cursorRow + 20);
+                cursorCol = Math.min(cursorCol, editLines.get(cursorRow).length());
+                break;
+            default:
+                if (KeyCode.isPrintable(key)) {
+                    editLines.get(cursorRow).insert(cursorCol, (char) key);
+                    cursorCol++;
+                    modified = true;
+                }
+                break;
+        }
+        ctx.requestRedraw();
+        return true;
+    }
+
+    private void splitLineAtCursor() {
+        StringBuilder currentLine = editLines.get(cursorRow);
+        String afterCursor = currentLine.substring(cursorCol);
+        currentLine.delete(cursorCol, currentLine.length());
+        cursorRow++;
+        cursorCol = 0;
+        editLines.add(cursorRow, new StringBuilder(afterCursor));
+    }
+
+    private void handleBackspace() {
+        if (cursorCol > 0) {
+            editLines.get(cursorRow).deleteCharAt(cursorCol - 1);
+            cursorCol--;
+            modified = true;
+        } else if (cursorRow > 0) {
+            StringBuilder previousLine = editLines.get(cursorRow - 1);
+            int mergePoint = previousLine.length();
+            previousLine.append(editLines.get(cursorRow));
+            editLines.remove(cursorRow);
+            cursorRow--;
+            cursorCol = mergePoint;
+            modified = true;
+        }
+    }
+
+    private void handleDelete() {
+        StringBuilder currentLine = editLines.get(cursorRow);
+        if (cursorCol < currentLine.length()) {
+            currentLine.deleteCharAt(cursorCol);
+            modified = true;
+        } else if (cursorRow < editLines.size() - 1) {
+            currentLine.append(editLines.get(cursorRow + 1));
+            editLines.remove(cursorRow + 1);
+            modified = true;
+        }
+    }
+
+    private void saveEditedContent() {
+        StringBuilder content = new StringBuilder();
+        for (int i = 0; i < editLines.size(); i++) {
+            if (i > 0) {
+                content.append('\n');
+            }
+            content.append(editLines.get(i));
+        }
+        ObjectNode params = new ObjectMapper().createObjectNode();
+        params.put("path", selectedFilePath);
+        params.put("content", content.toString());
+        ctx.getJsonRpcClient().call("devui-workspace", "saveWorkspaceItemContent", params);
+        selectedFileContent = content.toString();
+        modified = false;
+    }
+
+    private record WorkspaceItem(String name, String path) {
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/widgets/KeyValuePanel.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/widgets/KeyValuePanel.java
@@ -1,0 +1,94 @@
+package io.quarkus.devshell.deployment.tui.widgets;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.style.Style;
+
+public class KeyValuePanel {
+
+    private final String title;
+    private final List<Entry> entries = new ArrayList<>();
+
+    public KeyValuePanel(String title) {
+        this.title = title;
+    }
+
+    public KeyValuePanel() {
+        this.title = null;
+    }
+
+    public KeyValuePanel add(String key, String value) {
+        entries.add(new Entry(key, value != null ? value : "", null));
+        return this;
+    }
+
+    public KeyValuePanel addIfPresent(String key, String value) {
+        if (value != null && !value.isEmpty()) {
+            entries.add(new Entry(key, value, null));
+        }
+        return this;
+    }
+
+    public KeyValuePanel addStyled(String key, String value, Style valueStyle) {
+        entries.add(new Entry(key, value != null ? value : "", valueStyle));
+        return this;
+    }
+
+    public KeyValuePanel addBlank() {
+        entries.add(new Entry(null, null, null));
+        return this;
+    }
+
+    public int render(Buffer buffer, int startRow, int startCol, int width) {
+        int row = startRow;
+
+        Style headerStyle = Style.EMPTY.cyan().bold();
+        Style lineStyle = Style.EMPTY.gray();
+        Style labelStyle = Style.EMPTY.cyan();
+        Style valueStyle = Style.EMPTY.white();
+
+        if (title != null) {
+            buffer.setString(startCol, row, title, headerStyle);
+            row++;
+
+            buffer.setString(startCol, row, "─".repeat(width), lineStyle);
+            row++;
+        }
+
+        for (Entry entry : entries) {
+            if (entry.key == null) {
+                row++;
+                continue;
+            }
+            String label = entry.key + ": ";
+            buffer.setString(startCol, row, label, labelStyle);
+            Style vStyle = entry.valueStyle != null ? entry.valueStyle : valueStyle;
+            buffer.setString(startCol + label.length(), row, entry.value, vStyle);
+            row++;
+        }
+
+        return row;
+    }
+
+    public void clear() {
+        entries.clear();
+    }
+
+    public boolean isEmpty() {
+        return entries.isEmpty();
+    }
+
+    private static class Entry {
+        final String key;
+        final String value;
+        final Style valueStyle;
+
+        Entry(String key, String value, Style valueStyle) {
+            this.key = key;
+            this.value = value;
+            this.valueStyle = valueStyle;
+        }
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/widgets/ListView.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/widgets/ListView.java
@@ -1,0 +1,179 @@
+package io.quarkus.devshell.deployment.tui.widgets;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.style.Style;
+import io.quarkus.devshell.deployment.tui.AnsiRenderer;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+
+public class ListView<T> {
+
+    private final List<T> items = new ArrayList<>();
+    private final Function<T, String> labelExtractor;
+    private final Function<T, Style> styleExtractor;
+
+    private static final Style STYLE_SELECTED = Style.EMPTY.reversed();
+    private static final Style STYLE_SCROLL_INDICATOR = Style.EMPTY.gray();
+
+    private int selectedIndex = 0;
+    private int scrollOffset = 0;
+    private int visibleRows = 10;
+    private int width = 30;
+
+    public ListView(Function<T, String> labelExtractor) {
+        this(labelExtractor, null);
+    }
+
+    public ListView(Function<T, String> labelExtractor, Function<T, Style> styleExtractor) {
+        this.labelExtractor = labelExtractor;
+        this.styleExtractor = styleExtractor;
+    }
+
+    public void setItems(List<T> items) {
+        this.items.clear();
+        if (items != null) {
+            this.items.addAll(items);
+        }
+        if (selectedIndex >= this.items.size()) {
+            selectedIndex = Math.max(0, this.items.size() - 1);
+        }
+        adjustScroll();
+    }
+
+    public T getSelectedItem() {
+        if (items.isEmpty() || selectedIndex < 0 || selectedIndex >= items.size()) {
+            return null;
+        }
+        return items.get(selectedIndex);
+    }
+
+    public int getSelectedIndex() {
+        return selectedIndex;
+    }
+
+    public void setVisibleRows(int rows) {
+        this.visibleRows = rows;
+        adjustScroll();
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+
+    public boolean handleKey(int key) {
+        switch (key) {
+            case KeyCode.UP:
+                moveUp();
+                return true;
+            case KeyCode.DOWN:
+                moveDown();
+                return true;
+            case KeyCode.PAGE_UP:
+                pageUp();
+                return true;
+            case KeyCode.PAGE_DOWN:
+                pageDown();
+                return true;
+            case KeyCode.HOME:
+                moveToStart();
+                return true;
+            case KeyCode.END:
+                moveToEnd();
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public void moveUp() {
+        if (selectedIndex > 0) {
+            selectedIndex--;
+            adjustScroll();
+        }
+    }
+
+    public void moveDown() {
+        if (selectedIndex < items.size() - 1) {
+            selectedIndex++;
+            adjustScroll();
+        }
+    }
+
+    public void pageUp() {
+        selectedIndex = Math.max(0, selectedIndex - visibleRows);
+        adjustScroll();
+    }
+
+    public void pageDown() {
+        selectedIndex = Math.min(items.size() - 1, selectedIndex + visibleRows);
+        adjustScroll();
+    }
+
+    public void moveToStart() {
+        selectedIndex = 0;
+        adjustScroll();
+    }
+
+    public void moveToEnd() {
+        selectedIndex = Math.max(0, items.size() - 1);
+        adjustScroll();
+    }
+
+    private void adjustScroll() {
+        if (selectedIndex < scrollOffset) {
+            scrollOffset = selectedIndex;
+        } else if (selectedIndex >= scrollOffset + visibleRows) {
+            scrollOffset = selectedIndex - visibleRows + 1;
+        }
+        scrollOffset = Math.max(0, scrollOffset);
+        int maxOffset = Math.max(0, items.size() - visibleRows);
+        scrollOffset = Math.min(scrollOffset, maxOffset);
+    }
+
+    public void render(Buffer buffer, int startRow, int startCol) {
+        for (int i = 0; i < visibleRows; i++) {
+            int itemIndex = scrollOffset + i;
+            int row = startRow + i;
+
+            buffer.setString(startCol, row, " ".repeat(width), Style.EMPTY);
+
+            if (itemIndex < items.size()) {
+                T item = items.get(itemIndex);
+                String label = labelExtractor.apply(item);
+                String stripped = AnsiRenderer.stripAnsi(label);
+                boolean selected = itemIndex == selectedIndex;
+                Style itemStyle = styleExtractor != null ? styleExtractor.apply(item) : Style.EMPTY;
+
+                if (selected) {
+                    String text = AnsiRenderer.fixedWidth(stripped, width - 4);
+                    buffer.setString(startCol, row, AnsiRenderer.ARROW_RIGHT + " ", Style.EMPTY);
+                    buffer.setString(startCol + 2, row, text, STYLE_SELECTED);
+                } else {
+                    String text = AnsiRenderer.fixedWidth(stripped, width - 4);
+                    buffer.setString(startCol, row, "  " + text, itemStyle);
+                }
+            }
+        }
+
+        if (items.size() > visibleRows) {
+            int maxOffset = Math.max(1, items.size() - visibleRows);
+            if (scrollOffset > 0) {
+                buffer.setString(startCol + width - 1, startRow, "▲", STYLE_SCROLL_INDICATOR);
+            }
+            if (scrollOffset < maxOffset) {
+                buffer.setString(startCol + width - 1, startRow + visibleRows - 1, "▼", STYLE_SCROLL_INDICATOR);
+            }
+        }
+    }
+
+    public int size() {
+        return items.size();
+    }
+
+    public boolean isEmpty() {
+        return items.isEmpty();
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/widgets/LogPanel.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/widgets/LogPanel.java
@@ -1,0 +1,412 @@
+package io.quarkus.devshell.deployment.tui.widgets;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import io.quarkus.devshell.deployment.tui.AppContext;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * A log streaming widget that renders into a provided area.
+ * Displays real-time log output from the Dev UI logstream service
+ * with tabs for Server (all logs) and Testing (filtered) views.
+ */
+public class LogPanel {
+
+    private static final Logger log = Logger.getLogger(LogPanel.class);
+
+    private static final int MAX_ENTRIES = 500;
+    private static final String NAMESPACE = "devui-logstream";
+
+    private static final Style TAB_ACTIVE = Style.EMPTY.white().bold().onBlack();
+    private static final Style TAB_INACTIVE = Style.EMPTY.gray().onBlack();
+    private static final Style TAB_BAR_BG = Style.EMPTY.onBlack();
+    private static final Style LEVEL_ERROR = Style.EMPTY.red();
+    private static final Style LEVEL_WARN = Style.EMPTY.yellow();
+    private static final Style LEVEL_INFO = Style.EMPTY.green();
+    private static final Style LEVEL_DEBUG = Style.EMPTY.blue();
+    private static final Style LEVEL_TRACE = Style.EMPTY.gray();
+    private static final Style TIMESTAMP_STYLE = Style.EMPTY.gray();
+    private static final Style LOGGER_STYLE = Style.EMPTY.cyan();
+    private static final Style MESSAGE_STYLE = Style.EMPTY.white();
+
+    private final List<LogEntry> entries = Collections.synchronizedList(new ArrayList<>());
+    private int activeTab = 0; // 0=Server, 1=Testing
+    private int scrollOffset = 0;
+    private boolean autoScroll = true;
+    private int subscriptionId = -1;
+    private boolean streaming = false;
+    private AppContext ctx;
+
+    public void start(AppContext ctx) {
+        this.ctx = ctx;
+
+        // Load history asynchronously
+        ctx.getJsonRpcClient().callAsync(NAMESPACE, "history")
+                .thenAccept(this::parseHistory)
+                .exceptionally(t -> {
+                    log.debug("Failed to load log history", t);
+                    return null;
+                });
+
+        // Subscribe to live log stream
+        try {
+            subscriptionId = ctx.getJsonRpcClient().subscribe(NAMESPACE, "streamLog", this::onLogMessage);
+            streaming = true;
+        } catch (Exception e) {
+            log.debug("Failed to subscribe to log stream", e);
+            streaming = false;
+        }
+    }
+
+    public void stop() {
+        if (subscriptionId >= 0) {
+            try {
+                ctx.getJsonRpcClient().unsubscribe(subscriptionId);
+            } catch (Exception e) {
+                log.debug("Failed to unsubscribe from log stream", e);
+            }
+            subscriptionId = -1;
+            streaming = false;
+        }
+    }
+
+    public void render(Rect area, Buffer buffer) {
+        if (area.height() < 2) {
+            return;
+        }
+
+        // Fill background
+        buffer.fill(area, new Cell(" ", Style.EMPTY));
+
+        // Row 0: Tab bar
+        renderTabBar(area, buffer);
+
+        // Rows 1+: Log entries
+        int contentHeight = area.height() - 1;
+        if (contentHeight <= 0) {
+            return;
+        }
+
+        List<LogEntry> filtered = getFilteredEntries();
+
+        if (autoScroll) {
+            scrollOffset = Math.max(0, filtered.size() - contentHeight);
+        }
+
+        for (int i = 0; i < contentHeight; i++) {
+            int entryIndex = scrollOffset + i;
+            int row = area.y() + 1 + i;
+
+            if (entryIndex >= 0 && entryIndex < filtered.size()) {
+                renderLogEntry(filtered.get(entryIndex), area.x(), row, area.width(), buffer);
+            }
+        }
+    }
+
+    private void renderTabBar(Rect area, Buffer buffer) {
+        int y = area.y();
+
+        // Fill tab bar background
+        for (int x = area.x(); x < area.x() + area.width(); x++) {
+            buffer.set(x, y, new Cell(" ", TAB_BAR_BG));
+        }
+
+        int serverCount;
+        int testingCount;
+        synchronized (entries) {
+            serverCount = entries.size();
+            testingCount = (int) entries.stream()
+                    .filter(e -> e.threadName != null && e.threadName.contains("Test runner"))
+                    .count();
+        }
+
+        String serverLabel = " Server (" + serverCount + ") ";
+        String testingLabel = " Testing (" + testingCount + ") ";
+        String switchHint = " [1/2] switch";
+
+        Style serverStyle = activeTab == 0 ? TAB_ACTIVE : TAB_INACTIVE;
+        Style testingStyle = activeTab == 1 ? TAB_ACTIVE : TAB_INACTIVE;
+
+        int x = area.x() + 1;
+        buffer.setLine(x, y, Line.from(
+                Span.styled(serverLabel, serverStyle),
+                Span.styled(" ", TAB_BAR_BG),
+                Span.styled(testingLabel, testingStyle),
+                Span.styled(" ", TAB_BAR_BG),
+                Span.styled(switchHint, TAB_INACTIVE)));
+    }
+
+    private void renderLogEntry(LogEntry entry, int startX, int row, int width, Buffer buffer) {
+        int x = startX;
+        int maxX = startX + width;
+
+        // Timestamp (HH:mm:ss)
+        String ts = shortenTimestamp(entry.timestamp);
+        if (x + ts.length() < maxX) {
+            buffer.setString(x, row, ts, TIMESTAMP_STYLE);
+            x += ts.length();
+        }
+
+        // Space
+        if (x < maxX) {
+            buffer.setString(x, row, " ", Style.EMPTY);
+            x++;
+        }
+
+        // Level (5 chars, color-coded)
+        String level = String.format("%-5s", entry.level);
+        Style levelStyle = getLevelStyle(entry.level);
+        if (x + level.length() < maxX) {
+            buffer.setString(x, row, level, levelStyle);
+            x += level.length();
+        }
+
+        // Space
+        if (x < maxX) {
+            buffer.setString(x, row, " ", Style.EMPTY);
+            x++;
+        }
+
+        // Logger name (abbreviated)
+        int remainingForLogger = Math.min(25, (maxX - x) / 3);
+        if (remainingForLogger > 0) {
+            String loggerShort = shortenLoggerName(entry.loggerName, remainingForLogger);
+            loggerShort = String.format("%-" + remainingForLogger + "s", loggerShort);
+            if (x + loggerShort.length() < maxX) {
+                buffer.setString(x, row, loggerShort, LOGGER_STYLE);
+                x += loggerShort.length();
+            }
+        }
+
+        // Space
+        if (x < maxX) {
+            buffer.setString(x, row, " ", Style.EMPTY);
+            x++;
+        }
+
+        // Message (fill remaining width)
+        if (x < maxX && entry.message != null) {
+            int remaining = maxX - x;
+            String msg = entry.message.length() > remaining
+                    ? entry.message.substring(0, remaining - 1) + "…"
+                    : entry.message;
+            buffer.setString(x, row, msg, MESSAGE_STYLE);
+        }
+    }
+
+    public boolean handleKey(int key) {
+        if (key == '1') {
+            if (activeTab != 0) {
+                activeTab = 0;
+                scrollOffset = 0;
+                autoScroll = true;
+            }
+            return true;
+        } else if (key == '2') {
+            if (activeTab != 1) {
+                activeTab = 1;
+                scrollOffset = 0;
+                autoScroll = true;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    public void switchTab() {
+        activeTab = activeTab == 0 ? 1 : 0;
+        scrollOffset = 0;
+        autoScroll = true;
+    }
+
+    public boolean isStreaming() {
+        return streaming;
+    }
+
+    public int getActiveTab() {
+        return activeTab;
+    }
+
+    private void onLogMessage(JsonNode msg) {
+        LogEntry entry = parseLogEntry(msg);
+        if (entry != null) {
+            synchronized (entries) {
+                entries.add(entry);
+                while (entries.size() > MAX_ENTRIES) {
+                    entries.remove(0);
+                }
+            }
+            if (autoScroll && ctx != null) {
+                ctx.requestRedraw();
+            }
+        }
+    }
+
+    private void parseHistory(JsonNode result) {
+        if (result == null || !result.isArray()) {
+            return;
+        }
+        synchronized (entries) {
+            for (JsonNode item : result) {
+                LogEntry entry = parseLogEntry(item);
+                if (entry != null) {
+                    entries.add(entry);
+                }
+            }
+            while (entries.size() > MAX_ENTRIES) {
+                entries.remove(0);
+            }
+        }
+        autoScroll = true;
+        if (ctx != null) {
+            ctx.requestRedraw();
+        }
+    }
+
+    private LogEntry parseLogEntry(JsonNode node) {
+        if (node == null) {
+            return null;
+        }
+        String timestamp = node.path("timestamp").asText("");
+        String level = node.path("level").asText("INFO");
+        String loggerName = node.path("loggerName").asText("");
+        String message = node.path("message").asText("");
+        String threadName = node.path("threadName").asText("");
+        return new LogEntry(timestamp, level, loggerName, message, threadName);
+    }
+
+    private List<LogEntry> getFilteredEntries() {
+        synchronized (entries) {
+            if (activeTab == 1) {
+                List<LogEntry> filtered = new ArrayList<>();
+                for (LogEntry e : entries) {
+                    if (e.threadName != null && e.threadName.contains("Test runner")) {
+                        filtered.add(e);
+                    }
+                }
+                return filtered;
+            }
+            return new ArrayList<>(entries);
+        }
+    }
+
+    private String shortenTimestamp(String timestamp) {
+        if (timestamp == null || timestamp.isEmpty()) {
+            return "        ";
+        }
+        // Try to extract HH:mm:ss from various timestamp formats
+        // ISO format: 2024-01-01T12:34:56 or similar
+        int tIndex = timestamp.indexOf('T');
+        if (tIndex >= 0 && tIndex + 9 <= timestamp.length()) {
+            return timestamp.substring(tIndex + 1, tIndex + 9);
+        }
+        // Already short or has space separator
+        int spaceIndex = timestamp.indexOf(' ');
+        if (spaceIndex >= 0 && spaceIndex + 9 <= timestamp.length()) {
+            return timestamp.substring(spaceIndex + 1, spaceIndex + 9);
+        }
+        // If already 8 chars (HH:mm:ss), return as-is
+        if (timestamp.length() == 8 && timestamp.charAt(2) == ':') {
+            return timestamp;
+        }
+        // Truncate if too long
+        if (timestamp.length() > 8) {
+            return timestamp.substring(0, 8);
+        }
+        return String.format("%-8s", timestamp);
+    }
+
+    static String shortenLoggerName(String name, int maxLen) {
+        if (name == null || name.isEmpty()) {
+            return "";
+        }
+        if (name.length() <= maxLen) {
+            return name;
+        }
+
+        String[] parts = name.split("\\.");
+        if (parts.length <= 1) {
+            return name.length() > maxLen ? name.substring(0, maxLen) : name;
+        }
+
+        // Keep last segment full, abbreviate earlier segments to first char
+        String lastPart = parts[parts.length - 1];
+
+        // If even the last part is too long, truncate it
+        if (lastPart.length() >= maxLen) {
+            return lastPart.substring(0, maxLen);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < parts.length - 1; i++) {
+            if (parts[i].length() > 0) {
+                sb.append(parts[i].charAt(0)).append('.');
+            }
+            // Check if remaining parts fit
+            String remaining = sb.toString() + lastPart;
+            if (remaining.length() >= maxLen) {
+                // Too long with abbreviations, just use last part
+                return lastPart.length() > maxLen ? lastPart.substring(0, maxLen) : lastPart;
+            }
+        }
+        sb.append(lastPart);
+
+        String result = sb.toString();
+        return result.length() > maxLen ? result.substring(0, maxLen) : result;
+    }
+
+    private Style getLevelStyle(String level) {
+        if (level == null) {
+            return MESSAGE_STYLE;
+        }
+        switch (level.toUpperCase()) {
+            case "ERROR":
+            case "FATAL":
+            case "SEVERE":
+                return LEVEL_ERROR;
+            case "WARN":
+            case "WARNING":
+                return LEVEL_WARN;
+            case "INFO":
+                return LEVEL_INFO;
+            case "DEBUG":
+                return LEVEL_DEBUG;
+            case "TRACE":
+            case "FINE":
+            case "FINER":
+            case "FINEST":
+                return LEVEL_TRACE;
+            default:
+                return MESSAGE_STYLE;
+        }
+    }
+
+    /**
+     * A single log entry from the Dev UI logstream.
+     */
+    static class LogEntry {
+        final String timestamp;
+        final String level;
+        final String loggerName;
+        final String message;
+        final String threadName;
+
+        LogEntry(String timestamp, String level, String loggerName, String message, String threadName) {
+            this.timestamp = timestamp;
+            this.level = level;
+            this.loggerName = loggerName;
+            this.message = message;
+            this.threadName = threadName;
+        }
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/widgets/TableView.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/widgets/TableView.java
@@ -1,0 +1,251 @@
+package io.quarkus.devshell.deployment.tui.widgets;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.style.Style;
+import io.quarkus.devshell.deployment.tui.AnsiRenderer;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+
+public class TableView<T> {
+
+    private final List<T> items = new ArrayList<>();
+    private final List<Column<T>> columns = new ArrayList<>();
+
+    private int selectedIndex = 0;
+    private int scrollOffset = 0;
+    private int visibleRows = 10;
+    private int width = 80;
+
+    public TableView<T> addColumn(String header, Function<T, String> extractor, int minWidth) {
+        columns.add(new Column<>(header, extractor, minWidth));
+        return this;
+    }
+
+    public TableView<T> addColumn(String header, Function<T, String> extractor) {
+        return addColumn(header, extractor, 10);
+    }
+
+    public void setItems(List<T> items) {
+        this.items.clear();
+        if (items != null) {
+            this.items.addAll(items);
+        }
+        if (selectedIndex >= this.items.size()) {
+            selectedIndex = Math.max(0, this.items.size() - 1);
+        }
+        adjustScroll();
+    }
+
+    public T getSelectedItem() {
+        if (items.isEmpty() || selectedIndex < 0 || selectedIndex >= items.size()) {
+            return null;
+        }
+        return items.get(selectedIndex);
+    }
+
+    public int getSelectedIndex() {
+        return selectedIndex;
+    }
+
+    public void setVisibleRows(int rows) {
+        this.visibleRows = rows;
+        adjustScroll();
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+
+    public boolean handleKey(int key) {
+        switch (key) {
+            case KeyCode.UP:
+                moveUp();
+                return true;
+            case KeyCode.DOWN:
+                moveDown();
+                return true;
+            case KeyCode.PAGE_UP:
+                pageUp();
+                return true;
+            case KeyCode.PAGE_DOWN:
+                pageDown();
+                return true;
+            case KeyCode.HOME:
+                moveToStart();
+                return true;
+            case KeyCode.END:
+                moveToEnd();
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public void moveUp() {
+        if (selectedIndex > 0) {
+            selectedIndex--;
+            adjustScroll();
+        }
+    }
+
+    public void moveDown() {
+        if (selectedIndex < items.size() - 1) {
+            selectedIndex++;
+            adjustScroll();
+        }
+    }
+
+    public void pageUp() {
+        selectedIndex = Math.max(0, selectedIndex - visibleRows);
+        adjustScroll();
+    }
+
+    public void pageDown() {
+        selectedIndex = Math.min(items.size() - 1, selectedIndex + visibleRows);
+        adjustScroll();
+    }
+
+    public void moveToStart() {
+        selectedIndex = 0;
+        adjustScroll();
+    }
+
+    public void moveToEnd() {
+        selectedIndex = Math.max(0, items.size() - 1);
+        adjustScroll();
+    }
+
+    private void adjustScroll() {
+        if (selectedIndex < scrollOffset) {
+            scrollOffset = selectedIndex;
+        } else if (selectedIndex >= scrollOffset + visibleRows) {
+            scrollOffset = selectedIndex - visibleRows + 1;
+        }
+        scrollOffset = Math.max(0, scrollOffset);
+        int maxOffset = Math.max(0, items.size() - visibleRows);
+        scrollOffset = Math.min(scrollOffset, maxOffset);
+    }
+
+    public void render(Buffer buffer, int startRow, int startCol) {
+        if (columns.isEmpty()) {
+            return;
+        }
+
+        int[] colWidths = calculateColumnWidths();
+        int row = startRow;
+
+        renderHeader(buffer, row, startCol, colWidths);
+        row++;
+
+        renderSeparator(buffer, row, startCol, colWidths);
+        row++;
+
+        for (int i = 0; i < visibleRows; i++) {
+            int itemIndex = scrollOffset + i;
+            buffer.setString(startCol, row, " ".repeat(width), Style.EMPTY);
+
+            if (itemIndex < items.size()) {
+                T item = items.get(itemIndex);
+                boolean selected = itemIndex == selectedIndex;
+                renderRow(buffer, row, startCol, item, colWidths, selected);
+            }
+            row++;
+        }
+
+        if (items.size() > visibleRows) {
+            renderScrollIndicator(buffer, startRow + 2, startCol + width - 1);
+        }
+    }
+
+    private int[] calculateColumnWidths() {
+        int[] widths = new int[columns.size()];
+        int totalMinWidth = 0;
+
+        for (int i = 0; i < columns.size(); i++) {
+            widths[i] = Math.max(columns.get(i).minWidth, columns.get(i).header.length() + 2);
+            totalMinWidth += widths[i];
+        }
+
+        int available = width - totalMinWidth - (columns.size() - 1) * 2;
+        if (available > 0) {
+            int extra = available / columns.size();
+            for (int i = 0; i < columns.size(); i++) {
+                widths[i] += extra;
+            }
+        }
+
+        return widths;
+    }
+
+    private void renderHeader(Buffer buffer, int row, int startCol, int[] colWidths) {
+        Style headerStyle = Style.EMPTY.cyan().bold();
+        int col = startCol;
+        for (int i = 0; i < columns.size(); i++) {
+            String header = AnsiRenderer.fixedWidth(columns.get(i).header, colWidths[i]);
+            buffer.setString(col, row, header, headerStyle);
+            col += colWidths[i] + 2;
+        }
+    }
+
+    private void renderSeparator(Buffer buffer, int row, int startCol, int[] colWidths) {
+        Style sepStyle = Style.EMPTY.gray();
+        int col = startCol;
+        for (int i = 0; i < columns.size(); i++) {
+            buffer.setString(col, row, "─".repeat(colWidths[i]), sepStyle);
+            col += colWidths[i] + 2;
+        }
+    }
+
+    private void renderRow(Buffer buffer, int row, int startCol, T item, int[] colWidths, boolean selected) {
+        Style rowStyle = selected ? Style.EMPTY.reversed() : Style.EMPTY;
+
+        int col = startCol;
+        for (int i = 0; i < columns.size(); i++) {
+            String value = columns.get(i).extractor.apply(item);
+            if (value == null) {
+                value = "";
+            }
+            String stripped = AnsiRenderer.stripAnsi(value);
+            String padded = AnsiRenderer.fixedWidth(stripped, colWidths[i]);
+
+            buffer.setString(col, row, padded, rowStyle);
+            col += colWidths[i] + 2;
+        }
+    }
+
+    private void renderScrollIndicator(Buffer buffer, int startRow, int col) {
+        int maxOffset = Math.max(1, items.size() - visibleRows);
+        Style indicatorStyle = Style.EMPTY.gray();
+
+        if (scrollOffset > 0) {
+            buffer.setString(col, startRow, "▲", indicatorStyle);
+        }
+
+        if (scrollOffset < maxOffset) {
+            buffer.setString(col, startRow + visibleRows - 1, "▼", indicatorStyle);
+        }
+    }
+
+    public int size() {
+        return items.size();
+    }
+
+    public boolean isEmpty() {
+        return items.isEmpty();
+    }
+
+    private static class Column<T> {
+        final String header;
+        final Function<T, String> extractor;
+        final int minWidth;
+
+        Column(String header, Function<T, String> extractor, int minWidth) {
+            this.header = header;
+            this.extractor = extractor;
+            this.minWidth = minWidth;
+        }
+    }
+}

--- a/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/widgets/TreeView.java
+++ b/extensions/devshell/deployment/src/main/java/io/quarkus/devshell/deployment/tui/widgets/TreeView.java
@@ -1,0 +1,302 @@
+package io.quarkus.devshell.deployment.tui.widgets;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.style.Style;
+import io.quarkus.devshell.deployment.tui.KeyCode;
+
+public class TreeView<T> {
+
+    private final List<TreeNode<T>> rootNodes = new ArrayList<>();
+    private final Map<String, TreeNode<T>> nodeMap = new HashMap<>();
+    private final List<TreeNode<T>> flattenedNodes = new ArrayList<>();
+
+    private final Function<T, String> labelExtractor;
+    private final Function<T, String> pathExtractor;
+
+    private int selectedIndex = 0;
+    private int scrollOffset = 0;
+    private int visibleRows = 20;
+    private int width = 60;
+
+    private static final Style STYLE_SELECTED = Style.EMPTY.white().onBlue();
+    private static final Style STYLE_DIRECTORY = Style.EMPTY.cyan().bold();
+    private static final Style STYLE_GRAY = Style.EMPTY.gray();
+    private static final Style STYLE_JAVA = Style.EMPTY.green();
+    private static final Style STYLE_CONFIG = Style.EMPTY.yellow();
+    private static final Style STYLE_PROPERTIES = Style.EMPTY.magenta();
+    private static final Style STYLE_WEB = Style.EMPTY.cyan();
+    private static final Style STYLE_DEFAULT = Style.EMPTY.white();
+
+    public TreeView(Function<T, String> labelExtractor, Function<T, String> pathExtractor) {
+        this.labelExtractor = labelExtractor;
+        this.pathExtractor = pathExtractor;
+    }
+
+    public void setItems(List<T> items) {
+        rootNodes.clear();
+        nodeMap.clear();
+
+        for (T item : items) {
+            String path = pathExtractor.apply(item);
+            addToTree(path, item);
+        }
+
+        sortNodes(rootNodes);
+        rebuildFlatList();
+    }
+
+    private void addToTree(String path, T item) {
+        String[] parts = path.split("/");
+        List<TreeNode<T>> currentLevel = rootNodes;
+        StringBuilder currentPath = new StringBuilder();
+
+        for (int i = 0; i < parts.length; i++) {
+            String part = parts[i];
+            if (currentPath.length() > 0) {
+                currentPath.append("/");
+            }
+            currentPath.append(part);
+
+            String pathKey = currentPath.toString();
+            TreeNode<T> node = nodeMap.get(pathKey);
+
+            if (node == null) {
+                boolean isLeaf = (i == parts.length - 1);
+                node = new TreeNode<>(part, pathKey, isLeaf ? item : null, !isLeaf);
+                nodeMap.put(pathKey, node);
+                currentLevel.add(node);
+            }
+
+            currentLevel = node.children;
+        }
+    }
+
+    private void sortNodes(List<TreeNode<T>> nodes) {
+        nodes.sort((a, b) -> {
+            if (a.isDirectory && !b.isDirectory)
+                return -1;
+            if (!a.isDirectory && b.isDirectory)
+                return 1;
+            return a.name.compareToIgnoreCase(b.name);
+        });
+
+        for (TreeNode<T> node : nodes) {
+            if (!node.children.isEmpty()) {
+                sortNodes(node.children);
+            }
+        }
+    }
+
+    private void rebuildFlatList() {
+        flattenedNodes.clear();
+        flattenNodes(rootNodes, 0);
+
+        if (selectedIndex >= flattenedNodes.size()) {
+            selectedIndex = Math.max(0, flattenedNodes.size() - 1);
+        }
+        adjustScroll();
+    }
+
+    private void flattenNodes(List<TreeNode<T>> nodes, int depth) {
+        for (TreeNode<T> node : nodes) {
+            node.depth = depth;
+            flattenedNodes.add(node);
+
+            if (node.isDirectory && node.expanded && !node.children.isEmpty()) {
+                flattenNodes(node.children, depth + 1);
+            }
+        }
+    }
+
+    public void setVisibleRows(int rows) {
+        this.visibleRows = Math.max(1, rows);
+        adjustScroll();
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+
+    public TreeNode<T> getSelectedNode() {
+        if (flattenedNodes.isEmpty() || selectedIndex < 0 || selectedIndex >= flattenedNodes.size()) {
+            return null;
+        }
+        return flattenedNodes.get(selectedIndex);
+    }
+
+    public T getSelectedItem() {
+        TreeNode<T> node = getSelectedNode();
+        return node != null ? node.data : null;
+    }
+
+    public void render(Buffer buffer, int startRow, int startCol) {
+        if (flattenedNodes.isEmpty()) {
+            buffer.setString(startCol, startRow, "(empty)", STYLE_GRAY);
+            return;
+        }
+
+        int endIdx = Math.min(scrollOffset + visibleRows, flattenedNodes.size());
+
+        for (int i = scrollOffset; i < endIdx; i++) {
+            TreeNode<T> node = flattenedNodes.get(i);
+            int row = startRow + (i - scrollOffset);
+
+            boolean selected = (i == selectedIndex);
+
+            StringBuilder line = new StringBuilder();
+            line.append("  ".repeat(node.depth));
+
+            if (node.isDirectory) {
+                line.append(node.expanded ? "v " : "> ");
+            } else {
+                line.append("  ");
+            }
+
+            line.append(node.name);
+
+            Style nameStyle;
+            if (selected) {
+                nameStyle = STYLE_SELECTED;
+            } else if (node.isDirectory) {
+                nameStyle = STYLE_DIRECTORY;
+            } else {
+                nameStyle = getFileStyle(node.name);
+            }
+
+            String lineStr = line.toString();
+            if (lineStr.length() < width) {
+                lineStr = lineStr + " ".repeat(width - lineStr.length());
+            } else if (lineStr.length() > width) {
+                lineStr = lineStr.substring(0, width);
+            }
+
+            buffer.setString(startCol, row, lineStr, nameStyle);
+        }
+
+        if (scrollOffset > 0) {
+            buffer.setString(startCol + width - 2, startRow, "^", STYLE_GRAY);
+        }
+        if (endIdx < flattenedNodes.size()) {
+            buffer.setString(startCol + width - 2, startRow + visibleRows - 1, "v", STYLE_GRAY);
+        }
+    }
+
+    private Style getFileStyle(String name) {
+        if (name.endsWith(".java")) {
+            return STYLE_JAVA;
+        } else if (name.endsWith(".xml") || name.endsWith(".yaml") || name.endsWith(".yml") || name.endsWith(".json")) {
+            return STYLE_CONFIG;
+        } else if (name.endsWith(".properties") || name.endsWith(".conf")) {
+            return STYLE_PROPERTIES;
+        } else if (name.endsWith(".html") || name.endsWith(".css") || name.endsWith(".js") || name.endsWith(".ts")) {
+            return STYLE_WEB;
+        }
+        return STYLE_DEFAULT;
+    }
+
+    public boolean handleKey(int key) {
+        switch (key) {
+            case KeyCode.UP:
+            case 'k':
+                if (selectedIndex > 0) {
+                    selectedIndex--;
+                    adjustScroll();
+                    return true;
+                }
+                break;
+            case KeyCode.DOWN:
+            case 'j':
+                if (selectedIndex < flattenedNodes.size() - 1) {
+                    selectedIndex++;
+                    adjustScroll();
+                    return true;
+                }
+                break;
+            case KeyCode.LEFT:
+            case 'h':
+                TreeNode<T> current = getSelectedNode();
+                if (current != null && current.isDirectory && current.expanded) {
+                    current.expanded = false;
+                    rebuildFlatList();
+                    return true;
+                }
+                break;
+            case KeyCode.RIGHT:
+            case 'l':
+                TreeNode<T> node = getSelectedNode();
+                if (node != null && node.isDirectory && !node.expanded) {
+                    node.expanded = true;
+                    rebuildFlatList();
+                    return true;
+                }
+                break;
+            case KeyCode.ENTER:
+            case ' ':
+                TreeNode<T> sel = getSelectedNode();
+                if (sel != null && sel.isDirectory) {
+                    sel.expanded = !sel.expanded;
+                    rebuildFlatList();
+                    return true;
+                }
+                break;
+            case KeyCode.PAGE_UP:
+                selectedIndex = Math.max(0, selectedIndex - visibleRows);
+                adjustScroll();
+                return true;
+            case KeyCode.PAGE_DOWN:
+                selectedIndex = Math.min(flattenedNodes.size() - 1, selectedIndex + visibleRows);
+                adjustScroll();
+                return true;
+        }
+        return false;
+    }
+
+    private void adjustScroll() {
+        if (selectedIndex < scrollOffset) {
+            scrollOffset = selectedIndex;
+        } else if (selectedIndex >= scrollOffset + visibleRows) {
+            scrollOffset = selectedIndex - visibleRows + 1;
+        }
+    }
+
+    public void expandAll() {
+        for (TreeNode<T> node : nodeMap.values()) {
+            if (node.isDirectory) {
+                node.expanded = true;
+            }
+        }
+        rebuildFlatList();
+    }
+
+    public void collapseAll() {
+        for (TreeNode<T> node : nodeMap.values()) {
+            if (node.isDirectory) {
+                node.expanded = false;
+            }
+        }
+        rebuildFlatList();
+    }
+
+    public static class TreeNode<T> {
+        public final String name;
+        public final String path;
+        public final T data;
+        public final boolean isDirectory;
+        public final List<TreeNode<T>> children = new ArrayList<>();
+        public boolean expanded = false;
+        public int depth = 0;
+
+        public TreeNode(String name, String path, T data, boolean isDirectory) {
+            this.name = name;
+            this.path = path;
+            this.data = data;
+            this.isDirectory = isDirectory;
+        }
+    }
+}

--- a/extensions/devshell/pom.xml
+++ b/extensions/devshell/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-devshell-parent</artifactId>
+    <name>Quarkus - Dev Shell</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment-spi</module>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/extensions/devshell/runtime/pom.xml
+++ b/extensions/devshell/runtime/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-devshell-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-devshell</artifactId>
+    <name>Quarkus - Dev Shell - Runtime</name>
+    <description>Terminal TUI for Quarkus Dev Mode</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devui</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${project.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/devshell/runtime/src/main/java/io/quarkus/devshell/runtime/DevShellRecorder.java
+++ b/extensions/devshell/runtime/src/main/java/io/quarkus/devshell/runtime/DevShellRecorder.java
@@ -1,0 +1,7 @@
+package io.quarkus.devshell.runtime;
+
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class DevShellRecorder {
+}

--- a/extensions/devshell/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/devshell/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,14 @@
+name: "Dev Shell"
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+metadata:
+  keywords:
+  - "dev-shell"
+  - "tui"
+  - "terminal"
+  - "dev-mode"
+  categories:
+  - "core"
+  status: "preview"
+  unlisted: true
+  config:
+  - "quarkus.devshell."

--- a/extensions/flyway/deployment/pom.xml
+++ b/extensions/flyway/deployment/pom.xml
@@ -15,6 +15,10 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/deployment/devui/FlywayDevUIProcessor.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/deployment/devui/FlywayDevUIProcessor.java
@@ -14,6 +14,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devjsonrpc.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.flyway.runtime.FlywayBuildTimeConfig;
@@ -55,5 +56,11 @@ public class FlywayDevUIProcessor {
     @BuildStep(onlyIf = IsLocalDevelopment.class)
     JsonRPCProvidersBuildItem registerJsonRpcBackend() {
         return new JsonRPCProvidersBuildItem(FlywayJsonRpcService.class);
+    }
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    ShellPageBuildItem createShellPage() {
+        return ShellPageBuildItem.withCustomPage("Flyway", 'f',
+                "io.quarkus.devshell.deployment.tui.pages.extensions.FlywayShellPage");
     }
 }

--- a/extensions/grpc/deployment/pom.xml
+++ b/extensions/grpc/deployment/pom.xml
@@ -15,6 +15,10 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/devui/GrpcDevUIProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/devui/GrpcDevUIProcessor.java
@@ -41,6 +41,7 @@ import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.dev.console.DevConsoleManager;
 import io.quarkus.devjsonrpc.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.gizmo2.Const;
@@ -230,6 +231,12 @@ public class GrpcDevUIProcessor {
     @BuildStep(onlyIf = IsLocalDevelopment.class)
     JsonRPCProvidersBuildItem createJsonRPCServiceForCache() {
         return new JsonRPCProvidersBuildItem(GrpcJsonRPCService.class);
+    }
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    ShellPageBuildItem createShellPage() {
+        return ShellPageBuildItem.withCustomPage("gRPC", 'G',
+                "io.quarkus.devshell.deployment.tui.pages.extensions.GrpcShellPage");
     }
 
     private Collection<Class<?>> getGrpcServices(IndexView index) throws ClassNotFoundException {

--- a/extensions/hibernate-orm/deployment/pom.xml
+++ b/extensions/hibernate-orm/deployment/pom.xml
@@ -64,6 +64,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-validator-spi</artifactId>
         </dependency>
         <dependency>

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/dev/HibernateOrmDevUIProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/dev/HibernateOrmDevUIProcessor.java
@@ -9,6 +9,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.devjsonrpc.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.hibernate.orm.deployment.HibernateOrmConfig;
@@ -77,6 +78,12 @@ public class HibernateOrmDevUIProcessor {
             updateSQLGeneratorBuildItemBuildProducer
                     .produce(new JdbcUpdateSQLGeneratorBuildItem(dsName, new HibernateOrmDevInfoUpdateDDLSupplier(puName)));
         }
+    }
+
+    @BuildStep
+    ShellPageBuildItem createShellPage() {
+        return ShellPageBuildItem.withCustomPage("Hibernate ORM", 'o',
+                "io.quarkus.devshell.deployment.tui.pages.extensions.HibernateOrmShellPage");
     }
 
 }

--- a/extensions/info/deployment/pom.xml
+++ b/extensions/info/deployment/pom.xml
@@ -23,6 +23,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devmcp-deployment-spi</artifactId>
         </dependency>
         <dependency>

--- a/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoDevUIProcessor.java
+++ b/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoDevUIProcessor.java
@@ -1,9 +1,11 @@
 package io.quarkus.info.deployment;
 
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.ExternalPageBuilder;
 import io.quarkus.devui.spi.page.Page;
@@ -40,6 +42,12 @@ public class InfoDevUIProcessor {
         cardBuildItem.addPage(infoPage);
         cardBuildItem.addPage(rawPage);
         cardPageProducer.produce(cardBuildItem);
+    }
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    ShellPageBuildItem createShellPage() {
+        return ShellPageBuildItem.withCustomPage("Info", 'i',
+                "io.quarkus.devshell.deployment.tui.pages.extensions.InfoShellPage");
     }
 
 }

--- a/extensions/kafka-client/deployment/pom.xml
+++ b/extensions/kafka-client/deployment/pom.xml
@@ -16,6 +16,10 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kafka-client</artifactId>
         </dependency>
         <dependency>

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/devui/KafkaDevUIProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/devui/KafkaDevUIProcessor.java
@@ -5,6 +5,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.devjsonrpc.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.kafka.client.runtime.dev.ui.KafkaJsonRPCService;
@@ -53,5 +54,11 @@ public class KafkaDevUIProcessor {
     @BuildStep(onlyIf = IsLocalDevelopment.class)
     JsonRPCProvidersBuildItem createJsonRPCService() {
         return new JsonRPCProvidersBuildItem(KafkaJsonRPCService.class);
+    }
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    ShellPageBuildItem createShellPage() {
+        return ShellPageBuildItem.withCustomPage("Kafka", 'k',
+                "io.quarkus.devshell.deployment.tui.pages.extensions.KafkaShellPage");
     }
 }

--- a/extensions/liquibase/liquibase/deployment/pom.xml
+++ b/extensions/liquibase/liquibase/deployment/pom.xml
@@ -43,6 +43,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/liquibase/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/devui/LiquibaseDevUIProcessor.java
+++ b/extensions/liquibase/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/devui/LiquibaseDevUIProcessor.java
@@ -4,6 +4,7 @@ import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.devjsonrpc.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.liquibase.runtime.dev.ui.LiquibaseJsonRpcService;
@@ -32,5 +33,11 @@ public class LiquibaseDevUIProcessor {
     @BuildStep(onlyIf = IsLocalDevelopment.class)
     JsonRPCProvidersBuildItem registerJsonRpcBackend() {
         return new JsonRPCProvidersBuildItem(LiquibaseJsonRpcService.class);
+    }
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    ShellPageBuildItem createShellPage() {
+        return ShellPageBuildItem.withCustomPage("Liquibase", 'l',
+                "io.quarkus.devshell.deployment.tui.pages.extensions.LiquibaseShellPage");
     }
 }

--- a/extensions/micrometer/deployment/pom.xml
+++ b/extensions/micrometer/deployment/pom.xml
@@ -16,6 +16,10 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-micrometer</artifactId>
         </dependency>
 

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
@@ -24,6 +24,7 @@ import io.quarkus.arc.deployment.InterceptorBindingRegistrarBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.processor.InterceptorBindingRegistrar;
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
@@ -38,6 +39,7 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
 import io.quarkus.deployment.metrics.MetricsFactoryConsumerBuildItem;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.micrometer.deployment.export.PrometheusRegistryProcessor;
@@ -250,6 +252,12 @@ public class MicrometerProcessor {
         }
 
         return ReflectiveClassBuildItem.builder(classes.toArray(new String[0])).reason(getClass().getName()).build();
+    }
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    ShellPageBuildItem createShellPage() {
+        return ShellPageBuildItem.withCustomPage("Micrometer", 'M',
+                "io.quarkus.devshell.deployment.tui.pages.extensions.MicrometerShellPage");
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -41,6 +41,7 @@
         <module>vertx-http</module>
         <module>devjsonrpc</module>
         <module>devmcp</module>
+        <module>devshell</module>
         <module>devui</module>
         <module>undertow</module>
         <module>websockets</module>

--- a/extensions/resteasy-reactive/rest/deployment/pom.xml
+++ b/extensions/resteasy-reactive/rest/deployment/pom.xml
@@ -32,6 +32,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/devui/ResteasyReactiveDevUIProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/devui/ResteasyReactiveDevUIProcessor.java
@@ -4,6 +4,7 @@ import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.devjsonrpc.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.resteasy.reactive.server.runtime.dev.ui.ResteasyReactiveJsonRPCService;
@@ -45,5 +46,11 @@ public class ResteasyReactiveDevUIProcessor {
     @BuildStep(onlyIf = IsLocalDevelopment.class)
     public void createJsonRPCService(BuildProducer<JsonRPCProvidersBuildItem> jsonRPCServiceProducer) {
         jsonRPCServiceProducer.produce(new JsonRPCProvidersBuildItem(ResteasyReactiveJsonRPCService.class));
+    }
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    ShellPageBuildItem createShellPage() {
+        return ShellPageBuildItem.withCustomPage("REST Endpoints",
+                "io.quarkus.devshell.deployment.tui.pages.extensions.RestEndpointsShellPage");
     }
 }

--- a/extensions/scheduler/deployment/pom.xml
+++ b/extensions/scheduler/deployment/pom.xml
@@ -16,6 +16,10 @@
   <dependencies>
       <dependency>
           <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-devshell-deployment-spi</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>io.quarkus</groupId>
           <artifactId>quarkus-arc-deployment</artifactId>
       </dependency>
       <dependency>

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/devui/SchedulerDevUIProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/devui/SchedulerDevUIProcessor.java
@@ -7,6 +7,7 @@ import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.devjsonrpc.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
 import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.FooterPageBuildItem;
@@ -94,5 +95,11 @@ public class SchedulerDevUIProcessor {
     }
 
     final record CronResponse(String cron, String markdown) {
+    }
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    ShellPageBuildItem createShellPage() {
+        return ShellPageBuildItem.withCustomPage("Scheduler",
+                "io.quarkus.devshell.deployment.tui.pages.extensions.SchedulerShellPage");
     }
 }

--- a/extensions/smallrye-fault-tolerance/deployment/pom.xml
+++ b/extensions/smallrye-fault-tolerance/deployment/pom.xml
@@ -15,6 +15,10 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/devui/FaultToleranceDevUIProcessor.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/devui/FaultToleranceDevUIProcessor.java
@@ -3,6 +3,7 @@ package io.quarkus.smallrye.faulttolerance.deployment.devui;
 import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.devjsonrpc.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.smallrye.faulttolerance.runtime.devui.FaultToleranceJsonRpcService;
@@ -25,5 +26,11 @@ public class FaultToleranceDevUIProcessor {
     @BuildStep(onlyIf = IsLocalDevelopment.class)
     JsonRPCProvidersBuildItem jsonRPCService() {
         return new JsonRPCProvidersBuildItem(FaultToleranceJsonRpcService.class);
+    }
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    ShellPageBuildItem createShellPage() {
+        return ShellPageBuildItem.withCustomPage("Fault Tolerance", 'F',
+                "io.quarkus.devshell.deployment.tui.pages.extensions.FaultToleranceShellPage");
     }
 }

--- a/extensions/smallrye-graphql/deployment/pom.xml
+++ b/extensions/smallrye-graphql/deployment/pom.xml
@@ -16,6 +16,10 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-graphql</artifactId>
         </dependency>
         <dependency>

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/devui/SmallRyeGraphQLDevUIProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/devui/SmallRyeGraphQLDevUIProcessor.java
@@ -1,8 +1,10 @@
 package io.quarkus.smallrye.graphql.deployment.devui;
 
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.devjsonrpc.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.devui.spi.page.PageBuilder;
@@ -62,5 +64,11 @@ public class SmallRyeGraphQLDevUIProcessor {
     @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCService() {
         return new JsonRPCProvidersBuildItem(GraphQLJsonRpcService.class);
+    }
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    ShellPageBuildItem createShellPage() {
+        return ShellPageBuildItem.withCustomPage("GraphQL", 'g',
+                "io.quarkus.devshell.deployment.tui.pages.extensions.GraphQLShellPage");
     }
 }

--- a/extensions/smallrye-health/deployment/pom.xml
+++ b/extensions/smallrye-health/deployment/pom.xml
@@ -15,6 +15,10 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthDevUiProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthDevUiProcessor.java
@@ -1,11 +1,13 @@
 package io.quarkus.smallrye.health.deployment;
 
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.devjsonrpc.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.smallrye.health.runtime.SmallRyeHealthRecorder;
@@ -53,5 +55,11 @@ public class SmallRyeHealthDevUiProcessor {
     @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCService() {
         return new JsonRPCProvidersBuildItem(HealthJsonRPCService.class);
+    }
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    ShellPageBuildItem createShellPage() {
+        return ShellPageBuildItem.withCustomPage("Health", 'h',
+                "io.quarkus.devshell.deployment.tui.pages.extensions.HealthShellPage");
     }
 }

--- a/extensions/smallrye-openapi/deployment/pom.xml
+++ b/extensions/smallrye-openapi/deployment/pom.xml
@@ -27,6 +27,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-openapi-spi</artifactId>
         </dependency>
         <dependency>

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/devui/OpenApiDevUIProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/devui/OpenApiDevUIProcessor.java
@@ -6,9 +6,11 @@ import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.devjsonrpc.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
 import io.quarkus.devui.spi.DevContextBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
@@ -93,6 +95,12 @@ public class OpenApiDevUIProcessor {
     @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCService() {
         return new JsonRPCProvidersBuildItem(OpenApiJsonRpcService.class);
+    }
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    ShellPageBuildItem createShellPage() {
+        return ShellPageBuildItem.withCustomPage("OpenAPI", 'o',
+                "io.quarkus.devshell.deployment.tui.pages.extensions.OpenApiShellPage");
     }
 
 }

--- a/extensions/smallrye-reactive-messaging/deployment/pom.xml
+++ b/extensions/smallrye-reactive-messaging/deployment/pom.xml
@@ -54,6 +54,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devui-deployment-spi</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell-deployment-spi</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/devui/ReactiveMessagingDevUIProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/devui/ReactiveMessagingDevUIProcessor.java
@@ -13,6 +13,7 @@ import io.quarkus.arc.processor.InjectionPointInfo;
 import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.devjsonrpc.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames;
@@ -67,5 +68,11 @@ public class ReactiveMessagingDevUIProcessor {
     @BuildStep(onlyIf = IsLocalDevelopment.class)
     JsonRPCProvidersBuildItem createJsonRPCServiceForCache() {
         return new JsonRPCProvidersBuildItem(ReactiveMessagingJsonRpcService.class);
+    }
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    ShellPageBuildItem createShellPage() {
+        return ShellPageBuildItem.withCustomPage("Messaging", 'm',
+                "io.quarkus.devshell.deployment.tui.pages.extensions.ReactiveMessagingShellPage");
     }
 }

--- a/extensions/web-dependency-locator/deployment/pom.xml
+++ b/extensions/web-dependency-locator/deployment/pom.xml
@@ -22,6 +22,10 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devshell-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/devui/WebDependencyLocatorDevUIProcessor.java
+++ b/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/devui/WebDependencyLocatorDevUIProcessor.java
@@ -5,8 +5,10 @@ import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.devshell.deployment.spi.ShellPageBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.devui.spi.welcome.DynamicWelcomeBuildItem;
@@ -57,6 +59,12 @@ public class WebDependencyLocatorDevUIProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     public DynamicWelcomeBuildItem createDynamicWelcomeData() {
         return new DynamicWelcomeBuildItem(DYNAMIC_WELCOME);
+    }
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    ShellPageBuildItem createShellPage() {
+        return ShellPageBuildItem.withCustomPage("Web Libs", 'w',
+                "io.quarkus.devshell.deployment.tui.pages.extensions.WebDependencyLocatorShellPage");
     }
 
     private static final String DYNAMIC_WELCOME = """


### PR DESCRIPTION
Dev Shell brings the power of Dev UI directly to the terminal as an interactive, keyboard-driven TUI. During dev mode, pressing `t` launches a full-screen interface for inspecting configuration, endpoints, extensions, continuous testing, dev services, build metrics, dependencies, and more - without leaving the terminal.

The extension uses [TamboUI](https://github.com/niclaslindstedt/tamboui) for terminal rendering and connects to the existing Dev UI JSON-RPC backend for live data, so it stays consistent with what Dev UI shows in the browser.

Extensions can contribute custom shell pages via a new `ShellPageBuildItem` SPI (the CLI equivalent of `CardPageBuildItem`). This PR includes initial shell page support for 19 extensions: Agroal, ArC, Cache, Datasource, Flyway, gRPC, Hibernate ORM, Info, Kafka, Liquibase, Micrometer, REST, Scheduler, Fault Tolerance, GraphQL, Health, OpenAPI, Reactive Messaging, and Web Dependency Locator.

The shell can also be launched from a separate terminal to keep the log output visible while interacting with the TUI.

Preview status, disabled by default via `quarkus.devshell.enabled`.