### PR TITLE
Guard against null future when closing the OTLP HTTP client

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
@@ -27,6 +27,7 @@ import io.quarkus.vertx.core.runtime.BufferOutputStream;
 import io.smallrye.common.annotation.SuppressForbidden;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -187,7 +188,15 @@ public final class VertxHttpSender implements HttpSender {
         }
 
         try {
-            client.close()
+            Future<Void> closeFuture = client.close();
+            if (closeFuture == null) {
+                // A client that has already been closed can return null here rather than a
+                // completed future, in which case there is nothing left to wait for.
+                throttlingLogger.log(Level.FINE, "Client was already closed.");
+                shutdownResult.succeed();
+                return shutdownResult;
+            }
+            closeFuture
                     .onSuccess(
                             new Handler<>() {
                                 @Override


### PR DESCRIPTION
Fixes #55946.

## Problem

`VertxHttpSender.shutdown()` chains directly onto the result of `client.close()`:

```java
client.close()
        .onSuccess(...)
        .onFailure(...);
```

As reported, a client that has already been closed can return `null` there rather than a completed future, so the exporter shutdown path dies with:

```
java.lang.NullPointerException: Cannot invoke "io.vertx.core.Future.onSuccess(io.vertx.core.Handler)"
  because the return value of "io.vertx.core.http.HttpClient.close()" is null
    at ...VertxHttpSender.shutdown(VertxHttpSender.java:191)
```

The method already guards `client == null` a few lines above; this is the same situation one step later — nothing left to close — but it throws instead of completing.

## Change

Capture the future first and treat `null` as an already-completed close, so shutdown succeeds rather than propagating an NPE out of `BatchLogRecordProcessor`:

```java
Future<Void> closeFuture = client.close();
if (closeFuture == null) {
    throttlingLogger.log(Level.FINE, "Client was already closed.");
    shutdownResult.succeed();
    return shutdownResult;
}
closeFuture.onSuccess(...).onFailure(...);
```

`succeed()` rather than `fail()` because the desired end state — the client is closed — already holds; the existing `RejectedExecutionException` branch below stays as-is since that one genuinely failed to complete.

## Verification, and its limits

I want to be straight about what I did and did not run:

- The assignment is type-correct against the pinned Vert.x: `javap` on `io.vertx:vertx-core:5.1.6` (from `vertx.version` in the BOM) shows `public default io.vertx.core.Future<java.lang.Void> close();`.
- I did **not** run the Quarkus reactor build locally — it bootstraps `quarkus-extension-maven-plugin:999-SNAPSHOT` first and I couldn't complete that here. CI will be the real check on compilation.
- I also could not reproduce the NPE directly: it surfaces as a flaky `LgtmResourcesTest.testTracing` failure, so I'm working from the reported stack trace rather than a local reproduction.

Given that, this is a defensive guard on a shutdown path rather than a fix I could prove end-to-end. If you'd rather see the root cause chased in Vert.x — i.e. why `close()` returns `null` at all instead of a completed future — say so and I'll drop this.
