### PR TITLE
Guard against a null Future from client close in OTLP exporter shutdown

### DIFF
--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxGrpcSenderShutdownTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxGrpcSenderShutdownTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.opentelemetry.runtime.exporter.otlp.sender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.grpc.client.GrpcClient;
+
+class VertxGrpcSenderShutdownTest {
+
+    private VertxGrpcSender createSender(GrpcClient client) {
+        try (MockedStatic<GrpcClient> grpcClientFactory = mockStatic(GrpcClient.class)) {
+            grpcClientFactory.when(() -> GrpcClient.client(any(Vertx.class), any(HttpClientOptions.class)))
+                    .thenReturn(client);
+            return new VertxGrpcSender(URI.create("http://localhost:4317"), VertxGrpcSender.GRPC_TRACE_SERVICE_NAME, false,
+                    Duration.ofSeconds(10), Map.of(), options -> {
+                    }, mock(Vertx.class));
+        }
+    }
+
+    @Test
+    void shutdownSucceedsWhenCloseReturnsNull() {
+        // client.close() can return null when the underlying client was already reclaimed,
+        // see https://github.com/eclipse-vertx/vert.x/issues/6302
+        GrpcClient client = mock(GrpcClient.class);
+        when(client.close()).thenReturn(null);
+
+        var result = createSender(client).shutdown();
+
+        assertThat(result.isDone()).isTrue();
+        assertThat(result.isSuccess()).isFalse();
+    }
+
+    @Test
+    void shutdownSucceedsWhenCloseSucceeds() {
+        GrpcClient client = mock(GrpcClient.class);
+        when(client.close()).thenReturn(Future.succeededFuture());
+
+        var result = createSender(client).shutdown();
+
+        assertThat(result.isDone()).isTrue();
+        assertThat(result.isSuccess()).isTrue();
+    }
+}

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSenderShutdownTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSenderShutdownTest.java
@@ -1,0 +1,68 @@
+package io.quarkus.opentelemetry.runtime.exporter.otlp.sender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientAgent;
+import io.vertx.core.http.HttpClientBuilder;
+import io.vertx.core.http.HttpClientOptions;
+
+class VertxHttpSenderShutdownTest {
+
+    private VertxHttpSender createSender(HttpClientAgent client) {
+        Vertx vertx = mock(Vertx.class);
+        HttpClientBuilder builder = mock(HttpClientBuilder.class);
+        when(vertx.httpClientBuilder()).thenReturn(builder);
+        when(builder.with(any(HttpClientOptions.class))).thenReturn(builder);
+        when(builder.withConnectHandler(any())).thenReturn(builder);
+        when(builder.build()).thenReturn(client);
+        return new VertxHttpSender(URI.create("http://localhost:4318"), "/v1/traces", false, Duration.ofSeconds(10),
+                Map.of(), "application/x-protobuf", options -> {
+                }, vertx);
+    }
+
+    @Test
+    void shutdownSucceedsWhenCloseReturnsNull() {
+        // client.close() can return null when the underlying client was already reclaimed,
+        // see https://github.com/eclipse-vertx/vert.x/issues/6302
+        HttpClientAgent client = mock(HttpClientAgent.class);
+        when(client.close()).thenReturn(null);
+
+        var result = createSender(client).shutdown();
+
+        assertThat(result.isDone()).isTrue();
+        assertThat(result.isSuccess()).isFalse();
+    }
+
+    @Test
+    void shutdownSucceedsWhenCloseSucceeds() {
+        HttpClientAgent client = mock(HttpClientAgent.class);
+        when(client.close()).thenReturn(Future.succeededFuture());
+
+        var result = createSender(client).shutdown();
+
+        assertThat(result.isDone()).isTrue();
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    @Test
+    void shutdownFailsWhenCloseFails() {
+        HttpClientAgent client = mock(HttpClientAgent.class);
+        when(client.close()).thenReturn(Future.failedFuture(new IllegalStateException()));
+
+        var result = createSender(client).shutdown();
+
+        assertThat(result.isDone()).isTrue();
+        assertThat(result.isSuccess()).isFalse();
+    }
+}


### PR DESCRIPTION
The Vert.x HTTP and gRPC clients can return `null` from `close()` when the
underlying client was already reclaimed — typically when Vert.x shut down
before the exporter's `shutdown()` runs. The root cause is a vertx-core bug
(the `CleanableObject` cleaner action loses its close future when the weak
referent was collected, eclipse-vertx/vert.x#6302), but Quarkus runs on
released vertx-core versions, so the senders should defend against it —
`shutdown()` already handles two sibling symptoms of the same race (a null
client, and the `RejectedExecutionException` from a closed Netty pool).

Calling `.onSuccess()` on the null future threw a `NullPointerException`,
which is also what makes `LgtmResourcesTest.testTracing` flaky
(GC-timing-dependent, seen on the JDK 25 Semeru CI job in #55940).

The null-close tests reproduce the exact production NPE against the
unpatched code.

Fixes #55946
