### PR TITLE
Qute: add SectionHelperFactory#rawContent() to skip parsing section content

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -1608,6 +1608,39 @@ engineBuilder.addParserHook(new ParserHook() {
 ----
 <1> Escape all occurrences of `${`.
 
+==== Raw Content Sections
+
+By default, the content of a section is parsed just like any other part of a template - expressions, nested sections, comments, etc. are all processed.
+However, a custom `SectionHelperFactory` can override the `rawContent()` method to return `true`.
+In that case, the parser treats the section body as raw, unparsed text.
+The raw text is added as a single text node in the main block of the section.
+
+This can be useful for sections that need to process the content as-is, e.g. to escape or transform template syntax.
+
+.Raw Content Section Factory Example
+[source,java]
+----
+public class MySectionFactory implements SectionHelperFactory<MySectionHelper> {
+
+    @Override
+    public boolean rawContent() {
+        return true; <1>
+    }
+
+    @Override
+    public MySectionHelper initialize(SectionInitContext context) {
+        return new MySectionHelper();
+    }
+
+    // ...
+}
+----
+<1> The parser will not attempt to parse the section content. Expressions, sections, and other tags inside the section are treated as plain text.
+
+For example, a template `{#mySection}Hello {name}!{/mySection}` will pass the literal string `Hello {name}!` to the section helper, rather than evaluating `{name}` as an expression.
+
+NOTE: The section start tag parameters are still parsed and available via `SectionInitContext.getParameter(String)` during `SectionHelperFactory.initialize(SectionInitContext)`.
+
 [[strict_rendering]]
 ==== Strict Rendering
 
@@ -1750,6 +1783,8 @@ public class CustomSectionFactory implements SectionHelperFactory<CustomSectionF
 <4> Use the injected `Service` during rendering.
 
 TIP: The `@EngineConfiguration` annotation can be also used to register `ValueResolver`, `NamespaceResolver` and `ParserHook` components.
+
+TIP: A `SectionHelperFactory` can also override the `rawContent()` method to indicate that the section content should not be parsed. See <<Raw Content Sections>> for more details.
 
 [[template-locator-registration]]
 ==== Template Locator Registration

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/engineconfigurations/rawcontent/RawContentSectionFactory.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/engineconfigurations/rawcontent/RawContentSectionFactory.java
@@ -1,0 +1,43 @@
+package io.quarkus.qute.deployment.engineconfigurations.rawcontent;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import io.quarkus.qute.EngineConfiguration;
+import io.quarkus.qute.ResultNode;
+import io.quarkus.qute.SectionHelper;
+import io.quarkus.qute.SectionHelperFactory;
+import io.quarkus.qute.SingleResultNode;
+import io.quarkus.qute.TextNode;
+import io.quarkus.qute.deployment.engineconfigurations.rawcontent.RawContentSectionFactory.RawContentSectionHelper;
+
+@EngineConfiguration
+public class RawContentSectionFactory implements SectionHelperFactory<RawContentSectionHelper> {
+
+    @Override
+    public List<String> getDefaultAliases() {
+        return List.of("raw");
+    }
+
+    @Override
+    public boolean rawContent() {
+        return true;
+    }
+
+    @Override
+    public RawContentSectionHelper initialize(SectionInitContext context) {
+        return new RawContentSectionHelper();
+    }
+
+    class RawContentSectionHelper implements SectionHelper {
+
+        @Override
+        public CompletionStage<ResultNode> resolve(SectionResolutionContext context) {
+            return context.execute().thenApply(resultNode -> {
+                String text = ((TextNode) resultNode).getValue();
+                return new SingleResultNode(text.toUpperCase());
+            });
+        }
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/engineconfigurations/rawcontent/RawContentSectionTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/engineconfigurations/rawcontent/RawContentSectionTest.java
@@ -1,0 +1,30 @@
+package io.quarkus.qute.deployment.engineconfigurations.rawcontent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.Template;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class RawContentSectionTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot(root -> root.addClasses(RawContentSectionFactory.class)
+                    .addAsResource(new StringAsset("{#raw}Hello {name}! {illegal {/raw}"),
+                            "templates/foo.html"));
+
+    @Inject
+    Template foo;
+
+    @Test
+    public void testRawContent() {
+        assertEquals("HELLO {NAME}! {ILLEGAL ", foo.render());
+    }
+
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineBuilder.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineBuilder.java
@@ -475,6 +475,11 @@ public final class EngineBuilder {
         }
 
         @Override
+        public boolean rawContent() {
+            return delegate.rawContent();
+        }
+
+        @Override
         public MissingEndTagStrategy missingEndTagStrategy() {
             return delegate.missingEndTagStrategy();
         }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
@@ -40,7 +40,7 @@ import io.quarkus.qute.TemplateNode.Origin;
 /**
  * Simple non-reusable parser.
  */
-class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializer {
+class Parser implements ParserHelper, ParserDelegate, WithOrigin {
 
     private static final Logger LOGGER = Logger.getLogger(Parser.class);
     static final String ROOT_HELPER_NAME = "$root";
@@ -80,11 +80,12 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
     private final Deque<ParametersInfo> paramsStack;
     private final Deque<Scope> scopeStack;
     private int sectionBlockIdx;
-    private boolean ignoreContent;
     private int cdataPipeCount;
     private AtomicInteger expressionIdGenerator;
     private final List<Function<String, String>> contentFilters;
     private boolean hasLineSeparator;
+    private String rawContentSectionName;
+    private int rawContentSectionDepth;
 
     private TemplateImpl template;
 
@@ -163,6 +164,12 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
             while ((val = r.read()) != -1) {
                 processCharacter((char) val);
                 lineCharacter++;
+            }
+
+            if (state == State.RAW_CONTENT) {
+                // Flush the raw content as text; the unterminated section check below will report the error
+                flushText();
+                state = State.TAG_INSIDE;
             }
 
             if (buffer.length() > 0) {
@@ -274,6 +281,9 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
             case LINE_SEPARATOR:
                 lineSeparator(character);
                 break;
+            case RAW_CONTENT:
+                rawContent(character);
+                break;
             default:
                 throw error(ParserError.GENERAL_ERROR, "unknown parsing state: {state}").argument("state", state).build();
         }
@@ -357,6 +367,91 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
         return true;
     }
 
+    /**
+     * All characters are appended to the buffer as raw text. The only special character is the {@code END_DELIMITER} which
+     * may signal the end of a section tag. If the buffer ends with {@code {/sectionName}} (with optional trailing whitespace)
+     * and the depth is zero then we found the real end tag - remove it from the buffer, flush the raw content as a text node,
+     * and close the section. Nested occurrences of the same section tag (including parameterized ones like
+     * {@code {#raw param}}) are tracked with a depth counter. CRLF sequences are counted as a single line break.
+     */
+    private void rawContent(char character) {
+        if (character == END_DELIMITER && buffer.length() > 0) {
+            int endTagStart = findRawContentTag(Tag.SECTION_END.command);
+            if (endTagStart != -1) {
+                if (rawContentSectionDepth == 0) {
+                    buffer.delete(endTagStart, buffer.length());
+                    flushText();
+                    closeSection();
+                    state = State.TEXT;
+                    rawContentSectionName = null;
+                    return;
+                } else {
+                    rawContentSectionDepth--;
+                }
+            } else if (findRawContentTag(Tag.SECTION.command) != -1) {
+                rawContentSectionDepth++;
+            }
+        } else if (character == LINE_SEPARATOR_CR) {
+            line++;
+            lineCharacter = 1;
+        } else if (character == LINE_SEPARATOR_LF) {
+            // Don't increment for the LF part of a CRLF sequence
+            if (buffer.length() == 0 || buffer.charAt(buffer.length() - 1) != LINE_SEPARATOR_CR) {
+                line++;
+            }
+            lineCharacter = 1;
+        }
+        buffer.append(character);
+    }
+
+    /**
+     * @return the start position of the tag in the buffer, or {@code -1} if no match is found
+     */
+    private int findRawContentTag(char command) {
+        int bufLen = buffer.length();
+        int nameLen = rawContentSectionName.length();
+        if (bufLen < nameLen + 2) {
+            return -1;
+        }
+        // Scan backward for the last START_DELIMITER
+        int tagStart = -1;
+        for (int i = bufLen - 1; i >= 0; i--) {
+            if (buffer.charAt(i) == START_DELIMITER) {
+                tagStart = i;
+                break;
+            }
+        }
+        if (tagStart == -1 || tagStart + 1 >= bufLen) {
+            return -1;
+        }
+        if (buffer.charAt(tagStart + 1) != command) {
+            return -1;
+        }
+        int nameStart = tagStart + 2;
+        if (nameStart + nameLen > bufLen) {
+            return -1;
+        }
+        for (int i = 0; i < nameLen; i++) {
+            if (buffer.charAt(nameStart + i) != rawContentSectionName.charAt(i)) {
+                return -1;
+            }
+        }
+        // After the name: for end tags allow only whitespace; for start tags allow whitespace or end of buffer
+        int afterName = nameStart + nameLen;
+        if (afterName < bufLen) {
+            if (command == Tag.SECTION_END.command) {
+                for (int i = afterName; i < bufLen; i++) {
+                    if (!Character.isWhitespace(buffer.charAt(i))) {
+                        return -1;
+                    }
+                }
+            } else if (!Character.isWhitespace(buffer.charAt(afterName))) {
+                return -1;
+            }
+        }
+        return tagStart;
+    }
+
     private void tag(char character) {
         if (LiteralSupport.isStringLiteralSeparator(character)) {
             state = LiteralSupport.isStringLiteralSeparatorSingle(character) ? State.TAG_INSIDE_STRING_LITERAL_SINGLE
@@ -425,7 +520,7 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
     }
 
     private void flushText() {
-        if (buffer.length() > 0 && !ignoreContent) {
+        if (buffer.length() > 0) {
             SectionBlock.Builder block = sectionStack.peek().currentBlock();
             block.addNode(new TextNode(buffer.toString(), origin(0)));
         }
@@ -433,7 +528,7 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
     }
 
     private void flushNextLine() {
-        if (buffer.length() > 0 && !ignoreContent) {
+        if (buffer.length() > 0) {
             SectionBlock.Builder block = sectionStack.peek().currentBlock();
             block.addNode(new LineSeparatorNode(buffer.toString(), origin(0)));
         }
@@ -530,6 +625,11 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
             } else {
                 scopeStack.addFirst(newScope);
                 sectionStack.addFirst(sectionNode);
+                if (factory.rawContent()) {
+                    state = State.RAW_CONTENT;
+                    rawContentSectionName = sectionName;
+                    rawContentSectionDepth = 0;
+                }
             }
         }
     }
@@ -549,6 +649,7 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
                         .argument("tagName", block.getLabel()).build();
             }
             section.endBlock();
+            scopeStack.pop();
         } else {
             // Section end, e.g. {/if} or {/}
             if (section.helperName.equals(ROOT_HELPER_NAME)) {
@@ -568,12 +669,13 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
                             .build();
                 }
             }
-            // Pop the section and its main block
-            section = sectionStack.pop();
-            sectionStack.peek().currentBlock().addNode(section.build(this::currentTemplate));
+            closeSection();
         }
+    }
 
-        // Remove the last type info map from the stack
+    private void closeSection() {
+        SectionNode.Builder section = sectionStack.pop();
+        sectionStack.peek().currentBlock().addNode(section.build(this::currentTemplate));
         scopeStack.pop();
     }
 
@@ -585,9 +687,7 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
     private SectionNode.Builder handleOptionalEngTags(SectionNode.Builder section, String name) {
         while (section != null && !section.helperName.equals(name)) {
             if (section.factory.missingEndTagStrategy() == MissingEndTagStrategy.BIND_TO_PARENT) {
-                section = sectionStack.pop();
-                sectionStack.peek().currentBlock().addNode(section.build(this::currentTemplate));
-                scopeStack.pop();
+                closeSection();
                 section = sectionStack.peek();
             } else {
                 return section;
@@ -1012,6 +1112,7 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
         ESCAPE,
         CDATA,
         LINE_SEPARATOR,
+        RAW_CONTENT,
 
     }
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelper.java
@@ -86,9 +86,14 @@ public interface SectionHelper {
         CompletionStage<ResultNode> execute(SectionBlock block, ResolutionContext context);
 
         /**
-         * Parameters for a specific resolution.
+         * Returns the resolution parameters, i.e. parameters passed by the caller of
+         * {@link SectionNode#resolve(ResolutionContext, java.util.Map)}.
+         * <p>
+         * Note that these are <em>not</em> the parsed section tag parameters. Use
+         * {@link SectionInitContext#getParameter(String)} to access the parsed parameters during
+         * {@link SectionHelperFactory#initialize(SectionInitContext)}.
          *
-         * @return the immutable map of parameters, never {@code null}
+         * @return the immutable map of resolution parameters, never {@code null}
          */
         Map<String, Object> getParameters();
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelperFactory.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelperFactory.java
@@ -128,6 +128,17 @@ public interface SectionHelperFactory<T extends SectionHelper> {
     }
 
     /**
+     * If {@code true} then the content of the section is not parsed; instead it is treated as raw text.
+     * <p>
+     * The raw text is added as a single text node in the main block of the section.
+     *
+     * @return {@code true} if the section content should not be parsed
+     */
+    default boolean rawContent() {
+        return false;
+    }
+
+    /**
      * A section end tag may be mandatory or optional.
      *
      * @return the strategy

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
@@ -19,6 +19,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 
 import org.junit.jupiter.api.Test;
 
@@ -294,6 +295,111 @@ public class ParserTest {
                 engine.parse("Hello {name} {||||safe|}end||||}").data("name", "world").render());
         // Multi-pipe CDATA: content with Qute expressions is not parsed
         assertEquals("{name}", engine.parse("{|||{name}|||}").render());
+    }
+
+    @Test
+    public void testRawContent() {
+        SectionHelperFactory<?> rawFactory = new SectionHelperFactory<SectionHelper>() {
+            @Override
+            public SectionHelper initialize(SectionInitContext context) {
+                return new SectionHelper() {
+                    @Override
+                    public CompletionStage<ResultNode> resolve(SectionResolutionContext context) {
+                        return context.execute();
+                    }
+                };
+            }
+
+            @Override
+            public boolean rawContent() {
+                return true;
+            }
+        };
+        Engine engine = Engine.builder().addDefaults().addSectionHelper("raw", rawFactory).build();
+        // Expressions inside {#raw} are not parsed
+        assertEquals("{name}", engine.parse("{#raw}{name}{/raw}").render());
+        // Section tags inside {#raw} are not parsed
+        assertEquals("{#if true}hello{/if}", engine.parse("{#raw}{#if true}hello{/if}{/raw}").render());
+        // Content before and after the section is parsed normally
+        assertEquals("world {name} world",
+                engine.parse("{name} {#raw}{name}{/raw} {name}").data("name", "world").render());
+        // JS-like content with braces
+        assertEquals("function(){alert('bar');}",
+                engine.parse("{#raw}function(){alert('bar');}{/raw}").render());
+        // Nested raw section tags are handled correctly
+        assertEquals("{#raw}inner{/raw}",
+                engine.parse("{#raw}{#raw}inner{/raw}{/raw}").render());
+        // Multiline content preserves line breaks
+        assertEquals("line1\nline2\nline3",
+                engine.parse("{#raw}line1\nline2\nline3{/raw}").render());
+        // CDATA delimiters are not parsed inside raw content
+        assertEquals("{|foo|}",
+                engine.parse("{#raw}{|foo|}{/raw}").render());
+        // Combined: multiline, nested raw, cdata, section tag, incomplete expression
+        assertEquals("""
+                {#raw}
+                {|cdata|}
+                {#if true}yes{/if}
+                {foo
+                {/raw}""",
+                engine.parse("""
+                        {#raw}{#raw}
+                        {|cdata|}
+                        {#if true}yes{/if}
+                        {foo
+                        {/raw}{/raw}""").render());
+        // Whitespace in end tag is tolerated
+        assertEquals("hello",
+                engine.parse("{#raw}hello{/raw }").render());
+        // Nested raw section with parameters
+        assertEquals("{#raw param}inner{/raw}",
+                engine.parse("{#raw}{#raw param}inner{/raw}{/raw}").render());
+        // CRLF line endings are counted as single line breaks
+        assertEquals("a\r\nb",
+                engine.parse("{#raw}a\r\nb{/raw}").render());
+        // Unterminated raw section
+        try {
+            engine.parse("{#raw}hello");
+            fail("No parser error found");
+        } catch (TemplateException expected) {
+            assertEquals(ParserError.UNTERMINATED_SECTION, expected.getCode());
+        }
+    }
+
+    @Test
+    public void testRawContentTransform() {
+        SectionHelperFactory<?> transformFactory = new SectionHelperFactory<SectionHelper>() {
+
+            @Override
+            public ParametersInfo getParameters() {
+                return ParametersInfo.builder().addParameter("action").build();
+            }
+
+            @Override
+            public SectionHelper initialize(SectionInitContext context) {
+                String action = context.getParameter("action");
+                return new SectionHelper() {
+
+                    @Override
+                    public CompletionStage<ResultNode> resolve(SectionResolutionContext context) {
+                        return context.execute().thenApply(resultNode -> {
+                            String text = ((TextNode) resultNode).getValue();
+                            if ("upper".equals(action)) {
+                                text = text.toUpperCase();
+                            }
+                            return new SingleResultNode(text);
+                        });
+                    }
+                };
+            }
+
+            @Override
+            public boolean rawContent() {
+                return true;
+            }
+        };
+        Engine engine = Engine.builder().addDefaults().addSectionHelper("transform", transformFactory).build();
+        assertEquals("HELLO {NAME}!", engine.parse("{#transform action=upper}Hello {name}!{/transform}").render());
     }
 
     @Test


### PR DESCRIPTION
- if SectionHelperFactory#rawContent() == true, the parser treats the section body as raw text (not parsed
- this is useful for sections that need to process the content as-is, e.g. to escape or transform Qute syntax