### PR TITLE
Enable WebSocket traffic logging in aesh websocket tests

### DIFF
--- a/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/AeshRemoteConnectionHandler.java
+++ b/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/AeshRemoteConnectionHandler.java
@@ -113,6 +113,7 @@ public class AeshRemoteConnectionHandler {
         });
 
         try {
+            LOG.debugf("Setting up aesh console for %s session %s", transport, sessionId);
             var registryBuilder = registryFactory.create();
             var settingsBuilder = CliSettingsHelper.createBaseSettings(config, customizers);
             settingsBuilder.persistHistory(false);
@@ -128,9 +129,11 @@ public class AeshRemoteConnectionHandler {
                 runner.addExitCommand();
             }
 
+            LOG.debugf("Starting aesh console runner for %s session %s", transport, sessionId);
             runner.start();
+            LOG.debugf("Aesh console runner finished for %s session %s", transport, sessionId);
         } catch (Exception e) {
-            LOG.error("Error handling remote connection", e);
+            LOG.errorf(e, "Error handling remote %s connection (session %s)", transport, sessionId);
             connection.close();
         }
     }

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketAuthenticatedTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketAuthenticatedTest.java
@@ -40,7 +40,9 @@ public class AeshWebSocketAuthenticatedTest {
                     GoodbyeCommand.class,
                     TestIdentityProvider.class,
                     TestIdentityController.class))
-            .overrideConfigKey("quarkus.aesh.websocket.authenticated", "true");
+            .overrideConfigKey("quarkus.aesh.websocket.authenticated", "true")
+            .overrideConfigKey("quarkus.websockets-next.server.traffic-logging.enabled", "true")
+            .overrideConfigKey("quarkus.log.category.\"io.quarkus.websockets.next.traffic\".level", "DEBUG");
 
     @TestHTTPResource("/aesh/terminal")
     URI wsUri;

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketAuthenticatedTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketAuthenticatedTest.java
@@ -42,7 +42,8 @@ public class AeshWebSocketAuthenticatedTest {
                     TestIdentityController.class))
             .overrideConfigKey("quarkus.aesh.websocket.authenticated", "true")
             .overrideConfigKey("quarkus.websockets-next.server.traffic-logging.enabled", "true")
-            .overrideConfigKey("quarkus.log.category.\"io.quarkus.websockets.next.traffic\".level", "DEBUG");
+            .overrideConfigKey("quarkus.log.category.\"io.quarkus.websockets.next.traffic\".level", "DEBUG")
+            .overrideConfigKey("quarkus.log.category.\"io.quarkus.aesh\".level", "DEBUG");
 
     @TestHTTPResource("/aesh/terminal")
     URI wsUri;

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketConcurrentSessionsTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketConcurrentSessionsTest.java
@@ -33,7 +33,9 @@ public class AeshWebSocketConcurrentSessionsTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot(jar -> jar.addClasses(
-                    AeshWebSocketTestHelper.class, HelloCommand.class));
+                    AeshWebSocketTestHelper.class, HelloCommand.class))
+            .overrideConfigKey("quarkus.websockets-next.server.traffic-logging.enabled", "true")
+            .overrideConfigKey("quarkus.log.category.\"io.quarkus.websockets.next.traffic\".level", "DEBUG");
 
     @TestHTTPResource("/aesh/terminal")
     URI wsUri;

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketConcurrentSessionsTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketConcurrentSessionsTest.java
@@ -35,7 +35,8 @@ public class AeshWebSocketConcurrentSessionsTest {
             .withApplicationRoot(jar -> jar.addClasses(
                     AeshWebSocketTestHelper.class, HelloCommand.class))
             .overrideConfigKey("quarkus.websockets-next.server.traffic-logging.enabled", "true")
-            .overrideConfigKey("quarkus.log.category.\"io.quarkus.websockets.next.traffic\".level", "DEBUG");
+            .overrideConfigKey("quarkus.log.category.\"io.quarkus.websockets.next.traffic\".level", "DEBUG")
+            .overrideConfigKey("quarkus.log.category.\"io.quarkus.aesh\".level", "DEBUG");
 
     @TestHTTPResource("/aesh/terminal")
     URI wsUri;

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketConnectionTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketConnectionTest.java
@@ -31,7 +31,9 @@ public class AeshWebSocketConnectionTest {
             .withApplicationRoot(jar -> jar.addClasses(
                     AeshWebSocketTestHelper.class,
                     HelloCommand.class,
-                    GoodbyeCommand.class));
+                    GoodbyeCommand.class))
+            .overrideConfigKey("quarkus.websockets-next.server.traffic-logging.enabled", "true")
+            .overrideConfigKey("quarkus.log.category.\"io.quarkus.websockets.next.traffic\".level", "DEBUG");
 
     @TestHTTPResource("/aesh/terminal")
     URI wsUri;

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketConnectionTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketConnectionTest.java
@@ -33,7 +33,8 @@ public class AeshWebSocketConnectionTest {
                     HelloCommand.class,
                     GoodbyeCommand.class))
             .overrideConfigKey("quarkus.websockets-next.server.traffic-logging.enabled", "true")
-            .overrideConfigKey("quarkus.log.category.\"io.quarkus.websockets.next.traffic\".level", "DEBUG");
+            .overrideConfigKey("quarkus.log.category.\"io.quarkus.websockets.next.traffic\".level", "DEBUG")
+            .overrideConfigKey("quarkus.log.category.\"io.quarkus.aesh\".level", "DEBUG");
 
     @TestHTTPResource("/aesh/terminal")
     URI wsUri;

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketIdleTimeoutTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketIdleTimeoutTest.java
@@ -32,7 +32,8 @@ public class AeshWebSocketIdleTimeoutTest {
                     AeshWebSocketTestHelper.class, HelloCommand.class))
             .overrideConfigKey("quarkus.aesh.websocket.idle-timeout", "2s")
             .overrideConfigKey("quarkus.websockets-next.server.traffic-logging.enabled", "true")
-            .overrideConfigKey("quarkus.log.category.\"io.quarkus.websockets.next.traffic\".level", "DEBUG");
+            .overrideConfigKey("quarkus.log.category.\"io.quarkus.websockets.next.traffic\".level", "DEBUG")
+            .overrideConfigKey("quarkus.log.category.\"io.quarkus.aesh\".level", "DEBUG");
 
     @TestHTTPResource("/aesh/terminal")
     URI wsUri;

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketIdleTimeoutTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketIdleTimeoutTest.java
@@ -30,7 +30,9 @@ public class AeshWebSocketIdleTimeoutTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot(jar -> jar.addClasses(
                     AeshWebSocketTestHelper.class, HelloCommand.class))
-            .overrideConfigKey("quarkus.aesh.websocket.idle-timeout", "2s");
+            .overrideConfigKey("quarkus.aesh.websocket.idle-timeout", "2s")
+            .overrideConfigKey("quarkus.websockets-next.server.traffic-logging.enabled", "true")
+            .overrideConfigKey("quarkus.log.category.\"io.quarkus.websockets.next.traffic\".level", "DEBUG");
 
     @TestHTTPResource("/aesh/terminal")
     URI wsUri;

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketRolesAllowedTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketRolesAllowedTest.java
@@ -40,7 +40,9 @@ public class AeshWebSocketRolesAllowedTest {
                     GoodbyeCommand.class,
                     TestIdentityProvider.class,
                     TestIdentityController.class))
-            .overrideConfigKey("quarkus.aesh.websocket.roles-allowed", "admin");
+            .overrideConfigKey("quarkus.aesh.websocket.roles-allowed", "admin")
+            .overrideConfigKey("quarkus.websockets-next.server.traffic-logging.enabled", "true")
+            .overrideConfigKey("quarkus.log.category.\"io.quarkus.websockets.next.traffic\".level", "DEBUG");
 
     @TestHTTPResource("/aesh/terminal")
     URI wsUri;

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketRolesAllowedTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketRolesAllowedTest.java
@@ -42,7 +42,8 @@ public class AeshWebSocketRolesAllowedTest {
                     TestIdentityController.class))
             .overrideConfigKey("quarkus.aesh.websocket.roles-allowed", "admin")
             .overrideConfigKey("quarkus.websockets-next.server.traffic-logging.enabled", "true")
-            .overrideConfigKey("quarkus.log.category.\"io.quarkus.websockets.next.traffic\".level", "DEBUG");
+            .overrideConfigKey("quarkus.log.category.\"io.quarkus.websockets.next.traffic\".level", "DEBUG")
+            .overrideConfigKey("quarkus.log.category.\"io.quarkus.aesh\".level", "DEBUG");
 
     @TestHTTPResource("/aesh/terminal")
     URI wsUri;

--- a/extensions/aesh/websocket/runtime/src/main/java/io/quarkus/aesh/websocket/runtime/AeshWebSocketEndpoint.java
+++ b/extensions/aesh/websocket/runtime/src/main/java/io/quarkus/aesh/websocket/runtime/AeshWebSocketEndpoint.java
@@ -106,12 +106,14 @@ public class AeshWebSocketEndpoint implements TransportSessionInfo {
 
             conn = new AeshWebSocketConnection(ws);
             connections.put(ws.id(), conn);
+            LOG.debugf("New WebSocket aesh connection %s, processing init message", ws.id());
             conn.writeToDecoder(message);
 
             ensureIdleSchedulerStarted();
 
             AeshWebSocketConnection finalConn = conn;
             try {
+                LOG.debugf("Submitting aesh console setup to executor for connection %s", ws.id());
                 executor.submit(() -> connectionHandler.handle(finalConn, "websocket"));
             } catch (RejectedExecutionException e) {
                 LOG.warn("WebSocket executor has been shut down, rejecting new connection");
@@ -127,10 +129,13 @@ public class AeshWebSocketEndpoint implements TransportSessionInfo {
 
     @OnClose
     void onClose(WebSocketConnection ws) {
+        LOG.debugf("WebSocket connection %s closed", ws.id());
         AeshWebSocketConnection conn = connections.remove(ws.id());
         if (conn != null) {
             activeConnections.decrementAndGet();
             conn.close();
+        } else {
+            LOG.debugf("WebSocket connection %s closed but no aesh connection found (was never initialized)", ws.id());
         }
     }
 


### PR DESCRIPTION
Enable websockets-next traffic logging (DEBUG level) in all aesh websocket tests that use AeshWebSocketTestHelper.

Suggested-by: Martin Kouba <mkouba@redhat.com>

