### PR TITLE
Make `@TestTransaction` work with `Uni`-returning reactive test methods

### DIFF
--- a/extensions/hibernate-reactive/deployment/pom.xml
+++ b/extensions/hibernate-reactive/deployment/pom.xml
@@ -70,6 +70,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -16,32 +16,45 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.logging.Level;
 
+import jakarta.annotation.Priority;
+import jakarta.interceptor.Interceptor;
 import jakarta.persistence.PersistenceUnitTransactionType;
 
 import org.hibernate.reactive.provider.impl.ReactiveIntegrator;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
 import org.jboss.logging.Logger;
 
 import io.quarkus.agroal.spi.JdbcDataSourceBuildItem;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
+import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
 import io.quarkus.arc.deployment.RecorderBeanInitializedBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.datasource.common.runtime.DatabaseKind;
 import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.IsTest;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
+import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.LogCategoryBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
+import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.hibernate.orm.deployment.HibernateDataSourceUtil;
 import io.quarkus.hibernate.orm.deployment.HibernateOrmConfig;
 import io.quarkus.hibernate.orm.deployment.HibernateOrmConfigPersistenceUnit;
@@ -59,11 +72,13 @@ import io.quarkus.hibernate.orm.runtime.recording.RecordedConfig;
 import io.quarkus.hibernate.reactive.runtime.FastBootHibernateReactivePersistenceProvider;
 import io.quarkus.hibernate.reactive.runtime.HibernateReactivePersistenceUnitProviderHelper;
 import io.quarkus.hibernate.reactive.runtime.HibernateReactiveRecorder;
+import io.quarkus.hibernate.reactive.runtime.ReactiveTestTransactionInterceptor;
 import io.quarkus.hibernate.reactive.runtime.transaction.HibernateActionsStrategy;
 import io.quarkus.reactive.datasource.deployment.ReactiveDataSourceBuildItem;
 import io.quarkus.reactive.datasource.deployment.VertxPoolBuildItem;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.junit.common.ReactiveTestMethodTransformer;
 
 @BuildSteps(onlyIf = HibernateReactiveEnabled.class)
 public final class HibernateReactiveProcessor {
@@ -294,6 +309,80 @@ public final class HibernateReactiveProcessor {
     @BuildStep
     void silenceLogging(BuildProducer<LogCategoryBuildItem> logCategories) {
         logCategories.produce(new LogCategoryBuildItem(ReactiveIntegrator.class.getName(), Level.WARNING));
+    }
+
+    private static final String TEST_TRANSACTION = "io.quarkus.test.TestTransaction";
+
+    @BuildStep(onlyIf = IsTest.class)
+    void reactiveTestTx(BuildProducer<GeneratedBeanBuildItem> generatedBeanBuildItemBuildProducer,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        if (!testTransactionOnClassPath()) {
+            return;
+        }
+
+        try (ClassCreator c = ClassCreator.builder()
+                .classOutput(new GeneratedBeanGizmoAdaptor(generatedBeanBuildItemBuildProducer)).className(
+                        ReactiveTestTransactionInterceptor.class.getName() + "Generated")
+                .superClass(ReactiveTestTransactionInterceptor.class).build()) {
+            c.addAnnotation(TEST_TRANSACTION);
+            c.addAnnotation(Interceptor.class.getName());
+            c.addAnnotation(Priority.class).addValue("value", Interceptor.Priority.PLATFORM_BEFORE + 201);
+        }
+        additionalBeans.produce(AdditionalBeanBuildItem.builder().addBeanClass(ReactiveTestTransactionInterceptor.class)
+                .addBeanClass(TEST_TRANSACTION).build());
+    }
+
+    private static boolean testTransactionOnClassPath() {
+        try {
+            Class.forName(TEST_TRANSACTION, false, Thread.currentThread().getContextClassLoader());
+            return true;
+        } catch (ClassNotFoundException ignored) {
+            return false;
+        }
+    }
+
+    private static final DotName TEST_ANNOTATION = DotName.createSimple("org.junit.jupiter.api.Test");
+    private static final DotName TEST_TRANSACTION_ANNOTATION = DotName.createSimple(TEST_TRANSACTION);
+    private static final DotName UNI_DOTNAME = DotName.createSimple("io.smallrye.mutiny.Uni");
+
+    @BuildStep(onlyIf = IsTest.class)
+    void transformReactiveTestMethods(CombinedIndexBuildItem combinedIndex,
+            BuildProducer<BytecodeTransformerBuildItem> bytecodeTransformers) {
+        if (!testTransactionOnClassPath()) {
+            return;
+        }
+
+        Set<String> classNames = new HashSet<>();
+        for (AnnotationInstance ann : combinedIndex.getIndex().getAnnotations(TEST_TRANSACTION_ANNOTATION)) {
+            if (ann.target().kind() == AnnotationTarget.Kind.METHOD) {
+                MethodInfo method = ann.target().asMethod();
+                if (method.returnType().name().equals(UNI_DOTNAME)
+                        && method.hasAnnotation(TEST_ANNOTATION)) {
+                    classNames.add(method.declaringClass().name().toString());
+                }
+            } else if (ann.target().kind() == AnnotationTarget.Kind.CLASS) {
+                for (MethodInfo method : ann.target().asClass().methods()) {
+                    if (method.returnType().name().equals(UNI_DOTNAME)
+                            && method.hasAnnotation(TEST_ANNOTATION)) {
+                        classNames.add(method.declaringClass().name().toString());
+                        break;
+                    }
+                }
+            }
+        }
+
+        BiFunction<String, byte[], byte[]> inputTransformer = (name, bytes) -> {
+            byte[] result = ReactiveTestMethodTransformer.transformIfNeeded(bytes,
+                    Thread.currentThread().getContextClassLoader());
+            return result != null ? result : bytes;
+        };
+
+        for (String className : classNames) {
+            bytecodeTransformers.produce(new BytecodeTransformerBuildItem.Builder()
+                    .setClassToTransform(className)
+                    .setInputTransformer(inputTransformer)
+                    .build());
+        }
     }
 
     record QuarkusPersistenceUnitDescriptorWithSupportedDBKind(QuarkusPersistenceUnitDescriptor descriptor,

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/ReactiveTestTransactionTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/ReactiveTestTransactionTest.java
@@ -1,0 +1,79 @@
+package io.quarkus.hibernate.reactive.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.reactive.transaction.runtime.TransactionalInterceptorRequired;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.TestTransaction;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+import io.smallrye.mutiny.Uni;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ReactiveTestTransactionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar
+                    .addClasses(Hero.class)
+                    .addClasses(TransactionalInterceptorRequired.class)
+                    .addAsResource("initialTransactionData.sql", "import.sql"))
+            .withConfigurationResource("application-reactive-transaction.properties");
+
+    @Inject
+    Mutiny.SessionFactory sessionFactory;
+
+    @Inject
+    Mutiny.Session session;
+
+    @Test
+    @TestTransaction
+    @Order(1)
+    public Uni<Void> testInsertIsRolledBack() {
+        Hero hero = new Hero("ReactiveTestHero");
+        return session.persist(hero)
+                .call(() -> session.flush())
+                .invoke(() -> assertThat(hero.id).isNotNull());
+    }
+
+    @Test
+    @RunOnVertxContext
+    @Order(2)
+    public void testInsertWasRolledBack(UniAsserter asserter) {
+        asserter.assertThat(
+                () -> sessionFactory.withSession(s -> s.createQuery("from Hero where name = 'ReactiveTestHero'", Hero.class)
+                        .getResultList()),
+                list -> assertThat(list).isEmpty());
+    }
+
+    @Test
+    @TestTransaction
+    @Order(3)
+    public Uni<Void> testUpdateIsRolledBack() {
+        Long heroId = 50L;
+        return session.find(Hero.class, heroId)
+                .invoke(hero -> hero.setName("modifiedByReactiveTestTransaction"))
+                .call(() -> session.flush())
+                .invoke(hero -> assertThat(hero.getName()).isEqualTo("modifiedByReactiveTestTransaction"))
+                .replaceWithVoid();
+    }
+
+    @Test
+    @RunOnVertxContext
+    @Order(4)
+    public void testUpdateWasRolledBack(UniAsserter asserter) {
+        Long heroId = 50L;
+        asserter.assertThat(
+                () -> sessionFactory.withSession(s -> s.find(Hero.class, heroId)),
+                hero -> assertThat(hero.getName()).isEqualTo("initialName"));
+    }
+}

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/ReactiveTestTransactionInterceptor.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/ReactiveTestTransactionInterceptor.java
@@ -1,0 +1,70 @@
+package io.quarkus.hibernate.reactive.runtime;
+
+import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
+
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.InvocationContext;
+
+import io.quarkus.reactive.transaction.runtime.ReactiveResource;
+import io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase;
+import io.quarkus.reactive.transaction.runtime.pool.TransactionalContextPool;
+import io.smallrye.common.vertx.ContextLocals;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.Transaction;
+
+// Registered as an interceptor bean by HibernateReactiveProcessor.reactiveTestTx() only during tests
+public class ReactiveTestTransactionInterceptor {
+
+    @Inject
+    public ReactiveResource reactiveResource;
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ic) throws Exception {
+        if (!ic.getMethod().getReturnType().getName().equals(Uni.class.getName())) {
+            return ic.proceed();
+        }
+
+        return Uni.createFrom().deferred(() -> {
+            Context vertxContext = Vertx.currentContext();
+            ContextLocals.put(TRANSACTIONAL_METHOD_KEY, true);
+
+            return TransactionalInterceptorBase.proceedUni(ic)
+                    .call(() -> reactiveResource.beforeCommit(vertxContext))
+                    .onTermination().call(() -> rollback())
+                    .eventually(() -> reactiveResource.afterCommit(vertxContext))
+                    .eventually(() -> closeConnection());
+        });
+    }
+
+    private Uni<Void> rollback() {
+        Future<? extends SqlConnection> future = TransactionalContextPool.getCurrentConnectionFromVertxContext();
+        if (future == null) {
+            return Uni.createFrom().voidItem();
+        }
+        return toUni(future).onItem().transformToUni(connection -> {
+            Transaction transaction = connection.transaction();
+            if (transaction == null) {
+                return Uni.createFrom().voidItem();
+            }
+            return toUni(transaction.rollback());
+        });
+    }
+
+    private Uni<Void> closeConnection() {
+        Future<Void> closeFuture = TransactionalContextPool.closeAndClearCurrentConnection();
+        if (closeFuture == null) {
+            return Uni.createFrom().voidItem();
+        }
+        return toUni(closeFuture);
+    }
+
+    private static <T> Uni<T> toUni(Future<? extends T> future) {
+        return Uni.createFrom()
+                .emitter(emitter -> future.onComplete(emitter::complete, emitter::fail));
+    }
+}

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TestTransactionInterceptor.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TestTransactionInterceptor.java
@@ -29,6 +29,11 @@ public class TestTransactionInterceptor {
 
     @AroundInvoke
     public Object intercept(InvocationContext context) throws Exception {
+        // Uni-returning methods are handled by ReactiveTestTransactionInterceptor (hibernate-reactive)
+        if (context.getMethod().getReturnType().getName().equals("io.smallrye.mutiny.Uni")) {
+            return context.proceed();
+        }
+
         // do nothing in case there is already a transaction (e.g. self-intercepted non-private non-test method in test class)
         // w/o this check userTransaction.begin() would fail because there is already a tx associated with the current thread
         if (userTransaction.getStatus() != Status.STATUS_NO_TRANSACTION) {

--- a/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/ReactiveTestTransactionQuarkusTestTest.java
+++ b/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/ReactiveTestTransactionQuarkusTestTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.it.panache.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.TestTransaction;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+import io.smallrye.mutiny.Uni;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ReactiveTestTransactionQuarkusTestTest {
+
+    @Inject
+    Mutiny.SessionFactory sessionFactory;
+
+    @Inject
+    Mutiny.Session session;
+
+    @Test
+    @TestTransaction
+    @Order(1)
+    public Uni<Void> testInsertIsRolledBack() {
+        Person person = new Person();
+        person.name = "QuarkusTestReactivePerson";
+        return session.persist(person)
+                .call(() -> session.flush())
+                .invoke(() -> assertThat(person.id).isNotNull());
+    }
+
+    @Test
+    @RunOnVertxContext
+    @Order(2)
+    public void testInsertWasRolledBack(UniAsserter asserter) {
+        asserter.assertThat(
+                () -> sessionFactory.withSession(s -> s
+                        .createQuery("select count(p) from Person2 p where p.name = 'QuarkusTestReactivePerson'",
+                                Long.class)
+                        .getSingleResult()),
+                count -> assertThat(count).isEqualTo(0L));
+    }
+}

--- a/test-framework/common/src/main/java/io/quarkus/test/TestReactiveTransaction.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/TestReactiveTransaction.java
@@ -13,8 +13,11 @@ import jakarta.interceptor.InterceptorBinding;
  * This allows the test method to modify the database as required, and then have
  * these changes reverted at the end of the method.
  *
- * @see TestTransaction for JTA transactions.
+ * @deprecated Use {@link TestTransaction} instead. When used on a method that returns
+ *             {@link io.smallrye.mutiny.Uni}, {@code @TestTransaction} automatically uses
+ *             a reactive transaction with rollback.
  */
+@Deprecated(forRemoval = true, since = "4.0.0")
 @InterceptorBinding
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/test-framework/common/src/main/java/io/quarkus/test/TestTransaction.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/TestTransaction.java
@@ -8,12 +8,13 @@ import java.lang.annotation.Target;
 import jakarta.interceptor.InterceptorBinding;
 
 /**
- * Indicates that this method should be run in a rollback only JTA transaction.
- *
- * This allows the test method to modify the database as required, and then have
- * these changes reverted at the end of the method.
- *
- * @see TestReactiveTransaction for reactive transaction
+ * Indicates that this method should be run in a rollback-only transaction.
+ * <p>
+ * For imperative tests, a JTA transaction is used.
+ * <p>
+ * For reactive tests (when {@code quarkus-hibernate-reactive} is present), test methods
+ * that return {@code Uni} automatically run on a Vert.x event loop context with a reactive
+ * transaction that is rolled back at the end.
  */
 @InterceptorBinding
 @Retention(RetentionPolicy.RUNTIME)

--- a/test-framework/junit-common/pom.xml
+++ b/test-framework/junit-common/pom.xml
@@ -33,6 +33,24 @@
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.gizmo</groupId>
+            <artifactId>gizmo</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>jandex</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
             <scope>provided</scope>
@@ -40,7 +58,7 @@
         <dependency>
             <groupId>io.smallrye.config</groupId>
             <artifactId>smallrye-config</artifactId>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>

--- a/test-framework/junit-common/src/main/java/io/quarkus/test/junit/common/ReactiveTestLauncherSession.java
+++ b/test-framework/junit-common/src/main/java/io/quarkus/test/junit/common/ReactiveTestLauncherSession.java
@@ -1,0 +1,49 @@
+package io.quarkus.test.junit.common;
+
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.junit.platform.launcher.LauncherSession;
+import org.junit.platform.launcher.LauncherSessionListener;
+
+/**
+ * A {@link LauncherSessionListener} that wraps the TCCL with a
+ * {@link ReactiveTestTransformingClassLoader} to transform {@code Uni}-returning
+ * {@code @Test @TestTransaction} methods into synthetic void stubs for JUnit discovery.
+ * <p>
+ * When the {@code FacadeClassLoader} (from {@code quarkus-junit}) is also on the classpath,
+ * this wrapping still applies: {@code FacadeClassLoader} is created on top of the
+ * transforming classloader and delegates to it for non-QuarkusTest classes.
+ */
+public class ReactiveTestLauncherSession implements LauncherSessionListener {
+
+    private ClassLoader originalTccl;
+
+    @Override
+    public void launcherSessionOpened(LauncherSession session) {
+        originalTccl = Thread.currentThread().getContextClassLoader();
+        ClassLoader wrapper = new ReactiveTestTransformingClassLoader(originalTccl);
+        Thread.currentThread().setContextClassLoader(wrapper);
+        // If ConfigLauncherSession already ran, config is registered for originalTccl
+        // but not for our wrapper. Register it so lookups via the new TCCL succeed.
+        registerConfigForClassLoader(wrapper);
+    }
+
+    @Override
+    public void launcherSessionClosed(LauncherSession session) {
+        if (originalTccl != null) {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+            originalTccl = null;
+        }
+    }
+
+    private static void registerConfigForClassLoader(ClassLoader classLoader) {
+        try {
+            ConfigProviderResolver resolver = ConfigProviderResolver.instance();
+            // Get config registered for the parent (original TCCL) and register it
+            // for the wrapper too, so lookups by the new TCCL succeed.
+            resolver.registerConfig(resolver.getConfig(classLoader.getParent()), classLoader);
+        } catch (IllegalStateException ignored) {
+            // No ConfigProviderResolver set yet (we ran before ConfigLauncherSession) — that's
+            // fine, ConfigLauncherSession will see our wrapper as the TCCL and register for it.
+        }
+    }
+}

--- a/test-framework/junit-common/src/main/java/io/quarkus/test/junit/common/ReactiveTestMethodTransformer.java
+++ b/test-framework/junit-common/src/main/java/io/quarkus/test/junit/common/ReactiveTestMethodTransformer.java
@@ -1,0 +1,247 @@
+package io.quarkus.test.junit.common;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.jboss.jandex.MethodInfo;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+
+import io.quarkus.gizmo.ClassTransformer;
+import io.quarkus.gizmo.Gizmo;
+import io.quarkus.gizmo.MethodCreator;
+
+/**
+ * Transforms test classes so that {@code @Test @TestTransaction} methods returning
+ * {@code Uni} are discoverable by JUnit 5. JUnit rejects non-void {@code @Test} methods,
+ * so for each such method this transformer:
+ * <ol>
+ * <li>Removes the {@code @Test} annotation from the original Uni-returning method</li>
+ * <li>Adds a synthetic void stub method (original name + {@value #REACTIVE_TEST_SUFFIX})
+ * with {@code @Test} and {@code @TestTransaction} annotations</li>
+ * </ol>
+ * JUnit discovers the synthetic stub; at execution time the framework strips the suffix
+ * and invokes the original Uni-returning method.
+ */
+public final class ReactiveTestMethodTransformer {
+
+    public static final String REACTIVE_TEST_SUFFIX = "$quarkusRxTest";
+
+    private static final String TEST_ANNOTATION_FQN = "org.junit.jupiter.api.Test";
+    private static final String TEST_TRANSACTION_FQN = "io.quarkus.test.TestTransaction";
+    private static final String ORDER_ANNOTATION_FQN = "org.junit.jupiter.api.Order";
+
+    private static final DotName TEST_ANNOTATION = DotName.createSimple(TEST_ANNOTATION_FQN);
+    private static final DotName TEST_TRANSACTION_ANNOTATION = DotName.createSimple(TEST_TRANSACTION_FQN);
+    private static final DotName ORDER_ANNOTATION = DotName.createSimple(ORDER_ANNOTATION_FQN);
+    private static final DotName UNI_DOTNAME = DotName.createSimple("io.smallrye.mutiny.Uni");
+
+    private static final String TEST_ANNOTATION_DESC = "L" + TEST_ANNOTATION_FQN.replace('.', '/') + ";";
+    private static final String UNI_DESCRIPTOR_SUFFIX = "Lio/smallrye/mutiny/Uni;";
+
+    // Lio/quarkus/test/TestTransaction; as raw bytes for fast constant pool scanning
+    private static final byte[] TEST_TRANSACTION_BYTES = ("L" + TEST_TRANSACTION_FQN.replace('.', '/') + ";").getBytes();
+
+    private ReactiveTestMethodTransformer() {
+    }
+
+    /**
+     * Strips the reactive test suffix from a method name, if present.
+     */
+    public static String stripReactiveTestSuffix(String methodName) {
+        if (methodName.endsWith(REACTIVE_TEST_SUFFIX)) {
+            return methodName.substring(0, methodName.length() - REACTIVE_TEST_SUFFIX.length());
+        }
+        return methodName;
+    }
+
+    /**
+     * Transforms the class if it contains {@code @Test @TestTransaction} methods returning
+     * {@code Uni}. Returns {@code null} if no transformation is needed.
+     */
+    public static byte[] transformIfNeeded(byte[] classBytes, ClassLoader classLoader) {
+        List<ReactiveTestMethod> methods = findReactiveTestMethods(classBytes);
+        if (methods.isEmpty()) {
+            return null;
+        }
+        return transform(classBytes, methods, classLoader);
+    }
+
+    /**
+     * Uses Jandex to scan class bytes for methods annotated with both {@code @Test} and
+     * {@code @TestTransaction} that return {@code Uni}.
+     */
+    private static List<ReactiveTestMethod> findReactiveTestMethods(byte[] classBytes) {
+        if (!containsBytes(classBytes, TEST_TRANSACTION_BYTES)) {
+            return List.of();
+        }
+
+        Indexer indexer = new Indexer();
+        try {
+            indexer.index(new ByteArrayInputStream(classBytes));
+        } catch (IOException e) {
+            return List.of();
+        }
+        Index index = indexer.complete();
+        if (index.getKnownClasses().isEmpty()) {
+            return List.of();
+        }
+        ClassInfo classInfo = index.getKnownClasses().iterator().next();
+
+        List<ReactiveTestMethod> methods = new ArrayList<>();
+        for (MethodInfo method : classInfo.methods()) {
+            if (method.returnType().name().equals(UNI_DOTNAME)
+                    && method.hasAnnotation(TEST_ANNOTATION)
+                    && method.hasAnnotation(TEST_TRANSACTION_ANNOTATION)) {
+                int orderValue = -1;
+                AnnotationInstance orderAnn = method.annotation(ORDER_ANNOTATION);
+                if (orderAnn != null && orderAnn.value() != null) {
+                    orderValue = orderAnn.value().asInt();
+                }
+                String[] paramTypes = method.parameterTypes().stream()
+                        .map(t -> t.name().toString())
+                        .toArray(String[]::new);
+                methods.add(new ReactiveTestMethod(method.name(), paramTypes, method.flags(), orderValue));
+            }
+        }
+        return methods;
+    }
+
+    /**
+     * Transforms the class by removing {@code @Test} from the original Uni-returning
+     * methods (using raw ASM) and adding synthetic void stub methods that JUnit can
+     * discover (using Gizmo {@link ClassTransformer}).
+     */
+    private static byte[] transform(byte[] classBytes, List<ReactiveTestMethod> methods, ClassLoader classLoader) {
+        ClassReader reader = new ClassReader(classBytes);
+        String className = reader.getClassName().replace('/', '.');
+
+        // Gizmo ClassTransformer adds synthetic void stub methods
+        ClassTransformer transformer = new ClassTransformer(className);
+        for (ReactiveTestMethod method : methods) {
+            MethodCreator mc = transformer.addMethod(
+                    method.name + REACTIVE_TEST_SUFFIX, void.class, (Object[]) method.parameterTypes);
+            mc.setModifiers(method.access);
+            mc.addAnnotation(TEST_ANNOTATION_FQN, RetentionPolicy.RUNTIME);
+            mc.addAnnotation(TEST_TRANSACTION_FQN, RetentionPolicy.RUNTIME);
+            if (method.orderValue >= 0) {
+                mc.addAnnotation(ORDER_ANNOTATION_FQN, RetentionPolicy.RUNTIME)
+                        .addValue("value", method.orderValue);
+            }
+            mc.returnVoid();
+        }
+
+        Set<String> methodNames = new HashSet<>();
+        for (ReactiveTestMethod m : methods) {
+            methodNames.add(m.name);
+        }
+
+        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES) {
+            @Override
+            protected String getCommonSuperClass(String type1, String type2) {
+                ClassLoader cl = classLoader != null ? classLoader : ClassLoader.getSystemClassLoader();
+                try {
+                    Class<?> c1 = Class.forName(type1.replace('/', '.'), false, cl);
+                    Class<?> c2 = Class.forName(type2.replace('/', '.'), false, cl);
+                    if (c1.isAssignableFrom(c2)) {
+                        return type1;
+                    }
+                    if (c2.isAssignableFrom(c1)) {
+                        return type2;
+                    }
+                    if (c1.isInterface() || c2.isInterface()) {
+                        return "java/lang/Object";
+                    }
+                    do {
+                        c1 = c1.getSuperclass();
+                    } while (!c1.isAssignableFrom(c2));
+                    return c1.getName().replace('.', '/');
+                } catch (ClassNotFoundException e) {
+                    return "java/lang/Object";
+                }
+            }
+        };
+
+        // Raw ASM visitor strips @Test from the original Uni-returning methods
+        ClassVisitor strippingVisitor = new ClassVisitor(Gizmo.ASM_API_VERSION, writer) {
+            @Override
+            public MethodVisitor visitMethod(int access, String name, String descriptor,
+                    String signature, String[] exceptions) {
+                MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
+                if (methodNames.contains(name) && descriptor.endsWith(UNI_DESCRIPTOR_SUFFIX)) {
+                    return new MethodVisitor(Gizmo.ASM_API_VERSION, mv) {
+                        @Override
+                        public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+                            if (TEST_ANNOTATION_DESC.equals(desc)) {
+                                return null;
+                            }
+                            return super.visitAnnotation(desc, visible);
+                        }
+                    };
+                }
+                return mv;
+            }
+        };
+
+        // Chain: reader → gizmo (adds synthetic methods) → stripping (removes @Test) → writer
+        ClassVisitor gizmoVisitor = transformer.applyTo(strippingVisitor);
+        reader.accept(gizmoVisitor, 0);
+        return writer.toByteArray();
+    }
+
+    /**
+     * Reads class bytes from the given classloader's resources.
+     */
+    public static byte[] readClassBytes(String className, ClassLoader classLoader) {
+        String resourceName = className.replace('.', '/') + ".class";
+        try (InputStream is = classLoader.getResourceAsStream(resourceName)) {
+            if (is == null) {
+                return null;
+            }
+            return is.readAllBytes();
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private static boolean containsBytes(byte[] haystack, byte[] needle) {
+        int limit = haystack.length - needle.length;
+        outer: for (int i = 0; i <= limit; i++) {
+            for (int j = 0; j < needle.length; j++) {
+                if (haystack[i + j] != needle[j]) {
+                    continue outer;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private static final class ReactiveTestMethod {
+        final String name;
+        final String[] parameterTypes;
+        final int access;
+        final int orderValue;
+
+        ReactiveTestMethod(String name, String[] parameterTypes, int access, int orderValue) {
+            this.name = name;
+            this.parameterTypes = parameterTypes;
+            this.access = access;
+            this.orderValue = orderValue;
+        }
+    }
+}

--- a/test-framework/junit-common/src/main/java/io/quarkus/test/junit/common/ReactiveTestTransformingClassLoader.java
+++ b/test-framework/junit-common/src/main/java/io/quarkus/test/junit/common/ReactiveTestTransformingClassLoader.java
@@ -1,0 +1,56 @@
+package io.quarkus.test.junit.common;
+
+/**
+ * A classloader that adds synthetic void stub methods for {@code @Test @TestTransaction}
+ * methods returning {@code Uni}, so JUnit 5 discovers the stubs. At execution time, the
+ * framework strips the suffix and invokes the original Uni-returning method.
+ */
+final class ReactiveTestTransformingClassLoader extends ClassLoader {
+
+    ReactiveTestTransformingClassLoader(ClassLoader parent) {
+        super(parent);
+    }
+
+    @Override
+    public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        synchronized (getClassLoadingLock(name)) {
+            Class<?> loaded = findLoadedClass(name);
+            if (loaded != null) {
+                return loaded;
+            }
+
+            if (!shouldCheck(name)) {
+                return super.loadClass(name, resolve);
+            }
+
+            byte[] classBytes = ReactiveTestMethodTransformer.readClassBytes(name, getParent());
+            if (classBytes == null) {
+                return super.loadClass(name, resolve);
+            }
+
+            byte[] transformed = ReactiveTestMethodTransformer.transformIfNeeded(classBytes, getParent());
+            if (transformed == null) {
+                return super.loadClass(name, resolve);
+            }
+
+            Class<?> defined = defineClass(name, transformed, 0, transformed.length);
+            if (resolve) {
+                resolveClass(defined);
+            }
+            return defined;
+        }
+    }
+
+    private static boolean shouldCheck(String name) {
+        return !name.startsWith("java.")
+                && !name.startsWith("javax.")
+                && !name.startsWith("jakarta.")
+                && !name.startsWith("jdk.")
+                && !name.startsWith("sun.")
+                && !name.startsWith("com.sun.")
+                && !name.startsWith("org.junit.")
+                && !name.startsWith("org.objectweb.")
+                && !name.startsWith("org.jboss.")
+                && !name.startsWith("io.quarkus.test.junit.");
+    }
+}

--- a/test-framework/junit-common/src/main/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+++ b/test-framework/junit-common/src/main/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
@@ -1,0 +1,1 @@
+io.quarkus.test.junit.common.ReactiveTestLauncherSession

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/AbstractQuarkusExtensionTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/AbstractQuarkusExtensionTest.java
@@ -82,6 +82,7 @@ import io.quarkus.test.common.TestConfigUtil;
 import io.quarkus.test.common.TestResourceManager;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
 import io.quarkus.test.junit.common.ClearCache;
+import io.quarkus.test.junit.common.ReactiveTestMethodTransformer;
 import io.quarkus.value.registry.ValueRegistry;
 import io.smallrye.common.process.ProcessBuilder;
 import io.smallrye.common.process.ProcessUtil;
@@ -489,7 +490,8 @@ public abstract class AbstractQuarkusExtensionTest<S extends AbstractQuarkusExte
         while ((c != Object.class) && newMethod == null) {
             Method[] declaredMethods = c.getDeclaredMethods();
             for (Method declaredMethod : declaredMethods) {
-                if (!declaredMethod.getName().equals(invocationContext.getExecutable().getName())) {
+                if (!declaredMethod.getName().equals(ReactiveTestMethodTransformer
+                        .stripReactiveTestSuffix(invocationContext.getExecutable().getName()))) {
                     continue;
                 }
                 boolean parametersMatch = true;

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -81,6 +81,7 @@ import io.quarkus.test.config.ValueRegistryInjector;
 import io.quarkus.test.junit.callback.QuarkusTestContext;
 import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
 import io.quarkus.test.junit.common.ClearCache;
+import io.quarkus.test.junit.common.ReactiveTestMethodTransformer;
 import io.quarkus.value.registry.ValueRegistry;
 import io.smallrye.config.Config;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
@@ -1029,7 +1030,8 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                     parameterTypesFromTccl.add(type);
                 }
             }
-            return declaringClass.getDeclaredMethod(originalMethod.getName(),
+            String methodName = ReactiveTestMethodTransformer.stripReactiveTestSuffix(originalMethod.getName());
+            return declaringClass.getDeclaredMethod(methodName,
                     parameterTypesFromTccl.toArray(new Class[0]));
         } catch (NoSuchMethodException ignored) {
 

--- a/test-framework/vertx/src/main/java/io/quarkus/test/vertx/RunOnVertxContextTestMethodInvoker.java
+++ b/test-framework/vertx/src/main/java/io/quarkus/test/vertx/RunOnVertxContextTestMethodInvoker.java
@@ -14,6 +14,7 @@ import io.quarkus.test.TestReactiveTransaction;
 import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
 import io.smallrye.common.vertx.VertxContext;
+import io.smallrye.mutiny.Uni;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -45,8 +46,35 @@ public class RunOnVertxContextTestMethodInvoker implements TestMethodInvoker {
 
     @Override
     public boolean supportsMethod(Class<?> originalTestClass, Method originalTestMethod) {
-        return hasSupportedAnnotation(originalTestClass, originalTestMethod)
-                && hasSupportedParams(originalTestMethod);
+        if (hasSupportedAnnotation(originalTestClass, originalTestMethod)
+                && hasSupportedParams(originalTestMethod)) {
+            return true;
+        }
+        return isReactiveTestTransaction(originalTestClass, originalTestMethod);
+    }
+
+    private static final String REACTIVE_TEST_SUFFIX = "$quarkusRxTest";
+
+    /**
+     * Detects reactive test transaction methods via two paths:
+     * <ul>
+     * <li>{@code supportsMethod()} passes the synthetic stub whose name ends with the suffix
+     * — a direct match.</li>
+     * <li>{@code invoke()} receives the <em>real</em> method (suffix stripped by
+     * {@code AbstractQuarkusExtensionTest.runExtensionMethod()}), so we fall back to checking
+     * {@code @TestTransaction} + {@code Uni} return type on the original method and its class.</li>
+     * </ul>
+     */
+    private boolean isReactiveTestTransaction(Class<?> testClass, Method testMethod) {
+        if (testMethod.getName().endsWith(REACTIVE_TEST_SUFFIX)) {
+            return true;
+        }
+        if (testMethod.getReturnType().getName().equals(Uni.class.getName())
+                && (hasAnnotation("io.quarkus.test.TestTransaction", testMethod.getAnnotations())
+                        || hasAnnotation("io.quarkus.test.TestTransaction", testClass.getAnnotations()))) {
+            return true;
+        }
+        return false;
     }
 
     private boolean hasSupportedParams(Method originalTestMethod) {
@@ -117,15 +145,18 @@ public class RunOnVertxContextTestMethodInvoker implements TestMethodInvoker {
             runOnVertxContext = c.getAnnotation(RunOnVertxContext.class);
         }
         if (runOnVertxContext == null) {
-            // Use duplicated context if @TestReactiveTransaction is present
-            return m.isAnnotationPresent(TestReactiveTransaction.class)
-                    || m.getDeclaringClass().isAnnotationPresent(TestReactiveTransaction.class);
+            return hasAnnotation(TestReactiveTransaction.class, m.getAnnotations())
+                    || hasAnnotation(TestReactiveTransaction.class, m.getDeclaringClass().getAnnotations())
+                    || isReactiveTestTransaction(c, m);
         } else {
             return runOnVertxContext.duplicateContext();
         }
     }
 
     private boolean shouldRunOnEventLoop(Class<?> c, Method m) {
+        if (isReactiveTestTransaction(c, m)) {
+            return true;
+        }
         RunOnVertxContext runOnVertxContext = m.getAnnotation(RunOnVertxContext.class);
         if (runOnVertxContext == null) {
             runOnVertxContext = c.getAnnotation(RunOnVertxContext.class);
@@ -192,6 +223,20 @@ public class RunOnVertxContextTestMethodInvoker implements TestMethodInvoker {
                             promise.fail(t);
                         }
                     });
+                } else if (testMethodResult instanceof Uni<?> uni) {
+                    uni.subscribe().with(new Consumer<Object>() {
+                        @Override
+                        public void accept(Object o) {
+                            onTerminate.run();
+                            promise.complete(o);
+                        }
+                    }, new Consumer<Throwable>() {
+                        @Override
+                        public void accept(Throwable t) {
+                            onTerminate.run();
+                            promise.fail(t);
+                        }
+                    });
                 } else {
                     onTerminate.run();
                     promise.complete(testMethodResult);
@@ -240,6 +285,8 @@ public class RunOnVertxContextTestMethodInvoker implements TestMethodInvoker {
                 Object testMethodResult = targetMethod.invoke(testInstance, methodArgs.toArray(new Object[0]));
                 if (uniAsserter != null) {
                     uniAsserter.asUni().await().atMost(Duration.ofSeconds(30));
+                } else if (testMethodResult instanceof Uni<?> uni) {
+                    uni.await().atMost(Duration.ofSeconds(30));
                 }
                 onTerminate.run();
                 return testMethodResult;


### PR DESCRIPTION
I am not a fan of introducing another ClassLoader, but I don't see how it can be done differently. I've avoided it for the `@QuarkusTest` case using a transformer, but for `@QuarkusUnitTest` it was not sufficient. It is a small CL, and it only kicks in its logic when `@TestTransaction` is found in the class bytes, so its impact should be small.

I'll defer to our CL maintainers to judge if this is OK or mad.

The gist of it is that we're trying to make these methods run as tests:

```java
@Test
@TestTransaction
public Uni<Void> someTest() {
 // do something reactive
}
```

Because currently, we require this:

```java
@Test
@ReactiveTestTransaction
public void someTest(UniAsserter asserter) {
 // do something reactive within `asserter`
}
```

And that's just an annoying and weird pattern.

But… JUnit 5 silently rejects non-void @Test methods, so Uni-returning @TestTransaction tests were never discovered. This adds a bytecode transformation that generates synthetic void stub methods for JUnit discovery, while the framework strips the suffix at execution time to invoke the original Uni-returning method.

The interceptor chain skips JTA (narayana-jta, priority 200) and wraps the Uni in a rolled-back reactive transaction (hibernate-reactive, priority 201).

Three discovery paths are supported:
- @QuarkusTest: BytecodeTransformerBuildItem via HibernateReactiveProcessor
- QuarkusUnitTest with quarkus-junit: FacadeClassLoader delegates to ReactiveTestTransformingClassLoader parent
- QuarkusUnitTest without quarkus-junit: ReactiveTestLauncherSession wraps TCCL with ReactiveTestTransformingClassLoader

Fixes [#53622](https://github.com/quarkusio/quarkus/issues/54562)