### PR TITLE
Bump smallrye-reactive-messaging.version from 5.0.0-beta4 to 5.0.0-beta5

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -59,7 +59,7 @@
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
         <smallrye-openssl.version>0.2.3</smallrye-openssl.version>
         <smallrye-mutiny-vertx-binding.version>4.0.1</smallrye-mutiny-vertx-binding.version>
-        <smallrye-reactive-messaging.version>5.0.0-beta4</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>5.0.0-beta5</smallrye-reactive-messaging.version>
         <smallrye-stork.version>3.0.0</smallrye-stork.version>
         <jakarta.activation.version>2.1.4</jakarta.activation.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
@@ -2108,17 +2108,16 @@
                 <artifactId>quarkus-messaging-amqp-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            <!-- TODO MQTT Vert.x 5-->
-<!--            <dependency>-->
-<!--                <groupId>io.quarkus</groupId>-->
-<!--                <artifactId>quarkus-messaging-mqtt</artifactId>-->
-<!--                <version>${project.version}</version>-->
-<!--            </dependency>-->
-<!--            <dependency>-->
-<!--                <groupId>io.quarkus</groupId>-->
-<!--                <artifactId>quarkus-messaging-mqtt-deployment</artifactId>-->
-<!--                <version>${project.version}</version>-->
-<!--            </dependency>-->
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-messaging-mqtt</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-messaging-mqtt-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-messaging-rabbitmq</artifactId>

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -1716,6 +1716,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-messaging-mqtt</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-messaging-pulsar</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -1680,6 +1680,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-messaging-mqtt-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-messaging-pulsar-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -79,7 +79,7 @@
         <module>smallrye-reactive-messaging-kafka</module>
         <module>smallrye-reactive-messaging-amqp</module>
         <module>smallrye-reactive-messaging-pulsar</module>
-<!--        <module>smallrye-reactive-messaging-mqtt</module>-->
+        <module>smallrye-reactive-messaging-mqtt</module>
         <module>smallrye-reactive-messaging-rabbitmq</module>
         <module>smallrye-context-propagation</module>
         <module>reactive-datasource</module>

--- a/extensions/smallrye-reactive-messaging-rabbitmq/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/runtime/pom.xml
@@ -16,7 +16,7 @@
     <dependencies>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-reactive-messaging-rabbitmq-og</artifactId>
+            <artifactId>smallrye-reactive-messaging-rabbitmq</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ConnectorContextPropagationDecorator.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ConnectorContextPropagationDecorator.java
@@ -7,6 +7,7 @@ import java.util.concurrent.Executor;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.context.ThreadContext;
 import org.eclipse.microprofile.reactive.messaging.Message;
@@ -31,6 +32,15 @@ public class ConnectorContextPropagationDecorator implements PublisherDecorator,
                 .propagated(propagation.map(l -> l.toArray(String[]::new)).orElse(ThreadContext.NONE))
                 .cleared(ThreadContext.ALL_REMAINING)
                 .build();
+    }
+
+    @Override
+    public Multi<? extends Message<?>> decorate(Multi<? extends Message<?>> publisher, List<String> channelName,
+            Config connectorConfig) {
+        if (connectorConfig != null) {
+            return new ContextPropagationOperator<>(publisher, tc);
+        }
+        return publisher;
     }
 
     @Override

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -355,7 +355,7 @@
                 <module>reactive-messaging-amqp</module>
                 <module>reactive-messaging-kafka</module>
                 <module>reactive-messaging-pulsar</module>
-<!--                <module>reactive-messaging-mqtt</module>-->
+                <module>reactive-messaging-mqtt</module>
                 <module>reactive-messaging-rabbitmq</module>
                 <module>reactive-messaging-rabbitmq-devservices</module>
                 <module>reactive-messaging-rabbitmq-dyn</module>

--- a/integration-tests/reactive-messaging-mqtt/pom.xml
+++ b/integration-tests/reactive-messaging-mqtt/pom.xml
@@ -126,19 +126,19 @@
                 </exclusion>
             </exclusions>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>io.quarkus</groupId>-->
-<!--            <artifactId>quarkus-messaging-mqtt-deployment</artifactId>-->
-<!--            <version>${project.version}</version>-->
-<!--            <type>pom</type>-->
-<!--            <scope>test</scope>-->
-<!--            <exclusions>-->
-<!--                <exclusion>-->
-<!--                    <groupId>*</groupId>-->
-<!--                    <artifactId>*</artifactId>-->
-<!--                </exclusion>-->
-<!--            </exclusions>-->
-<!--        </dependency>-->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-messaging-mqtt-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-reactive-messaging-api</artifactId>


### PR DESCRIPTION
- Re-enable the mqtt extension and tests
- Smallrye Reactive messaging renamed the connector "rabbitmq-og" to "rabbitmq"