### PR TITLE
Bump dekorate to 4.1.11

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -160,7 +160,7 @@
         <kotlin-serialization.version>1.11.0</kotlin-serialization.version>
         <kotlin-metadata.version>0.9.0</kotlin-metadata.version>
         <azure.toolkit-lib.version>0.56.0</azure.toolkit-lib.version>
-        <dekorate.version>4.1.8</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
+        <dekorate.version>4.1.11</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.3.0</awaitility.version>
         <jboss-logmanager.version>3.2.2.Final</jboss-logmanager.version>


### PR DESCRIPTION
- Bump dekorate to 4.1.11 fixing:
  - Fixes https://github.com/quarkusio/quarkus/issues/34749
  - Replacing the big jline jar with only jansi

