### PR TITLE
Avoid eagerly initializing the full map of System#getProperties when not necessary

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
@@ -355,7 +355,7 @@ public abstract class QuarkusBootstrapMojo extends AbstractMojo {
      * @return true if the package type system property was set, otherwise - false
      */
     protected boolean setNativeEnabledIfNativeProfileEnabled() {
-        if (!System.getProperties().containsKey("quarkus.native.enabled") && isNativeProfileEnabled(mavenProject())) {
+        if (System.getProperty("quarkus.native.enabled") == null && isNativeProfileEnabled(mavenProject())) {
             Object nativeEnabledProp = mavenProject().getProperties().get("quarkus.native.enabled");
             String nativeEnabled;
             if (nativeEnabledProp != null) {

--- a/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/codegen/GrpcCodeGen.java
+++ b/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/codegen/GrpcCodeGen.java
@@ -108,7 +108,7 @@ public class GrpcCodeGen implements CodeGenProvider {
 
     @Override
     public boolean trigger(CodeGenContext context) throws CodeGenException {
-        if (TRUE.toString().equalsIgnoreCase(System.getProperties().getProperty("grpc.codegen.skip", "false"))
+        if (TRUE.toString().equalsIgnoreCase(System.getProperty("grpc.codegen.skip", "false"))
                 || context.config().getOptionalValue("quarkus.grpc.codegen.skip", Boolean.class).orElse(false)) {
             log.info("Skipping gRPC code generation on user's request");
             return false;
@@ -284,7 +284,7 @@ public class GrpcCodeGen implements CodeGenProvider {
     }
 
     private void postprocessing(CodeGenContext context, Path outDir) {
-        if (TRUE.toString().equalsIgnoreCase(System.getProperties().getProperty(POST_PROCESS_SKIP, "false"))
+        if (TRUE.toString().equalsIgnoreCase(System.getProperty(POST_PROCESS_SKIP, "false"))
                 || context.config().getOptionalValue(POST_PROCESS_SKIP, Boolean.class).orElse(false)) {
             log.info("Skipping gRPC Post-Processing on user's request");
             return;

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -374,7 +374,7 @@ public class VertxHttpRecorder {
             throws IOException {
 
         // disable websockets if we have determined at build time that we should and the user has not overridden the relevant Vert.x property
-        if (disableWebSockets && !System.getProperties().containsKey(DISABLE_WEBSOCKETS_PROP_NAME)) {
+        if (disableWebSockets && System.getProperty(DISABLE_WEBSOCKETS_PROP_NAME) == null) {
             System.setProperty(DISABLE_WEBSOCKETS_PROP_NAME, "true");
         }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdateCommand.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdateCommand.java
@@ -144,7 +144,7 @@ public class QuarkusUpdateCommand {
     }
 
     private static void propagateSystemPropertyIfSet(String name, List<String> command) {
-        if (System.getProperties().containsKey(name)) {
+        if (System.getProperty(name) != null) {
             final StringBuilder buf = new StringBuilder();
             buf.append("-D").append(name);
             final String value = System.getProperty(name);

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/WrapperRunner.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/WrapperRunner.java
@@ -114,7 +114,7 @@ public final class WrapperRunner {
     }
 
     private static void propagateSystemPropertyIfSet(String name, List<String> command) {
-        if (System.getProperties().containsKey(name)) {
+        if (System.getProperty(name) != null) {
             final StringBuilder buf = new StringBuilder();
             buf.append("-D").append(name);
             final String value = System.getProperty(name);


### PR DESCRIPTION

The fix in the `VertxHttpRecorder` is actually quite impactul in native images, as fully materializing the map of all system properties triggers a non-trivial sequence of system calls.

This brings my bootstrap times from ~5.2ms down to ~4.5ms: it's not much in absolute terms, but in relative terms it's huge and it's essentially free to grab.

The other changes are cosmetic and micro allocation optimisations, simply because I can't stand it that we have to materialize a full-fat Map with all values when the client code just wants a single property.