### PR TITLE
Fix serialization of string-shaped dates without a pattern in reflection-free Jackson serializers

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
@@ -624,7 +624,8 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
             } else if ("STRING".equals(formatShape) && fieldSpecs.formatPattern() == null && isJavaTimeDateType(typeName)) {
                 writeToStringValue(fieldSpecs, bytecode, ctx, pkgName, arg);
             } else if ("STRING".equals(formatShape) && fieldSpecs.formatPattern() == null && isJavaUtilDateType(typeName)) {
-                writeToStringValue(fieldSpecs, bytecode, ctx, pkgName, arg);
+                // java.util.Date#toString() is not a valid representation: use the configured date format instead
+                writeDefaultFormatDateValue(fieldSpecs, bytecode, ctx, pkgName, arg);
             } else if (fieldSpecs.isFormatShapeNumber() && isBooleanType(typeName)) {
                 writeNumberShapedBoolean(fieldSpecs, bytecode, ctx, pkgName, typeName, arg);
             } else if (fieldSpecs.isFormatShapeNumber() && isJavaUtilDateType(typeName)) {
@@ -682,6 +683,19 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
                 bytecode.load(fieldSpecs.formatPattern()),
                 timezone != null ? bytecode.load(timezone) : bytecode.loadNull(),
                 ctx.jsonGenerator);
+    }
+
+    private static void writeDefaultFormatDateValue(FieldSpecs fieldSpecs, BytecodeCreator bytecode,
+            GenerationSerializationContext ctx,
+            String pkgName, ResultHandle arg) {
+        writeFieldName(fieldSpecs, bytecode, ctx, pkgName);
+        String timezone = fieldSpecs.formatTimezone();
+        MethodDescriptor serializeDefaultFormat = MethodDescriptor.ofMethod(JacksonMapperUtil.class.getName(),
+                "serializeDefaultFormatDate", void.class, Object.class, String.class, JsonGenerator.class,
+                SerializationContext.class);
+        bytecode.invokeStaticMethod(serializeDefaultFormat, arg,
+                timezone != null ? bytecode.load(timezone) : bytecode.loadNull(),
+                ctx.jsonGenerator, ctx.serializerProvider);
     }
 
     private static void writeToStringValue(FieldSpecs fieldSpecs, BytecodeCreator bytecode,

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
@@ -721,6 +721,30 @@ public abstract class AbstractGeneratedAnnotationTest {
                 .body("[0].directDate", Matchers.is("2026-07-20T11:11:11Z"));
     }
 
+    // --- @JsonFormat(shape = STRING) without pattern on java.util.Date ---
+
+    @Test
+    public void testFormatDateStringShapeWithoutPatternSerialization() {
+        RestAssured.get("/generated/date-string-shape-no-pattern")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("date-string-shape"))
+                .body("utcDate", Matchers.is("2026-07-20T11:11:11.000Z"))
+                .body("pragueDate", Matchers.is("2026-07-20T13:11:11.000+02:00"));
+    }
+
+    @Test
+    public void testFormatDateStringShapeWithoutPatternListSerialization() {
+        RestAssured.get("/generated/date-string-shape-no-pattern-list")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("[0].name", Matchers.is("date-string-shape"))
+                .body("[0].utcDate", Matchers.is("2026-07-20T11:11:11.000Z"))
+                .body("[0].pragueDate", Matchers.is("2026-07-20T13:11:11.000+02:00"));
+    }
+
     // --- @JsonFormat ---
 
     @Test

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/DateStringShapeNoPatternBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/DateStringShapeNoPatternBean.java
@@ -1,0 +1,40 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+public class DateStringShapeNoPatternBean {
+
+    private String name;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "UTC")
+    private Date utcDate;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "Europe/Prague")
+    private Date pragueDate;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Date getUtcDate() {
+        return utcDate;
+    }
+
+    public void setUtcDate(Date utcDate) {
+        this.utcDate = utcDate;
+    }
+
+    public Date getPragueDate() {
+        return pragueDate;
+    }
+
+    public void setPragueDate(Date pragueDate) {
+        this.pragueDate = pragueDate;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
@@ -621,6 +621,24 @@ public class GeneratedAnnotationResource {
         return List.of(bean);
     }
 
+    // --- DateStringShapeNoPatternBean: @JsonFormat(shape = STRING) without pattern on java.util.Date ---
+
+    @GET
+    @Path("/date-string-shape-no-pattern")
+    public DateStringShapeNoPatternBean getDateStringShapeNoPattern() {
+        DateStringShapeNoPatternBean bean = new DateStringShapeNoPatternBean();
+        bean.setName("date-string-shape");
+        bean.setUtcDate(Date.from(Instant.parse("2026-07-20T11:11:11Z")));
+        bean.setPragueDate(Date.from(Instant.parse("2026-07-20T11:11:11Z")));
+        return bean;
+    }
+
+    @GET
+    @Path("/date-string-shape-no-pattern-list")
+    public List<DateStringShapeNoPatternBean> getDateStringShapeNoPatternList() {
+        return List.of(getDateStringShapeNoPattern());
+    }
+
     // --- FormatArrayShapeBean: @JsonFormat(shape = ARRAY) on class ---
 
     @GET

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
@@ -44,6 +44,7 @@ public class GeneratedAnnotationTest extends AbstractGeneratedAnnotationTest {
                                     ManagedReferenceChild.class,
                                     DateFormatBean.class,
                                     DateStringShapeWithPatternBean.class,
+                                    DateStringShapeNoPatternBean.class,
                                     DurationFormatBean.class,
                                     NumberShapedTemporalBean.class,
                                     ZonedDateTimeFormatBean.class,

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
@@ -47,6 +47,7 @@ public class GeneratedAnnotationWithReflectionFreeSerializersTest extends Abstra
                                     ManagedReferenceChild.class,
                                     DateFormatBean.class,
                                     DateStringShapeWithPatternBean.class,
+                                    DateStringShapeNoPatternBean.class,
                                     DurationFormatBean.class,
                                     NumberShapedTemporalBean.class,
                                     ZonedDateTimeFormatBean.class,

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
+import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
@@ -92,6 +93,21 @@ public class JacksonMapperUtil {
             sdf.setTimeZone(TimeZone.getTimeZone(timezone));
         }
         generator.writeString(sdf.format(value));
+    }
+
+    public static void serializeDefaultFormatDate(Object value, String timezone, JsonGenerator generator,
+            SerializationContext context) {
+        if (value == null) {
+            generator.writeNull();
+            return;
+        }
+        // mirrors Jackson's DateSerializer: the configured date format (StdDateFormat unless overridden),
+        // re-zoned to the timezone from the @JsonFormat annotation, if any
+        DateFormat dateFormat = (DateFormat) context.getConfig().getDateFormat().clone();
+        if (timezone != null) {
+            dateFormat.setTimeZone(TimeZone.getTimeZone(timezone));
+        }
+        generator.writeString(dateFormat.format(value));
     }
 
     public static void serializeFormattedTemporal(Object value, String pattern, String timezone,


### PR DESCRIPTION
The reflection-free serializers introduced in 31180c8d95d route
`java.util.Date` fields annotated with `@JsonFormat(shape = STRING)` but
no `pattern` to `Date#toString()`. That produces the legacy
`EEE MMM dd HH:mm:ss zzz yyyy` representation — in the JVM default
timezone, so the output also varies by server locale — and the annotation's
`timezone` attribute is ignored. Jackson's semantics for that annotation
are to format with the configured date format (`StdDateFormat` unless
overridden), re-zoned to the annotation timezone.

The generated serializers now delegate to a runtime helper that clones the
`SerializationContext`'s configured date format and applies the annotation
timezone, mirroring Jackson's `DateSerializer`, so the output matches plain
databind exactly (including for applications that override the global date
format). The `toString()` path is unchanged for the `java.time` types,
whose string representations are ISO-8601.

The new test asserts identical output for the generated and reflection
based serializers via `AbstractGeneratedAnnotationTest`, and failed against
the unpatched generator with `Mon Jul 20 07:11:11 EDT 2026`.

Fixes #55907
