### PR TITLE
Fall back to the basic console when terminal initialization fails in dev mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleHelper.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleHelper.java
@@ -1,5 +1,6 @@
 package io.quarkus.deployment.console;
 
+import java.io.IOError;
 import java.io.IOException;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.function.Consumer;
@@ -7,12 +8,15 @@ import java.util.function.Supplier;
 
 import org.aesh.terminal.Connection;
 import org.aesh.terminal.tty.TerminalConnection;
+import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.dev.testing.TestConfig;
 import io.quarkus.dev.console.BasicConsole;
 import io.quarkus.dev.console.QuarkusConsole;
 
 public class ConsoleHelper {
+
+    private static final Logger log = Logger.getLogger(ConsoleHelper.class);
 
     public static synchronized void installConsole(TestConfig config, ConsoleConfig consoleConfig, boolean test) {
         if (QuarkusConsole.installed) {
@@ -88,7 +92,10 @@ public class ConsoleHelper {
                     }
                 }
             });
-        } catch (IOException e) {
+        } catch (IOException | IOError e) {
+            // terminal probing failures surface as IOError, e.g. when an incompatible stty is first in the PATH,
+            // see https://github.com/quarkusio/quarkus/issues/55918
+            log.warn("Failed to initialize the advanced console, falling back to the basic console: " + e);
             QuarkusConsole.INSTANCE = new BasicConsole(colorEnabled, false, QuarkusConsole.ORIGINAL_OUT, System.console());
         }
         QuarkusConsole.installRedirects();


### PR DESCRIPTION
`ConsoleHelper.installConsole` already degrades gracefully to the basic
console when terminal setup throws an `IOException` — but terminal probing
failures actually surface as `java.io.IOError` (an `Error`, not an
`IOException`), which escapes that catch and fails the whole dev mode
build. That's what #55918 reports: with Homebrew's GNU coreutils `stty`
shadowing `/bin/stty` on macOS, the aesh size probe throws
`IOError: IOException: Error executing 'stty -f /dev/ttys013 size'` and
dev mode won't start at all.

The stty flag resolution itself was fixed upstream in aesh terminal-api
3.16.3 (aeshell/aesh-readline#224), which main already ships since
6ade4387384 — so that specific trigger disappears with the next release.
This change addresses the remaining gap: any terminal initialization
failure now falls back to the basic console with a warning, matching the
intent the `IOException` branch already expresses, instead of taking down
the build.

There is no automated test because the failure requires a PTY whose
terminal probing fails, which isn't reproducible in the test harness (on
Linux, aesh resolves the terminal size without stty via its FFM provider
and environment fallbacks — verified while investigating). The fix is the
minimal broadening of an existing, already-exercised fallback path.

Fixes #55918
