### PR TITLE
Install the OpenTelemetry log handler without waiting for the SDK

### DIFF
--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/logging/LogHandlerProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/logging/LogHandlerProcessor.java
@@ -1,5 +1,8 @@
 package io.quarkus.opentelemetry.deployment.logging;
 
+import java.util.Optional;
+import java.util.logging.Handler;
+
 import org.jboss.jandex.DotName;
 
 import io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider;
@@ -18,6 +21,7 @@ import io.quarkus.deployment.builditem.OpenTelemetrySdkBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.opentelemetry.runtime.logs.OpenTelemetryLogRecorder;
 import io.quarkus.opentelemetry.runtime.logs.spi.LogsExporterCDIProvider;
+import io.quarkus.runtime.RuntimeValue;
 
 @BuildSteps(onlyIf = LogsEnabled.class)
 class LogHandlerProcessor {
@@ -38,11 +42,30 @@ class LogHandlerProcessor {
                         LogsExporterCDIProvider.class.getName()));
     }
 
+    /**
+     * The handler is created without waiting for the OpenTelemetry SDK (or the CDI container
+     * it requires), so that runtime logging setup — which consumes all {@link LogHandlerBuildItem}s —
+     * is not delayed until the SDK is ready. Delaying logging setup leaves every logger at the
+     * initial all-enabling level while CDI startup and eagerly started services run, which
+     * triggers debug/trace-only code paths, see
+     * <a href="https://github.com/quarkusio/quarkus/issues/55889">GitHub issue #55889</a>.
+     */
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void build(OpenTelemetryLogRecorder recorder,
+            BuildProducer<LogHandlerBuildItem> logHandlerProducer,
+            BuildProducer<OpenTelemetryLogHandlerBuildItem> otelLogHandlerProducer) {
+        RuntimeValue<Optional<Handler>> handler = recorder.initializeHandler();
+        logHandlerProducer.produce(new LogHandlerBuildItem(handler));
+        otelLogHandlerProducer.produce(new OpenTelemetryLogHandlerBuildItem(handler));
+    }
+
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     @Consume(OpenTelemetrySdkBuildItem.class)
-    LogHandlerBuildItem build(OpenTelemetryLogRecorder recorder,
+    void activate(OpenTelemetryLogRecorder recorder,
+            OpenTelemetryLogHandlerBuildItem logHandler,
             BeanContainerBuildItem beanContainerBuildItem) {
-        return new LogHandlerBuildItem(recorder.initializeHandler(beanContainerBuildItem.getValue()));
+        recorder.activateHandler(logHandler.getHandler(), beanContainerBuildItem.getValue());
     }
 }

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/logging/OpenTelemetryLogHandlerBuildItem.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/logging/OpenTelemetryLogHandlerBuildItem.java
@@ -1,0 +1,24 @@
+package io.quarkus.opentelemetry.deployment.logging;
+
+import java.util.Optional;
+import java.util.logging.Handler;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.runtime.RuntimeValue;
+
+/**
+ * Carries the OpenTelemetry log handler so it can be activated once the OpenTelemetry SDK
+ * is available, after having been installed during early logging setup.
+ */
+public final class OpenTelemetryLogHandlerBuildItem extends SimpleBuildItem {
+
+    private final RuntimeValue<Optional<Handler>> handler;
+
+    public OpenTelemetryLogHandlerBuildItem(RuntimeValue<Optional<Handler>> handler) {
+        this.handler = handler;
+    }
+
+    public RuntimeValue<Optional<Handler>> getHandler() {
+        return handler;
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingEarlyLevelsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingEarlyLevelsTest.java
@@ -1,0 +1,82 @@
+package io.quarkus.opentelemetry.deployment.logs;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryLogRecordExporter;
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryLogRecordExporterProvider;
+import io.quarkus.opentelemetry.runtime.AutoConfiguredOpenTelemetrySdkBuilderCustomizer;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Enabling the OpenTelemetry log handler must not delay runtime logging setup: loggers must
+ * already be at their configured levels while the OpenTelemetry SDK (and the CDI container it
+ * needs) initializes. Otherwise every logger runs at the initial all-enabling level during the
+ * rest of runtime initialization, triggering debug/trace-only code paths in libraries started
+ * eagerly, see <a href="https://github.com/quarkusio/quarkus/issues/55889">GitHub issue #55889</a>.
+ */
+public class OtelLoggingEarlyLevelsTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(SdkInitProbe.class)
+                            .addClasses(InMemoryLogRecordExporter.class, InMemoryLogRecordExporterProvider.class)
+                            .addAsResource(new StringAsset(InMemoryLogRecordExporterProvider.class.getCanonicalName()),
+                                    "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider")
+                            .add(new StringAsset(
+                                    "quarkus.otel.logs.enabled=true\n"),
+                                    "application.properties"));
+
+    @Inject
+    InMemoryLogRecordExporter logRecordExporter;
+
+    @Test
+    public void loggerLevelsAreConfiguredBeforeSdkInitialization() {
+        assertTrue(SdkInitProbe.probed, "The probe customizer should have run during SDK initialization");
+        assertFalse(SdkInitProbe.debugEnabledDuringSdkInit,
+                "Loggers should already be at their configured levels while the OpenTelemetry SDK initializes; "
+                        + "an arbitrary category must not be debug-enabled");
+    }
+
+    @Test
+    public void recordsPublishedBeforeSdkIsReadyAreDelivered() {
+        List<LogRecordData> records = logRecordExporter.getFinishedLogRecordItemsAtLeast(1);
+        assertTrue(records.stream().anyMatch(r -> SdkInitProbe.EARLY_MESSAGE.equals(r.getBodyValue().asString())),
+                "A record published while the SDK was initializing should be buffered and delivered");
+    }
+
+    @Singleton
+    public static class SdkInitProbe implements AutoConfiguredOpenTelemetrySdkBuilderCustomizer {
+
+        static final String EARLY_MESSAGE = "Log record published while the OpenTelemetry SDK initializes";
+
+        static volatile boolean probed;
+        static volatile boolean debugEnabledDuringSdkInit;
+
+        @Override
+        public void customize(AutoConfiguredOpenTelemetrySdkBuilder builder) {
+            // Runs while the OpenTelemetry SDK bean is created, before the SDK is available
+            // to the log handler.
+            debugEnabledDuringSdkInit = Logger.getLogger("org.acme.some.arbitrary.category").isLoggable(Level.FINE);
+            probed = true;
+            org.jboss.logging.Logger.getLogger("org.acme.early.logger").info(EARLY_MESSAGE);
+        }
+    }
+}

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/OpenTelemetryLogHandler.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/OpenTelemetryLogHandler.java
@@ -13,6 +13,8 @@ import static io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig.INST
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Map;
 import java.util.logging.Formatter;
 import java.util.logging.Level;
@@ -35,13 +37,25 @@ public class OpenTelemetryLogHandler extends ExtHandler {
     // See: https://github.com/open-telemetry/semantic-conventions/issues/1550
     public static final AttributeKey<String> BRIDGE_NAME = AttributeKey.stringKey("bridge.name");
 
-    private final OpenTelemetry openTelemetry;
+    private static final int PENDING_RECORDS_LIMIT = 256;
+
+    private volatile OpenTelemetry openTelemetry;
     private final boolean logFileEnabled;
     private final String logFilePath;
 
-    public OpenTelemetryLogHandler(final OpenTelemetry openTelemetry) {
-        this.openTelemetry = openTelemetry;
+    private final Object lock = new Object();
 
+    // Records published before the OpenTelemetry SDK is available; drained on activation.
+    // Set to null after activation or close to release the backing array.
+    private Deque<ExtLogRecord> pendingRecords = new ArrayDeque<>();
+
+    /**
+     * Creates a handler that buffers records (up to a limit) until
+     * {@link #activate(OpenTelemetry)} provides the SDK instance. This allows the handler
+     * to be installed during early logging setup, before the OpenTelemetry SDK — which
+     * requires the CDI container — has been initialized.
+     */
+    public OpenTelemetryLogHandler() {
         final Config config = ConfigProvider.getConfig();
         this.logFileEnabled = config.getOptionalValue("quarkus.log.file.enable", Boolean.class)
                 .orElse(config.getOptionalValue("quarkus.log.file.enabled", Boolean.class)
@@ -50,11 +64,51 @@ public class OpenTelemetryLogHandler extends ExtHandler {
                 : null;
     }
 
+    /**
+     * Provides the SDK instance and emits any records that were published before it was available.
+     */
+    void activate(OpenTelemetry openTelemetry) {
+        Deque<ExtLogRecord> pendingRecords;
+        synchronized (lock) {
+            this.openTelemetry = openTelemetry;
+            pendingRecords = this.pendingRecords;
+            this.pendingRecords = null;
+        }
+        if (pendingRecords != null) {
+            ExtLogRecord record;
+            while ((record = pendingRecords.pollFirst()) != null) {
+                emit(openTelemetry, record);
+            }
+        }
+    }
+
     @Override
     protected void doPublish(ExtLogRecord record) {
+        OpenTelemetry openTelemetry = this.openTelemetry;
         if (openTelemetry == null) {
-            return; // might happen at shutdown
+            synchronized (lock) {
+                openTelemetry = this.openTelemetry;
+                if (openTelemetry == null) {
+                    Deque<ExtLogRecord> pendingRecords = this.pendingRecords;
+                    if (pendingRecords == null) {
+                        // closed before activation
+                        return;
+                    }
+                    // The SDK is not available yet: hold on to the record until it is.
+                    // Drop new records when full: the window only lasts until runtime init completes.
+                    if (pendingRecords.size() < PENDING_RECORDS_LIMIT) {
+                        // prepare the record to be formatted on another thread, later
+                        record.copyAll();
+                        pendingRecords.addLast(record);
+                    }
+                    return;
+                }
+            }
         }
+        emit(openTelemetry, record);
+    }
+
+    private void emit(OpenTelemetry openTelemetry, ExtLogRecord record) {
         final LogRecordBuilder logRecordBuilder = openTelemetry.getLogsBridge()
                 .loggerBuilder(INSTRUMENTATION_NAME)
                 .build().logRecordBuilder()
@@ -148,5 +202,8 @@ public class OpenTelemetryLogHandler extends ExtHandler {
 
     @Override
     public void close() throws SecurityException {
+        synchronized (lock) {
+            pendingRecords = null;
+        }
     }
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/OpenTelemetryLogRecorder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/OpenTelemetryLogRecorder.java
@@ -17,13 +17,28 @@ public class OpenTelemetryLogRecorder {
         this.runtimeConfig = runtimeConfig;
     }
 
-    public RuntimeValue<Optional<Handler>> initializeHandler(final BeanContainer beanContainer) {
+    /**
+     * Creates the handler without touching the CDI container, so it can be installed during
+     * early logging setup. Making logging setup wait for the OpenTelemetry SDK would leave
+     * all loggers running at the initial (all-enabling) level while the rest of runtime
+     * initialization — CDI startup, eagerly started services — executes, see
+     * <a href="https://github.com/quarkusio/quarkus/issues/55889">GitHub issue #55889</a>.
+     * The handler buffers published records until {@link #activateHandler} provides the SDK.
+     */
+    public RuntimeValue<Optional<Handler>> initializeHandler() {
         if (runtimeConfig.getValue().sdkDisabled() || !runtimeConfig.getValue().logs().handlerEnabled()) {
             return new RuntimeValue<>(Optional.empty());
         }
-        final OpenTelemetry openTelemetry = beanContainer.beanInstance(OpenTelemetry.class);
-        final OpenTelemetryLogHandler logHandler = new OpenTelemetryLogHandler(openTelemetry);
+        final OpenTelemetryLogHandler logHandler = new OpenTelemetryLogHandler();
         logHandler.setLevel(runtimeConfig.getValue().logs().level());
         return new RuntimeValue<>(Optional.of(logHandler));
+    }
+
+    public void activateHandler(final RuntimeValue<Optional<Handler>> handler, final BeanContainer beanContainer) {
+        if (handler.getValue().isEmpty()) {
+            return;
+        }
+        final OpenTelemetry openTelemetry = beanContainer.beanInstance(OpenTelemetry.class);
+        ((OpenTelemetryLogHandler) handler.getValue().get()).activate(openTelemetry);
     }
 }


### PR DESCRIPTION
Producing the OpenTelemetry `LogHandlerBuildItem` from a build step that consumes `OpenTelemetrySdkBuildItem` and the bean container forces runtime logging setup — which consumes all log handlers — to wait until CDI and the OpenTelemetry SDK are fully initialized. Until logging setup runs, every logger operates at the initial all-enabling level, so CDI startup and eagerly started services execute with `isDebugEnabled()` returning `true` for every category (verified with a probe app: during SDK initialization the root logger is at `ALL` with `quarkus.otel.logs.enabled=true` and at `INFO` without it).

On the 3.20 LTS branch this window covers the Hibernate ORM startup thread and deterministically aborts `SessionFactory` creation for `TABLE_PER_CLASS` collections (reproduced on 3.20.5): a debug-only diagnostic calls `RemoveCoordinatorTablePerSubclass#getSqlString`, which throws `UnsupportedOperationException`. On main the crash does not surface (Hibernate ORM 7 guards that path with trace, and the window closes before the ORM startup thread runs), but the widened window still exists, and in dev/test mode the late handler installation silently dropped records logged while the SDK was initializing.

This change creates the handler eagerly so logging setup keeps its early position, and buffers published records (bounded, mirroring `QuarkusDelayedHandler`) until a later build step provides the SDK instance and drains the buffer. The new `OtelLoggingEarlyLevelsTest` fails before this change (early records lost) and passes with it.

The Hibernate-side `UnsupportedOperationException` is being handled separately in the Hibernate ORM tracker as suggested in the issue. This fix should be backported to 3.20, where the startup failure actually manifests.

Fixes #55889