### PR TITLE
Use testcontainers' oracle-free instead of oracle-xe

### DIFF
--- a/extensions/devservices/oracle/pom.xml
+++ b/extensions/devservices/oracle/pom.xml
@@ -18,7 +18,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers-oracle-xe</artifactId>
+            <artifactId>testcontainers-oracle-free</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import org.jboss.logging.Logger;
-import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.oracle.OracleContainer;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
@@ -38,7 +38,7 @@ public class OracleDevServicesProcessor {
      * This is the container name as defined by the Testcontainer's OracleContainer:
      * does not necessarily match the container name that Quarkus will default to use.
      */
-    public static final String ORIGINAL_IMAGE_NAME = "gvenzl/oracle-xe";
+    public static final String ORIGINAL_IMAGE_NAME = "gvenzl/oracle-free";
     public static final int PORT = 1521;
 
     private static final OracleDatasourceServiceConfigurator configurator = new OracleDatasourceServiceConfigurator();

--- a/integration-tests/opentelemetry-jdbc-instrumentation/pom.xml
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/pom.xml
@@ -80,7 +80,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers-oracle-xe</artifactId>
+            <artifactId>testcontainers-oracle-free</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
The image used is oracle-free for some time and eg. the default database name is different between xe and free.

