### PR TITLE
Allow class-level @NameBinding on constructor-injected RESTEasy resources

### DIFF
--- a/extensions/resteasy-classic/resteasy-common/spi/src/main/java/io/quarkus/resteasy/common/spi/ResteasyDotNames.java
+++ b/extensions/resteasy-classic/resteasy-common/spi/src/main/java/io/quarkus/resteasy/common/spi/ResteasyDotNames.java
@@ -29,6 +29,7 @@ public final class ResteasyDotNames {
     public static final DotName PUT = DotName.createSimple("jakarta.ws.rs.PUT");
     public static final DotName APPLICATION_PATH = DotName.createSimple("jakarta.ws.rs.ApplicationPath");
     public static final DotName PATH = DotName.createSimple("jakarta.ws.rs.Path");
+    public static final DotName NAME_BINDING = DotName.createSimple("jakarta.ws.rs.NameBinding");
     public static final DotName DYNAMIC_FEATURE = DotName.createSimple("jakarta.ws.rs.container.DynamicFeature");
     public static final DotName CONTEXT = DotName.createSimple("jakarta.ws.rs.core.Context");
     public static final DotName PATH_PARAM = DotName.createSimple("jakarta.ws.rs.PathParam");

--- a/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -375,8 +375,8 @@ public class ResteasyServerCommonProcessor {
 
         // generate default constructors for suitable concrete @Path classes that don't have them
         // see https://issues.jboss.org/browse/RESTEASY-2183
-        generateDefaultConstructors(transformers, withoutDefaultCtor, additionalJaxRsResourceDefiningAnnotations,
-                friendlyJaxRsAnnotationPrefixes);
+        generateDefaultConstructors(beanArchiveIndexBuildItem.getIndex(), transformers, withoutDefaultCtor,
+                additionalJaxRsResourceDefiningAnnotations, friendlyJaxRsAnnotationPrefixes);
 
         checkParameterNames(beanArchiveIndexBuildItem.getIndex(), additionalJaxRsResourceMethodParamAnnotations);
 
@@ -748,7 +748,8 @@ public class ResteasyServerCommonProcessor {
                 .build());
     }
 
-    private static void generateDefaultConstructors(BuildProducer<BytecodeTransformerBuildItem> transformers,
+    private static void generateDefaultConstructors(IndexView index,
+            BuildProducer<BytecodeTransformerBuildItem> transformers,
             Map<DotName, ClassInfo> withoutDefaultCtor,
             List<AdditionalJaxRsResourceDefiningAnnotationBuildItem> additionalJaxRsResourceDefiningAnnotations,
             List<AllowedJaxRsAnnotationPrefixBuildItem> friendlyJaxRsAnnotationPrefixes) {
@@ -777,6 +778,11 @@ public class ResteasyServerCommonProcessor {
                 DotName name = instance.name();
                 final String packageName = packageName(name);
                 if (packageName == null || !isPackageAllowed(allowedAnnotationPrefixes, packageName)) {
+                    // A jakarta.ws.rs.NameBinding annotation is a Jakarta REST construct even though it typically
+                    // lives in the user's package, so it must not prevent the default constructor generation
+                    if (isNameBindingAnnotation(index, name)) {
+                        continue;
+                    }
                     log.debug("Annotation " + name + " results in Quarkus not being able to generate a default constructor for "
                             + classInfo.name());
                     hasNonJaxRSAnnotations = true;
@@ -819,6 +825,11 @@ public class ResteasyServerCommonProcessor {
 
     private static boolean isPackageAllowed(Set<String> allowedAnnotationPrefixes, String packageName) {
         return allowedAnnotationPrefixes.stream().anyMatch(prefix -> packageName.startsWith(prefix));
+    }
+
+    private static boolean isNameBindingAnnotation(IndexView index, DotName annotationName) {
+        ClassInfo annotationClass = index.getClassByName(annotationName);
+        return annotationClass != null && annotationClass.hasDeclaredAnnotation(ResteasyDotNames.NAME_BINDING);
     }
 
     private static String packageName(DotName dotName) {

--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/ClassLevelNameBindingResource.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/ClassLevelNameBindingResource.java
@@ -1,0 +1,20 @@
+package io.quarkus.resteasy.test;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Hello
+@Path("/ctor-namebinding")
+public class ClassLevelNameBindingResource {
+
+    final Service service;
+
+    public ClassLevelNameBindingResource(Service service) {
+        this.service = service;
+    }
+
+    @GET
+    public String val() {
+        return service.execute();
+    }
+}

--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/Hello.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/Hello.java
@@ -1,0 +1,14 @@
+package io.quarkus.resteasy.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.ws.rs.NameBinding;
+
+@NameBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface Hello {
+}

--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/HelloFilter.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/HelloFilter.java
@@ -1,0 +1,16 @@
+package io.quarkus.resteasy.test;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+@Hello
+public class HelloFilter implements ContainerResponseFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        responseContext.getHeaders().add("X-Hello", "true");
+    }
+}

--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/MethodLevelNameBindingResource.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/MethodLevelNameBindingResource.java
@@ -1,0 +1,20 @@
+package io.quarkus.resteasy.test;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/method-namebinding")
+public class MethodLevelNameBindingResource {
+
+    final Service service;
+
+    public MethodLevelNameBindingResource(Service service) {
+        this.service = service;
+    }
+
+    @Hello
+    @GET
+    public String val() {
+        return service.execute();
+    }
+}

--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/NameBindingConstructorInjectionTestCase.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/NameBindingConstructorInjectionTestCase.java
@@ -1,0 +1,52 @@
+package io.quarkus.resteasy.test;
+
+import static org.hamcrest.Matchers.nullValue;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+/**
+ * A resource using constructor injection has no no-arg constructor, so Quarkus generates a synthetic one for RESTEasy
+ * Classic. A class-level {@link jakarta.ws.rs.NameBinding} annotation used to prevent that generation, making startup
+ * fail with {@code RESTEASY003190: Could not find constructor}. This verifies both the class-level and method-level
+ * binding placements work with constructor injection, and that the name-bound filter is actually applied only where the
+ * binding is present.
+ */
+public class NameBindingConstructorInjectionTestCase {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(ClassLevelNameBindingResource.class, MethodLevelNameBindingResource.class,
+                            NoNameBindingResource.class, Hello.class, HelloFilter.class, Service.class));
+
+    @Test
+    public void testClassLevelNameBindingWithConstructorInjection() {
+        RestAssured.when().get("/ctor-namebinding").then()
+                .statusCode(200)
+                .body(Matchers.is("service"))
+                .header("X-Hello", "true");
+    }
+
+    @Test
+    public void testMethodLevelNameBindingWithConstructorInjection() {
+        RestAssured.when().get("/method-namebinding").then()
+                .statusCode(200)
+                .body(Matchers.is("service"))
+                .header("X-Hello", "true");
+    }
+
+    @Test
+    public void testFilterNotAppliedWithoutNameBinding() {
+        // negative control: the name-bound filter must not run on a resource without the binding, so a passing
+        // class/method-level test above genuinely proves the binding is honored rather than the filter being global
+        RestAssured.when().get("/no-namebinding").then()
+                .statusCode(200)
+                .body(Matchers.is("service"))
+                .header("X-Hello", nullValue());
+    }
+}

--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/NoNameBindingResource.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/NoNameBindingResource.java
@@ -1,0 +1,19 @@
+package io.quarkus.resteasy.test;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/no-namebinding")
+public class NoNameBindingResource {
+
+    final Service service;
+
+    public NoNameBindingResource(Service service) {
+        this.service = service;
+    }
+
+    @GET
+    public String val() {
+        return service.execute();
+    }
+}


### PR DESCRIPTION
RE needs no args constructor which is added by Quarkus.
However, the addition only happens if certain annotations are detected - and meta annotation are not taken into consideration.

I've had Claude draft a fix based on the above though I am not sure if there aren't other annotations that would need similar treatment.
I could use someone with more knowledge of this code and RE in general to tell me if the fix makes sense.

- Fixes: #55989