### PR TITLE
DevUI: use bean class as source for synthetic observers

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/DevObserverInfo.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/DevObserverInfo.java
@@ -23,14 +23,16 @@ public class DevObserverInfo implements Comparable<DevObserverInfo> {
             return new DevObserverInfo(predicate.test(observer.getObserverMethod().declaringClass().name()),
                     Name.from(observer.getObserverMethod().declaringClass().name()), observer.getObserverMethod().name(),
                     Name.from(observer.getObservedType()), qualifiers, observer.getPriority(), observer.isAsync(),
-                    observer.getReception(), observer.getTransactionPhase());
+                    observer.getReception(), observer.getTransactionPhase(), Name.from(observer.getBeanClass()));
         } else {
             return new DevObserverInfo(false, null, null, Name.from(observer.getObservedType()), qualifiers,
-                    observer.getPriority(), observer.isAsync(), observer.getReception(), observer.getTransactionPhase());
+                    observer.getPriority(), observer.isAsync(), observer.getReception(), observer.getTransactionPhase(),
+                    Name.from(observer.getBeanClass()));
         }
     }
 
     private final boolean isApplicationObserver;
+    private final Name beanClass;
     private final Name declaringClass;
     private final String methodName;
     private final Name observedType;
@@ -41,7 +43,8 @@ public class DevObserverInfo implements Comparable<DevObserverInfo> {
     private final TransactionPhase transactionPhase;
 
     public DevObserverInfo(boolean isApplicationObserver, Name declaringClass, String methodName, Name observedType,
-            List<Name> qualifiers, int priority, boolean isAsync, Reception reception, TransactionPhase transactionPhase) {
+            List<Name> qualifiers, int priority, boolean isAsync, Reception reception, TransactionPhase transactionPhase,
+            Name beanClass) {
         this.isApplicationObserver = isApplicationObserver;
         this.declaringClass = declaringClass;
         this.methodName = methodName;
@@ -51,6 +54,7 @@ public class DevObserverInfo implements Comparable<DevObserverInfo> {
         this.isAsync = isAsync;
         this.reception = reception;
         this.transactionPhase = transactionPhase;
+        this.beanClass = beanClass;
     }
 
     public Name getDeclaringClass() {
@@ -59,6 +63,17 @@ public class DevObserverInfo implements Comparable<DevObserverInfo> {
 
     public String getMethodName() {
         return methodName;
+    }
+
+    public String getSource() {
+        if (declaringClass != null) {
+            return declaringClass.toString();
+        }
+        return "Synthetic with bean class " + beanClass.toString();
+    }
+
+    public Name getBeanClass() {
+        return beanClass;
     }
 
     public Name getObservedType() {

--- a/extensions/arc/deployment/src/main/resources/dev-ui/qwc-arc-observers.js
+++ b/extensions/arc/deployment/src/main/resources/dev-ui/qwc-arc-observers.js
@@ -63,7 +63,7 @@ export class QwcArcObservers extends LitElement {
             return html`${this._renderFilterBar()}
                 <vaadin-grid .items="${this._filteredObservers}" class="arctable" theme="no-border">
 
-                    <vaadin-grid-sort-column path="declaringClass.name" auto-width
+                    <vaadin-grid-sort-column path="source" auto-width
                         header=${msg('Source', { id: 'quarkus-arc-source' })}
                         ${columnBodyRenderer(this._sourceRenderer, [])}
                         resizable>
@@ -116,9 +116,9 @@ export class QwcArcObservers extends LitElement {
                             };
                             if (searchTerm?.trim()) {
                                 this._filteredObservers = this._observers.filter(
-                                    ({ declaringClass, observedType , priority}) => {
+                                    ({ source, observedType , priority}) => {
                                         return !searchTerm ||
-                                            matchesTerm(declaringClass?.name) ||
+                                            matchesTerm(source) ||
                                             matchesTerm(observedType?.name) ||
                                             matchesTerm(priority.toString());
                                 });
@@ -131,7 +131,10 @@ export class QwcArcObservers extends LitElement {
   }
   
   _sourceRenderer(bean){
-    return html`<qui-ide-link fileName='${bean.declaringClass.name}'><code>${bean.declaringClass.name}</code><code class="method">#${bean.methodName}()</code></qui-ide-link>`;
+    if (bean.declaringClass?.name) {
+      return html`<qui-ide-link fileName='${bean.declaringClass.name}'><code>${bean.source}</code><code class="method">#${bean.methodName}()</code></qui-ide-link>`;
+    }
+    return html`<code>${bean.source}</code>`;
   }
 
   _typeRenderer(bean){

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/devconsole/DevObserverInfoTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/devconsole/DevObserverInfoTest.java
@@ -22,16 +22,21 @@ public class DevObserverInfoTest {
         List<DevObserverInfo> observers = new ArrayList<>();
         // Synthetic non-app - should be last
         observers.add(new DevObserverInfo(false, null, null, new Name("Delta"),
-                Collections.emptyList(), 0, false, Reception.ALWAYS, TransactionPhase.IN_PROGRESS));
+                Collections.emptyList(), 0, false, Reception.ALWAYS, TransactionPhase.IN_PROGRESS,
+                new Name("DeltaClass")));
         // App observers
         observers.add(new DevObserverInfo(true, new Name("Alpha"), "fooish", new Name("java.lang.String"),
-                Collections.emptyList(), 0, false, Reception.ALWAYS, TransactionPhase.IN_PROGRESS));
+                Collections.emptyList(), 0, false, Reception.ALWAYS, TransactionPhase.IN_PROGRESS,
+                new Name("AlphaClass")));
         observers.add(new DevObserverInfo(true, new Name("Alpha"), "blabla", new Name("java.lang.String"),
-                Collections.emptyList(), 1, false, Reception.ALWAYS, TransactionPhase.IN_PROGRESS));
+                Collections.emptyList(), 1, false, Reception.ALWAYS, TransactionPhase.IN_PROGRESS,
+                new Name("AlphaClass")));
         observers.add(new DevObserverInfo(true, null, null, new Name("Charlie"),
-                Collections.emptyList(), 0, false, Reception.ALWAYS, TransactionPhase.IN_PROGRESS));
+                Collections.emptyList(), 0, false, Reception.ALWAYS, TransactionPhase.IN_PROGRESS,
+                new Name("CharlieClass")));
         observers.add(new DevObserverInfo(true, new Name("Bravo"), "hop", new Name("java.lang.String"),
-                Collections.emptyList(), 0, false, Reception.IF_EXISTS, TransactionPhase.IN_PROGRESS));
+                Collections.emptyList(), 0, false, Reception.IF_EXISTS, TransactionPhase.IN_PROGRESS,
+                new Name("BravoClass")));
 
         Collections.sort(observers);
         assertEquals("blabla", observers.get(0).getMethodName());
@@ -40,10 +45,15 @@ public class DevObserverInfoTest {
         assertEquals("Alpha", observers.get(1).getDeclaringClass().toString());
         assertEquals("hop", observers.get(2).getMethodName());
         assertEquals("Bravo", observers.get(2).getDeclaringClass().toString());
+        assertEquals("Bravo", observers.get(2).getSource());
         assertNull(observers.get(3).getMethodName());
         assertEquals("Charlie", observers.get(3).getObservedType().toString());
+        assertEquals("Synthetic with bean class CharlieClass",
+                observers.get(3).getSource());
         assertEquals("Delta", observers.get(observers.size() - 1).getObservedType().toString());
         assertNull(observers.get(observers.size() - 1).getDeclaringClass());
+        assertEquals("Synthetic with bean class DeltaClass",
+                observers.get(observers.size() - 1).getSource());
     }
 
 }


### PR DESCRIPTION
- fix Dev UI for synthetic CDI observers by avoiding null declaringClass access