### PR TITLE
Sort the Quarkus dependency dump by artifact coordinates

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/TrackConfigChangesMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/TrackConfigChangesMojo.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Properties;
 import java.util.zip.Checksum;
@@ -25,6 +26,7 @@ import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.maven.dependency.DependencyFlags;
+import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.runtime.LaunchMode;
 
 /**
@@ -138,13 +140,20 @@ public class TrackConfigChangesMojo extends QuarkusBootstrapMojo {
             }
 
             if (dumpDependencies) {
-                final List<Path> deps = new ArrayList<>();
+                // Sort by artifact coordinates rather than by resolved path: the same dependency may resolve
+                // to a workspace module output in one build and to the local Maven repository in another,
+                // and sorting by path would then reorder the file without its content having changed.
+                final List<ResolvedDependency> sortedDeps = new ArrayList<>();
                 for (var d : curatedApplication.getApplicationModel().getDependencies(DependencyFlags.DEPLOYMENT_CP)) {
+                    sortedDeps.add(d);
+                }
+                sortedDeps.sort(Comparator.comparing(ResolvedDependency::toGACTVString));
+                final List<Path> deps = new ArrayList<>();
+                for (var d : sortedDeps) {
                     for (Path resolvedPath : d.getResolvedPaths()) {
                         deps.add(resolvedPath.toAbsolutePath());
                     }
                 }
-                Collections.sort(deps);
                 final Path targetFile = getOutputFile(dependenciesFile, launchMode.getDefaultProfile(),
                         "-dependencies.txt");
                 Files.createDirectories(targetFile.getParent());


### PR DESCRIPTION
## Problem

`quarkus:track-config-changes` dumps the Quarkus application dependencies (the deployment classpath) to `target/quarkus-<profile>-dependencies.txt`. That list was sorted by resolved **absolute path**.

A dependency's resolved path is not stable across builds. The same artifact resolves to a workspace module output when its module is part of the reactor, and to the local Maven repository when it is not — for example between Quarkus CI's `Initial JDK 17 Build` (whole repo in the reactor) and its `JVM Integration Tests` jobs (a module subset, the rest restored into `~/.m2`). Sorting by path therefore reorders the dump between two builds of the same commit, even though its contents are identical.

The Develocity build cache consumes this file as a `CLASSPATH`-normalized input named `quarkus-dependencies` for `quarkus:generate-code`, `quarkus:generate-code-tests` and `quarkus:build` (see [quarkus-project-develocity-extension](https://github.com/quarkusio/quarkus-project-develocity-extension)). Under `CLASSPATH` normalization the entry order is part of the cache key, so a reordering on its own is enough to force a cache miss.

## Evidence

Comparing two `ge.quarkus.io` build scans from the same CI run at the same commit (`2d1b4e28`):

- [`j6zxgca6tzhas`](https://ge.quarkus.io/s/j6zxgca6tzhas) — Initial JDK 17 Build
- [`ni3dcipbjdcbq`](https://ge.quarkus.io/s/ni3dcipbjdcbq) — JVM Integration Tests - JDK 17

**42** `quarkus:generate-code` executions differ, and in every case the only diverging input is `quarkus-dependencies`, with Develocity reporting `File order is different` and no content change. Notably the sibling `compileClassPath` input does *not* diverge — it is ordered by dependency declaration rather than by path, which is consistent with path-sorting being the source of the instability.

## Fix

Sort by artifact coordinates (GACTV) instead. That key is location-independent, so the dump stays stable regardless of where each artifact resolved from, while still serving the file's documented purpose of detecting build-time classpath changes.

## Impact

Small in absolute terms — the measured avoidable waste for these goal executions is ~0.1 CI hours/week, since `generate-code` is fast. The value is mostly in removing a spurious source of cache-key churn that also affects `quarkus:build` and `quarkus:generate-code-tests`.

## Validation

Reviewed statically: `ResolvedDependency` inherits `toGACTVString()` from `ArtifactCoords` via `Dependency`, and imports are ordered per the project's `impsort` configuration.

⚠️ **Not compile-validated locally.** Building `-pl devtools/maven -am` from an empty local repository did not complete within the time available for this change, so I am relying on CI to compile it. Please treat the build as unverified until CI reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
