### PR TITLE
Use sentence case in guide titles

### DIFF
--- a/docs/src/main/asciidoc/aesh.adoc
+++ b/docs/src/main/asciidoc/aesh.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Command Mode with Aesh
+= Command mode with Aesh
 include::_attributes.adoc[]
 :summary: Develop command line applications with the Aesh extension.
 :topics: command-line,cli,aesh,ssh,websocket,terminal

--- a/docs/src/main/asciidoc/all-builditems.adoc
+++ b/docs/src/main/asciidoc/all-builditems.adoc
@@ -6,7 +6,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Build Items
+= Build items
 include::_attributes.adoc[]
 :summary: Explore all the BuildItems you can consume/produce in your extensions.
 

--- a/docs/src/main/asciidoc/amqp-reference.adoc
+++ b/docs/src/main/asciidoc/amqp-reference.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Reactive Messaging AMQP 1.0 Connector Reference Documentation
+= Reactive Messaging AMQP 1.0 Connector reference documentation
 include::_attributes.adoc[]
 :extensions: io.quarkus:quarkus-messaging-amqp
 :topics: messaging,amqp

--- a/docs/src/main/asciidoc/amqp.adoc
+++ b/docs/src/main/asciidoc/amqp.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Getting Started to Quarkus Messaging with AMQP 1.0
+= Getting started with Quarkus Messaging and AMQP 1.0
 include::_attributes.adoc[]
 :summary: This guide demonstrates how your Quarkus application can utilize Quarkus Messaging to interact with AMQP.
 :extensions: io.quarkus:quarkus-messaging-amqp

--- a/docs/src/main/asciidoc/aot.adoc
+++ b/docs/src/main/asciidoc/aot.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Ahead-of-Time (AOT) Caching
+= Ahead-of-time (AOT) caching
 include::_attributes.adoc[]
 :summary: This guide explains how to use Leyden AOT caching with Quarkus for dramatically faster startup times on JDK 24+.
 :topics: aot,leyden,startup,performance

--- a/docs/src/main/asciidoc/aws-lambda-snapstart.adoc
+++ b/docs/src/main/asciidoc/aws-lambda-snapstart.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= AWS Lambda SnapStart Configuration
+= AWS Lambda SnapStart configuration
 include::_attributes.adoc[]
 :summary: This document explains how to optimize your AWS Lambda application for SnapStart
 :topics: aws,lambda,serverless,function,snapstart,cloud

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Building a Native Executable
+= Building a native executable
 include::_attributes.adoc[]
 :summary: Build native executables with GraalVM or Mandrel.
 :topics: native,graalvm,mandrel

--- a/docs/src/main/asciidoc/cache.adoc
+++ b/docs/src/main/asciidoc/cache.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Application Data Caching
+= Application data caching
 include::_attributes.adoc[]
 :summary: This guide explains how to cache expensive method calls of your CDI beans using simple annotations.
 :topics: cache,data

--- a/docs/src/main/asciidoc/capabilities.adoc
+++ b/docs/src/main/asciidoc/capabilities.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Extension Capabilities
+= Extension capabilities
 include::_attributes.adoc[]
 :summary: How capabilities are implemented and used in Quarkus.
 :topics: extensions

--- a/docs/src/main/asciidoc/cdi-integration.adoc
+++ b/docs/src/main/asciidoc/cdi-integration.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= CDI Integration Guide
+= CDI integration guide
 :summary: Learn how to integrate your extension with Quarkus' CDI container.
 include::_attributes.adoc[]
 :numbered:

--- a/docs/src/main/asciidoc/class-loading-reference.adoc
+++ b/docs/src/main/asciidoc/class-loading-reference.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Class Loading Reference
+= Class loading reference
 include::_attributes.adoc[]
 :summary: Learn more about Quarkus class loading infrastructure.
 :topics: internals,extensions

--- a/docs/src/main/asciidoc/command-mode-reference.adoc
+++ b/docs/src/main/asciidoc/command-mode-reference.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Command Mode Applications
+= Command mode applications
 include::_attributes.adoc[]
 :summary: This reference guide explains how to develop command line applications with Quarkus.
 :topics: command-line,cli

--- a/docs/src/main/asciidoc/conditional-extension-dependencies.adoc
+++ b/docs/src/main/asciidoc/conditional-extension-dependencies.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Conditional Extension Dependencies
+= Conditional extension dependencies
 include::_attributes.adoc[]
 :summary: Trigger the inclusion of additional extensions based on certain conditions.
 :topics: extensions

--- a/docs/src/main/asciidoc/config-extending-support.adoc
+++ b/docs/src/main/asciidoc/config-extending-support.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Extending Configuration Support
+= Extending configuration support
 include::_attributes.adoc[]
 :summary: Extend and customize the Configuration.
 :numbered:

--- a/docs/src/main/asciidoc/config-reference.adoc
+++ b/docs/src/main/asciidoc/config-reference.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Configuration Reference Guide
+= Configuration reference guide
 include::_attributes.adoc[]
 :summary: Learn more about how to configure your Quarkus applications.
 :numbered:

--- a/docs/src/main/asciidoc/config-secrets.adoc
+++ b/docs/src/main/asciidoc/config-secrets.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Secrets in Configuration
+= Secrets in configuration
 include::_attributes.adoc[]
 :diataxis-type: core
 

--- a/docs/src/main/asciidoc/config.adoc
+++ b/docs/src/main/asciidoc/config.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Configuring Your Application
+= Configuring your application
 include::_attributes.adoc[]
 :summary: Hardcoded values in your code is a no go (even if we all did it at some point ;-)). In this guide, we learn how to configure your application.
 :topics: configuration

--- a/docs/src/main/asciidoc/container-image.adoc
+++ b/docs/src/main/asciidoc/container-image.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Container Images
+= Container images
 include::_attributes.adoc[]
 :summary: Learn how to build and push container images with Jib, OpenShift, Docker, or Podman as part of the Quarkus build.
 :topics: devops,cloud

--- a/docs/src/main/asciidoc/context-propagation.adoc
+++ b/docs/src/main/asciidoc/context-propagation.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Context Propagation in Quarkus
+= Context propagation in Quarkus
 include::_attributes.adoc[]
 :summary: Learn more about how you can pass contextual information with SmallRye Context Propagation.
 :topics: context-propagation

--- a/docs/src/main/asciidoc/continuous-testing.adoc
+++ b/docs/src/main/asciidoc/continuous-testing.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Continuous Testing
+= Continuous testing
 include::_attributes.adoc[]
 :summary: Get early test feedback with Continuous Testing.
 :numbered:

--- a/docs/src/main/asciidoc/credentials-provider.adoc
+++ b/docs/src/main/asciidoc/credentials-provider.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Using a Credentials Provider
+= Using a credentials provider
 include::_attributes.adoc[]
 :summary: This guide explains how to use the Vault credentials provider or implement your own custom one.
 :extension-status: preview

--- a/docs/src/main/asciidoc/cyclonedx.adoc
+++ b/docs/src/main/asciidoc/cyclonedx.adoc
@@ -4,7 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id="cyclonedx"]
-= Generating and Using CycloneDX SBOMs
+= Generating and using CycloneDX SBOMs
 include::_attributes.adoc[]
 :summary: This guide explains how to generate and use SBOMs for Quarkus applications in the CycloneDX format.
 :topics: sbom

--- a/docs/src/main/asciidoc/databases-dev-services.adoc
+++ b/docs/src/main/asciidoc/databases-dev-services.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Dev Services for Databases
+= Dev Services for databases
 include::_attributes.adoc[]
 :topics: dev-services,data,database,datasource,dev-mode,testing
 :extensions: io.quarkus:quarkus-agroal,io.quarkus:quarkus-reactive-mysql-client,io.quarkus:quarkus-reactive-oracle-client,io.quarkus:quarkus-reactive-pg-client,io.quarkus:quarkus-jdbc-db2,io.quarkus:quarkus-jdbc-h2,io.quarkus:quarkus-jdbc-mariadb,io.quarkus:quarkus-jdbc-mssql,io.quarkus:quarkus-jdbc-mysql,io.quarkus:quarkus-jdbc-oracle,io.quarkus:quarkus-jdbc-postgresql

--- a/docs/src/main/asciidoc/dev-services.adoc
+++ b/docs/src/main/asciidoc/dev-services.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Dev Services Overview
+= Dev Services overview
 include::_attributes.adoc[]
 :summary: An introduction to Dev Services and a list of all extensions that support Dev Services and their configuration options.
 :topics: dev-services,dev-mode,testing

--- a/docs/src/main/asciidoc/extension-metadata.adoc
+++ b/docs/src/main/asciidoc/extension-metadata.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Quarkus Extension Metadata
+= Quarkus extension metadata
 include::_attributes.adoc[]
 :topics: extensions,codestarts
 

--- a/docs/src/main/asciidoc/extension-registry-user.adoc
+++ b/docs/src/main/asciidoc/extension-registry-user.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Quarkus Extension Registry
+= Quarkus extension registry
 include::_attributes.adoc[]
 :summary: Learn more about the notion of extension registry and how you can use your own.
 :topics: internals,extensions

--- a/docs/src/main/asciidoc/funqy-aws-lambda.adoc
+++ b/docs/src/main/asciidoc/funqy-aws-lambda.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Funqy AWS Lambda Binding
+= Funqy AWS Lambda binding
 :extension-status: preview
 :devtools-no-gradle:
 include::_attributes.adoc[]

--- a/docs/src/main/asciidoc/funqy-azure-functions-http.adoc
+++ b/docs/src/main/asciidoc/funqy-azure-functions-http.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Funqy HTTP Binding with Azure Functions
+= Funqy HTTP binding with Azure Functions
 :extension-status: preview
 include::_attributes.adoc[]
 :summary: Use Funqy HTTP binding with Microsoft Azure Functions to deploy your serverless Quarkus applications.

--- a/docs/src/main/asciidoc/funqy-gcp-functions-http.adoc
+++ b/docs/src/main/asciidoc/funqy-gcp-functions-http.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Funqy HTTP Binding with Google Cloud Functions
+= Funqy HTTP binding with Google Cloud Functions
 :extension-status: preview
 include::_attributes.adoc[]
 :summary: This guide explains Funqy's Google Cloud Platform Functions HTTP binding.

--- a/docs/src/main/asciidoc/funqy-http.adoc
+++ b/docs/src/main/asciidoc/funqy-http.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Funqy HTTP Binding (Standalone)
+= Funqy HTTP binding (standalone)
 include::_attributes.adoc[]
 :summary: This guide explains Funqy's HTTP binding.
 :extension-status: preview

--- a/docs/src/main/asciidoc/funqy-knative-events.adoc
+++ b/docs/src/main/asciidoc/funqy-knative-events.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Funqy Knative Events Binding
+= Funqy Knative events binding
 include::_attributes.adoc[]
 :summary: This guide explains Funqy's Knative Events binding.
 :devtools-no-gradle:

--- a/docs/src/main/asciidoc/gcp-functions.adoc
+++ b/docs/src/main/asciidoc/gcp-functions.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Google Cloud Functions (Serverless)
+= Google Cloud Functions (serverless)
 :extension-status: preview
 include::_attributes.adoc[]
 :summary: This guide explains how you can deploy Quarkus-based Google Cloud Functions.

--- a/docs/src/main/asciidoc/getting-started-reactive.adoc
+++ b/docs/src/main/asciidoc/getting-started-reactive.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Getting Started With Reactive
+= Getting started with Reactive
 include::_attributes.adoc[]
 :summary: Learn more about developing reactive applications with Quarkus.
 :topics: getting-started,reactive

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -4,7 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id="testing"]
-= Testing Your Application
+= Testing your application
 include::_attributes.adoc[]
 :summary: This guide covers testing in JVM mode, native mode, and injection of resources into tests
 :numbered:

--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Creating Your First Application
+= Creating your first application
 include::_attributes.adoc[]
 :summary: Build a REST API with live reload, dependency injection, and tests, in under 15 minutes.
 :numbered:

--- a/docs/src/main/asciidoc/grpc-getting-started.adoc
+++ b/docs/src/main/asciidoc/grpc-getting-started.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Getting Started with gRPC
+= Getting started with gRPC
 include::_attributes.adoc[]
 :summary: This guide explains how to start using gRPC in your Quarkus application.
 :topics: grpc

--- a/docs/src/main/asciidoc/grpc-kubernetes.adoc
+++ b/docs/src/main/asciidoc/grpc-kubernetes.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Deploying your gRPC Service in Kubernetes
+= Deploying your gRPC service in Kubernetes
 include::_attributes.adoc[]
 :summary: This guide explains how to deploy your gRPC services in Quarkus to Kubernetes.
 :topics: grpc,kubernetes

--- a/docs/src/main/asciidoc/grpc-service-consumption.adoc
+++ b/docs/src/main/asciidoc/grpc-service-consumption.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Consuming a gRPC Service
+= Consuming a gRPC service
 include::_attributes.adoc[]
 :summary: This guide explains how to consume gRPC services in your Quarkus application.
 :topics: grpc

--- a/docs/src/main/asciidoc/grpc-service-implementation.adoc
+++ b/docs/src/main/asciidoc/grpc-service-implementation.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Implementing a gRPC Service
+= Implementing a gRPC service
 include::_attributes.adoc[]
 :summary: This guide explains how to implement gRPC services in your Quarkus application.
 :topics: grpc

--- a/docs/src/main/asciidoc/grpc-virtual-threads.adoc
+++ b/docs/src/main/asciidoc/grpc-virtual-threads.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Quarkus Virtual Thread support for gRPC services
+= Quarkus virtual thread support for gRPC services
 include::_attributes.adoc[]
 :runonvthread: https://javadoc.io/doc/io.smallrye.common/smallrye-common-annotation/latest/io/smallrye/common/annotation/RunOnVirtualThread.html
 :blocking_annotation: https://javadoc.io/doc/io.smallrye.reactive/smallrye-reactive-messaging-api/latest/io/smallrye/reactive/messaging/annotations/Blocking.html

--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= HTTP Reference
+= HTTP reference
 include::_attributes.adoc[]
 :summary: Learn more about configuring Quarkus' Vert.x based HTTP layer - and Undertow if you are using servlets.
 :numbered:

--- a/docs/src/main/asciidoc/http3-reference.adoc
+++ b/docs/src/main/asciidoc/http3-reference.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= HTTP/3 Reference
+= HTTP/3 reference
 include::_attributes.adoc[]
 :categories: web
 :summary: Enable HTTP/3 (QUIC) support in Quarkus for reduced latency and improved performance.

--- a/docs/src/main/asciidoc/ide-tooling.adoc
+++ b/docs/src/main/asciidoc/ide-tooling.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Quarkus Tools in your favorite IDE
+= Quarkus tools in your favorite IDE
 include::_attributes.adoc[]
 :summary: Learn more about Quarkus integrations in IDEs.
 :topics: ide,tooling

--- a/docs/src/main/asciidoc/infinispan-client-reference.adoc
+++ b/docs/src/main/asciidoc/infinispan-client-reference.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Infinispan Client Extension Reference Guide
+= Infinispan Client extension reference guide
 include::_attributes.adoc[]
 :summary: Infinispan is an in memory distributed data store and cache server that offers flexible deployment options and robust capabilities for storing, managing, and processing data.
 :topics: data,infinispan

--- a/docs/src/main/asciidoc/info.adoc
+++ b/docs/src/main/asciidoc/info.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Application Info Endpoint
+= Application info endpoint
 include::_attributes.adoc[]
 :summary: Expose build, git, Java, and OS information via the /q/info endpoint.
 :topics: info,observability

--- a/docs/src/main/asciidoc/jreleaser.adoc
+++ b/docs/src/main/asciidoc/jreleaser.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Packaging And Releasing With JReleaser
+= Packaging and releasing with JReleaser
 include::_attributes.adoc[]
 :jreleaser-version: 1.6.0
 :numbered:

--- a/docs/src/main/asciidoc/kafka-getting-started.adoc
+++ b/docs/src/main/asciidoc/kafka-getting-started.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Getting Started with Quarkus Messaging and Apache Kafka
+= Getting started with Quarkus Messaging and Apache Kafka
 include::_attributes.adoc[]
 :summary: Build two applications that communicate via Apache Kafka using Quarkus Messaging.
 :topics: messaging,kafka,reactive-messaging

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Apache Kafka Reference Guide
+= Apache Kafka reference guide
 include::_attributes.adoc[]
 :summary: This reference guide provides an in-depth look on Apache Kafka and Quarkus Messaging extensions.
 :numbered:

--- a/docs/src/main/asciidoc/lifecycle.adoc
+++ b/docs/src/main/asciidoc/lifecycle.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Application Initialization and Termination
+= Application initialization and termination
 include::_attributes.adoc[]
 :keywords: lifecycle event
 :summary: You often need to execute custom actions when the application starts and clean up everything when the application stops. This guide explains how to be notified when an application stops or starts.

--- a/docs/src/main/asciidoc/load-shedding-reference.adoc
+++ b/docs/src/main/asciidoc/load-shedding-reference.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Load Shedding reference guide
+= Load shedding reference guide
 include::_attributes.adoc[]
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/lra.adoc
+++ b/docs/src/main/asciidoc/lra.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Narayana LRA Participant Support
+= Narayana LRA participant support
 include::_attributes.adoc[]
 :summary: This guide covers the usage of LRA to coordinate activities across services.
 :topics: data,lra,narayana

--- a/docs/src/main/asciidoc/mailer-reference.adoc
+++ b/docs/src/main/asciidoc/mailer-reference.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Mailer Reference Guide
+= Mailer reference guide
 include::_attributes.adoc[]
 :summary: This reference guide explains in more details the configuration and usage of the Quarkus Mailer.
 :topics: mail,mailer

--- a/docs/src/main/asciidoc/messaging-virtual-threads.adoc
+++ b/docs/src/main/asciidoc/messaging-virtual-threads.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Quarkus Virtual Thread support with Reactive Messaging
+= Quarkus virtual thread support with Reactive Messaging
 include::_attributes.adoc[]
 :topics: messaging,kafka,reactive-messaging,virtual-threads
 :extensions: io.quarkus:quarkus-messaging-kafka

--- a/docs/src/main/asciidoc/messaging.adoc
+++ b/docs/src/main/asciidoc/messaging.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Quarkus Messaging Extensions
+= Quarkus Messaging extensions
 include::_attributes.adoc[]
 :topics: messaging,reactive-messaging
 :extensions: io.quarkus:quarkus-messaging

--- a/docs/src/main/asciidoc/native-and-ssl.adoc
+++ b/docs/src/main/asciidoc/native-and-ssl.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Using SSL With Native Executables
+= Using SSL with native executables
 include::_attributes.adoc[]
 :summary: In this guide, we will discuss how you can get your native images to support SSL, as native images don't support it out of the box.
 :devtools-no-gradle:

--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -4,7 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id="native-reference"]
-= Native Reference Guide
+= Native reference guide
 include::_attributes.adoc[]
 :topics: native
 

--- a/docs/src/main/asciidoc/native-transport-reference.adoc
+++ b/docs/src/main/asciidoc/native-transport-reference.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Native Transport Reference
+= Native transport reference
 include::_attributes.adoc[]
 :categories: web
 :summary: Configure Netty native transports (epoll, kqueue, io_uring) for improved I/O performance.

--- a/docs/src/main/asciidoc/performance-measure.adoc
+++ b/docs/src/main/asciidoc/performance-measure.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Measuring Performance
+= Measuring performance
 include::_attributes.adoc[]
 :summary: This guide explains how to best measure the footprint of a Quarkus application.
 :topics: internals,performance

--- a/docs/src/main/asciidoc/picocli.adoc
+++ b/docs/src/main/asciidoc/picocli.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Command Mode with Picocli
+= Command mode with Picocli
 include::_attributes.adoc[]
 :summary: Simplify command line applications creation with the Picocli extension.
 :topics: command-line,cli,picocli

--- a/docs/src/main/asciidoc/pulsar-getting-started.adoc
+++ b/docs/src/main/asciidoc/pulsar-getting-started.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Getting Started to Quarkus Messaging with Apache Pulsar
+= Getting started with Quarkus Messaging and Apache Pulsar
 include::_attributes.adoc[]
 :topics: messaging,reactive-messaging,pulsar
 :extensions: io.quarkus:quarkus-messaging-pulsar

--- a/docs/src/main/asciidoc/pulsar.adoc
+++ b/docs/src/main/asciidoc/pulsar.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Apache Pulsar Reference Guide
+= Apache Pulsar reference guide
 include::_attributes.adoc[]
 :summary: This reference guide provides an in-depth look on Apache Pulsar and the Quarkus Messaging extensions.
 :numbered:

--- a/docs/src/main/asciidoc/quarkus-maven-plugin.adoc
+++ b/docs/src/main/asciidoc/quarkus-maven-plugin.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Quarkus Maven Plugin
+= Quarkus Maven plugin
 include::_attributes.adoc[]
 :topics: maven,tooling
 :diataxis-type: reference

--- a/docs/src/main/asciidoc/quarkus-reactive-architecture.adoc
+++ b/docs/src/main/asciidoc/quarkus-reactive-architecture.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Quarkus Reactive Architecture
+= Quarkus reactive architecture
 include::_attributes.adoc[]
 :summary: Learn more about Quarkus reactive architecture.
 :topics: internals,reactive

--- a/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
+++ b/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Quarkus Base Runtime Image
+= Quarkus base runtime image
 include::_attributes.adoc[]
 :topics: docker,podman,images
 

--- a/docs/src/main/asciidoc/quartz.adoc
+++ b/docs/src/main/asciidoc/quartz.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Scheduling Periodic Tasks with Quartz
+= Scheduling periodic tasks with Quartz
 include::_attributes.adoc[]
 :summary: You need clustering support for your scheduled tasks? This guide explains how to use the Quartz extension for that.
 :topics: scheduling,cronjob,quartz

--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Qute Reference Guide
+= Qute reference guide
 include::_attributes.adoc[]
 :summary: Learn everything you need to know about the Qute template engine.
 :numbered:

--- a/docs/src/main/asciidoc/qute.adoc
+++ b/docs/src/main/asciidoc/qute.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Qute Templating Engine
+= Qute templating engine
 include::_attributes.adoc[]
 :summary: Learn more about how you can use templating in your applications with the Qute template engine.
 :topics: templating,qute

--- a/docs/src/main/asciidoc/rabbitmq-reference.adoc
+++ b/docs/src/main/asciidoc/rabbitmq-reference.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Reactive Messaging RabbitMQ Connector Reference Documentation
+= Reactive Messaging RabbitMQ Connector reference documentation
 include::_attributes.adoc[]
 :extension-status: preview
 :topics: messaging,reactive-messaging,rabbitmq,dev-services,testing,dev-mode

--- a/docs/src/main/asciidoc/rabbitmq.adoc
+++ b/docs/src/main/asciidoc/rabbitmq.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Getting Started to Quarkus Messaging with RabbitMQ
+= Getting started with Quarkus Messaging and RabbitMQ
 :extension-status: preview
 include::_attributes.adoc[]
 :topics: messaging,reactive-messaging,rabbitmq

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Reactive SQL Clients
+= Reactive SQL clients
 include::_attributes.adoc[]
 :summary: This guide covers how to use the Reactive SQL Clients in Quarkus.
 :config-file: application.properties

--- a/docs/src/main/asciidoc/reaugmentation.adoc
+++ b/docs/src/main/asciidoc/reaugmentation.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Re-augment a Quarkus Application
+= Re-augment a Quarkus application
 include::_attributes.adoc[]
 :summary: Use mutable jars to rebuild your application with different build time configurations.
 :topics: mutable-jars,tooling

--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Redis Extension Reference Guide
+= Redis extension reference guide
 :extension-status: stable
 include::_attributes.adoc[]
 :numbered:

--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Writing JSON REST Services
+= Writing JSON REST services
 include::_attributes.adoc[]
 :summary: JSON is now the lingua franca between microservices. In this guide, we see how you can get your REST services to consume and produce JSON payloads.
 :topics: rest,json,resteasy-reactive

--- a/docs/src/main/asciidoc/rest.adoc
+++ b/docs/src/main/asciidoc/rest.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Writing REST Services with Quarkus REST (formerly RESTEasy Reactive)
+= Writing REST services with Quarkus REST (formerly RESTEasy Reactive)
 include::_attributes.adoc[]
 :topics: rest,resteasy-reactive,virtual-threads
 :extensions: io.quarkus:quarkus-rest,io.quarkus:quarkus-rest-jackson,io.quarkus:quarkus-rest-jsonb,io.quarkus:quarkus-rest-client,io.quarkus:quarkus-rest-client-jackson,io.quarkus:quarkus-rest-client-jsonb

--- a/docs/src/main/asciidoc/scheduler-reference.adoc
+++ b/docs/src/main/asciidoc/scheduler-reference.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Scheduler Reference Guide
+= Scheduler reference guide
 include::_attributes.adoc[]
 :summary: Learn more about the Scheduler extension.
 :numbered:

--- a/docs/src/main/asciidoc/scheduler.adoc
+++ b/docs/src/main/asciidoc/scheduler.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Scheduling Periodic Tasks
+= Scheduling periodic tasks
 include::_attributes.adoc[]
 :summary: Modern applications often need to run specific tasks periodically. In this guide, you learn how to schedule periodic tasks.
 :topics: scheduling,cronjob

--- a/docs/src/main/asciidoc/security-csrf-prevention.adoc
+++ b/docs/src/main/asciidoc/security-csrf-prevention.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Cross-Site Request Forgery Prevention
+= Cross-Site Request Forgery prevention
 include::_attributes.adoc[]
 :topics: security,csrf,http
 :extensions: io.quarkus:quarkus-rest-csrf

--- a/docs/src/main/asciidoc/security-customization.adoc
+++ b/docs/src/main/asciidoc/security-customization.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Security Tips and Tricks
+= Security tips and tricks
 include::_attributes.adoc[]
 :topics: security
 :extensions: io.quarkus:quarkus-security

--- a/docs/src/main/asciidoc/security-jdbc.adoc
+++ b/docs/src/main/asciidoc/security-jdbc.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Using Security with JDBC
+= Using security with JDBC
 include::_attributes.adoc[]
 :summary: This guide demonstrates how your Quarkus application can use a database to store your user identities.
 :topics: security,identity-providers,jdbc,sql,database

--- a/docs/src/main/asciidoc/security-ldap.adoc
+++ b/docs/src/main/asciidoc/security-ldap.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Using Security with an LDAP Realm
+= Using security with an LDAP realm
 include::_attributes.adoc[]
 :summary: This guide demonstrates how your Quarkus application can use an LDAP directory to store your user identities.
 :topics: security,identity-providers,ldap

--- a/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
+++ b/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
@@ -4,7 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id="security-oidc-expanded-configuration"]
-= Quarkus OpenId Connect (OIDC) Expanded Configuration Reference
+= Quarkus OpenID Connect (OIDC) expanded configuration reference
 include::_attributes.adoc[]
 :diataxis-type: concept
 :topics: security

--- a/docs/src/main/asciidoc/security-openid-connect-providers.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-providers.adoc
@@ -4,7 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id="security-openid-connect-providers"]
-= Configuring Well-Known OpenID Connect Providers
+= Configuring well-known OpenID Connect providers
 include::_attributes.adoc[]
 :diataxis-type: concept
 :keywords: oidc github twitter google facebook mastodon microsoft apple spotify twitch linkedin strava

--- a/docs/src/main/asciidoc/security-properties.adoc
+++ b/docs/src/main/asciidoc/security-properties.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Using Security with .properties File
+= Using security with .properties file
 
 include::_attributes.adoc[]
 :summary: This guide demonstrates how your Quarkus application can use a .properties file to store your user identities.

--- a/docs/src/main/asciidoc/security-testing.adoc
+++ b/docs/src/main/asciidoc/security-testing.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Security Testing
+= Security testing
 include::_attributes.adoc[]
 :topics: security,testing
 :extensions: io.quarkus:quarkus-test-security

--- a/docs/src/main/asciidoc/security-webauthn.adoc
+++ b/docs/src/main/asciidoc/security-webauthn.adoc
@@ -4,7 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id="security-webauthn"]
-= Using Security with WebAuthn
+= Using security with WebAuthn
 include::_attributes.adoc[]
 :extension-status: experimental
 :topics: security,webauthn,authorization

--- a/docs/src/main/asciidoc/spring-cache.adoc
+++ b/docs/src/main/asciidoc/spring-cache.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Quarkus Extension for Spring Cache API
+= Quarkus extension for Spring Cache API
 include::_attributes.adoc[]
 :summary: While you are encouraged to use the Cache extension for your application-level caching, Quarkus provides a compatibility layer for Spring Cache in the form of the spring-cache extension.
 :topics: spring,cache,compatibility

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Quarkus Extension for Spring DI API
+= Quarkus extension for Spring DI API
 include::_attributes.adoc[]
 :summary: While you are encouraged to use CDI annotations for injection, Quarkus provides a compatibility layer for Spring dependency injection in the form of the spring-di extension.
 :topics: spring,cdi,injection,compatibility

--- a/docs/src/main/asciidoc/spring-scheduled.adoc
+++ b/docs/src/main/asciidoc/spring-scheduled.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Quarkus Extension for Spring Scheduling API
+= Quarkus extension for Spring Scheduling API
 include::_attributes.adoc[]
 :summary: While you are encouraged to use the Scheduler or Quartz extensions to schedule tasks, Quarkus provides a compatibility layer for Spring Scheduled in the form of the spring-scheduled extension.
 :topics: spring,scheduling,compatibility

--- a/docs/src/main/asciidoc/spring-security.adoc
+++ b/docs/src/main/asciidoc/spring-security.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Quarkus Extension for Spring Security API
+= Quarkus extension for Spring Security API
 include::_attributes.adoc[]
 :summary: While you are encouraged to use the Quarkus Security layer to secure your applications, Quarkus provides a compatibility layer for Spring Security in the form of the spring-security extension.
 :topics: spring,security,compatibility

--- a/docs/src/main/asciidoc/spring-test.adoc
+++ b/docs/src/main/asciidoc/spring-test.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Testing Spring-style Applications in Quarkus
+= Testing Spring-style applications in Quarkus
 include::_attributes.adoc[]
 :categories: compatibility,testing
 :summary: Quarkus supports the @SpringBootTest annotation out of the box, letting Spring developers write tests in a familiar style while running on the Quarkus runtime.

--- a/docs/src/main/asciidoc/spring-tx.adoc
+++ b/docs/src/main/asciidoc/spring-tx.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Quarkus Extension for Spring Transaction API
+= Quarkus extension for Spring Transaction API
 include::_attributes.adoc[]
 :summary: While you are encouraged to use Jakarta @Transactional directly, Quarkus provides a compatibility layer for Spring @Transactional in the form of the spring-tx extension.
 :topics: spring,transactions,compatibility

--- a/docs/src/main/asciidoc/spring-web.adoc
+++ b/docs/src/main/asciidoc/spring-web.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Quarkus Extension for Spring Web API
+= Quarkus extension for Spring Web API
 include::_attributes.adoc[]
 :summary: While you are encouraged to use Jakarta REST annotations for defining REST endpoints, Quarkus provides a compatibility layer for Spring Web in the form of the spring-web extension.
 :topics: spring,rest,compatibility

--- a/docs/src/main/asciidoc/stork-manual-service-registration.adoc
+++ b/docs/src/main/asciidoc/stork-manual-service-registration.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Implementing a Custom Stork Service Registrar
+= Implementing a custom Stork service registrar
 :extension-status: preview
 include::_attributes.adoc[]
 :topics: service-discovery,service-registration,stork

--- a/docs/src/main/asciidoc/stork-reference.adoc
+++ b/docs/src/main/asciidoc/stork-reference.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Stork Reference Guide
+= Stork reference guide
 :extension-status: preview
 include::_attributes.adoc[]
 :topics: service-discovery,load-balancing,stork

--- a/docs/src/main/asciidoc/stork.adoc
+++ b/docs/src/main/asciidoc/stork.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Getting Started with SmallRye Stork
+= Getting started with SmallRye Stork
 :extension-status: preview
 include::_attributes.adoc[]
 :topics: service-discovery,load-balancing,stork

--- a/docs/src/main/asciidoc/tooling.adoc
+++ b/docs/src/main/asciidoc/tooling.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Using our Tooling
+= Using our tooling
 include::_attributes.adoc[]
 :summary: Explore the Quarkus developer toolchain which makes Quarkus development so fast and enjoyable.
 :topics: tooling

--- a/docs/src/main/asciidoc/vertx-reference.adoc
+++ b/docs/src/main/asciidoc/vertx-reference.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Vert.x Reference Guide
+= Vert.x reference guide
 include::_attributes.adoc[]
 :keywords: vertx event verticle
 :summary: This reference guide provides advanced details about the usage and the configuration of the Vert.x instance used by Quarkus.

--- a/docs/src/main/asciidoc/vertx.adoc
+++ b/docs/src/main/asciidoc/vertx.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Using Eclipse Vert.x API from a Quarkus Application
+= Using Eclipse Vert.x API from a Quarkus application
 include::_attributes.adoc[]
 :keywords: vertx event verticle
 :summary: This guide explains how to use Vert.x in Quarkus to build reactive applications.

--- a/docs/src/main/asciidoc/virtual-threads.adoc
+++ b/docs/src/main/asciidoc/virtual-threads.adoc
@@ -4,7 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [[virtual-threads]]
-= Virtual Thread support reference
+= Virtual thread support reference
 include::_attributes.adoc[]
 :diataxis-type: reference
 :resteasy-reactive-api: https://javadoc.io/doc/io.quarkus.resteasy.reactive/resteasy-reactive/{quarkus-version}

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Writing Your Own Extension
+= Writing your own extension
 include::_attributes.adoc[]
 :summary: Quarkus extensions optimize your applications by pushing as much work as possible to the build operation. This guide explains the rationale of Quarkus extensions and guides you through authoring your own extensions.
 :numbered:


### PR DESCRIPTION
Until now, we were uppercasing them anyway but we now need them clean for the new menu.