### PR TITLE
Aesh: fix flaky WebSocket tests on Semeru by closing WebSocketClient

### DIFF
--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketAuthenticatedTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketAuthenticatedTest.java
@@ -63,22 +63,26 @@ public class AeshWebSocketAuthenticatedTest {
         CopyOnWriteArrayList<Throwable> errors = new CopyOnWriteArrayList<>();
 
         WebSocketClient client = vertx.createWebSocketClient();
-        WebSocketConnectOptions options = new WebSocketConnectOptions()
-                .setHost(wsUri.getHost())
-                .setPort(wsUri.getPort())
-                .setURI(wsUri.getPath());
+        try {
+            WebSocketConnectOptions options = new WebSocketConnectOptions()
+                    .setHost(wsUri.getHost())
+                    .setPort(wsUri.getPort())
+                    .setURI(wsUri.getPath());
 
-        client.connect(options).onComplete(ar -> {
-            if (ar.failed()) {
-                errors.add(ar.cause());
-            }
-            latch.countDown();
-        });
+            client.connect(options).onComplete(ar -> {
+                if (ar.failed()) {
+                    errors.add(ar.cause());
+                }
+                latch.countDown();
+            });
 
-        boolean completed = latch.await(10, TimeUnit.SECONDS);
-        Assertions.assertThat(completed).isTrue();
-        Assertions.assertThat(errors).hasSize(1);
-        Assertions.assertThat(errors.get(0).getMessage()).contains("401");
+            boolean completed = latch.await(10, TimeUnit.SECONDS);
+            Assertions.assertThat(completed).isTrue();
+            Assertions.assertThat(errors).hasSize(1);
+            Assertions.assertThat(errors.get(0).getMessage()).contains("401");
+        } finally {
+            client.close();
+        }
     }
 
     @Test
@@ -87,34 +91,38 @@ public class AeshWebSocketAuthenticatedTest {
         CountDownLatch latch = new CountDownLatch(1);
 
         WebSocketClient client = vertx.createWebSocketClient();
-        WebSocketConnectOptions options = new WebSocketConnectOptions()
-                .setHost(wsUri.getHost())
-                .setPort(wsUri.getPort())
-                .setURI(wsUri.getPath())
-                .addHeader("Authorization", basicAuth("user", "user"));
+        try {
+            WebSocketConnectOptions options = new WebSocketConnectOptions()
+                    .setHost(wsUri.getHost())
+                    .setPort(wsUri.getPort())
+                    .setURI(wsUri.getPath())
+                    .addHeader("Authorization", basicAuth("user", "user"));
 
-        client.connect(options).onComplete(ar -> {
-            if (ar.failed()) {
-                latch.countDown();
-                return;
-            }
-            var ws = ar.result();
-            AeshWebSocketTestHelper.sendCommandOnPrompt(ws, "hello", "Hello World!", output, latch);
-            ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
-            // Retry init if server did not respond (handles slow JVMs like Semeru)
-            vertx.setTimer(2000, id -> {
-                if (output.length() == 0) {
-                    ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+            client.connect(options).onComplete(ar -> {
+                if (ar.failed()) {
+                    latch.countDown();
+                    return;
                 }
+                var ws = ar.result();
+                AeshWebSocketTestHelper.sendCommandOnPrompt(ws, "hello", "Hello World!", output, latch);
+                ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+                // Retry init if server did not respond (handles slow JVMs like Semeru)
+                vertx.setTimer(2000, id -> {
+                    if (output.length() == 0) {
+                        ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+                    }
+                });
             });
-        });
 
-        boolean completed = latch.await(30, TimeUnit.SECONDS);
+            boolean completed = latch.await(30, TimeUnit.SECONDS);
 
-        Assertions.assertThat(completed)
-                .as("Expected to receive 'Hello World!' in WebSocket output within 30s. Received: %s", output)
-                .isTrue();
-        Assertions.assertThat(output.toString()).contains("Hello World!");
+            Assertions.assertThat(completed)
+                    .as("Expected to receive 'Hello World!' in WebSocket output within 30s. Received: %s", output)
+                    .isTrue();
+            Assertions.assertThat(output.toString()).contains("Hello World!");
+        } finally {
+            client.close();
+        }
     }
 
     private static String basicAuth(String username, String password) {

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketConnectionTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketConnectionTest.java
@@ -48,33 +48,37 @@ public class AeshWebSocketConnectionTest {
         CountDownLatch latch = new CountDownLatch(1);
 
         WebSocketClient client = vertx.createWebSocketClient();
-        WebSocketConnectOptions options = new WebSocketConnectOptions()
-                .setHost(wsUri.getHost())
-                .setPort(wsUri.getPort())
-                .setURI(wsUri.getPath());
+        try {
+            WebSocketConnectOptions options = new WebSocketConnectOptions()
+                    .setHost(wsUri.getHost())
+                    .setPort(wsUri.getPort())
+                    .setURI(wsUri.getPath());
 
-        client.connect(options).onComplete(ar -> {
-            if (ar.failed()) {
-                latch.countDown();
-                return;
-            }
-            var ws = ar.result();
-            AeshWebSocketTestHelper.sendCommandOnPrompt(ws, "hello", "Hello World!", output, latch);
-            ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
-            // Retry init if server did not respond (handles slow JVMs like Semeru)
-            vertx.setTimer(2000, id -> {
-                if (output.length() == 0) {
-                    ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+            client.connect(options).onComplete(ar -> {
+                if (ar.failed()) {
+                    latch.countDown();
+                    return;
                 }
+                var ws = ar.result();
+                AeshWebSocketTestHelper.sendCommandOnPrompt(ws, "hello", "Hello World!", output, latch);
+                ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+                // Retry init if server did not respond (handles slow JVMs like Semeru)
+                vertx.setTimer(2000, id -> {
+                    if (output.length() == 0) {
+                        ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+                    }
+                });
             });
-        });
 
-        boolean completed = latch.await(30, TimeUnit.SECONDS);
+            boolean completed = latch.await(30, TimeUnit.SECONDS);
 
-        Assertions.assertThat(completed)
-                .as("Expected to receive 'Hello World!' in WebSocket output within 30s. Received: %s", output)
-                .isTrue();
-        Assertions.assertThat(output.toString()).contains("Hello World!");
+            Assertions.assertThat(completed)
+                    .as("Expected to receive 'Hello World!' in WebSocket output within 30s. Received: %s", output)
+                    .isTrue();
+            Assertions.assertThat(output.toString()).contains("Hello World!");
+        } finally {
+            client.close();
+        }
     }
 
     @CommandDefinition(name = "hello", description = "Say hello")

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketMalformedMessageTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketMalformedMessageTest.java
@@ -45,44 +45,48 @@ public class AeshWebSocketMalformedMessageTest {
         CountDownLatch latch = new CountDownLatch(1);
 
         WebSocketClient client = vertx.createWebSocketClient();
-        WebSocketConnectOptions options = new WebSocketConnectOptions()
-                .setHost(wsUri.getHost())
-                .setPort(wsUri.getPort())
-                .setURI(wsUri.getPath());
+        try {
+            WebSocketConnectOptions options = new WebSocketConnectOptions()
+                    .setHost(wsUri.getHost())
+                    .setPort(wsUri.getPort())
+                    .setURI(wsUri.getPath());
 
-        client.connect(options).onComplete(ar -> {
-            if (ar.failed()) {
-                latch.countDown();
-                return;
-            }
-            var ws = ar.result();
-            ws.textMessageHandler(msg -> {
-                messages.add(msg);
-                if (msg.contains("Hello!")) {
+            client.connect(options).onComplete(ar -> {
+                if (ar.failed()) {
                     latch.countDown();
+                    return;
                 }
-            });
+                var ws = ar.result();
+                ws.textMessageHandler(msg -> {
+                    messages.add(msg);
+                    if (msg.contains("Hello!")) {
+                        latch.countDown();
+                    }
+                });
 
-            // Send invalid JSON -- should be handled gracefully
-            ws.writeTextMessage("this is not json at all");
+                // Send invalid JSON -- should be handled gracefully
+                ws.writeTextMessage("this is not json at all");
 
-            // After a short delay, send valid init + command
-            vertx.setTimer(500, id -> {
-                ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
-                vertx.setTimer(500, id2 -> {
-                    ws.writeTextMessage("{\"action\":\"read\",\"data\":\"hello\\r\"}");
+                // After a short delay, send valid init + command
+                vertx.setTimer(500, id -> {
+                    ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+                    vertx.setTimer(500, id2 -> {
+                        ws.writeTextMessage("{\"action\":\"read\",\"data\":\"hello\\r\"}");
+                    });
                 });
             });
-        });
 
-        boolean completed = latch.await(10, TimeUnit.SECONDS);
-        String allOutput = String.join("", messages);
+            boolean completed = latch.await(10, TimeUnit.SECONDS);
+            String allOutput = String.join("", messages);
 
-        Assertions.assertThat(completed)
-                .as("Connection should survive invalid JSON and process subsequent valid messages. Output: %s",
-                        allOutput)
-                .isTrue();
-        Assertions.assertThat(allOutput).contains("Hello!");
+            Assertions.assertThat(completed)
+                    .as("Connection should survive invalid JSON and process subsequent valid messages. Output: %s",
+                            allOutput)
+                    .isTrue();
+            Assertions.assertThat(allOutput).contains("Hello!");
+        } finally {
+            client.close();
+        }
     }
 
     @Test
@@ -92,46 +96,50 @@ public class AeshWebSocketMalformedMessageTest {
         CountDownLatch latch = new CountDownLatch(1);
 
         WebSocketClient client = vertx.createWebSocketClient();
-        WebSocketConnectOptions options = new WebSocketConnectOptions()
-                .setHost(wsUri.getHost())
-                .setPort(wsUri.getPort())
-                .setURI(wsUri.getPath());
+        try {
+            WebSocketConnectOptions options = new WebSocketConnectOptions()
+                    .setHost(wsUri.getHost())
+                    .setPort(wsUri.getPort())
+                    .setURI(wsUri.getPath());
 
-        client.connect(options).onComplete(ar -> {
-            if (ar.failed()) {
-                latch.countDown();
-                return;
-            }
-            var ws = ar.result();
-            ws.textMessageHandler(msg -> {
-                messages.add(msg);
-                if (msg.contains("Hello!")) {
+            client.connect(options).onComplete(ar -> {
+                if (ar.failed()) {
                     latch.countDown();
+                    return;
                 }
-            });
+                var ws = ar.result();
+                ws.textMessageHandler(msg -> {
+                    messages.add(msg);
+                    if (msg.contains("Hello!")) {
+                        latch.countDown();
+                    }
+                });
 
-            // Valid JSON init first (so connection is established)
-            ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+                // Valid JSON init first (so connection is established)
+                ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
 
-            vertx.setTimer(500, id -> {
-                // Unknown action -- should be silently ignored
-                ws.writeTextMessage("{\"action\":\"unknown_action\",\"data\":\"something\"}");
+                vertx.setTimer(500, id -> {
+                    // Unknown action -- should be silently ignored
+                    ws.writeTextMessage("{\"action\":\"unknown_action\",\"data\":\"something\"}");
 
-                vertx.setTimer(300, id2 -> {
-                    // Valid command should still work
-                    ws.writeTextMessage("{\"action\":\"read\",\"data\":\"hello\\r\"}");
+                    vertx.setTimer(300, id2 -> {
+                        // Valid command should still work
+                        ws.writeTextMessage("{\"action\":\"read\",\"data\":\"hello\\r\"}");
+                    });
                 });
             });
-        });
 
-        boolean completed = latch.await(10, TimeUnit.SECONDS);
-        String allOutput = String.join("", messages);
+            boolean completed = latch.await(10, TimeUnit.SECONDS);
+            String allOutput = String.join("", messages);
 
-        Assertions.assertThat(completed)
-                .as("Connection should survive unknown actions and process subsequent valid messages. Output: %s",
-                        allOutput)
-                .isTrue();
-        Assertions.assertThat(allOutput).contains("Hello!");
+            Assertions.assertThat(completed)
+                    .as("Connection should survive unknown actions and process subsequent valid messages. Output: %s",
+                            allOutput)
+                    .isTrue();
+            Assertions.assertThat(allOutput).contains("Hello!");
+        } finally {
+            client.close();
+        }
     }
 
     @Test
@@ -140,42 +148,46 @@ public class AeshWebSocketMalformedMessageTest {
         CountDownLatch latch = new CountDownLatch(1);
 
         WebSocketClient client = vertx.createWebSocketClient();
-        WebSocketConnectOptions options = new WebSocketConnectOptions()
-                .setHost(wsUri.getHost())
-                .setPort(wsUri.getPort())
-                .setURI(wsUri.getPath());
+        try {
+            WebSocketConnectOptions options = new WebSocketConnectOptions()
+                    .setHost(wsUri.getHost())
+                    .setPort(wsUri.getPort())
+                    .setURI(wsUri.getPath());
 
-        client.connect(options).onComplete(ar -> {
-            if (ar.failed()) {
-                latch.countDown();
-                return;
-            }
-            var ws = ar.result();
-            ws.textMessageHandler(msg -> {
-                messages.add(msg);
-                if (msg.contains("Hello!")) {
+            client.connect(options).onComplete(ar -> {
+                if (ar.failed()) {
                     latch.countDown();
+                    return;
                 }
-            });
+                var ws = ar.result();
+                ws.textMessageHandler(msg -> {
+                    messages.add(msg);
+                    if (msg.contains("Hello!")) {
+                        latch.countDown();
+                    }
+                });
 
-            // Empty string -- should be handled gracefully
-            ws.writeTextMessage("");
+                // Empty string -- should be handled gracefully
+                ws.writeTextMessage("");
 
-            vertx.setTimer(500, id -> {
-                ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
-                vertx.setTimer(500, id2 -> {
-                    ws.writeTextMessage("{\"action\":\"read\",\"data\":\"hello\\r\"}");
+                vertx.setTimer(500, id -> {
+                    ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+                    vertx.setTimer(500, id2 -> {
+                        ws.writeTextMessage("{\"action\":\"read\",\"data\":\"hello\\r\"}");
+                    });
                 });
             });
-        });
 
-        boolean completed = latch.await(10, TimeUnit.SECONDS);
-        String allOutput = String.join("", messages);
+            boolean completed = latch.await(10, TimeUnit.SECONDS);
+            String allOutput = String.join("", messages);
 
-        Assertions.assertThat(completed)
-                .as("Connection should survive empty messages. Output: %s", allOutput)
-                .isTrue();
-        Assertions.assertThat(allOutput).contains("Hello!");
+            Assertions.assertThat(completed)
+                    .as("Connection should survive empty messages. Output: %s", allOutput)
+                    .isTrue();
+            Assertions.assertThat(allOutput).contains("Hello!");
+        } finally {
+            client.close();
+        }
     }
 
     @CommandDefinition(name = "hello", description = "Say hello")

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketRolesAllowedTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketRolesAllowedTest.java
@@ -64,23 +64,27 @@ public class AeshWebSocketRolesAllowedTest {
         CopyOnWriteArrayList<Throwable> errors = new CopyOnWriteArrayList<>();
 
         WebSocketClient client = vertx.createWebSocketClient();
-        WebSocketConnectOptions options = new WebSocketConnectOptions()
-                .setHost(wsUri.getHost())
-                .setPort(wsUri.getPort())
-                .setURI(wsUri.getPath())
-                .addHeader("Authorization", basicAuth("user", "user"));
+        try {
+            WebSocketConnectOptions options = new WebSocketConnectOptions()
+                    .setHost(wsUri.getHost())
+                    .setPort(wsUri.getPort())
+                    .setURI(wsUri.getPath())
+                    .addHeader("Authorization", basicAuth("user", "user"));
 
-        client.connect(options).onComplete(ar -> {
-            if (ar.failed()) {
-                errors.add(ar.cause());
-            }
-            latch.countDown();
-        });
+            client.connect(options).onComplete(ar -> {
+                if (ar.failed()) {
+                    errors.add(ar.cause());
+                }
+                latch.countDown();
+            });
 
-        boolean completed = latch.await(10, TimeUnit.SECONDS);
-        Assertions.assertThat(completed).isTrue();
-        Assertions.assertThat(errors).hasSize(1);
-        Assertions.assertThat(errors.get(0).getMessage()).contains("403");
+            boolean completed = latch.await(10, TimeUnit.SECONDS);
+            Assertions.assertThat(completed).isTrue();
+            Assertions.assertThat(errors).hasSize(1);
+            Assertions.assertThat(errors.get(0).getMessage()).contains("403");
+        } finally {
+            client.close();
+        }
     }
 
     @Test
@@ -89,34 +93,38 @@ public class AeshWebSocketRolesAllowedTest {
         CountDownLatch latch = new CountDownLatch(1);
 
         WebSocketClient client = vertx.createWebSocketClient();
-        WebSocketConnectOptions options = new WebSocketConnectOptions()
-                .setHost(wsUri.getHost())
-                .setPort(wsUri.getPort())
-                .setURI(wsUri.getPath())
-                .addHeader("Authorization", basicAuth("admin", "admin"));
+        try {
+            WebSocketConnectOptions options = new WebSocketConnectOptions()
+                    .setHost(wsUri.getHost())
+                    .setPort(wsUri.getPort())
+                    .setURI(wsUri.getPath())
+                    .addHeader("Authorization", basicAuth("admin", "admin"));
 
-        client.connect(options).onComplete(ar -> {
-            if (ar.failed()) {
-                latch.countDown();
-                return;
-            }
-            var ws = ar.result();
-            AeshWebSocketTestHelper.sendCommandOnPrompt(ws, "hello", "Hello World!", output, latch);
-            ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
-            // Retry init if server did not respond (handles slow JVMs like Semeru)
-            vertx.setTimer(2000, id -> {
-                if (output.length() == 0) {
-                    ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+            client.connect(options).onComplete(ar -> {
+                if (ar.failed()) {
+                    latch.countDown();
+                    return;
                 }
+                var ws = ar.result();
+                AeshWebSocketTestHelper.sendCommandOnPrompt(ws, "hello", "Hello World!", output, latch);
+                ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+                // Retry init if server did not respond (handles slow JVMs like Semeru)
+                vertx.setTimer(2000, id -> {
+                    if (output.length() == 0) {
+                        ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+                    }
+                });
             });
-        });
 
-        boolean completed = latch.await(30, TimeUnit.SECONDS);
+            boolean completed = latch.await(30, TimeUnit.SECONDS);
 
-        Assertions.assertThat(completed)
-                .as("Expected to receive 'Hello World!' in WebSocket output within 30s. Received: %s", output)
-                .isTrue();
-        Assertions.assertThat(output.toString()).contains("Hello World!");
+            Assertions.assertThat(completed)
+                    .as("Expected to receive 'Hello World!' in WebSocket output within 30s. Received: %s", output)
+                    .isTrue();
+            Assertions.assertThat(output.toString()).contains("Hello World!");
+        } finally {
+            client.close();
+        }
     }
 
     private static String basicAuth(String username, String password) {


### PR DESCRIPTION
- Vert.x wraps every WebSocketClient in a CleanableWebSocketClient that uses java.lang.ref.Cleaner to call shutdown() when garbage collected
- the shutdown tears down the underlying NetClient and its TCP connections
- after client.connect() returns, the local variable is never read again in the test, so the JIT may treat it as dead
- an aggressive GC collects the client mid-test, the Cleaner fires, and the TCP connection backing the active WebSocket is closed
- wrapping each test in try/finally with client.close() prevents premature GC and ensures proper resource cleanup

NOTE: This is not a verified fix, but (1) closing the clients correctly definitely does not hurt, and (2) it's a very reasonable theory (constructed by Claude Code).