### PR TITLE
Upgrade google-http-client-bom to 2.2.0 to match Google SDK

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -188,7 +188,7 @@
         <checker-qual.version>4.2.2</checker-qual.version>
         <error-prone-annotations.version>2.49.0</error-prone-annotations.version>
         <jib-core.version>0.28.2</jib-core.version>
-        <google-http-client.version>1.47.1</google-http-client.version>
+        <google-http-client.version>2.2.0</google-http-client.version>
         <scram-client.version>3.3</scram-client.version>
         <picocli.version>4.7.7</picocli.version>
         <google-cloud-functions.version>2.0.2</google-cloud-functions.version>


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
and the AI/LLM usage policy at https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md
-->

This change upgrades the google-http-client-bom to version 2.2.0, matching the current version used by the Google SDK. This upgrade is blocking the upgrade of the Google Client SDK version used for the Quarkus Google Cloud extension. See https://github.com/quarkiverse/quarkus-google-cloud-services/pull/1087

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

