### PR TITLE
Disable tree-shake in test mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarTreeShakeProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarTreeShakeProcessor.java
@@ -49,6 +49,7 @@ import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.DependencyFlags;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.paths.OpenPathTree;
+import io.quarkus.runtime.LaunchMode;
 
 public class JarTreeShakeProcessor {
 
@@ -58,14 +59,17 @@ public class JarTreeShakeProcessor {
 
     static class TreeShakeEnabled implements BooleanSupplier {
         private final PackageConfig packageConfig;
+        private final LaunchMode launchMode;
 
-        TreeShakeEnabled(PackageConfig packageConfig) {
+        TreeShakeEnabled(PackageConfig packageConfig, LaunchMode launchMode) {
             this.packageConfig = packageConfig;
+            this.launchMode = launchMode;
         }
 
         @Override
         public boolean getAsBoolean() {
-            return packageConfig.jar().treeShake().mode() == TreeShakeConfig.TreeShakeMode.CLASSES
+            return launchMode == LaunchMode.NORMAL
+                    && packageConfig.jar().treeShake().mode() == TreeShakeConfig.TreeShakeMode.CLASSES
                     && packageConfig.jar().type() != PackageConfig.JarConfig.JarType.MUTABLE_JAR;
         }
     }


### PR DESCRIPTION
Typically, tree-shake doesn't run in test mode. But if `quarkus-cyclonedx` is present, it may expose an SBOM endpoint in test mode and it consumes the computed result of tree-shaking.

Currently, tree-shake filtering is applied only when building a package. It's not applied when bootstrapping a test app (although it'd be great). So for now, it'd be better to disable tree-shake for non-prod modes.