### PR TITLE
Fix: Entities with MappedSuperclass not being mocked

### DIFF
--- a/extensions/panache/panache-mock/src/main/java/io/quarkus/panache/mock/impl/PanacheQuarkusComponentTestCallbacks.java
+++ b/extensions/panache/panache-mock/src/main/java/io/quarkus/panache/mock/impl/PanacheQuarkusComponentTestCallbacks.java
@@ -10,6 +10,7 @@ import java.util.function.BiFunction;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Opcodes;
@@ -44,11 +45,10 @@ public class PanacheQuarkusComponentTestCallbacks implements QuarkusComponentTes
         List<ClassInfo> mockedEntities = new ArrayList<>();
         for (Class<?> mockClass : panacheMocks.value()) {
             ClassInfo maybeMockedEntity = buildContext.getComputingBeanArchiveIndex().getClassByName(mockClass);
-            DotName superName = maybeMockedEntity.superName();
             if (maybeMockedEntity.isAbstract()
-                    || superName == null
-                    || (!superName.equals(PANACHE_ENTITY)
-                            && !superName.equals(PANACHE_ENTITY_BASE))) {
+                    || (!isPanacheEntity(
+                            maybeMockedEntity,
+                            buildContext.getComputingBeanArchiveIndex()))) {
                 continue;
             }
             mockedEntities.add(maybeMockedEntity);
@@ -114,6 +114,24 @@ public class PanacheQuarkusComponentTestCallbacks implements QuarkusComponentTes
                         }
                     }));
         }
+    }
+
+    private static boolean isPanacheEntity(ClassInfo entity, IndexView index) {
+        ClassInfo current = entity;
+
+        while (current != null) {
+            DotName superName = current.superName();
+            if (superName == null) {
+                return false;
+            }
+            if (PANACHE_ENTITY.equals(superName)
+                    || PANACHE_ENTITY_BASE.equals(superName)) {
+                return true;
+            }
+            current = index.getClassByName(superName);
+        }
+
+        return false;
     }
 
     private void addMethod(String entityClass, ClassTransformer transformer, MethodInfo method) {

--- a/extensions/panache/panache-mock/src/test/java/io/quarkus/panache/mock/BaseClass.java
+++ b/extensions/panache/panache-mock/src/test/java/io/quarkus/panache/mock/BaseClass.java
@@ -1,0 +1,10 @@
+package io.quarkus.panache.mock;
+
+import jakarta.persistence.MappedSuperclass;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+
+@MappedSuperclass
+public class BaseClass extends PanacheEntityBase {
+
+}

--- a/extensions/panache/panache-mock/src/test/java/io/quarkus/panache/mock/EntityComponentTest.java
+++ b/extensions/panache/panache-mock/src/test/java/io/quarkus/panache/mock/EntityComponentTest.java
@@ -13,7 +13,7 @@ import org.mockito.Mockito;
 import io.quarkus.test.component.QuarkusComponentTest;
 
 @QuarkusComponentTest
-@MockPanacheEntities(Person.class)
+@MockPanacheEntities({ Person.class, Subclass.class })
 public class EntityComponentTest {
 
     @Inject
@@ -34,6 +34,14 @@ public class EntityComponentTest {
         // default values
         assertEquals(0, Person.deleteAll());
         assertNull(Person.findById("1"));
+    }
+
+    @Test
+    public void testSubclass() {
+        Mockito.when(Subclass.count()).thenReturn(23L);
+        Mockito.when(Subclass.count("from foo")).thenReturn(13L);
+        assertEquals(23, Subclass.count());
+        assertEquals(13, Subclass.count("from foo"));
     }
 
 }

--- a/extensions/panache/panache-mock/src/test/java/io/quarkus/panache/mock/Subclass.java
+++ b/extensions/panache/panache-mock/src/test/java/io/quarkus/panache/mock/Subclass.java
@@ -1,0 +1,8 @@
+package io.quarkus.panache.mock;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class Subclass extends BaseClass {
+
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
and the AI/LLM usage policy at https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md
-->

Fix for the issue #56027, quarkus-panache-mock does not mock entities that have superclasses extending Panache classes.

* Fixes #56027

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

