### PR TITLE
Fix native image build failure on aarch64 when using BC FIPS Poly1305-AES

### DIFF
--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
@@ -397,6 +397,12 @@ public class SecurityProcessor {
             reflection.produce(ReflectiveClassBuildItem.builder("org.bouncycastle.crypto.general.AES")
                     .methods().fields().build());
             runtimeReInitialized.produce(new RuntimeInitializedClassBuildItem("org.bouncycastle.crypto.general.AES"));
+            // Poly1305's static initializer eagerly builds AES/Camellia/SEED/Serpent/Twofish engine instances
+            // (e.g. MACwithAES -> AESEngine -> AESWorkingBuffer). Those engine buffer classes embed a Cleaner and are
+            // run-time initialized (see below), so the holder class must be run-time initialized too, otherwise its
+            // baked-in engine constants reach the build-time image heap and the analysis aborts (this only manifests on
+            // some architectures, depending on points-to reachability). See https://github.com/quarkusio/quarkus/issues/56005
+            runtimeReInitialized.produce(new RuntimeInitializedClassBuildItem("org.bouncycastle.crypto.general.Poly1305"));
             runtimeReInitialized
                     .produce(new RuntimeInitializedClassBuildItem(
                             "org.bouncycastle.crypto.asymmetric.NamedECDomainParameters"));

--- a/integration-tests/bouncycastle-fips/src/main/java/io/quarkus/it/bouncycastle/BouncyCastleFipsEndpoint.java
+++ b/integration-tests/bouncycastle-fips/src/main/java/io/quarkus/it/bouncycastle/BouncyCastleFipsEndpoint.java
@@ -1,12 +1,17 @@
 package io.quarkus.it.bouncycastle;
 
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.security.Security;
 import java.security.Signature;
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import javax.crypto.KeyGenerator;
+import javax.crypto.Mac;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -35,6 +40,33 @@ public class BouncyCastleFipsEndpoint {
         // This algorithm name is only supported with BC, Java (11+) equivalent is `RSASSA-PSS`
         Signature.getInstance("SHA256withRSAandMGF1", "BCFIPS");
         return "success";
+    }
+
+    @GET
+    @Path("poly1305")
+    public String poly1305() throws Exception {
+        // Reproducer for https://github.com/quarkusio/quarkus/issues/56005:
+        // resolving the POLY1305-AES MAC forces ProvPoly1305's AES engine creator to be reachable, which drags
+        // org.bouncycastle.crypto.general.Poly1305's statically built AESEngine (and its AESWorkingBuffer) into the
+        // native image heap. Since AESWorkingBuffer is run-time initialized, this fails the native build unless the
+        // Poly1305 holder class is run-time initialized too.
+        // POLY1305-AES is a general (non-FIPS-approved) algorithm. BC FIPS approved-only mode is thread-local
+        // and one-way (cannot be reset to false), so a fresh thread is needed to avoid inheriting approved-only
+        // mode set by the fipsmode endpoint on a reused worker thread.
+        AtomicReference<String> result = new AtomicReference<>();
+        Thread worker = new Thread(() -> {
+            try {
+                Mac mac = Mac.getInstance("POLY1305-AES", "BCFIPS");
+                mac.init(new SecretKeySpec(new byte[32], "POLY1305"), new IvParameterSpec(new byte[16]));
+                mac.update("quarkus".getBytes(StandardCharsets.UTF_8));
+                result.set(mac.doFinal().length == 16 ? "success" : "unexpected");
+            } catch (Exception e) {
+                result.set(e.getClass().getName() + ": " + e.getMessage());
+            }
+        });
+        worker.start();
+        worker.join();
+        return result.get();
     }
 
     @GET

--- a/integration-tests/bouncycastle-fips/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleFipsTestCase.java
+++ b/integration-tests/bouncycastle-fips/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleFipsTestCase.java
@@ -31,6 +31,16 @@ public class BouncyCastleFipsTestCase {
     }
 
     @Test
+    public void testPoly1305() {
+        RestAssured.given()
+                .when()
+                .get("/jca/poly1305")
+                .then()
+                .statusCode(200)
+                .body(equalTo("success"));
+    }
+
+    @Test
     public void testFipsMode() {
         RestAssured.given()
                 .when()


### PR DESCRIPTION
The Poly1305 static initializer eagerly builds engine instances (AESEngine, CamelliEngine, etc.) which hold AESWorkingBuffer and other buffer classes marked for run-time init. When Poly1305 itself was build-time initialized, GraalVM folded these engine constants into the image heap, conflicting with their run-time-init marking. This caused native builds to fail during points-to analysis on certain architectures.

Mark Poly1305 for run-time initialization so its engine singletons are initialized at runtime rather than embedded in the image heap. Add a test case that explicitly uses POLY1305-AES to ensure the fix prevents regression.

Fixes #56005