### PR TITLE
Inherit the parent context MDC in Vert.x contexts created for nested operations

### DIFF
--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ClientLogMdcTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ClientLogMdcTest.java
@@ -1,0 +1,79 @@
+package io.quarkus.rest.client.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.LogRecord;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.logging.MDC;
+import org.jboss.logmanager.ExtLogRecord;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+public class ClientLogMdcTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(Resource.class, Client.class))
+            .setLogRecordPredicate(record -> record.getLoggerName()
+                    .equals("org.jboss.resteasy.reactive.client.logging.DefaultClientLogger"))
+            .withConfiguration("""
+                    quarkus.rest-client.my-client.url=http://localhost:${quarkus.http.test-port:8081}
+                    quarkus.rest-client.logging.scope=request-response
+                    """)
+            .assertLogRecords(records -> {
+                assertThat(records).hasSize(2);
+                for (LogRecord record : records) {
+                    assertThat(((ExtLogRecord) record).getMdc("requestId")).isEqualTo("abc-123");
+                }
+            });
+
+    @Test
+    void clientLogsCarryTheMdcOfTheServedRequest() {
+        RestAssured.get("/caller").then().statusCode(200).body(org.hamcrest.Matchers.is("hello"));
+    }
+
+    @Path("/")
+    public static class Resource {
+
+        @RestClient
+        Client client;
+
+        @GET
+        @Path("caller")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String caller() {
+            MDC.put("requestId", "abc-123");
+            try {
+                return client.callee();
+            } finally {
+                MDC.remove("requestId");
+            }
+        }
+
+        @GET
+        @Path("callee")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String callee() {
+            return "hello";
+        }
+    }
+
+    @RegisterRestClient(configKey = "my-client")
+    @Path("/")
+    public interface Client {
+
+        @GET
+        @Path("callee")
+        String callee();
+    }
+}

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/mdc/NestedContextMdcTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/mdc/NestedContextMdcTest.java
@@ -1,0 +1,123 @@
+package io.quarkus.vertx.mdc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.inject.Inject;
+
+import org.jboss.logging.MDC;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.smallrye.common.vertx.VertxContext;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.internal.ContextInternal;
+
+/**
+ * A duplicated context created for a nested operation and linked to the context the operation
+ * originates from (the way the REST Client creates a per-invocation context: a fresh duplicate
+ * of the root context carrying {@link VertxContext#PARENT_CONTEXT_LOCAL}) must inherit the MDC
+ * of the originating context, so log statements emitted while the nested operation runs keep
+ * the contextual data of the originating request.
+ * See <a href="https://github.com/quarkusio/quarkus/issues/55828">GitHub issue #55828</a>.
+ */
+public class NestedContextMdcTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    void parentLinkedContextInheritsMdc() throws InterruptedException {
+        AtomicReference<Object> inherited = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        runOnNewDuplicatedContext(() -> {
+            MDC.put("requestId", "some-request-id");
+            Context nested = newParentLinkedContext(Vertx.currentContext());
+            nested.runOnContext(v -> {
+                inherited.set(MDC.get("requestId"));
+                latch.countDown();
+            });
+        });
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertEquals("some-request-id", inherited.get());
+    }
+
+    @Test
+    void parentLinkedContextInheritsMdcThroughIntermediateContext() throws InterruptedException {
+        AtomicReference<Object> inherited = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        runOnNewDuplicatedContext(() -> {
+            MDC.put("requestId", "grandparent-request-id");
+            // the intermediate context never touches the MDC, so it has no materialized MDC map
+            Context intermediate = newParentLinkedContext(Vertx.currentContext());
+            intermediate.runOnContext(v -> {
+                Context nested = newParentLinkedContext(Vertx.currentContext());
+                nested.runOnContext(v2 -> {
+                    inherited.set(MDC.get("requestId"));
+                    latch.countDown();
+                });
+            });
+        });
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertEquals("grandparent-request-id", inherited.get());
+    }
+
+    @Test
+    void parentLinkedContextMdcIsIsolatedFromParent() throws InterruptedException {
+        AtomicReference<Object> parentValueAfterNestedWrite = new AtomicReference<>();
+        AtomicReference<Object> parentOwnValue = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        runOnNewDuplicatedContext(() -> {
+            MDC.put("requestId", "parent-request-id");
+            Context parent = Vertx.currentContext();
+            Context nested = newParentLinkedContext(parent);
+            nested.runOnContext(v -> {
+                MDC.put("nestedOnly", "nested-value");
+                MDC.put("requestId", "overwritten-by-nested");
+                parent.runOnContext(v2 -> {
+                    parentValueAfterNestedWrite.set(MDC.get("nestedOnly"));
+                    parentOwnValue.set(MDC.get("requestId"));
+                    latch.countDown();
+                });
+            });
+        });
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertNull(parentValueAfterNestedWrite.get(), "MDC writes on a nested context must not leak to the parent");
+        assertEquals("parent-request-id", parentOwnValue.get(), "MDC writes on a nested context must not leak to the parent");
+    }
+
+    /**
+     * Creates a per-invocation context the same way the REST Client does: a fresh duplicate of the
+     * root context (so no Vert.x context locals are propagated) with a reference to the context the
+     * invocation originates from.
+     */
+    private static Context newParentLinkedContext(Context current) {
+        Context nested = VertxContext.createNewDuplicatedContext(current);
+        ((ContextInternal) nested).putLocal(VertxContext.PARENT_CONTEXT_LOCAL, current);
+        return nested;
+    }
+
+    private void runOnNewDuplicatedContext(Runnable runnable) {
+        Context duplicated = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        duplicated.runOnContext(v -> runnable.run());
+    }
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxMDC.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxMDC.java
@@ -9,9 +9,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 import org.jboss.logmanager.MDCProvider;
 
+import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.core.spi.context.storage.ContextLocal;
@@ -365,6 +367,36 @@ public enum VertxMDC implements MDCProvider {
             return inheritableThreadLocalMap.get();
         }
 
-        return ctx.getLocal(MDC_LOCAL, ConcurrentHashMap::new);
+        return ctx.getLocal(MDC_LOCAL, new Supplier<ConcurrentHashMap<String, Object>>() {
+            @Override
+            public ConcurrentHashMap<String, Object> get() {
+                return initialContextualDataMap(ctx);
+            }
+        });
+    }
+
+    /**
+     * A context created for a nested operation may be duplicated from the root context rather than from the
+     * context the operation originates from, in which case it only keeps a reference to that originating
+     * context and none of its Vert.x context locals. This is how the REST Client creates the context of each
+     * invocation. Without inheriting the originating context's MDC, log statements emitted while the nested
+     * operation runs — such as the REST Client request/response logs — lose the contextual data of the
+     * originating request, including the OpenTelemetry trace identifiers.
+     * See <a href="https://github.com/quarkusio/quarkus/issues/55828">GitHub issue #55828</a>.
+     */
+    private static ConcurrentHashMap<String, Object> initialContextualDataMap(Context ctx) {
+        // the immediate parent may not have logged anything yet and so have no materialized MDC map,
+        // in which case we keep walking up the parent chain. The chain is acyclic by construction, as the
+        // parent reference is always set at creation time to an already existing context, and it is
+        // walked at most once per context since the result is stored as the context's own MDC map.
+        Context parent = ctx.getLocal(VertxContext.PARENT_CONTEXT_LOCAL);
+        while (parent != null) {
+            ConcurrentHashMap<String, Object> parentMap = parent.getLocal(MDC_LOCAL);
+            if (parentMap != null) {
+                return new ConcurrentHashMap<>(parentMap);
+            }
+            parent = parent.getLocal(VertxContext.PARENT_CONTEXT_LOCAL);
+        }
+        return new ConcurrentHashMap<>();
     }
 }

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/InMemoryLogHandler.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/InMemoryLogHandler.java
@@ -7,6 +7,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
 import org.jboss.logmanager.ExtHandler;
+import org.jboss.logmanager.ExtLogRecord;
 
 import io.smallrye.common.constraint.Assert;
 
@@ -23,6 +24,10 @@ public class InMemoryLogHandler extends ExtHandler {
     @Override
     public void publish(LogRecord record) {
         if (predicate.test(record)) {
+            if (record instanceof ExtLogRecord extLogRecord) {
+                // the records are inspected from the test thread, whose MDC is not the one of the logging thread
+                extLogRecord.copyMdc();
+            }
             records.add(record);
         }
     }


### PR DESCRIPTION
On `main`, the REST Client request/response logs carry no `traceId`/`spanId` (empty MDC), while the server logs around the call do. No 3.x release has this: it is a regression of the Vert.x 5 migration (#53310).

The REST Client creates the Vert.x context of each invocation with `VertxContext.createNewDuplicatedContext(current)`, which duplicates from the root context, and copies only the old-style local map (`DATA_MAP_LOCAL`) from the caller's context. In 3.x the MDC map was one of those old-style locals, so it came along; since #53310 it lives in its own typed context local (`VertxMDC.MDC_LOCAL`), which is not copied, so every log statement emitted on the client's context materializes an empty MDC.

This seeds the MDC of such a context from the nearest ancestor that has one, walking the `PARENT_CONTEXT_LOCAL` chain because an intermediate context may never have logged and so may have no materialized MDC map. The map is copied rather than shared, so writes during the nested operation stay isolated from the originating request (covered by `NestedContextMdcTest`).

Reproducer application, as asked: https://github.com/jnbdz/quarkus-55828-reproducer (REST resource → REST Client, `quarkus-opentelemetry`, request/response logging, console format printing the MDC ids; `-Pmain` builds against a local 999-SNAPSHOT):

| Quarkus | client `Request:` / `Response:` lines |
|---|---|
| 3.31.1 (the issue's version) | `traceId`/`spanId` present |
| 3.39.2 | present |
| `main` (2026-09-06) | **empty** |
| `main` + this PR | present |

`ClientLogMdcTest` (rest-client/deployment) covers the same scenario in-tree with a plain MDC key: it fails on `main` and passes with the change. Suites run: vertx, opentelemetry and rest-client deployment, all green.

About #55828 itself: the issue is on 3.31.1, where the MDC ids are present on both client lines (as the reporter's own excerpt shows); what they observed is Dynatrace not correlating the response line, which this change does not address. Relates to #55828 rather than fixing it.
