### PR TITLE
Keep MDC and NDC data in the ECS log format

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -508,6 +508,8 @@ The option is available for all handler types:
 This format modifies some default field names and adds other fields to align with ECS.
 +
 Fields include `@timestamp`, `log.logger`, `log.level`, `process.pid`, `process.name`, `process.thread.name`, `process.thread.id`, `host.hostname`, `event.sequence`, `error.message`, `error.stack_trace`, `ecs.version`, `data_stream.type`, `service.name`, `service.version`, and `service.environment`.
++
+MDC data is kept in the `mdc` field, which is not part of the ECS schema. Set `mdc.flat-fields` to write those entries as root-level fields instead, or add `mdc` to `excluded-keys` to leave them out entirely.
 * *gcp*: Uses the link:https://cloud.google.com/logging/docs/structured-logging#structured_logging_special_fields[Google Cloud] format.
 This format follows the *default* format. When using GCP format, if `exception-output-type` is set to `DETAILED` (the default), it is automatically upgraded to `DETAILED_AND_FORMATTED` to ensure stack traces appear in the `stack_trace` field.
 +

--- a/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/ConsoleJsonFormatterECSConfigTest.java
+++ b/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/ConsoleJsonFormatterECSConfigTest.java
@@ -82,13 +82,11 @@ public class ConsoleJsonFormatterECSConfigTest {
         Assertions.assertThat(node.has("log.logger")).isTrue();
         Assertions.assertThat(node.has("ecs.version")).isTrue();
 
-        // mdc and ndc are not ECS fields and must be absent
+        // mdc and ndc are not part of the ECS schema, but the data is application-provided and must
+        // not be dropped. See https://github.com/quarkusio/quarkus/issues/56021
         Assertions.assertThat(node.has("mdc"))
-                .as("mdc is not an ECS field and must be excluded")
-                .isFalse();
-        Assertions.assertThat(node.has("ndc"))
-                .as("ndc is not an ECS field and must be excluded")
-                .isFalse();
+                .as("mdc must be retained in ECS output")
+                .isTrue();
 
         // process.name must be the short executable name, not the full JVM path
         if (node.has("process.name")) {
@@ -110,8 +108,5 @@ public class ConsoleJsonFormatterECSConfigTest {
         Assertions.assertThat(node.has("error.stack_trace")).isFalse();
         Assertions.assertThat(node.has("exception")).isFalse();
         Assertions.assertThat(node.get("message").asText()).isEqualTo("Hello ECS");
-        // mdc and ndc must also be absent for non-exception records
-        Assertions.assertThat(node.has("mdc")).isFalse();
-        Assertions.assertThat(node.has("ndc")).isFalse();
     }
 }

--- a/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/ConsoleJsonFormatterEcsMdcTest.java
+++ b/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/ConsoleJsonFormatterEcsMdcTest.java
@@ -1,0 +1,88 @@
+package io.quarkus.logging.json;
+
+import static io.quarkus.logging.json.ConsoleJsonFormatterDefaultConfigTest.getJsonFormatter;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.Level;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.logging.json.runtime.JsonFormatter;
+import io.quarkus.test.QuarkusExtensionTest;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * MDC data must survive the ECS log format. ECS does not define an {@code mdc} field, but it does
+ * allow custom fields, and dropping the data altogether loses information the application put
+ * there deliberately — including the OpenTelemetry trace identifiers.
+ * See <a href="https://github.com/quarkusio/quarkus/issues/56021">GitHub issue #56021</a>.
+ */
+public class ConsoleJsonFormatterEcsMdcTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClasses(ConsoleJsonFormatterDefaultConfigTest.class))
+            .withConfigurationResource("application-console-json-formatter-ecs.properties");
+
+    @Test
+    public void mdcIsRetainedInEcsFormat() throws Exception {
+        JsonFormatter jsonFormatter = getJsonFormatter();
+
+        ExtLogRecord record = new ExtLogRecord(Level.INFO, "ecs mdc test", ConsoleJsonFormatterEcsMdcTest.class.getName());
+        record.putMdc("requestId", "abc123");
+        record.putMdc("traceId", "0af7651916cd43dd8448eb211c80319c");
+
+        JsonNode node = new ObjectMapper().readTree(jsonFormatter.format(record));
+
+        assertThat(node.has("mdc"))
+                .as("MDC data must not be dropped from ECS output")
+                .isTrue();
+        assertThat(node.get("mdc").get("requestId").asText()).isEqualTo("abc123");
+        assertThat(node.get("mdc").get("traceId").asText()).isEqualTo("0af7651916cd43dd8448eb211c80319c");
+
+        // The ECS field mapping must still apply
+        assertThat(node.has("@timestamp")).isTrue();
+        assertThat(node.has("log.level")).isTrue();
+    }
+
+    @Test
+    public void mdcIsRetainedAsFlatFieldsInEcsFormat() throws Exception {
+        JsonFormatter jsonFormatter = getJsonFormatter();
+        boolean originalFlatMdc = jsonFormatter.isFlatMdc();
+        jsonFormatter.setFlatMdc(true);
+        try {
+            ExtLogRecord record = new ExtLogRecord(Level.INFO, "ecs flat mdc test",
+                    ConsoleJsonFormatterEcsMdcTest.class.getName());
+            record.putMdc("requestId", "abc123");
+
+            JsonNode node = new ObjectMapper().readTree(jsonFormatter.format(record));
+
+            assertThat(node.has("mdc"))
+                    .as("with flat fields the nested mdc object must not be written")
+                    .isFalse();
+            assertThat(node.has("requestId"))
+                    .as("MDC entries must be written as root-level fields in ECS output")
+                    .isTrue();
+            assertThat(node.get("requestId").asText()).isEqualTo("abc123");
+        } finally {
+            jsonFormatter.setFlatMdc(originalFlatMdc);
+        }
+    }
+
+    @Test
+    public void ndcIsRetainedInEcsFormat() throws Exception {
+        JsonFormatter jsonFormatter = getJsonFormatter();
+
+        ExtLogRecord record = new ExtLogRecord(Level.INFO, "ecs ndc test", ConsoleJsonFormatterEcsMdcTest.class.getName());
+        record.setNdc("some-nested-context");
+
+        JsonNode node = new ObjectMapper().readTree(jsonFormatter.format(record));
+
+        assertThat(node.has("ndc"))
+                .as("NDC data must not be dropped from ECS output")
+                .isTrue();
+        assertThat(node.get("ndc").asText()).isEqualTo("some-nested-context");
+    }
+}

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/LoggingJsonRecorder.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/LoggingJsonRecorder.java
@@ -190,9 +190,10 @@ public class LoggingJsonRecorder {
         Set<String> excludedKeys = new HashSet<>(overridableJsonConfig.excludedKeys());
         excludedKeys.add(Key.LOGGER_CLASS_NAME.getKey());
         excludedKeys.add(Key.RECORD.getKey());
-        // mdc and ndc are not ECS fields; exclude them from ECS output.
-        excludedKeys.add(Key.MDC.getKey());
-        excludedKeys.add(Key.NDC.getKey());
+        // mdc and ndc are not part of the ECS schema, but ECS allows custom fields and the data was
+        // put there deliberately by the application, so it is kept rather than dropped. Users who
+        // want it elsewhere can flatten it with quarkus.log.console.json.mdc.flat-fields or remove
+        // it with the excluded-keys configuration.
 
         Map<String, AdditionalField> additionalFields = new LinkedHashMap<>(overridableJsonConfig.additionalFields());
         additionalFields.computeIfAbsent(ECS_VERSION.getKey(), k -> new AdditionalField("1.12.2", Type.STRING));


### PR DESCRIPTION
Since 3.36.0.CR1, selecting `log-format=ecs` silently drops all MDC and NDC data. `addEcsFieldOverrides` adds both keys to the excluded keys, on the grounds that they are not ECS fields (added in #54045, whose subject was the `error.stack_trace` flattening).

ECS does not define an `mdc` field, but it does permit custom fields, and the data is put there deliberately by the application — so dropping it loses information rather than making the output more correct. It also takes the OpenTelemetry trace identifiers with it, which is precisely the data users correlate logs on. Elastic's own ECS logging libraries retain MDC entries rather than discarding them.

Worth noting for triage: the exclusion could not be worked around. It is applied before the flat-fields branch in `FormatterJsonGenerator#add(String, Map)`, so `mdc.flat-fields=true` had no effect in ECS mode either, and the only escape was to abandon the ECS format entirely — which is what the reporter ended up doing.

This stops excluding the two keys, restoring the pre-3.36 output. Users who do not want the data can still remove it with the existing `excluded-keys` configuration, and `mdc.flat-fields` now behaves in ECS mode as it does in the other formats. The two assertions from #54045 that codified the exclusion are updated accordingly, and the ECS section of the logging guide now states where MDC data goes.

Added `ConsoleJsonFormatterEcsMdcTest`, covering nested MDC, flat MDC and NDC in ECS format; all three fail before this change. Full `logging-json` suite green (54 tests).

If the preference is instead to map MDC into an ECS-idiomatic namespace such as `labels.*`, that would be a larger behaviour change than a regression fix, so I have kept this to restoring what users had.

Fixes #56021