### PR TITLE
Avoid OpenTelemetry API usage warning from the Prometheus exemplar sampler

### DIFF
--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/exemplars/OpenTelemetryExemplarSamplerProvider.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/exemplars/OpenTelemetryExemplarSamplerProvider.java
@@ -6,6 +6,7 @@ import java.util.function.Function;
 import jakarta.enterprise.inject.Produces;
 
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import io.quarkus.opentelemetry.runtime.QuarkusContextStorage;
 
 public class OpenTelemetryExemplarSamplerProvider {
@@ -34,7 +35,13 @@ public class OpenTelemetryExemplarSamplerProvider {
             }
 
             private <T> T get(Function<io.opentelemetry.api.trace.SpanContext, T> valueExtractor) {
-                return Optional.ofNullable(Span.fromContextOrNull(QuarkusContextStorage.INSTANCE.current()))
+                Context context = QuarkusContextStorage.INSTANCE.current();
+                if (context == null) {
+                    // no active context, e.g. a meter recorded outside any Vert.x context;
+                    // Span.fromContextOrNull() would log an OpenTelemetry API usage complaint for the null parameter
+                    return null;
+                }
+                return Optional.ofNullable(Span.fromContextOrNull(context))
                         .map(Span::getSpanContext)
                         .map(valueExtractor)
                         .orElse(null);

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/export/exemplars/OpenTelemetryExemplarSamplerProviderTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/export/exemplars/OpenTelemetryExemplarSamplerProviderTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.micrometer.runtime.export.exemplars;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OpenTelemetryExemplarSamplerProviderTest {
+
+    private static final Logger USAGE_LOGGER = Logger.getLogger("io.opentelemetry.usage");
+
+    private final List<LogRecord> usageRecords = new CopyOnWriteArrayList<>();
+    private final Handler recordingHandler = new Handler() {
+        @Override
+        public void publish(LogRecord record) {
+            usageRecords.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    };
+    private Level originalLevel;
+
+    @BeforeEach
+    void installRecordingHandler() {
+        originalLevel = USAGE_LOGGER.getLevel();
+        USAGE_LOGGER.setLevel(Level.ALL);
+        USAGE_LOGGER.addHandler(recordingHandler);
+    }
+
+    @AfterEach
+    void removeRecordingHandler() {
+        USAGE_LOGGER.removeHandler(recordingHandler);
+        USAGE_LOGGER.setLevel(originalLevel);
+    }
+
+    @Test
+    void noOpenTelemetryApiUsageComplaintWhenNoContextIsActive() {
+        // outside any Vert.x/OpenTelemetry context, e.g. registry setup on the main thread
+        var spanContext = new OpenTelemetryExemplarSamplerProvider().exemplarSampler().orElseThrow();
+
+        assertNull(spanContext.getCurrentTraceId());
+        assertNull(spanContext.getCurrentSpanId());
+        assertFalse(spanContext.isCurrentSpanSampled());
+
+        assertTrue(usageRecords.isEmpty(),
+                "querying the exemplar sampler without an active context should not trip the OpenTelemetry API usage logger, but got: "
+                        + usageRecords.stream().map(LogRecord::getMessage).toList());
+    }
+}


### PR DESCRIPTION
`OpenTelemetryExemplarSamplerProvider` passed the result of `QuarkusContextStorage.current()` straight to `Span.fromContextOrNull()`. That returns null whenever there is no OpenTelemetry context on the current Vert.x context, which is the normal situation when an exemplar is sampled outside a request. OpenTelemetry treats a null argument as an API usage issue and logs `OpenTelemetry API usage issue detected` at WARNING, so any application combining `opentelemetry` with `micrometer-registry-prometheus` saw an unexplained warning at startup.

Reproduced on 3.38.1 with the reporter's setup. Enabling FINEST on `io.opentelemetry.usage` gives the call site:

```
Span.fromContextOrNull(): context is null
  at io.opentelemetry.api.trace.Span.fromContextOrNull(Span.java:60)
  at ...export.exemplars.OpentelemetryExemplarSamplerProvider$1.get(...:36)
  at io.prometheus.client.exemplars.DefaultExemplarSampler.doSample(...)
  at io.micrometer.prometheus.PrometheusCounter.increment(...)
  at io.quarkus.micrometer.runtime.binder.JVMInfoBinder.bindTo(JVMInfoBinder.java:17)
  at io.quarkus.micrometer.runtime.MicrometerRecorder.configureRegistries(...)
```

Worth noting for triage, since it affects how you read a "does it still happen?" check: on current main that particular startup path no longer samples an exemplar, because the Prometheus client v1 migration changed when the sampler is consulted, so simply running the reporter's application against main produces no warning. The null argument is still passed whenever the sampler runs without a current context, though, and the added test reproduces the warning on main without this fix.

Two details that make the warning hard to investigate, in case they help anyone reading this later: the detail line needs `-Dlogging.initial-configurator.min-level=ALL`, because the warning is emitted while the bootstrap configurator still caps at `FINE`; and the category needs level `ALL` rather than `TRACE`, because JBoss `TRACE` is 400 while `isLoggable(FINEST)` requires 300 or lower.

Fixes #55855