### PR TITLE
Allow NotBody on annotation types

### DIFF
--- a/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -361,7 +361,18 @@ public class JaxrsClientReactiveProcessor {
                 .setSkipMethodParameter(new Predicate<Map<DotName, AnnotationInstance>>() {
                     @Override
                     public boolean test(Map<DotName, AnnotationInstance> anns) {
-                        return anns.containsKey(NOT_BODY) || anns.containsKey(URL);
+                        if (anns.containsKey(NOT_BODY)) {
+                            return true;
+                        }
+
+                        for (final DotName annotationName : anns.keySet()) {
+                            final ClassInfo type = index.getClassByName(annotationName);
+                            if (type != null && type.declaredAnnotation(NOT_BODY) != null) {
+                                return true;
+                            }
+                        }
+
+                        return false;
                     }
                 })
                 .setValidateEndpoint(validationPredicatesBuildItems.stream().map(item -> item.getPredicate())

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/NotBodyParameterTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/NotBodyParameterTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.rest.client.reactive;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class NotBodyParameterTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest();
+
+    @TestHTTPResource
+    String baseUrl;
+
+    @RestClient
+    Client client;
+
+    @Test
+    public void testCorrectBodyParameter() {
+        final Client client = RestClientBuilder.newBuilder()
+                .baseUri(baseUrl)
+                .build(Client.class);
+
+        assertEquals("def", client.test("abc", "def"));
+    }
+
+    @Test
+    public void testUrlAnnotationNotABodyParameter() {
+        assertEquals("abc", client.testUrlAnnotation(baseUrl, "abc"));
+    }
+
+    @NotBody
+    @Target(ElementType.PARAMETER)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface MyTestAnnotation {
+
+    }
+
+    @Path("test")
+    @RegisterRestClient(baseUri = "http://not-a-thing")
+    public interface Client {
+
+        @POST
+        String test(@MyTestAnnotation String someCustomParameter, String foo);
+
+        @POST
+        String testUrlAnnotation(@Url String uri, String foo);
+    }
+
+    @Path("test")
+    public static class Resource {
+
+        @POST
+        public String test(String foo) {
+            return foo;
+        }
+    }
+
+}

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/NotBody.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/NotBody.java
@@ -7,14 +7,20 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * The sole purpose of this annotation is to allow REST Client methods to contain multiple non-annotated Jakarta REST parameters
- * which would normally not be allowed because all the parameters would be considered to represent the body of the request.
+ * Marks a REST Client method parameter as not being the request body parameter.
  * <p>
- * The primary use case of this annotation is to facilitate obtaining method parameters in
- * {@link org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam}
- * when using method invocation or parameter reference.
+ * By default, a REST Client method parameter that is not recognized as another supported parameter type
+ * (path, query, header, etc.) is treated as the request body. This annotation can be used to avoid this behavior.
+ * One specific use case is to facilitate obtaining method parameters in
+ * {@link org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam} when using method invocation
+ * or parameter references.
+ * <p>
+ * This annotation can also be used as a meta-annotation on custom parameter annotations: any parameter
+ * annotated with an annotation type that is itself annotated with {@code @NotBody} is also excluded from
+ * the request body. This is useful for extensions that introduce custom parameter types without requiring
+ * each parameter to be annotated individually.
  */
-@Target({ ElementType.PARAMETER })
+@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface NotBody {

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/Url.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/Url.java
@@ -19,5 +19,6 @@ import java.lang.annotation.Target;
 @Target({ ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@NotBody
 public @interface Url {
 }


### PR DESCRIPTION
This PR aims to allow the NotBody annotation to be used as a meta-annotation. This will make custom annotations that use parameters no longer require users to manually add `@NotBody` to each custom parameter alongside the custom annotation.
 
* resolves #56015
