### PR TITLE
Bootstrap JSON enhancements

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFFMConfigStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFFMConfigStep.java
@@ -1,7 +1,5 @@
 package io.quarkus.deployment.steps;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -58,20 +56,15 @@ public class NativeImageFFMConfigStep {
         }
         final JsonObjectBuilder root = Json.object();
         root.put("foreign", foreignJson);
-        try (StringWriter writer = new StringWriter()) {
-            root.appendTo(writer);
-            // The nested location seems important to the native-image metadata lookup.
-            reachabilityMetadata.produce(new GeneratedResourceBuildItem(
-                    /*
-                     * Despite the doc [1] stating:
-                     * "located in any of the classpath entries at META-INF/native-image/<group.Id>\/<artifactId>\/."
-                     * it is fine both leaving it in `META-INF/native-image` and nesting it in an arbitrary dir.
-                     * [1] https://www.graalvm.org/latest/reference-manual/native-image/metadata/#specifying-metadata-with-json
-                     */
-                    "META-INF/native-image/foreign/reachability-metadata.json",
-                    writer.toString().getBytes(StandardCharsets.UTF_8)));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        // The nested location seems important to the native-image metadata lookup.
+        reachabilityMetadata.produce(new GeneratedResourceBuildItem(
+                /*
+                 * Despite the doc [1] stating:
+                 * "located in any of the classpath entries at META-INF/native-image/<group.Id>\/<artifactId>\/."
+                 * it is fine both leaving it in `META-INF/native-image` and nesting it in an arbitrary dir.
+                 * [1] https://www.graalvm.org/latest/reference-manual/native-image/metadata/#specifying-metadata-with-json
+                 */
+                "META-INF/native-image/foreign/reachability-metadata.json",
+                root.toJsonString().getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageJNIConfigStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageJNIConfigStep.java
@@ -1,7 +1,5 @@
 package io.quarkus.deployment.steps;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -86,13 +84,8 @@ public class NativeImageJNIConfigStep {
             root.add(json);
         }
 
-        try (StringWriter writer = new StringWriter()) {
-            root.appendTo(writer);
-            jniConfig.produce(new GeneratedResourceBuildItem("META-INF/native-image/jni-config.json",
-                    writer.toString().getBytes(StandardCharsets.UTF_8)));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        jniConfig.produce(new GeneratedResourceBuildItem("META-INF/native-image/jni-config.json",
+                root.toJsonString().getBytes(StandardCharsets.UTF_8)));
     }
 
     private void addJniClass(Map<String, JniInfo> jniClasses, JniRuntimeAccessBuildItem jniRuntimeAccessBuildItem) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageProxyConfigStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageProxyConfigStep.java
@@ -1,7 +1,5 @@
 package io.quarkus.deployment.steps;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -31,12 +29,7 @@ public class NativeImageProxyConfigStep {
             root.add(proxyJson);
         }
 
-        try (StringWriter writer = new StringWriter()) {
-            root.appendTo(writer);
-            proxyConfig.produce(new GeneratedResourceBuildItem("META-INF/native-image/proxy-config.json",
-                    writer.toString().getBytes(StandardCharsets.UTF_8)));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        proxyConfig.produce(new GeneratedResourceBuildItem("META-INF/native-image/proxy-config.json",
+                root.toJsonString().getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageReflectConfigStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageReflectConfigStep.java
@@ -1,7 +1,5 @@
 package io.quarkus.deployment.steps;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashSet;
@@ -149,13 +147,8 @@ public class NativeImageReflectConfigStep {
             root.add(json);
         }
 
-        try (StringWriter writer = new StringWriter()) {
-            root.appendTo(writer);
-            reflectConfig.produce(new GeneratedResourceBuildItem("META-INF/native-image/reflect-config.json",
-                    writer.toString().getBytes(StandardCharsets.UTF_8)));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        reflectConfig.produce(new GeneratedResourceBuildItem("META-INF/native-image/reflect-config.json",
+                root.toJsonString().getBytes(StandardCharsets.UTF_8)));
     }
 
     private static void extractToJsonArray(Set<ReflectiveMethodBuildItem> methodSet, JsonArrayBuilder methodsArray) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageResourceConfigStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageResourceConfigStep.java
@@ -1,7 +1,5 @@
 package io.quarkus.deployment.steps;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -66,13 +64,8 @@ public class NativeImageResourceConfigStep {
         }
         root.put("bundles", bundles);
 
-        try (StringWriter writer = new StringWriter()) {
-            root.appendTo(writer);
-            resourceConfig.produce(new GeneratedResourceBuildItem("META-INF/native-image/resource-config.json",
-                    writer.toString().getBytes(StandardCharsets.UTF_8)));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        resourceConfig.produce(new GeneratedResourceBuildItem("META-INF/native-image/resource-config.json",
+                root.toJsonString().getBytes(StandardCharsets.UTF_8)));
     }
 
     private void addListToJsonArray(JsonArrayBuilder array, List<String> patterns) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageSerializationConfigStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageSerializationConfigStep.java
@@ -1,7 +1,5 @@
 package io.quarkus.deployment.steps;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashSet;
@@ -48,13 +46,8 @@ public class NativeImageSerializationConfigStep {
         }
         root.put("lambdaCapturingTypes", lambdaCapturingTypes);
 
-        try (StringWriter writer = new StringWriter()) {
-            root.appendTo(writer);
-            serializationConfig.produce(new GeneratedResourceBuildItem("META-INF/native-image/serialization-config.json",
-                    writer.toString().getBytes(StandardCharsets.UTF_8)));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        serializationConfig.produce(new GeneratedResourceBuildItem("META-INF/native-image/serialization-config.json",
+                root.toJsonString().getBytes(StandardCharsets.UTF_8)));
     }
 
 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/NativeImageAgentMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/NativeImageAgentMojo.java
@@ -131,7 +131,7 @@ public class NativeImageAgentMojo extends QuarkusBootstrapMojo {
     private boolean discardResource(String attribute, JsonValue value) {
         if (value instanceof JsonMember) {
             final JsonMember member = (JsonMember) value;
-            if (attribute.equals(member.attribute().value())) {
+            if (attribute.equals(member.attributeName())) {
                 final JsonString memberValue = (JsonString) member.value();
                 final boolean discarded = resourceSkipPattern.matcher(memberValue.value()).find();
                 if (discarded) {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ApplicationModelSerializer.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ApplicationModelSerializer.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -92,7 +91,7 @@ public class ApplicationModelSerializer {
         if (JOS) {
             serializeWithJos(model, serializedModel);
         } else {
-            writeJson(toJsonObjectBuilder(model.asMap()), serializedModel);
+            ((Json.JsonObjectBuilder) model.asMap(JSON_CONTAINER_FACTORY)).writeTo(serializedModel);
         }
         return serializedModel;
     }
@@ -174,20 +173,7 @@ public class ApplicationModelSerializer {
      * @throws IOException in case of a failure
      */
     private static void toJson(ApplicationModel appModel, Path file) throws IOException {
-        writeJson((Json.JsonObjectBuilder) appModel.asMap(JSON_CONTAINER_FACTORY), file);
-    }
-
-    /**
-     * Serializes a {@link io.quarkus.bootstrap.json.Json.JsonObjectBuilder} to a JSON file.
-     *
-     * @param jsonObject JSON object builder
-     * @param file target file
-     * @throws IOException in case of a failure
-     */
-    private static void writeJson(Json.JsonObjectBuilder jsonObject, Path file) throws IOException {
-        try (Writer writer = Files.newBufferedWriter(file)) {
-            jsonObject.appendTo(writer);
-        }
+        ((Json.JsonObjectBuilder) appModel.asMap(JSON_CONTAINER_FACTORY)).writeTo(file);
     }
 
     /**
@@ -198,7 +184,7 @@ public class ApplicationModelSerializer {
      * @throws IOException in case of a failure
      */
     private static ApplicationModel fromJson(Path file) throws IOException {
-        final Map<String, Object> modelMap = asMap(JsonReader.of(Files.readString(file)).read());
+        final Map<String, Object> modelMap = asMap(JsonReader.read(file));
         return ApplicationModelBuilder.fromMap(modelMap);
     }
 
@@ -212,7 +198,7 @@ public class ApplicationModelSerializer {
         var members = jsonObject.members();
         final Map<String, Object> map = new HashMap<>(members.size());
         for (var member : members) {
-            map.put(member.attribute().value(), asObject(member.value()));
+            map.put(member.attributeName(), asObject(member.value()));
         }
         return map;
     }
@@ -244,50 +230,6 @@ public class ApplicationModelSerializer {
             return asCollection(jsonArray);
         }
         return jsonValue.toString();
-    }
-
-    /**
-     * Converts a {@link Map} instance to a {@link io.quarkus.bootstrap.json.Json.JsonObjectBuilder}.
-     *
-     * @param map map to convert
-     * @return JSON object builder
-     */
-    private static Json.JsonObjectBuilder toJsonObjectBuilder(Map<String, Object> map) {
-        final Json.JsonObjectBuilder result = Json.object(map.size());
-        for (Map.Entry<String, Object> entry : map.entrySet()) {
-            result.put(entry.getKey(), toJsonTypeBuilder(entry.getValue()));
-        }
-        return result;
-    }
-
-    /**
-     * Converts a {@link Collection} instance to a {@link io.quarkus.bootstrap.json.Json.JsonArrayBuilder}.
-     *
-     * @param col collection to convert
-     * @return JSON array builder
-     */
-    private static Json.JsonArrayBuilder toJsonArrayBuilder(Collection<Object> col) {
-        final Json.JsonArrayBuilder result = Json.array(col.size());
-        for (Object o : col) {
-            result.add(toJsonTypeBuilder(o));
-        }
-        return result;
-    }
-
-    /**
-     * Converts an {@link Object} to a JSON type builder.
-     *
-     * @param o object to convert
-     * @return JSON type builder
-     */
-    private static Object toJsonTypeBuilder(Object o) {
-        if (o instanceof Map map) {
-            return toJsonObjectBuilder(map);
-        }
-        if (o instanceof Collection col) {
-            return toJsonArrayBuilder(col);
-        }
-        return o;
     }
 
     private static void logMap(Map<String, Object> map, int offset) {

--- a/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/Json.java
+++ b/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/Json.java
@@ -1,10 +1,15 @@
 package io.quarkus.bootstrap.json;
 
+import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -132,6 +137,22 @@ public final class Json {
         public abstract void appendTo(Appendable appendable) throws IOException;
 
         /**
+         * Writes the JSON content to the specified file, creating parent directories if needed.
+         *
+         * @param p target file path
+         * @throws IOException if the file cannot be written
+         */
+        public void writeTo(Path p) throws IOException {
+            final Path parent = p.getParent();
+            if (parent != null && !Files.exists(parent)) {
+                Files.createDirectories(parent);
+            }
+            try (BufferedWriter writer = Files.newBufferedWriter(p)) {
+                appendTo(writer);
+            }
+        }
+
+        /**
          * @param value value to check
          * @return <code>true</code> if the value is null or an empty builder and {@link #ignoreEmptyBuilders} is set to
          *         <code>true</code>, <code>false</code>
@@ -166,6 +187,16 @@ public final class Json {
         public void transform(JsonMultiValue value, JsonTransform transform) {
             final ResolvedTransform resolved = new ResolvedTransform(this, transform);
             value.forEach(resolved);
+        }
+
+        public String toJsonString() {
+            try {
+                StringBuilder sb = new StringBuilder();
+                appendTo(sb);
+                return sb.toString();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
     }
 
@@ -206,12 +237,37 @@ public final class Json {
             return this;
         }
 
+        public JsonArrayBuilder add(Boolean value) {
+            addInternal(value);
+            return this;
+        }
+
         public JsonArrayBuilder add(int value) {
             addInternal(value);
             return this;
         }
 
+        public JsonArrayBuilder add(Integer value) {
+            addInternal(value);
+            return this;
+        }
+
         public JsonArrayBuilder add(long value) {
+            addInternal(value);
+            return this;
+        }
+
+        public JsonArrayBuilder add(Long value) {
+            addInternal(value);
+            return this;
+        }
+
+        public JsonArrayBuilder add(double value) {
+            addInternal(value);
+            return this;
+        }
+
+        public JsonArrayBuilder add(Double value) {
             addInternal(value);
             return this;
         }
@@ -357,12 +413,12 @@ public final class Json {
 
         private JsonObjectBuilder(boolean ignoreEmptyBuilders) {
             super(ignoreEmptyBuilders);
-            this.properties = new HashMap<>();
+            this.properties = new LinkedHashMap<>();
         }
 
         private JsonObjectBuilder(boolean ignoreEmptyBuilders, int initialCapacity) {
             super(ignoreEmptyBuilders);
-            this.properties = new HashMap<>(initialCapacity);
+            this.properties = new LinkedHashMap<>(initialCapacity);
         }
 
         public JsonObjectBuilder put(String name, String value) {
@@ -385,13 +441,68 @@ public final class Json {
             return this;
         }
 
+        public JsonObjectBuilder put(String name, Boolean value) {
+            putInternal(name, value);
+            return this;
+        }
+
         public JsonObjectBuilder put(String name, int value) {
+            putInternal(name, value);
+            return this;
+        }
+
+        public JsonObjectBuilder put(String name, Integer value) {
             putInternal(name, value);
             return this;
         }
 
         public JsonObjectBuilder put(String name, long value) {
             putInternal(name, value);
+            return this;
+        }
+
+        public JsonObjectBuilder put(String name, Long value) {
+            putInternal(name, value);
+            return this;
+        }
+
+        public JsonObjectBuilder put(String name, double value) {
+            putInternal(name, value);
+            return this;
+        }
+
+        public JsonObjectBuilder put(String name, Double value) {
+            putInternal(name, value);
+            return this;
+        }
+
+        /**
+         * Recursively converts the map to nested {@link JsonObjectBuilder} and {@link JsonArrayBuilder}
+         * instances and adds the result under the given name.
+         *
+         * @param name property name
+         * @param map map to convert (may be {@code null})
+         * @return this builder
+         */
+        public JsonObjectBuilder put(String name, Map<String, ?> map) {
+            if (map != null && !map.isEmpty()) {
+                putInternal(name, fromMap(map));
+            }
+            return this;
+        }
+
+        /**
+         * Recursively converts the collection to a {@link JsonArrayBuilder}
+         * and adds the result under the given name.
+         *
+         * @param name property name
+         * @param collection collection to convert (may be {@code null})
+         * @return this builder
+         */
+        public JsonObjectBuilder put(String name, Collection<?> collection) {
+            if (collection != null && !collection.isEmpty()) {
+                putInternal(name, fromCollection(collection));
+            }
             return this;
         }
 
@@ -497,7 +608,7 @@ public final class Json {
         @Override
         void add(JsonValue element) {
             if (element instanceof JsonMember member) {
-                final String attribute = member.attribute().value();
+                final String attribute = member.attributeName();
                 final JsonValue value = member.value();
                 if (value instanceof JsonString jsonStr) {
                     put(attribute, jsonStr.value());
@@ -535,7 +646,7 @@ public final class Json {
             jsonArr.appendTo(appendable);
         } else if (value instanceof String str) {
             appendStringValue(appendable, str);
-        } else if (value instanceof Boolean || value instanceof Integer || value instanceof Long) {
+        } else if (value instanceof Boolean || value instanceof Integer || value instanceof Long || value instanceof Double) {
             appendable.append(value.toString());
         } else {
             throw new IllegalStateException("Unsupported value type: " + value);
@@ -564,6 +675,75 @@ public final class Json {
                 appendable.append(c);
             }
         }
+    }
+
+    /**
+     * Recursively converts a {@link Map} to a {@link JsonObjectBuilder}.
+     * Values may be strings, numbers, booleans, nested maps, or collections.
+     *
+     * @param map the map to convert
+     * @return a JSON object builder representing the map
+     */
+    @SuppressWarnings("unchecked")
+    public static JsonObjectBuilder fromMap(Map<String, ?> map) {
+        JsonObjectBuilder builder = object(map.size());
+        for (Map.Entry<String, ?> entry : map.entrySet()) {
+            Object v = entry.getValue();
+            if (v instanceof String s) {
+                builder.put(entry.getKey(), s);
+            } else if (v instanceof Integer i) {
+                builder.put(entry.getKey(), i);
+            } else if (v instanceof Long l) {
+                builder.put(entry.getKey(), l);
+            } else if (v instanceof Double d) {
+                builder.put(entry.getKey(), d);
+            } else if (v instanceof Float f) {
+                builder.put(entry.getKey(), (double) f);
+            } else if (v instanceof Boolean b) {
+                builder.put(entry.getKey(), b);
+            } else if (v instanceof Map<?, ?> m) {
+                builder.put(entry.getKey(), fromMap((Map<String, ?>) m));
+            } else if (v instanceof Collection<?> c) {
+                builder.put(entry.getKey(), fromCollection(c));
+            } else if (v != null) {
+                builder.put(entry.getKey(), v.toString());
+            }
+        }
+        return builder;
+    }
+
+    /**
+     * Recursively converts a {@link Collection} to a {@link JsonArrayBuilder}.
+     * Elements may be strings, numbers, booleans, maps, or nested collections.
+     *
+     * @param collection the collection to convert
+     * @return a JSON array builder representing the collection
+     */
+    @SuppressWarnings("unchecked")
+    public static JsonArrayBuilder fromCollection(Collection<?> collection) {
+        JsonArrayBuilder builder = array(collection.size());
+        for (Object v : collection) {
+            if (v instanceof String s) {
+                builder.add(s);
+            } else if (v instanceof Integer i) {
+                builder.add(i);
+            } else if (v instanceof Long l) {
+                builder.add(l);
+            } else if (v instanceof Double d) {
+                builder.add(d);
+            } else if (v instanceof Float f) {
+                builder.add((double) f);
+            } else if (v instanceof Boolean b) {
+                builder.add(b);
+            } else if (v instanceof Map<?, ?> m) {
+                builder.add(fromMap((Map<String, ?>) m));
+            } else if (v instanceof Collection<?> c) {
+                builder.add(fromCollection(c));
+            } else if (v != null) {
+                builder.add(v.toString());
+            }
+        }
+        return builder;
     }
 
     private static final class ResolvedTransform implements JsonTransform {

--- a/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonArray.java
+++ b/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonArray.java
@@ -1,6 +1,8 @@
 package io.quarkus.bootstrap.json;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 public final class JsonArray implements JsonMultiValue {
@@ -17,6 +19,48 @@ public final class JsonArray implements JsonMultiValue {
     @SuppressWarnings("unchecked")
     public <T extends JsonValue> Stream<T> stream() {
         return (Stream<T>) value.stream();
+    }
+
+    /**
+     * Applies the given mapping function to each element and returns the results as a list.
+     *
+     * @param mapper function to apply to each element
+     * @param <T> the type of the mapped result
+     * @return a list of mapped results
+     */
+    public <T> List<T> map(Function<JsonValue, T> mapper) {
+        List<T> result = new ArrayList<>(value.size());
+        for (JsonValue v : value) {
+            result.add(mapper.apply(v));
+        }
+        return result;
+    }
+
+    /**
+     * Converts each element to a string using {@link Object#toString()} and returns the results as a list.
+     *
+     * @return a list of string representations of the elements
+     */
+    public List<String> toStringList() {
+        List<String> result = new ArrayList<>(value.size());
+        for (JsonValue v : value) {
+            result.add(v.toString());
+        }
+        return result;
+    }
+
+    /**
+     * Recursively converts this JSON array to a {@link List} of Java objects
+     * by calling {@link JsonValue#unwrap()} on each element.
+     *
+     * @return a mutable list of unwrapped Java values
+     */
+    public List<Object> toList() {
+        List<Object> result = new ArrayList<>(value.size());
+        for (JsonValue v : value) {
+            result.add(v.unwrap());
+        }
+        return result;
     }
 
     @Override

--- a/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonBoolean.java
+++ b/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonBoolean.java
@@ -13,4 +13,12 @@ public enum JsonBoolean implements JsonValue {
     public boolean value() {
         return value;
     }
+
+    /**
+     * Returns {@code "true"} or {@code "false"} (lowercase) matching JSON literal syntax.
+     */
+    @Override
+    public String toString() {
+        return Boolean.toString(value);
+    }
 }

--- a/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonDouble.java
+++ b/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonDouble.java
@@ -10,4 +10,9 @@ public final class JsonDouble implements JsonNumber {
     public double value() {
         return value;
     }
+
+    @Override
+    public String toString() {
+        return Double.toString(value);
+    }
 }

--- a/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonMember.java
+++ b/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonMember.java
@@ -1,15 +1,19 @@
 package io.quarkus.bootstrap.json;
 
 public final class JsonMember implements JsonValue {
-    private final JsonString attribute;
+    private final String attribute;
     private final JsonValue value;
 
-    public JsonMember(JsonString attribute, JsonValue value) {
+    public JsonMember(String attribute, JsonValue value) {
         this.attribute = attribute;
         this.value = value;
     }
 
     public JsonString attribute() {
+        return new JsonString(attribute);
+    }
+
+    public String attributeName() {
         return attribute;
     }
 

--- a/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonObject.java
+++ b/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonObject.java
@@ -1,19 +1,214 @@
 package io.quarkus.bootstrap.json;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public final class JsonObject implements JsonMultiValue {
-    private final Map<JsonString, JsonValue> value;
+    private final Map<String, JsonValue> value;
 
-    public JsonObject(Map<JsonString, JsonValue> value) {
+    public JsonObject(Map<String, JsonValue> value) {
         this.value = value;
     }
 
+    /**
+     * Returns the raw {@link JsonValue} for the given attribute, or {@code null} if absent.
+     *
+     * @param attribute attribute name
+     * @return the JSON value, or {@code null}
+     */
     @SuppressWarnings("unchecked")
     public <T extends JsonValue> T get(String attribute) {
-        return (T) value.get(new JsonString(attribute));
+        return (T) value.get(attribute);
+    }
+
+    /**
+     * Unwraps the value of the given attribute as a {@link String}.
+     *
+     * @param attribute attribute name
+     * @return the string value, or {@code null} if the attribute is absent
+     * @throws IllegalArgumentException if the attribute is present but is not a JSON string
+     */
+    public String unwrapString(String attribute) {
+        JsonValue v = get(attribute);
+        if (v == null) {
+            return null;
+        }
+        if (v instanceof JsonString s) {
+            return s.value();
+        }
+        throw typeMismatch(attribute, "string", v);
+    }
+
+    /**
+     * Unwraps the value of the given attribute as a {@code boolean}.
+     *
+     * @param attribute attribute name
+     * @return the boolean value, or {@code false} if the attribute is absent
+     * @throws IllegalArgumentException if the attribute is present but is not a JSON boolean
+     */
+    public boolean unwrapBoolean(String attribute) {
+        JsonValue v = get(attribute);
+        if (v == null) {
+            return false;
+        }
+        if (v instanceof JsonBoolean b) {
+            return b.value();
+        }
+        throw typeMismatch(attribute, "boolean", v);
+    }
+
+    /**
+     * Unwraps the value of the given attribute as an {@code int}.
+     *
+     * @param attribute attribute name
+     * @param defaultValue value to return if the attribute is absent
+     * @return the int value, or {@code defaultValue} if the attribute is absent
+     * @throws IllegalArgumentException if the attribute is present but is not a JSON integer
+     */
+    public int unwrapInt(String attribute, int defaultValue) {
+        JsonValue v = get(attribute);
+        if (v == null) {
+            return defaultValue;
+        }
+        if (v instanceof JsonInteger n) {
+            return n.intValue();
+        }
+        throw typeMismatch(attribute, "integer", v);
+    }
+
+    /**
+     * Unwraps the value of the given attribute as a {@code long}.
+     *
+     * @param attribute attribute name
+     * @param defaultValue value to return if the attribute is absent
+     * @return the long value, or {@code defaultValue} if the attribute is absent
+     * @throws IllegalArgumentException if the attribute is present but is not a JSON integer
+     */
+    public long unwrapLong(String attribute, long defaultValue) {
+        JsonValue v = get(attribute);
+        if (v == null) {
+            return defaultValue;
+        }
+        if (v instanceof JsonInteger n) {
+            return n.longValue();
+        }
+        throw typeMismatch(attribute, "integer", v);
+    }
+
+    /**
+     * Unwraps the value of the given attribute as a {@code double}.
+     * JSON integers are accepted and widened to double.
+     *
+     * @param attribute attribute name
+     * @param defaultValue value to return if the attribute is absent
+     * @return the double value, or {@code defaultValue} if the attribute is absent
+     * @throws IllegalArgumentException if the attribute is present but is not a JSON number
+     */
+    public double unwrapDouble(String attribute, double defaultValue) {
+        JsonValue v = get(attribute);
+        if (v == null) {
+            return defaultValue;
+        }
+        if (v instanceof JsonDouble d) {
+            return d.value();
+        }
+        if (v instanceof JsonInteger n) {
+            return n.longValue();
+        }
+        throw typeMismatch(attribute, "number", v);
+    }
+
+    /**
+     * Returns the value of the given attribute as a {@link JsonObject}.
+     *
+     * @param attribute attribute name
+     * @return the JSON object, or {@code null} if the attribute is absent
+     * @throws IllegalArgumentException if the attribute is present but is not a JSON object
+     */
+    public JsonObject unwrapObject(String attribute) {
+        JsonValue v = get(attribute);
+        if (v == null) {
+            return null;
+        }
+        if (v instanceof JsonObject o) {
+            return o;
+        }
+        throw typeMismatch(attribute, "object", v);
+    }
+
+    /**
+     * Returns the value of the given attribute as a {@link JsonArray}.
+     *
+     * @param attribute attribute name
+     * @return the JSON array, or {@code null} if the attribute is absent
+     * @throws IllegalArgumentException if the attribute is present but is not a JSON array
+     */
+    public JsonArray unwrapArray(String attribute) {
+        JsonValue v = get(attribute);
+        if (v == null) {
+            return null;
+        }
+        if (v instanceof JsonArray a) {
+            return a;
+        }
+        throw typeMismatch(attribute, "array", v);
+    }
+
+    /**
+     * Unwraps the array at the given attribute and maps each element through the provided function.
+     * Each array element is expected to be a {@link JsonObject}.
+     *
+     * @param attribute attribute name
+     * @param mapper function to apply to each JSON object element
+     * @return the mapped list, or an empty list if the attribute is absent
+     * @throws IllegalArgumentException if the attribute is present but is not a JSON array
+     */
+    public <T> List<T> mapArray(String attribute, Function<JsonObject, T> mapper) {
+        JsonArray arr = unwrapArray(attribute);
+        if (arr == null) {
+            return List.of();
+        }
+        return arr.map(v -> mapper.apply((JsonObject) v));
+    }
+
+    /**
+     * Unwraps the array at the given attribute as a list of strings.
+     * Each element is converted using {@link Object#toString()}.
+     *
+     * @param attribute attribute name
+     * @return the string list, or an empty list if the attribute is absent
+     * @throws IllegalArgumentException if the attribute is present but is not a JSON array
+     */
+    public List<String> unwrapStringList(String attribute) {
+        JsonArray arr = unwrapArray(attribute);
+        if (arr == null) {
+            return List.of();
+        }
+        List<String> result = new ArrayList<>(arr.size());
+        for (JsonValue v : arr.value()) {
+            result.add(v.toString());
+        }
+        return result;
+    }
+
+    /**
+     * Recursively converts this JSON object to a {@link Map}.
+     * Nested JSON objects become nested maps, JSON arrays become lists,
+     * and scalar values are unwrapped to their Java equivalents
+     * ({@link String}, {@link Integer}, {@link Long}, {@link Double}, {@link Boolean}, or {@code null}).
+     *
+     * @return a mutable map representation of this JSON object
+     */
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new LinkedHashMap<>(value.size());
+        for (var entry : value.entrySet()) {
+            map.put(entry.getKey(), entry.getValue().unwrap());
+        }
+        return map;
     }
 
     public List<JsonMember> members() {
@@ -25,5 +220,10 @@ public final class JsonObject implements JsonMultiValue {
     @Override
     public void forEach(JsonTransform transform) {
         members().forEach(member -> transform.accept(null, member));
+    }
+
+    private static IllegalArgumentException typeMismatch(String attribute, String expected, JsonValue actual) {
+        return new IllegalArgumentException(
+                "Attribute '" + attribute + "' is not a JSON " + expected + ": " + actual.getClass().getSimpleName());
     }
 }

--- a/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonReader.java
+++ b/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonReader.java
@@ -1,7 +1,10 @@
 package io.quarkus.bootstrap.json;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -22,6 +25,10 @@ public class JsonReader {
 
     public static JsonReader of(String source) {
         return new JsonReader(source);
+    }
+
+    public static <T extends JsonValue> T read(Path path) throws IOException {
+        return of(Files.readString(path)).read();
     }
 
     @SuppressWarnings("unchecked")
@@ -89,7 +96,7 @@ public class JsonReader {
     private JsonValue readObject() {
         position++;
 
-        Map<JsonString, JsonValue> members = new HashMap<>();
+        Map<String, JsonValue> members = new LinkedHashMap<>();
 
         while (position < length) {
             ignoreWhitespace();
@@ -113,7 +120,7 @@ public class JsonReader {
      * member
      * |----- ws string ws ':' element
      */
-    private void readMember(Map<JsonString, JsonValue> members) {
+    private void readMember(Map<String, JsonValue> members) {
         final JsonString attribute = readString();
         ignoreWhitespace();
         final int colon = nextChar();
@@ -121,7 +128,7 @@ public class JsonReader {
             throw new IllegalArgumentException("Expected : after attribute");
         }
         final JsonValue element = readElement();
-        members.put(attribute, element);
+        members.put(attribute.value(), element);
     }
 
     /**
@@ -278,6 +285,7 @@ public class JsonReader {
         switch (ch) {
             case 'e':
             case 'E':
+                isFraction = true;
                 position++;
                 ch = nextChar();
                 switch (ch) {

--- a/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonValue.java
+++ b/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonValue.java
@@ -1,4 +1,51 @@
 package io.quarkus.bootstrap.json;
 
 public sealed interface JsonValue permits JsonBoolean, JsonMember, JsonMultiValue, JsonNull, JsonNumber, JsonString {
+
+    /**
+     * Unwraps this JSON value to its Java equivalent.
+     * <ul>
+     * <li>{@link JsonString} &rarr; {@link String}</li>
+     * <li>{@link JsonInteger} &rarr; {@link Integer} (if the value fits) or {@link Long}</li>
+     * <li>{@link JsonDouble} &rarr; {@link Double}</li>
+     * <li>{@link JsonBoolean} &rarr; {@link Boolean}</li>
+     * <li>{@link JsonNull} &rarr; {@code null}</li>
+     * <li>{@link JsonObject} &rarr; {@link java.util.Map Map&lt;String, Object&gt;} (via {@link JsonObject#toMap()})</li>
+     * <li>{@link JsonArray} &rarr; {@link java.util.List List&lt;Object&gt;} (via {@link JsonArray#toList()})</li>
+     * <li>{@link JsonMember} &rarr; unwraps the member's value</li>
+     * </ul>
+     *
+     * @return the Java equivalent of this JSON value
+     */
+    default Object unwrap() {
+        if (this instanceof JsonString s) {
+            return s.value();
+        }
+        if (this instanceof JsonInteger n) {
+            long l = n.longValue();
+            if (l == (int) l) {
+                return (int) l;
+            }
+            return l;
+        }
+        if (this instanceof JsonDouble d) {
+            return d.value();
+        }
+        if (this instanceof JsonBoolean b) {
+            return b.value();
+        }
+        if (this instanceof JsonNull) {
+            return null;
+        }
+        if (this instanceof JsonObject o) {
+            return o.toMap();
+        }
+        if (this instanceof JsonArray a) {
+            return a.toList();
+        }
+        if (this instanceof JsonMember m) {
+            return m.value().unwrap();
+        }
+        return toString();
+    }
 }

--- a/independent-projects/bootstrap/json/src/test/java/io/quarkus/bootstrap/json/test/JsonConvenienceMethodsTest.java
+++ b/independent-projects/bootstrap/json/src/test/java/io/quarkus/bootstrap/json/test/JsonConvenienceMethodsTest.java
@@ -1,0 +1,333 @@
+package io.quarkus.bootstrap.json.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.bootstrap.json.JsonArray;
+import io.quarkus.bootstrap.json.JsonBoolean;
+import io.quarkus.bootstrap.json.JsonDouble;
+import io.quarkus.bootstrap.json.JsonInteger;
+import io.quarkus.bootstrap.json.JsonMember;
+import io.quarkus.bootstrap.json.JsonNull;
+import io.quarkus.bootstrap.json.JsonObject;
+import io.quarkus.bootstrap.json.JsonReader;
+import io.quarkus.bootstrap.json.JsonString;
+
+class JsonConvenienceMethodsTest {
+
+    @Test
+    void unwrapString() {
+        JsonObject obj = JsonReader.of("{\"name\":\"Alice\"}").read();
+        assertEquals("Alice", obj.unwrapString("name"));
+    }
+
+    @Test
+    void unwrapStringReturnsNullWhenAbsent() {
+        JsonObject obj = JsonReader.of("{\"name\":\"Alice\"}").read();
+        assertNull(obj.unwrapString("missing"));
+    }
+
+    @Test
+    void unwrapStringThrowsOnTypeMismatch() {
+        JsonObject obj = JsonReader.of("{\"age\":30}").read();
+        var e = assertThrows(IllegalArgumentException.class, () -> obj.unwrapString("age"));
+        assertTrue(e.getMessage().contains("age"));
+        assertTrue(e.getMessage().contains("string"));
+    }
+
+    @Test
+    void unwrapBoolean() {
+        JsonObject obj = JsonReader.of("{\"active\":true,\"deleted\":false}").read();
+        assertTrue(obj.unwrapBoolean("active"));
+        assertFalse(obj.unwrapBoolean("deleted"));
+    }
+
+    @Test
+    void unwrapBooleanReturnsFalseWhenAbsent() {
+        JsonObject obj = JsonReader.of("{}").read();
+        assertFalse(obj.unwrapBoolean("missing"));
+    }
+
+    @Test
+    void unwrapBooleanThrowsOnTypeMismatch() {
+        JsonObject obj = JsonReader.of("{\"flag\":\"yes\"}").read();
+        var e = assertThrows(IllegalArgumentException.class, () -> obj.unwrapBoolean("flag"));
+        assertTrue(e.getMessage().contains("flag"));
+        assertTrue(e.getMessage().contains("boolean"));
+    }
+
+    @Test
+    void unwrapInt() {
+        JsonObject obj = JsonReader.of("{\"count\":42}").read();
+        assertEquals(42, obj.unwrapInt("count", -1));
+    }
+
+    @Test
+    void unwrapIntReturnsDefaultWhenAbsent() {
+        JsonObject obj = JsonReader.of("{}").read();
+        assertEquals(-1, obj.unwrapInt("missing", -1));
+    }
+
+    @Test
+    void unwrapIntThrowsOnTypeMismatch() {
+        JsonObject obj = JsonReader.of("{\"count\":\"not a number\"}").read();
+        var e = assertThrows(IllegalArgumentException.class, () -> obj.unwrapInt("count", 0));
+        assertTrue(e.getMessage().contains("count"));
+        assertTrue(e.getMessage().contains("integer"));
+    }
+
+    @Test
+    void unwrapLong() {
+        JsonObject obj = JsonReader.of("{\"big\":9999999999}").read();
+        assertEquals(9999999999L, obj.unwrapLong("big", 0L));
+        assertEquals(0L, obj.unwrapLong("missing", 0L));
+    }
+
+    @Test
+    void unwrapLongThrowsOnTypeMismatch() {
+        JsonObject obj = JsonReader.of("{\"big\":true}").read();
+        assertThrows(IllegalArgumentException.class, () -> obj.unwrapLong("big", 0L));
+    }
+
+    @Test
+    void unwrapDouble() {
+        JsonObject obj = JsonReader.of("{\"ratio\":3.14,\"count\":5}").read();
+        assertEquals(3.14, obj.unwrapDouble("ratio", 0.0), 0.001);
+        assertEquals(5.0, obj.unwrapDouble("count", 0.0), 0.001);
+        assertEquals(0.0, obj.unwrapDouble("missing", 0.0), 0.001);
+    }
+
+    @Test
+    void unwrapDoubleThrowsOnTypeMismatch() {
+        JsonObject obj = JsonReader.of("{\"ratio\":\"high\"}").read();
+        assertThrows(IllegalArgumentException.class, () -> obj.unwrapDouble("ratio", 0.0));
+    }
+
+    @Test
+    void unwrapObject() {
+        JsonObject obj = JsonReader.of("{\"inner\":{\"x\":1}}").read();
+        JsonObject inner = obj.unwrapObject("inner");
+        assertEquals(1, inner.unwrapInt("x", 0));
+    }
+
+    @Test
+    void unwrapObjectReturnsNullWhenAbsent() {
+        JsonObject obj = JsonReader.of("{}").read();
+        assertNull(obj.unwrapObject("missing"));
+    }
+
+    @Test
+    void unwrapObjectThrowsOnTypeMismatch() {
+        JsonObject obj = JsonReader.of("{\"inner\":\"not an object\"}").read();
+        assertThrows(IllegalArgumentException.class, () -> obj.unwrapObject("inner"));
+    }
+
+    @Test
+    void unwrapArray() {
+        JsonObject obj = JsonReader.of("{\"items\":[1,2,3]}").read();
+        JsonArray items = obj.unwrapArray("items");
+        assertEquals(3, items.size());
+    }
+
+    @Test
+    void unwrapArrayReturnsNullWhenAbsent() {
+        JsonObject obj = JsonReader.of("{}").read();
+        assertNull(obj.unwrapArray("missing"));
+    }
+
+    @Test
+    void unwrapArrayThrowsOnTypeMismatch() {
+        JsonObject obj = JsonReader.of("{\"items\":42}").read();
+        assertThrows(IllegalArgumentException.class, () -> obj.unwrapArray("items"));
+    }
+
+    @Test
+    void mapArray() {
+        JsonObject obj = JsonReader.of("{\"people\":[{\"name\":\"A\"},{\"name\":\"B\"}]}").read();
+        List<String> names = obj.mapArray("people", o -> o.unwrapString("name"));
+        assertEquals(List.of("A", "B"), names);
+    }
+
+    @Test
+    void mapArrayReturnsEmptyWhenAbsent() {
+        JsonObject obj = JsonReader.of("{}").read();
+        assertEquals(List.of(), obj.mapArray("missing", o -> o.unwrapString("name")));
+    }
+
+    @Test
+    void unwrapStringList() {
+        JsonObject obj = JsonReader.of("{\"tags\":[\"a\",\"b\",\"c\"]}").read();
+        assertEquals(List.of("a", "b", "c"), obj.unwrapStringList("tags"));
+    }
+
+    @Test
+    void unwrapStringListReturnsEmptyWhenAbsent() {
+        JsonObject obj = JsonReader.of("{}").read();
+        assertEquals(List.of(), obj.unwrapStringList("missing"));
+    }
+
+    @Test
+    void unwrapStringListWithMixedTypes() {
+        JsonObject obj = JsonReader.of("{\"vals\":[\"a\",42,true]}").read();
+        List<String> vals = obj.unwrapStringList("vals");
+        assertEquals(List.of("a", "42", "true"), vals);
+    }
+
+    @Test
+    void mapArrayThrowsOnTypeMismatch() {
+        JsonObject obj = JsonReader.of("{\"people\":\"not an array\"}").read();
+        assertThrows(IllegalArgumentException.class, () -> obj.mapArray("people", o -> o.unwrapString("name")));
+    }
+
+    @Test
+    void unwrapStringListThrowsOnTypeMismatch() {
+        JsonObject obj = JsonReader.of("{\"tags\":42}").read();
+        assertThrows(IllegalArgumentException.class, () -> obj.unwrapStringList("tags"));
+    }
+
+    @Test
+    void toMap() {
+        JsonObject obj = JsonReader.of(
+                "{\"name\":\"test\",\"count\":5,\"active\":true,\"nested\":{\"x\":\"y\"},\"items\":[1,\"two\"]}").read();
+        Map<String, Object> map = obj.toMap();
+        assertEquals("test", map.get("name"));
+        assertEquals(5, map.get("count"));
+        assertEquals(true, map.get("active"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> nested = (Map<String, Object>) map.get("nested");
+        assertEquals("y", nested.get("x"));
+
+        @SuppressWarnings("unchecked")
+        List<Object> items = (List<Object>) map.get("items");
+        assertEquals(1, items.get(0));
+        assertEquals("two", items.get(1));
+    }
+
+    @Test
+    void toMapWithNull() {
+        JsonObject obj = JsonReader.of("{\"key\":null}").read();
+        Map<String, Object> map = obj.toMap();
+        assertTrue(map.containsKey("key"));
+        assertNull(map.get("key"));
+    }
+
+    @Test
+    void arrayMap() {
+        JsonArray arr = JsonReader.of("[{\"id\":1},{\"id\":2},{\"id\":3}]").read();
+        List<Integer> ids = arr.map(v -> ((JsonObject) v).unwrapInt("id", 0));
+        assertEquals(List.of(1, 2, 3), ids);
+    }
+
+    @Test
+    void arrayToStringList() {
+        JsonArray arr = JsonReader.of("[\"a\",\"b\",\"c\"]").read();
+        assertEquals(List.of("a", "b", "c"), arr.toStringList());
+    }
+
+    @Test
+    void arrayToList() {
+        JsonArray arr = JsonReader.of("[1,\"two\",true,null,{\"k\":\"v\"},[3]]").read();
+        List<Object> list = arr.toList();
+        assertEquals(1, list.get(0));
+        assertEquals("two", list.get(1));
+        assertEquals(true, list.get(2));
+        assertNull(list.get(3));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> obj = (Map<String, Object>) list.get(4);
+        assertEquals("v", obj.get("k"));
+
+        @SuppressWarnings("unchecked")
+        List<Object> nested = (List<Object>) list.get(5);
+        assertEquals(List.of(3), nested);
+    }
+
+    // --- JsonValue.unwrap() direct tests ---
+
+    @Test
+    void unwrapJsonString() {
+        assertEquals("hello", new JsonString("hello").unwrap());
+    }
+
+    @Test
+    void unwrapJsonIntegerFitsInt() {
+        Object result = new JsonInteger(42).unwrap();
+        assertEquals(Integer.class, result.getClass());
+        assertEquals(42, result);
+    }
+
+    @Test
+    void unwrapJsonIntegerRequiresLong() {
+        Object result = new JsonInteger(9999999999L).unwrap();
+        assertEquals(Long.class, result.getClass());
+        assertEquals(9999999999L, result);
+    }
+
+    @Test
+    void unwrapJsonDouble() {
+        assertEquals(3.14, new JsonDouble(3.14).unwrap());
+    }
+
+    @Test
+    void unwrapJsonBooleanTrue() {
+        assertEquals(true, JsonBoolean.TRUE.unwrap());
+    }
+
+    @Test
+    void unwrapJsonBooleanFalse() {
+        assertEquals(false, JsonBoolean.FALSE.unwrap());
+    }
+
+    @Test
+    void unwrapJsonNull() {
+        assertNull(JsonNull.INSTANCE.unwrap());
+    }
+
+    @Test
+    void unwrapJsonObject() {
+        JsonObject obj = JsonReader.of("{\"a\":1}").read();
+        Object result = obj.unwrap();
+        assertTrue(result instanceof Map);
+        assertEquals(1, ((Map<?, ?>) result).get("a"));
+    }
+
+    @Test
+    void unwrapJsonArray() {
+        JsonArray arr = JsonReader.of("[1,2]").read();
+        Object result = arr.unwrap();
+        assertTrue(result instanceof List);
+        assertEquals(List.of(1, 2), result);
+    }
+
+    @Test
+    void unwrapJsonMember() {
+        JsonMember member = new JsonMember("key", new JsonString("value"));
+        assertEquals("value", member.unwrap());
+    }
+
+    // --- Ordering and toString tests ---
+
+    @Test
+    void toMapPreservesInsertionOrder() {
+        JsonObject obj = JsonReader.of("{\"z\":1,\"a\":2,\"m\":3}").read();
+        Map<String, Object> map = obj.toMap();
+        List<String> keys = new ArrayList<>(map.keySet());
+        assertEquals(List.of("z", "a", "m"), keys);
+    }
+
+    @Test
+    void booleanToString() {
+        assertEquals("true", JsonBoolean.TRUE.toString());
+        assertEquals("false", JsonBoolean.FALSE.toString());
+    }
+}

--- a/independent-projects/bootstrap/json/src/test/java/io/quarkus/bootstrap/json/test/JsonDeserializerTest.java
+++ b/independent-projects/bootstrap/json/src/test/java/io/quarkus/bootstrap/json/test/JsonDeserializerTest.java
@@ -195,6 +195,17 @@ class JsonDeserializerTest {
     }
 
     @Test
+    void testExponentWithoutFraction() {
+        JsonObject obj = JsonReader.of("{\"a\":1e10,\"b\":2E3,\"c\":1e+2,\"d\":1e-2,\"e\":-3E4}").read();
+        assertInstanceOf(JsonDouble.class, obj.get("a"));
+        assertEquals(1e10, ((JsonDouble) obj.get("a")).value(), 0.001);
+        assertEquals(2E3, ((JsonDouble) obj.get("b")).value(), 0.001);
+        assertEquals(1e+2, ((JsonDouble) obj.get("c")).value(), 0.001);
+        assertEquals(1e-2, ((JsonDouble) obj.get("d")).value(), 0.0001);
+        assertEquals(-3E4, ((JsonDouble) obj.get("e")).value(), 0.001);
+    }
+
+    @Test
     void testLargeNumbers() {
         JsonObject obj = JsonReader
                 .of("{\"maxInt\":2147483647,\"minInt\":-2147483648,\"maxLong\":9223372036854775807,\"minLong\":-9223372036854775808}")

--- a/independent-projects/bootstrap/json/src/test/java/io/quarkus/bootstrap/json/test/JsonSerializerTest.java
+++ b/independent-projects/bootstrap/json/src/test/java/io/quarkus/bootstrap/json/test/JsonSerializerTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.bootstrap.json.Json;
@@ -206,15 +205,18 @@ class JsonSerializerTest {
         assertEquals("{\"emoji\":\"Hello 🌍\"}", json);
     }
 
-    @Disabled("https://github.com/quarkusio/quarkus/issues/52196")
     @Test
-    void testFluentApiIncompatibility() throws IOException {
+    void testBoxedTypeOverloads() throws IOException {
         JsonObjectBuilder obj = Json.object();
-        // calls JsonObjectBuilder#put(String, Object) and results in {"bar":null} instead of {"bar":{"val":30}}
         obj.put("bar", Json.object().put("val", Long.valueOf(30)));
         JsonArrayBuilder arr = Json.array();
-        // calls JsonArrayBuilder#add(Object) and results in {"foo":true} instead of {"foo":[30]}
         obj.put("foo", arr.add(Long.valueOf(30)));
         assertEquals("{\"bar\":{\"val\":30},\"foo\":[30]}", toJson(obj));
+
+        obj = Json.object();
+        obj.put("i", Json.object().put("v", Integer.valueOf(42)));
+        obj.put("d", Json.object().put("v", Double.valueOf(3.14)));
+        obj.put("b", Json.object().put("v", Boolean.valueOf(true)));
+        assertEquals("{\"i\":{\"v\":42},\"d\":{\"v\":3.14},\"b\":{\"v\":true}}", toJson(obj));
     }
 }

--- a/independent-projects/tools/analytics-common/src/main/java/io/quarkus/analytics/util/JsonSerializer.java
+++ b/independent-projects/tools/analytics-common/src/main/java/io/quarkus/analytics/util/JsonSerializer.java
@@ -1,10 +1,8 @@
 package io.quarkus.analytics.util;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -55,12 +53,12 @@ public final class JsonSerializer {
 
         JsonArray denyAnonymousIds = obj.get("deny_anonymous_ids");
         if (denyAnonymousIds != null) {
-            config.setDenyAnonymousIds(toStringList(denyAnonymousIds));
+            config.setDenyAnonymousIds(denyAnonymousIds.toStringList());
         }
 
         JsonArray denyQuarkusVersions = obj.get("deny_quarkus_versions");
         if (denyQuarkusVersions != null) {
-            config.setDenyQuarkusVersions(toStringList(denyQuarkusVersions));
+            config.setDenyQuarkusVersions(denyQuarkusVersions.toStringList());
         }
 
         JsonValue refreshInterval = obj.get("refresh_interval");
@@ -150,7 +148,7 @@ public final class JsonSerializer {
 
         JsonObject context = obj.get("context");
         if (context != null) {
-            track.setContext(toMap(context));
+            track.setContext(context.toMap());
         }
 
         JsonString timestamp = obj.get("timestamp");
@@ -278,53 +276,8 @@ public final class JsonSerializer {
         return builder;
     }
 
-    private static List<String> toStringList(JsonArray array) {
-        List<String> result = new ArrayList<>();
-        for (JsonValue value : array.value()) {
-            if (value instanceof JsonString str) {
-                result.add(str.value());
-            }
-        }
-        return result;
-    }
-
-    private static Map<String, Object> toMap(JsonObject obj) {
-        Map<String, Object> result = new HashMap<>();
-        for (var member : obj.members()) {
-            String key = member.attribute().value();
-            JsonValue value = member.value();
-            result.put(key, toJavaValue(value));
-        }
-        return result;
-    }
-
-    private static Object toJavaValue(JsonValue value) {
-        if (value instanceof JsonString str) {
-            return str.value();
-        } else if (value instanceof JsonBoolean bool) {
-            return bool.value();
-        } else if (value instanceof JsonInteger intVal) {
-            return intVal.longValue();
-        } else if (value instanceof JsonObject obj) {
-            return toMap(obj);
-        } else if (value instanceof JsonArray arr) {
-            List<Object> list = new ArrayList<>();
-            for (JsonValue item : arr.value()) {
-                list.add(toJavaValue(item));
-            }
-            return list;
-        }
-        return null;
-    }
-
     private static String toJsonString(Json.JsonObjectBuilder builder) {
-        StringBuilder sb = new StringBuilder();
-        try {
-            builder.appendTo(sb);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to serialize JSON", e);
-        }
-        return sb.toString();
+        return builder.toJsonString();
     }
 
     public static Identity parseIdentity(String json) {
@@ -338,7 +291,7 @@ public final class JsonSerializer {
 
         JsonObject ctx = obj.get("context");
         if (ctx != null) {
-            builder.context(toMap(ctx));
+            builder.context(ctx.toMap());
         }
 
         JsonString timestamp = obj.get("timestamp");


### PR DESCRIPTION
This PR is about usability improvements of the bootstrap JSON API based on its current consumers and a few bug fixes.
Fixes https://github.com/quarkusio/quarkus/issues/52196

It's also a foundation for parsing registry extension catalogs with this API.

JSON API enhancements and parsing bug fixes:
    
- Add boxed-type overloads (Long, Integer, Double, Boolean) for JsonObjectBuilder.put() and JsonArrayBuilder.add() to fix fluent API chaining with boxed types (resolves #52196)
- Add toJsonString() convenience method on JsonBuilder
- Add JsonReader.read(Path) convenience for file-based parsing
- Add JsonMember.attributeName() for direct String access without wrapping in JsonString
- Add JsonDouble.toString() override (was missing)
- Fix exponent-only number parsing (e.g. 1e10) to produce JsonDouble instead of throwing NumberFormatException
- Change JsonObject internal map to Map<String, JsonValue> to avoid allocating a new JsonString on every attribute lookup
- Add typed accessor/unwrap methods on JsonObject, convenience methods on JsonArray, and JsonValue.unwrap() for recursive conversion

