### PR TITLE
Report the missing parameter name instead of failing with an NPE

### DIFF
--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -1308,7 +1308,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
             builder.setType(ParameterType.PATH);
             convertible = true;
         } else if (restPathParam != null) {
-            builder.setName(valueOrDefault(restPathParam.value(), sourceName));
+            builder.setName(parameterNameOrFail(restPathParam.value(), sourceName, "RestPath", builder.getErrorLocation()));
             builder.setType(ParameterType.PATH);
             convertible = true;
         } else if (queryParam != null) {
@@ -1317,7 +1317,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
             builder.setSeparator(getSeparator(anns));
             convertible = true;
         } else if (restQueryParam != null) {
-            builder.setName(valueOrDefault(restQueryParam.value(), sourceName));
+            builder.setName(parameterNameOrFail(restQueryParam.value(), sourceName, "RestQuery", builder.getErrorLocation()));
             builder.setType(ParameterType.QUERY);
             builder.setSeparator(getSeparator(anns));
             convertible = true;
@@ -1326,7 +1326,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
             builder.setType(ParameterType.COOKIE);
             convertible = true;
         } else if (restCookieParam != null) {
-            builder.setName(valueOrDefault(restCookieParam.value(), sourceName));
+            builder.setName(parameterNameOrFail(restCookieParam.value(), sourceName, "RestCookie", builder.getErrorLocation()));
             builder.setType(ParameterType.COOKIE);
             convertible = true;
         } else if (headerParam != null) {
@@ -1335,7 +1335,8 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
             convertible = true;
         } else if (restHeaderParam != null) {
             if (restHeaderParam.value() == null || restHeaderParam.value().asString().isEmpty()) {
-                builder.setName(StringUtil.hyphenateWithCapitalFirstLetter(sourceName));
+                builder.setName(StringUtil.hyphenateWithCapitalFirstLetter(
+                        parameterNameOrFail(null, sourceName, "RestHeader", builder.getErrorLocation())));
             } else {
                 builder.setName(restHeaderParam.value().asString());
             }
@@ -1346,7 +1347,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
             builder.setType(ParameterType.FORM);
             convertible = isFormParamConvertible(paramType);
         } else if (restFormParam != null) {
-            builder.setName(valueOrDefault(restFormParam.value(), sourceName));
+            builder.setName(parameterNameOrFail(restFormParam.value(), sourceName, "RestForm", builder.getErrorLocation()));
             builder.setType(ParameterType.FORM);
             convertible = isFormParamConvertible(paramType);
         } else if (matrixParam != null) {
@@ -1354,7 +1355,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
             builder.setType(ParameterType.MATRIX);
             convertible = true;
         } else if (restMatrixParam != null) {
-            builder.setName(valueOrDefault(restMatrixParam.value(), sourceName));
+            builder.setName(parameterNameOrFail(restMatrixParam.value(), sourceName, "RestMatrix", builder.getErrorLocation()));
             builder.setType(ParameterType.MATRIX);
             convertible = true;
         } else if (contextParam != null) {
@@ -1626,6 +1627,27 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
             return defaultValue;
         String val = annotation.asString();
         return val != null && !val.isEmpty() ? val : defaultValue;
+    }
+
+    /**
+     * Resolves the name of a parameter whose annotation falls back to the name of the parameter itself.
+     * <p>
+     * The parameter name is only present in the bytecode when the class was compiled with {@code -parameters},
+     * so it can be {@code null}. Failing here names the cause, instead of letting the missing name travel until
+     * something dereferences it. See <a href="https://github.com/quarkusio/quarkus/issues/56004">issue #56004</a>.
+     */
+    private String parameterNameOrFail(AnnotationValue annotation, String sourceName, String annotationName,
+            String errorLocation) {
+        String name = valueOrDefault(annotation, sourceName);
+        if (name == null) {
+            throw new DeploymentException("Unable to determine the name of the @" + annotationName + " parameter of "
+                    + errorLocation
+                    + " because parameter names are not available in the compiled class."
+                    + " Either give the name explicitly, as in @" + annotationName + "(\"some-name\"),"
+                    + " or compile the class with the -parameters option of javac"
+                    + " (maven.compiler.parameters=true for Maven, options.compilerArgs.add(\"-parameters\") for Gradle).");
+        }
+        return name;
     }
 
     public Set<String> nameBindingNames(ClassInfo selectedAppClass) {


### PR DESCRIPTION
Annotations such as `@RestHeader` fall back to the name of the parameter they are placed on when no name is given. That name only exists in the bytecode when the class was compiled with `-parameters`, so Jandex returns `null` for it otherwise.

The null then reached `StringUtil.hyphenateWithCapitalFirstLetter`, which hands it to `camelHumpsIterator(final String str)` — a method that captures the string in an anonymous `Iterator` and only dereferences it later in `hasNext()`. The captured field is compiled as `val$str`, so the failure surfaced as the message from #56004 with nothing pointing at the parameter, the annotation, or the compiler option that fixes it:

```
Cannot invoke "String.length()" because "this.val$str" is null
```

With this change, the same application reports:

```
Unable to determine the name of the @RestHeader parameter of method
Response get(MultivaluedMap<String, String>) on class repro.ExampleRestClient because
parameter names are not available in the compiled class. Either give the name explicitly,
as in @RestHeader("some-name"), or compile the class with the -parameters option of javac
(maven.compiler.parameters=true for Maven, options.compilerArgs.add('-parameters') for Gradle).
```

The same fallback is shared by `@RestPath`, `@RestQuery`, `@RestHeader`, `@RestCookie`, `@RestForm` and `@RestMatrix`, so the check sits in one helper used by all six rather than only in the header branch.

Verified with the reproducer attached to the issue: it fails with the NPE on 3.38.1 and produces the message above with this change. Worth noting for anyone retracing it — injecting the client is not enough to trigger it, because the proxy is generated on first use, and at build time this only produced a `WARN` ("Ignoring interface for creating client proxy"), so the build succeeds and the failure appears at runtime.

Two things deliberately left out. The reporter's second request — that a `Map`/`MultivaluedMap`-typed `@RestHeader` should not need a parameter name at all, since the header names come from the map keys — is a behaviour change rather than an error-reporting fix, and it overlaps the question @gsmet raised about enforcing `-parameters` globally, so I left it for that discussion. And there is no test: `common/processor` has no test sources at all, and reproducing this requires a class compiled *without* `-parameters`, which the build always passes. Happy to add one if you would like the test infrastructure introduced.

- Closes: #56004