### PR TITLE
Make the generated CycloneDX SBOM reproducible

### DIFF
--- a/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxProcessor.java
+++ b/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxProcessor.java
@@ -3,6 +3,7 @@ package io.quarkus.cyclonedx.deployment;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -20,6 +21,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.AppModelProviderBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.pkg.builditem.JarTreeShakeBuildItem;
@@ -50,6 +52,7 @@ public class CycloneDxProcessor {
      * @param artifactResultBuildItems packaged artifact results carrying {@link CoreSbomContributionConfig}
      * @param sbomContributions extension SBOM contributions (npm, PyPI, etc.)
      * @param cdxSbomConfig CycloneDX SBOM generation configuration
+     * @param packageConfig packaging configuration, providing the reproducible build timestamp
      * @param sbomProducer SBOM build item producer
      */
     @BuildStep
@@ -58,6 +61,7 @@ public class CycloneDxProcessor {
             List<ArtifactResultBuildItem> artifactResultBuildItems,
             List<SbomContributionBuildItem> sbomContributions,
             CycloneDxConfig cdxSbomConfig,
+            PackageConfig packageConfig,
             BuildProducer<SbomBuildItem> sbomProducer) {
         if (!cdxSbomConfig.enabled() || artifactResultBuildItems.isEmpty()) {
             return;
@@ -79,6 +83,7 @@ public class CycloneDxProcessor {
                     .setLibrariesOnly(cdxSbomConfig.librariesOnly())
                     .setRuntimeOnly(cdxSbomConfig.runtimeOnly())
                     .setIncludeQuarkusComponentScope(cdxSbomConfig.includeQuarkusComponentScope())
+                    .setOutputTimestamp(packageConfig.outputTimestamp().orElse(null))
                     .setContributions(contributions)
                     .generate()) {
                 sbomProducer.produce(new SbomBuildItem(sbom));
@@ -131,6 +136,7 @@ public class CycloneDxProcessor {
      * @param treeShakeResult tree-shake results used to compute pedigree notes for shaken dependencies
      * @param embeddedSbomRequests explicit requests to embed an SBOM
      * @param sbomContributions extension SBOM contributions (npm, PyPI, etc.)
+     * @param packageConfig packaging configuration, providing the reproducible build timestamp
      */
     @BuildStep
     public void generateEmbeddedSbom(BuildProducer<SbomGeneratedResourceBuildItem> sbomResourceProducer,
@@ -139,13 +145,14 @@ public class CycloneDxProcessor {
             AppModelProviderBuildItem appModelProviderBuildItem,
             JarTreeShakeBuildItem treeShakeResult,
             List<EmbeddedSbomRequestBuildItem> embeddedSbomRequests,
-            List<SbomContributionBuildItem> sbomContributions) {
+            List<SbomContributionBuildItem> sbomContributions,
+            PackageConfig packageConfig) {
         if (!isEmbeddedSbomEnabled(cdxConfig, embeddedSbomRequests)) {
             return;
         }
 
         byte[] sbomBytes = generateEmbeddedSbomBytes(cdxConfig, curateOutcomeBuildItem, appModelProviderBuildItem,
-                computePedigrees(treeShakeResult), sbomContributions);
+                computePedigrees(treeShakeResult), sbomContributions, packageConfig.outputTimestamp().orElse(null));
         String effectiveResourceName = effectiveResourceName(cdxConfig.embedded());
         if (cdxConfig.embedded().compress()) {
             sbomBytes = gzip(sbomBytes);
@@ -158,7 +165,8 @@ public class CycloneDxProcessor {
             CurateOutcomeBuildItem curateOutcomeBuildItem,
             AppModelProviderBuildItem appModelProviderBuildItem,
             Map<ArtifactKey, String> pedigrees,
-            List<SbomContributionBuildItem> sbomContributions) {
+            List<SbomContributionBuildItem> sbomContributions,
+            Instant outputTimestamp) {
         final String resourceName = cdxConfig.embedded().resourceName();
 
         CoreSbomContributionConfig config = new CoreSbomContributionConfig()
@@ -176,6 +184,7 @@ public class CycloneDxProcessor {
                 .setLibrariesOnly(cdxConfig.librariesOnly())
                 .setRuntimeOnly(cdxConfig.runtimeOnly())
                 .setIncludeQuarkusComponentScope(cdxConfig.includeQuarkusComponentScope())
+                .setOutputTimestamp(outputTimestamp)
                 .setContributions(collectContributions(coreContribution, sbomContributions))
                 .generateText();
 

--- a/extensions/cyclonedx/generator/src/main/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGenerator.java
+++ b/extensions/cyclonedx/generator/src/main/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGenerator.java
@@ -414,20 +414,29 @@ public class CycloneDxSbomGenerator {
     /**
      * Generates a serial number for the BOM in {@code urn:uuid:} format.
      * <p>
-     * The UUID is derived from the BOM's {@link Bom#hashCode() hashCode}, which covers
-     * metadata, components, dependency relationships, properties, and other structural
-     * fields. When a reproducible {@link #setOutputTimestamp(Instant) output timestamp}
-     * is configured, the serial number is fully deterministic across identical builds.
+     * The UUID is derived from the serialized BOM, not from {@link Bom#hashCode() Bom.hashCode()}.
+     * The latter folds in the identity hash codes of the {@link Component.Type} and
+     * {@link Component.Scope} enum constants, and those are drawn from a per-thread PRNG, so they
+     * differ between builds even when the BOM content is identical. Serializing to a compact JSON
+     * form keeps the serial number a pure function of the BOM content, independent of the
+     * configured output format and of {@code prettyPrint}. Combined with a reproducible
+     * {@link #setOutputTimestamp(Instant) output timestamp}, the serial number is then stable
+     * across identical builds.
      * <p>
-     * Must be called after the BOM is fully assembled and before the serial number
-     * itself is set, since {@code Bom.hashCode()} includes the serial number field.
+     * Must be called after the BOM is fully assembled and before the serial number itself is set,
+     * so that the serialized form it hashes does not yet contain one.
      *
      * @param bom the fully assembled BOM (with serial number still {@code null})
      * @return a {@code urn:uuid:} serial number string
      */
-    private static String generateSerialNumber(Bom bom) {
-        return "urn:uuid:" + UUID.nameUUIDFromBytes(
-                Integer.toString(bom.hashCode()).getBytes(StandardCharsets.UTF_8));
+    private String generateSerialNumber(Bom bom) {
+        final String content;
+        try {
+            content = BomGeneratorFactory.createJson(getSchemaVersion(), bom).toJsonString(false);
+        } catch (Throwable e) {
+            throw new RuntimeException("Failed to serialize the SBOM to compute its serial number", e);
+        }
+        return "urn:uuid:" + UUID.nameUUIDFromBytes(content.getBytes(StandardCharsets.UTF_8));
     }
 
     private void renderMainComponent(Bom bom, ComponentDescriptor descriptor) {

--- a/extensions/cyclonedx/generator/src/test/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGeneratorTest.java
+++ b/extensions/cyclonedx/generator/src/test/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGeneratorTest.java
@@ -226,9 +226,9 @@ class CycloneDxSbomGeneratorTest {
                 .setContributions(List.of(contribution))
                 .generateText().get(0));
 
+        // pinned to a literal on purpose; we need to make sure that the serial number is deterministic
         assertThat(bom1.getSerialNumber())
-                .isNotNull()
-                .startsWith("urn:uuid:")
+                .isEqualTo("urn:uuid:9d197c65-1a43-3cf5-bb49-5a88553d1dfc")
                 .isEqualTo(bom2.getSerialNumber());
     }
 


### PR DESCRIPTION
The embedded SBOM differed on every build for two independent reasons:

- its timestamp was the current time, because neither build step passed `quarkus.package.output-timestamp` to the generator
- its serial number came from `Bom.hashCode()`, which is not stable and differs from build to build

The timestamp is now wired through, and the serial number is derived from the serialized BOM instead.

Serial numbers therefore change from previous releases.