### PR TITLE
Explain integration test container start failures caused by a missing Dev Services network

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
@@ -313,15 +313,43 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
                 .redirectOutput(ProcessBuilder.Redirect.appendTo(logPath.toFile()))
                 .start();
 
-        if (startedFunction != null) {
-            waitForStartedFunction(startedFunction, containerProcess, waitTimeSeconds, logPath);
-            return ListeningAddresses.EMPTY;
-        } else {
-            log.info("Wait for server to start by capturing listening data...");
-            ListeningAddresses result = waitForCapturedListeningData(containerProcess, logPath, waitTimeSeconds);
-            result.address().ifPresent(listeningAddress -> log.infof("Server started on port %s", listeningAddress.port()));
-            return result;
+        try {
+            if (startedFunction != null) {
+                waitForStartedFunction(startedFunction, containerProcess, waitTimeSeconds, logPath);
+                return ListeningAddresses.EMPTY;
+            } else {
+                log.info("Wait for server to start by capturing listening data...");
+                ListeningAddresses result = waitForCapturedListeningData(containerProcess, logPath, waitTimeSeconds);
+                result.address()
+                        .ifPresent(listeningAddress -> log.infof("Server started on port %s", listeningAddress.port()));
+                return result;
+            }
+        } catch (RuntimeException e) {
+            String hint = devServicesNetworkHint(devServicesLaunchResult);
+            if (hint == null) {
+                throw e;
+            }
+            throw new IllegalStateException(e.getMessage() + " " + hint, e);
         }
+    }
+
+    /**
+     * When the application container could not start, explain the most likely cause if the test framework had to
+     * generate a network for it: Dev Services provided configuration for the application, but no build step reported the
+     * network their containers were joined to, so the application container cannot resolve their hostnames.
+     * <p>
+     * {@code null} when this does not apply.
+     */
+    static String devServicesNetworkHint(ArtifactLauncher.InitContext.DevServicesLaunchResult devServicesLaunchResult) {
+        if (!devServicesLaunchResult.manageNetwork() || devServicesLaunchResult.properties().isEmpty()) {
+            return null;
+        }
+        return "The application container was started on the network '" + devServicesLaunchResult.networkId()
+                + "', which was created by the test framework because no Dev Services network id was reported by the build,"
+                + " while Dev Services configured " + String.join(", ", devServicesLaunchResult.properties().keySet())
+                + ". Dev Service containers that are not on that network cannot be reached from the application container."
+                + " The network id is reported when the extension providing the Dev Service depends on"
+                + " io.quarkus:quarkus-devservices-deployment; report this to the maintainers of that extension.";
     }
 
     private void handleAotFileArgs(List<String> args, ContainerRuntime containerRuntime) throws IOException {

--- a/test-framework/common/src/test/java/io/quarkus/test/common/DefaultDockerContainerLauncherTest.java
+++ b/test-framework/common/src/test/java/io/quarkus/test/common/DefaultDockerContainerLauncherTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.test.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.bootstrap.app.CuratedApplication;
+
+public class DefaultDockerContainerLauncherTest {
+
+    @Test
+    void noHintWhenTheNetworkWasReportedByTheBuild() {
+        assertThat(DefaultDockerContainerLauncher.devServicesNetworkHint(
+                launchResult(Map.of("quarkus.datasource.jdbc.url", "jdbc:postgresql://db:5432/test"), "reported", false)))
+                .isNull();
+    }
+
+    @Test
+    void noHintWithoutDevServices() {
+        assertThat(DefaultDockerContainerLauncher.devServicesNetworkHint(
+                launchResult(Map.of(), "quarkus-integration-test-abcde", true)))
+                .isNull();
+    }
+
+    @Test
+    void hintWhenTheNetworkWasGeneratedWhileDevServicesConfiguredTheApplication() {
+        String hint = DefaultDockerContainerLauncher.devServicesNetworkHint(
+                launchResult(Map.of("quarkus.datasource.jdbc.url", "jdbc:postgresql://db:5432/test"),
+                        "quarkus-integration-test-abcde", true));
+
+        assertThat(hint)
+                .contains("quarkus-integration-test-abcde")
+                .contains("quarkus.datasource.jdbc.url")
+                .contains("quarkus-devservices-deployment");
+    }
+
+    private static ArtifactLauncher.InitContext.DevServicesLaunchResult launchResult(Map<String, String> properties,
+            String networkId, boolean manageNetwork) {
+        return new ArtifactLauncher.InitContext.DevServicesLaunchResult() {
+            @Override
+            public Map<String, String> properties() {
+                return properties;
+            }
+
+            @Override
+            public String networkId() {
+                return networkId;
+            }
+
+            @Override
+            public boolean manageNetwork() {
+                return manageNetwork;
+            }
+
+            @Override
+            public CuratedApplication getCuratedApplication() {
+                return null;
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+    }
+}


### PR DESCRIPTION
An extension whose deployment module depends only on `quarkus-devservices-common` joins its Dev Service container to the shared network through `ConfigureUtil.configureSharedNetwork()`, but the build step reporting that network to the test framework lives in `quarkus-devservices-deployment`. Without it, `DefaultDockerContainerLauncher` starts the application container on a `quarkus-integration-test-XXXX` network of its own, the application cannot resolve the Dev Service hostname, and the only symptom is `Unable to determine the status of the running process` after the start timeout, which is what quarkiverse/quarkus-zeebe#412 ran into.

As discussed with @holly-cummins, this no longer moves any build step: it only makes the failure explain itself. When the application container fails to start, the launcher had to generate a network because none was reported (`manageNetwork`), and Dev Services provided configuration to the application, the exception now says so:

> Unable to determine the status of the running process. See the above logs for details. The application container was started on the network 'quarkus-integration-test-abcde', which was created by the test framework because no Dev Services network id was reported by the build, while Dev Services configured quarkus.datasource.jdbc.url. Dev Service containers that are not on that network cannot be reached from the application container. The network id is reported when the extension providing the Dev Service depends on io.quarkus:quarkus-devservices-deployment; report this to the maintainers of that extension.

Nothing changes when the network was reported or when no Dev Service configured the application. The hint is computed by a small static method with a unit test; the container start path itself only rewraps the existing exception when the hint applies.

- Fixes: #55474
