### PR TITLE
Do not build a Quarkus application for tests JUnit excludes through tags

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1642,6 +1642,9 @@ You can use this tag to isolate the `@QuarkusTest` test in a specific execution 
 </plugin>
 ----
 
+When tags exclude every test of a `@QuarkusTest` class from an execution run, as in the `default-test` execution above,
+Quarkus does not build an application for that class: no Dev Services are started and no container runtime is needed for that run.
+
 [NOTE]
 =====
 Currently `@QuarkusTest` and `@QuarkusIntegrationTest` should not be run in the same test run.

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/QuarkusTestIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/QuarkusTestIT.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -71,6 +73,49 @@ public class QuarkusTestIT extends RunAndCheckMojoTestBase {
         assertThat(installInvocation.getExecutionException()).isNull();
         assertThat(installInvocation.getExitCode()).isEqualTo(0);
 
+    }
+
+    /**
+     * When JUnit is going to exclude every test of a {@code @QuarkusTest} class through its tags, no Quarkus
+     * application must be built for that class: the application in this project deliberately fails to build (see
+     * {@code BrokenBean}), and building it means Dev Services would be started (and Docker required) for tests that
+     * never run.
+     *
+     * See https://github.com/quarkusio/quarkus/issues/54435
+     */
+    @Test
+    public void testQuarkusTestsExcludedByTagsDoNotBuildAnApplication()
+            throws MavenInvocationException, InterruptedException, IOException {
+        String sourceDir = "projects/test-quarkus-tests-excluded-by-tags";
+        testDir = initProject(sourceDir, sourceDir + "-processed");
+
+        // Every test in both @QuarkusTest classes carries the class-level tag (the nested test inherits it)
+        RunningInvoker excludedByClassTag = runTests("-DexcludedGroups=quarkus-app");
+        assertThat(excludedByClassTag.getResult().getExitCode()).as(excludedByClassTag.log()).isEqualTo(0);
+        assertThat(excludedByClassTag.log()).contains("Tests run: 1, Failures: 0, Errors: 0, Skipped: 0")
+                .doesNotContain("Unsatisfied dependency");
+
+        // Same thing expressed as an inclusion: only the plain JUnit test is selected
+        RunningInvoker includedByTag = runTests("-Dgroups=vanilla");
+        assertThat(includedByTag.getResult().getExitCode()).as(includedByTag.log()).isEqualTo(0);
+        assertThat(includedByTag.log()).contains("Tests run: 1, Failures: 0, Errors: 0, Skipped: 0")
+                .doesNotContain("Unsatisfied dependency");
+
+        // Control: MethodTaggedQuarkusTest still has an untagged test to run, so the application has to be built,
+        // which fails. This proves the runs above would have hit the same failure without the exclusion.
+        RunningInvoker partiallyExcluded = runTests("-DexcludedGroups=partial");
+        assertThat(partiallyExcluded.getResult().getExitCode()).as(partiallyExcluded.log()).isNotEqualTo(0);
+        assertThat(partiallyExcluded.log()).contains("Unsatisfied dependency");
+    }
+
+    private RunningInvoker runTests(String... args) throws MavenInvocationException, InterruptedException {
+        RunningInvoker invoker = new RunningInvoker(testDir, false);
+        List<String> goals = new ArrayList<>(List.of("clean", "test", "-Dquarkus.analytics.disabled=true"));
+        goals.addAll(List.of(args));
+        MavenProcessInvocationResult result = invoker.execute(goals, Collections.emptyMap());
+        assertThat(result.getProcess().waitFor(2, TimeUnit.MINUTES)).isTrue();
+        assertThat(result.getExecutionException()).isNull();
+        return invoker;
     }
 
     @Test

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-quarkus-tests-excluded-by-tags/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-quarkus-tests-excluded-by-tags/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.acme</groupId>
+    <artifactId>quarkus-tests-excluded-by-tags</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>quarkus</packaging>
+
+    <properties>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.version>@project.version@</quarkus.platform.version>
+        <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>\${quarkus.platform.group-id}</groupId>
+                <artifactId>\${quarkus.platform.artifact-id}</artifactId>
+                <version>\${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>\${surefire-plugin.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>\${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>\${quarkus-plugin.version}</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-quarkus-tests-excluded-by-tags/src/main/java/org/acme/BrokenBean.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-quarkus-tests-excluded-by-tags/src/main/java/org/acme/BrokenBean.java
@@ -1,0 +1,11 @@
+package org.acme;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class BrokenBean {
+
+    @Inject
+    Missing missing;
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-quarkus-tests-excluded-by-tags/src/main/java/org/acme/Missing.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-quarkus-tests-excluded-by-tags/src/main/java/org/acme/Missing.java
@@ -1,0 +1,9 @@
+package org.acme;
+
+/**
+ * Deliberately has no implementation, so that any attempt to build the application fails during augmentation
+ * with an unsatisfied dependency. That is how the tests in this project tell whether Quarkus tried to build an
+ * application for a test class.
+ */
+public interface Missing {
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-quarkus-tests-excluded-by-tags/src/test/java/org/acme/ClassTaggedQuarkusTest.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-quarkus-tests-excluded-by-tags/src/test/java/org/acme/ClassTaggedQuarkusTest.java
@@ -1,0 +1,33 @@
+package org.acme;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Excluded as a whole through its class-level tag; the nested test inherits that tag.
+ * The application cannot be built (see {@link BrokenBean}), so this project only builds if no application is
+ * created for this class.
+ */
+@QuarkusTest
+@Tag("quarkus-app")
+public class ClassTaggedQuarkusTest {
+
+    @Test
+    void neverRuns() {
+        fail("This test is excluded by its class-level tag and should never run");
+    }
+
+    @Nested
+    class Inner {
+
+        @Test
+        void neverRunsEither() {
+            fail("This nested test inherits the class-level tag and should never run");
+        }
+    }
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-quarkus-tests-excluded-by-tags/src/test/java/org/acme/MethodTaggedQuarkusTest.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-quarkus-tests-excluded-by-tags/src/test/java/org/acme/MethodTaggedQuarkusTest.java
@@ -1,0 +1,29 @@
+package org.acme;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Only one of the two tests carries the "partial" tag: excluding that tag still leaves a test to run, so Quarkus
+ * still has to build the application (which fails, see {@link BrokenBean}). Excluding the class-level tag excludes
+ * both.
+ */
+@QuarkusTest
+@Tag("quarkus-app")
+public class MethodTaggedQuarkusTest {
+
+    @Test
+    @Tag("partial")
+    void tagged() {
+        fail("This test should never run");
+    }
+
+    @Test
+    void untagged() {
+        fail("This test should never run");
+    }
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-quarkus-tests-excluded-by-tags/src/test/java/org/acme/VanillaTest.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-quarkus-tests-excluded-by-tags/src/test/java/org/acme/VanillaTest.java
@@ -1,0 +1,18 @@
+package org.acme;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A plain JUnit test, to show that the run itself is not empty when the Quarkus tests are excluded.
+ */
+@Tag("vanilla")
+public class VanillaTest {
+
+    @Test
+    void runs() {
+        assertTrue(true);
+    }
+}

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/classloading/FacadeClassLoader.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/classloading/FacadeClassLoader.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.commons.support.HierarchyTraversalMode;
+import org.junit.platform.launcher.PostDiscoveryFilter;
 
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.app.StartupAction;
@@ -112,6 +113,8 @@ public final class FacadeClassLoader extends ClassLoader implements Closeable {
     private Class<? extends Annotation> extendWithAnnotation;
     private Class<? extends Annotation> registerExtensionAnnotation;
     private Class<? extends Annotation> testAnnotation;
+    // Null when the JUnit annotations could not be loaded, and so there cannot be QuarkusTests
+    private PostDiscoveryFilterEvaluator postDiscoveryFilterEvaluator;
 
     // TODO maybe refactor this into a ContinuousFacadeClassLoader subclass
     private final Map<String, Class<?>> profiles;
@@ -204,6 +207,7 @@ public final class FacadeClassLoader extends ClassLoader implements Closeable {
             nestedAnnotation = (Class<? extends Annotation>) annotationLoader
                     .loadClass(Nested.class.getName());
             testAnnotation = (Class<? extends Annotation>) annotationLoader.loadClass(Test.class.getName());
+            postDiscoveryFilterEvaluator = new PostDiscoveryFilterEvaluator(annotationLoader);
         } catch (ClassNotFoundException | NoSuchMethodException e) {
             // If QuarkusTest is not on the classpath, that's fine; it just means we definitely won't have QuarkusTests. That means we can bypass a whole bunch of logic.
             log.debug("Could not load annotations for FacadeClassLoader: " + e);
@@ -328,10 +332,12 @@ public final class FacadeClassLoader extends ClassLoader implements Closeable {
                         // Ideally we would check for every way of disabling a test, but we don't want to recreate the JUnit logic, so just do common ones that might be guarding classes with classloading or dev-service-starting issues
                         // That does mean our behaviour in this area is slightly inconsistent between annotations; for some we will augment before giving up and for some we won't
                         boolean isDisabled = AnnotationSupport.isAnnotated(inspectionClass, disabledAnnotation)
-                                || isDisabledOnOs(inspectionClass);
+                                || isDisabledOnOs(inspectionClass)
+                                || isExcludedByPostDiscoveryFilters(inspectionClass);
 
                         // If a whole test class has an @Disabled annotation, do not bother creating a quarkus app for it
                         // Pragmatically, this fixes a LinkageError in grpc-cli which only reproduces in CI, but it's also probably what users would expect
+                        // The same goes for a class whose tests are all going to be filtered out by JUnit tags, otherwise dev services get started for tests which never run, see https://github.com/quarkusio/quarkus/issues/54435
                         if (!isDisabled) {
                             // There are several ways a test could be identified as a QuarkusTest:
                             // A Quarkus Test could be annotated with @QuarkusTest or with @ExtendWith[... QuarkusTestExtension.class ] or @RegisterExtension (or the service loader mechanism could be used)
@@ -410,6 +416,30 @@ public final class FacadeClassLoader extends ClassLoader implements Closeable {
             }
         }
 
+    }
+
+    /**
+     * Tells this classloader about the post-discovery filters (typically tag inclusions and exclusions) of the JUnit
+     * request that is about to be discovered, so that no application is built for test classes those filters are going
+     * to exclude entirely.
+     */
+    public void setPostDiscoveryFilters(List<? extends PostDiscoveryFilter> filters) {
+        if (postDiscoveryFilterEvaluator != null) {
+            postDiscoveryFilterEvaluator.setFilters(filters);
+        }
+    }
+
+    private boolean isExcludedByPostDiscoveryFilters(Class<?> inspectionClass) {
+        if (postDiscoveryFilterEvaluator == null) {
+            return false;
+        }
+        boolean excluded = postDiscoveryFilterEvaluator.excludesEveryTestIn(inspectionClass);
+        if (excluded) {
+            log.debugf(
+                    "Not creating a Quarkus application for %s because JUnit's post-discovery filters exclude all of its tests",
+                    inspectionClass.getName());
+        }
+        return excluded;
     }
 
     private boolean isDisabledOnOs(Class<?> inspectionClass) {

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/classloading/PostDiscoveryFilterEvaluator.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/classloading/PostDiscoveryFilterEvaluator.java
@@ -1,0 +1,236 @@
+package io.quarkus.test.junit.classloading;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jboss.logging.Logger;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.commons.support.HierarchyTraversalMode;
+import org.junit.platform.commons.support.ReflectionSupport;
+import org.junit.platform.engine.Filter;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.TestTag;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.launcher.PostDiscoveryFilter;
+
+/**
+ * Works out, before a test class is loaded for real, whether the post-discovery filters of the current JUnit launcher
+ * request (tag exclusions and inclusions from surefire's {@code groups}/{@code excludedGroups}, Gradle's
+ * {@code includeTags}/{@code excludeTags}, IDE tag expressions, ...) are going to exclude every single test in it.
+ * <p>
+ * The {@link FacadeClassLoader} has to decide whether to build a Quarkus application for a class at the moment JUnit
+ * loads it, which is before JUnit applies those filters. Building an application for a class none of whose tests will
+ * run wastes time and, more importantly, starts Dev Services (and requires a container runtime) for nothing; see
+ * https://github.com/quarkusio/quarkus/issues/54435.
+ * <p>
+ * JUnit applies post-discovery filters to the leaves of the discovered tree (the individual tests), and prunes
+ * containers that end up empty. A leaf's tags are its own {@code @Tag}s plus those of the enclosing class(es). This
+ * evaluator does the same: it feeds each test method of the class (including inherited ones and those of
+ * {@code @Nested} classes) with its full tag set to the request's own filter objects. This deliberately does not
+ * reimplement any filter logic; and it errs on the side of caution, so whenever the answer is unclear the class is
+ * treated as one that will run and an application is built for it, exactly as before.
+ */
+final class PostDiscoveryFilterEvaluator {
+
+    private static final Logger log = Logger.getLogger(PostDiscoveryFilterEvaluator.class);
+
+    private static final String JUPITER_ENGINE_ID = "junit-jupiter";
+
+    // These are loaded with the same classloader as the classes being inspected, which may hold a different copy of
+    // JUnit than the one this class sees; hence they cannot be referenced statically
+    private final Class<? extends Annotation> tagAnnotation;
+    private final Method tagAnnotationValue;
+    private final Class<? extends Annotation> testableAnnotation;
+    private final Class<? extends Annotation> nestedAnnotation;
+
+    private volatile List<? extends PostDiscoveryFilter> filters = List.of();
+
+    @SuppressWarnings("unchecked")
+    PostDiscoveryFilterEvaluator(ClassLoader annotationLoader) throws ClassNotFoundException, NoSuchMethodException {
+        tagAnnotation = (Class<? extends Annotation>) annotationLoader.loadClass("org.junit.jupiter.api.Tag");
+        tagAnnotationValue = tagAnnotation.getMethod("value");
+        testableAnnotation = (Class<? extends Annotation>) annotationLoader
+                .loadClass("org.junit.platform.commons.annotation.Testable");
+        nestedAnnotation = (Class<? extends Annotation>) annotationLoader.loadClass("org.junit.jupiter.api.Nested");
+    }
+
+    void setFilters(List<? extends PostDiscoveryFilter> filters) {
+        this.filters = filters == null ? List.of() : List.copyOf(filters);
+    }
+
+    /**
+     * @return {@code true} only when it is certain that the post-discovery filters exclude every test JUnit could run
+     *         from {@code testClass}; {@code false} when any test may run, when no filters are set, or when the
+     *         evaluation cannot be completed
+     */
+    boolean excludesEveryTestIn(Class<?> testClass) {
+        List<? extends PostDiscoveryFilter> currentFilters = filters;
+        if (currentFilters.isEmpty()) {
+            return false;
+        }
+        try {
+            Filter<TestDescriptor> filter = Filter.composeFilters(currentFilters);
+            return excludesEveryTestIn(testClass, enclosingTags(testClass), uniqueIdOf(testClass), filter);
+        } catch (Exception | LinkageError e) {
+            log.debugf(e, "Could not evaluate the JUnit post-discovery filters for %s, assuming its tests will run",
+                    testClass.getName());
+            return false;
+        }
+    }
+
+    private boolean excludesEveryTestIn(Class<?> clazz, Set<TestTag> inheritedTags, UniqueId classId,
+            Filter<TestDescriptor> filter) throws Exception {
+        Set<TestTag> classTags = union(inheritedTags, tagsOf(clazz));
+
+        // Every kind of Jupiter test method (@Test, @TestFactory, @TestTemplate, @RepeatedTest, @ParameterizedTest,
+        // ...) is meta-annotated with @Testable. Considering too many methods is harmless: it can only lead to keeping
+        // the application, never to dropping it.
+        for (Method method : AnnotationSupport.findAnnotatedMethods(clazz, testableAnnotation,
+                HierarchyTraversalMode.TOP_DOWN)) {
+            Set<TestTag> tags = union(classTags, tagsOf(method));
+            if (filter.apply(new LeafTestDescriptor(classId, clazz, method, tags)).included()) {
+                return false;
+            }
+        }
+        for (Class<?> nested : ReflectionSupport.findNestedClasses(clazz,
+                candidate -> AnnotationSupport.isAnnotated(candidate, nestedAnnotation))) {
+            if (!excludesEveryTestIn(nested, classTags, classId.append("nested-class", nested.getSimpleName()),
+                    filter)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * A {@code @Nested} class may be loaded on its own; its tests still carry the tags of the enclosing classes.
+     */
+    private Set<TestTag> enclosingTags(Class<?> clazz) throws Exception {
+        Set<TestTag> tags = new LinkedHashSet<>();
+        Class<?> enclosing = clazz;
+        while (AnnotationSupport.isAnnotated(enclosing, nestedAnnotation) && enclosing.getEnclosingClass() != null) {
+            enclosing = enclosing.getEnclosingClass();
+            tags.addAll(tagsOf(enclosing));
+        }
+        return tags;
+    }
+
+    private UniqueId uniqueIdOf(Class<?> clazz) {
+        if (AnnotationSupport.isAnnotated(clazz, nestedAnnotation) && clazz.getEnclosingClass() != null) {
+            return uniqueIdOf(clazz.getEnclosingClass()).append("nested-class", clazz.getSimpleName());
+        }
+        return UniqueId.forEngine(JUPITER_ENGINE_ID).append("class", clazz.getName());
+    }
+
+    // Same rules as JUnit: repeatable, meta-annotations and (for classes) inheritance are honoured, invalid tags ignored
+    private Set<TestTag> tagsOf(AnnotatedElement element) throws Exception {
+        Set<TestTag> tags = new LinkedHashSet<>();
+        for (Annotation tag : AnnotationSupport.findRepeatableAnnotations(element, tagAnnotation)) {
+            String value = (String) tagAnnotationValue.invoke(tag);
+            if (TestTag.isValid(value)) {
+                tags.add(TestTag.create(value));
+            }
+        }
+        return tags;
+    }
+
+    private static Set<TestTag> union(Set<TestTag> a, Set<TestTag> b) {
+        if (b.isEmpty()) {
+            return a;
+        }
+        Set<TestTag> union = new LinkedHashSet<>(a);
+        union.addAll(b);
+        return union;
+    }
+
+    /**
+     * Stands in for the test descriptor JUnit would create for a test method. Tag filters only look at the tags;
+     * the unique id and source are provided on a best-effort basis for filters that look at those.
+     */
+    private static final class LeafTestDescriptor implements TestDescriptor {
+
+        private final UniqueId uniqueId;
+        private final Method method;
+        private final MethodSource source;
+        private final Set<TestTag> tags;
+
+        LeafTestDescriptor(UniqueId classId, Class<?> clazz, Method method, Set<TestTag> tags) {
+            String parameterTypes = Arrays.stream(method.getParameterTypes()).map(Class::getName)
+                    .collect(Collectors.joining(", "));
+            this.uniqueId = classId.append("method", method.getName() + "(" + parameterTypes + ")");
+            this.method = method;
+            this.source = MethodSource.from(clazz, method);
+            this.tags = Collections.unmodifiableSet(tags);
+        }
+
+        @Override
+        public UniqueId getUniqueId() {
+            return uniqueId;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return method.getName() + "()";
+        }
+
+        @Override
+        public Set<TestTag> getTags() {
+            return tags;
+        }
+
+        @Override
+        public Optional<TestSource> getSource() {
+            return Optional.of(source);
+        }
+
+        @Override
+        public Optional<TestDescriptor> getParent() {
+            return Optional.empty();
+        }
+
+        @Override
+        public void setParent(TestDescriptor parent) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<? extends TestDescriptor> getChildren() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public void addChild(TestDescriptor descriptor) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeChild(TestDescriptor descriptor) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeFromHierarchy() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Type getType() {
+            return Type.TEST;
+        }
+
+        @Override
+        public Optional<? extends TestDescriptor> findByUniqueId(UniqueId uniqueId) {
+            return this.uniqueId.equals(uniqueId) ? Optional.of(this) : Optional.empty();
+        }
+    }
+}

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/CustomLauncherInterceptor.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/CustomLauncherInterceptor.java
@@ -97,6 +97,11 @@ public class CustomLauncherInterceptor
         if (!isProductionModeTests()) {
             initializeFacadeClassLoader();
             adjustContextClassLoader();
+            // Test classes get loaded (and Quarkus applications built for them) during discovery, before JUnit applies these filters;
+            // let the facade classloader know about them so it does not build applications for classes JUnit is going to drop anyway
+            if (facadeLoader != null) {
+                facadeLoader.setPostDiscoveryFilters(request.getPostDiscoveryFilters());
+            }
 
             // we need to ensure that the Fork-Join pool will use our thread factory, otherwise the TCCL
             // of the threads could be wrong


### PR DESCRIPTION
Fixes #54435

The `FacadeClassLoader` has to decide whether to build a Quarkus application for a test class at the moment JUnit loads it, which is before JUnit applies the post-discovery filters that surefire's `groups`/`excludedGroups` (and Gradle's `includeTags`/`excludeTags`, IDE tag expressions) turn into. So a `@QuarkusTest` class excluded through a tag still got an application built at class-load time: Dev Services were started and a container runtime was required for tests that never ran, and with no container runtime available the build failed outright (`DevServicesDatasourceProcessor` throws in TEST mode when Docker is missing) — which is what the reproducer in the issue does on 3.35.4 and on `main`.

The `LauncherDiscoveryRequest` is available in `CustomLauncherInterceptor#launcherDiscoveryStarted`, before any test class is loaded, so the interceptor now hands its post-discovery filters to the facade classloader. Alongside the existing `@Disabled`/`@DisabledOnOs` bypass, the classloader then skips creating an application for a class when *every* test JUnit could run from it is excluded by those filters. To stay honest to JUnit rather than replicate its logic, the check evaluates the request's own filter objects (`Filter.composeFilters`) against each candidate leaf — every `@Testable` method incl. inherited ones and those of `@Nested` classes, each with its full tag set (own `@Tag`s plus enclosing classes', collected with `AnnotationSupport.findRepeatableAnnotations`), which mirrors how JUnit applies post-discovery filters to leaves and prunes empty containers. Whenever the outcome is unclear (no filters, evaluation error, any leaf included) it builds the application exactly as before, so a wrong answer can only ever mean "still slow", never "test not run as a Quarkus test".

Verified with the reporter's reproducer on `999-SNAPSHOT` with `DOCKER_HOST` pointing at a non-existent socket: `mvn package` with `excludedGroups=io.quarkus.test.junit.QuarkusTest` now succeeds with no Testcontainers activity at all. The new `QuarkusTestIT` case uses a project whose application deliberately fails augmentation (unsatisfied injection point), so it needs no Docker: excluding the class tag or including only the plain JUnit test passes, and a partial exclusion (one method still to run) fails on the augmentation error as a control. `spring-cloud-config-client`, which runs real `@QuarkusTest`s under `groups`, still passes.

Gradle loads test classes before the discovery phase starts (see the comment in `launcherSessionOpened`), so it does not benefit from this yet; it simply keeps the current behaviour.

cc @holly-cummins
