### PR TITLE
[3.38] Revert "Bump org.bouncycastle:bc-jdk18on-bom from 1.84 to 1.85"

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <angus-activation.version>2.0.3</angus-activation.version>
         <angus-mail.version>2.0.5</angus-mail.version> <!-- keep in sync with angus-activation (mail depends on activation) -->
-        <bouncycastle.version>1.85</bouncycastle.version>
+        <bouncycastle.version>1.84</bouncycastle.version>
         <bouncycastle.fips.version>2.1.3</bouncycastle.fips.version>
         <bouncycastle.tls.fips.version>2.1.24</bouncycastle.tls.fips.version>
         <cyclonedx.version>12.2.0</cyclonedx.version>


### PR DESCRIPTION
This reverts commit b49c2385cf3e3ce609db7d48d12bb5189ca60ee1.

I think it's causing the failures we are seeing here: https://github.com/quarkusio/quarkus-platform/pull/2125 . It was my mistake trying to upgrade to a new minor, I didn't know things were so sensitive.
