### PR TITLE
Support `org.jboss.resteasy.reactive.Separator` for REST Client query parameters

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -149,11 +149,13 @@ package org.acme.rest.client;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.jboss.resteasy.reactive.RestQuery;
+import org.jboss.resteasy.reactive.Separator;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MultivaluedMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Optional;
@@ -177,11 +179,15 @@ public interface ExtensionsService {
     @GET
     Set<Extension> getByFilters(@RestQuery MultivaluedMap<String, String> filters); <3>
 
+    @GET
+    Set<Extension> getByNamesDefiningSeparator(@Separator(",") @RestQuery List<String> names); <4>
+
 }
 ----
 <1> @RestQuery will include parameter with key `name`
 <2> Each `Map` entry represents exactly one query parameter
 <3> `MultivaluedMap` allows you to send array values
+<4> @Separator lets you specify a custom delimiter between the values of a collection-valued parameter
 
 ==== Using @ClientQueryParam
 

--- a/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -1121,7 +1121,8 @@ public class JaxrsClientReactiveProcessor {
                                             methodCreator.getMethodParam(paramIdx),
                                             jandexMethod.parameterType(paramIdx), index, methodCreator.getThis(),
                                             getGenericTypeFromArray(methodCreator, methodGenericParametersField, paramIdx),
-                                            getAnnotationsFromArray(methodCreator, methodParamAnnotationsField, paramIdx)));
+                                            getAnnotationsFromArray(methodCreator, methodParamAnnotationsField, paramIdx),
+                                            param.separator));
                         } else if (param.parameterType == ParameterType.MATRIX) {
                             // matrix params have to be set on a method-level web target (they vary between invocations)
                             methodCreator.assign(methodTarget,
@@ -1785,7 +1786,8 @@ public class JaxrsClientReactiveProcessor {
                                             getGenericTypeFromArray(subMethodCreator, subParamField.genericsParametersField,
                                                     subParamField.paramIndex),
                                             getAnnotationsFromArray(subMethodCreator, subParamField.paramAnnotationsField,
-                                                    subParamField.paramIndex)));
+                                                    subParamField.paramIndex),
+                                            param.separator));
                         } else if (param.parameterType == ParameterType.MATRIX) {
                             // matrix params have to be set on a method-level web target (they vary between invocations)
                             subMethodCreator.assign(methodTarget,
@@ -1943,7 +1945,8 @@ public class JaxrsClientReactiveProcessor {
                                             getGenericTypeFromArray(subMethodCreator, subMethodGenericParametersField,
                                                     paramIdx),
                                             getAnnotationsFromArray(subMethodCreator, subMethodParamAnnotationsField,
-                                                    paramIdx)));
+                                                    paramIdx),
+                                            param.separator));
                         } else if (param.parameterType == ParameterType.MATRIX) {
                             // matrix params have to be set on a method-level web target (they vary between invocations)
                             subMethodCreator.assign(methodTarget,
@@ -3068,7 +3071,7 @@ public class JaxrsClientReactiveProcessor {
                                     queryParam.getValueType(),
                                     index, client,
                                     getGenericTypeFromParameter(creator, beanParamDescriptorField, item.fieldName()),
-                                    getAnnotationsFromParameter(creator, beanParamDescriptorField, item.fieldName())));
+                                    getAnnotationsFromParameter(creator, beanParamDescriptorField, item.fieldName()), null));
                     break;
                 case MATRIX_PARAM:
                     MatrixParamItem matrixParam = (MatrixParamItem) item;
@@ -3208,9 +3211,10 @@ public class JaxrsClientReactiveProcessor {
             // this client or containing client if we're in a subresource
             ResultHandle client,
             ResultHandle genericType,
-            ResultHandle paramAnnotations) {
+            ResultHandle paramAnnotations,
+            String separator) {
         return addWebTargetParam(jandexMethod, methodCreator, webTarget, paramName, queryParamHandle, type, index, client,
-                genericType, paramAnnotations, "queryParam");
+                genericType, paramAnnotations, "queryParam", separator);
     }
 
     // takes a result handle to target as one of the parameters, returns a result handle to a modified target
@@ -3225,7 +3229,7 @@ public class JaxrsClientReactiveProcessor {
             ResultHandle genericType,
             ResultHandle paramAnnotations) {
         return addWebTargetParam(jandexMethod, methodCreator, webTarget, paramName, matrixParamHandle, type, index, client,
-                genericType, paramAnnotations, "matrixParam");
+                genericType, paramAnnotations, "matrixParam", null);
     }
 
     // takes a result handle to target as one of the parameters, returns a result handle to a modified target
@@ -3239,7 +3243,8 @@ public class JaxrsClientReactiveProcessor {
             ResultHandle client,
             ResultHandle genericType,
             ResultHandle paramAnnotations,
-            String webTargetParamMethod) {
+            String webTargetParamMethod,
+            String separator) {
 
         AssignableResultHandle result = methodCreator.createVariable(WebTarget.class);
         BranchResult isParamNull = methodCreator.ifNull(paramHandle);
@@ -3286,7 +3291,7 @@ public class JaxrsClientReactiveProcessor {
             }
             // get the new WebTarget
             addWebTargetParamToWebTarget(loopCreator, key, result, client, genericType, paramAnnotations,
-                    paramArray, componentType, result, webTargetParamMethod);
+                    paramArray, componentType, result, webTargetParamMethod, separator);
         } else {
             ResultHandle paramArray;
             String componentType = null;
@@ -3378,7 +3383,7 @@ public class JaxrsClientReactiveProcessor {
             }
 
             addWebTargetParamToWebTarget(notNullParam, notNullParam.load(paramName), webTarget, client, genericType,
-                    paramAnnotations, paramArray, componentType, result, webTargetParamMethod);
+                    paramAnnotations, paramArray, componentType, result, webTargetParamMethod, separator);
         }
 
         isParamNull.trueBranch().assign(result, webTarget);
@@ -3420,11 +3425,13 @@ public class JaxrsClientReactiveProcessor {
             ResultHandle paramAnnotations, ResultHandle paramArray,
             String componentType,
             AssignableResultHandle resultVariable,
-            String webTargetParamMethod) {
+            String webTargetParamMethod,
+            String separator) {
         ResultHandle convertedParamArray = creator.invokeVirtualMethod(
                 MethodDescriptor.ofMethod(RestClientBase.class, "convertParamArray", Object[].class, Object[].class,
-                        Class.class, java.lang.reflect.Type.class, Annotation[].class),
-                client, paramArray, creator.loadClassFromTCCL(componentType), genericType, paramAnnotations);
+                        Class.class, java.lang.reflect.Type.class, Annotation[].class, String.class),
+                client, paramArray, creator.loadClassFromTCCL(componentType), genericType, paramAnnotations,
+                separator == null ? creator.loadNull() : creator.load(separator));
 
         creator.assign(resultVariable, creator.invokeInterfaceMethod(
                 MethodDescriptor.ofMethod(WebTarget.class, webTargetParamMethod, WebTarget.class,
@@ -3574,9 +3581,9 @@ public class JaxrsClientReactiveProcessor {
                         formParamHandle);
                 ResultHandle convertedParamArray = creator.invokeVirtualMethod(
                         MethodDescriptor.ofMethod(RestClientBase.class, "convertParamArray", Object[].class, Object[].class,
-                                Class.class, java.lang.reflect.Type.class, Annotation[].class),
+                                Class.class, java.lang.reflect.Type.class, Annotation[].class, String.class),
                         client, paramArray, creator.loadClassFromTCCL(componentType), genericType,
-                        creator.newArray(Annotation.class, 0));
+                        creator.newArray(Annotation.class, 0), creator.loadNull());
                 creator.invokeInterfaceMethod(MULTIVALUED_MAP_ADD_ALL, formParams,
                         creator.load(paramName), convertedParamArray);
             } else if (isMap(parameterType, index)) {
@@ -3620,9 +3627,9 @@ public class JaxrsClientReactiveProcessor {
                 }
                 ResultHandle convertedParamArray = loopCreator.invokeVirtualMethod(
                         MethodDescriptor.ofMethod(RestClientBase.class, "convertParamArray", Object[].class, Object[].class,
-                                Class.class, java.lang.reflect.Type.class, Annotation[].class),
+                                Class.class, java.lang.reflect.Type.class, Annotation[].class, String.class),
                         client, paramArray, loopCreator.loadClassFromTCCL(componentType), genericType,
-                        loopCreator.newArray(Annotation.class, 0));
+                        loopCreator.newArray(Annotation.class, 0), loopCreator.loadNull());
                 loopCreator.invokeInterfaceMethod(MULTIVALUED_MAP_ADD_ALL, formParams,
                         key, convertedParamArray);
             } else {

--- a/extensions/resteasy-reactive/rest-client-jaxrs/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/RestClientBase.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/RestClientBase.java
@@ -5,6 +5,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
+import java.util.StringJoiner;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -121,19 +122,31 @@ public abstract class RestClientBase implements Closeable {
     }
 
     @SuppressWarnings("unused") // used by generated code
-    public <T> Object[] convertParamArray(T[] value, Class<T> type, Type genericType, Annotation[] annotations) {
+    public <T> Object[] convertParamArray(T[] values, Class<T> type, Type genericType, Annotation[] annotations,
+            String separator) {
         ParamConverter<T> converter = getConverter(type, genericType, annotations);
 
-        if (converter == null) {
-            return value;
-        } else {
-            Object[] result = new Object[value.length];
+        Object[] resultArray;
 
-            for (int i = 0; i < value.length; i++) {
-                result[i] = converter.toString(value[i]);
+        if (converter == null) {
+            resultArray = values;
+        } else {
+            resultArray = new Object[values.length];
+            for (int i = 0; i < values.length; i++) {
+                resultArray[i] = converter.toString(values[i]);
             }
-            return result;
         }
+
+        if (separator == null || separator.isEmpty() || resultArray.length < 2)
+            return resultArray;
+
+        StringJoiner sj = new StringJoiner(separator);
+
+        for (Object result : resultArray) {
+            sj.add(result.toString());
+        }
+
+        return new Object[] { sj.toString() };
     }
 
     @SuppressWarnings("unused") // used by generated code

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/queries/SeparatorQueryParamTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/queries/SeparatorQueryParamTest.java
@@ -1,0 +1,143 @@
+package io.quarkus.rest.client.reactive.queries;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.ext.ParamConverter;
+import jakarta.ws.rs.ext.ParamConverterProvider;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.jboss.resteasy.reactive.RestQuery;
+import org.jboss.resteasy.reactive.Separator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class SeparatorQueryParamTest {
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClasses(SeparatorQueryParamTest.Resource.class));
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @Test
+    void shouldJoinOnlyForMultipleSizedRestQuery() {
+        Client client = createClient();
+        assertThat(client.restQuery(List.of())).isEqualTo("none");
+        assertThat(client.restQuery(List.of("QUARKUS"))).isEqualTo("frameworks=QUARKUS");
+        //%2C - comma
+        assertThat(client.restQuery(List.of("QUARKUS", "HELIDON"))).isEqualTo("frameworks=QUARKUS%2CHELIDON");
+    }
+
+    @Test
+    void shouldWorkForQueryParamSame() {
+        Client client = createClient();
+        //%2C - comma
+        assertThat(client.queryParam(List.of("QUARKUS", "HELIDON"))).isEqualTo("frameworks=QUARKUS%2CHELIDON");
+    }
+
+    @Test
+    void shouldConvertParamBeforeDoingJoin() {
+        Client client = createClient();
+        assertThat(client.queryParamConvertible(
+                List.of(JavaFramework.QUARKUS, JavaFramework.SPRING, JavaFramework.HELIDON, JavaFramework.JAVALIN)))
+                .isEqualTo("frameworks=QUARKUS%2CSPRING%2CHELIDON%2CJAVALIN");
+    }
+
+    /*
+     * MultiQueryParamMode.MULTI_PAIRS is default, so we should get &javaVersions=21&javaVersions=25 for second parameter
+     */
+    @Test
+    void shouldApplyOnlyForAnnotated() {
+        Client client = createClient();
+        assertThat(client.mixed(
+                List.of(JavaFramework.QUARKUS, JavaFramework.SPRING, JavaFramework.HELIDON, JavaFramework.JAVALIN),
+                List.of("21", "25")))
+                .isEqualTo("frameworks=QUARKUS%2CSPRING%2CHELIDON%2CJAVALIN&javaVersions=21&javaVersions=25");
+    }
+
+    enum JavaFramework {
+        QUARKUS,
+        SPRING,
+        JAVALIN,
+        HELIDON
+    }
+
+    public static class JavaFrameworkParamConverter implements ParamConverter<SeparatorQueryParamTest.JavaFramework> {
+
+        @Override
+        public SeparatorQueryParamTest.JavaFramework fromString(String value) {
+            return Enum.valueOf(SeparatorQueryParamTest.JavaFramework.class, value);
+        }
+
+        @Override
+        public String toString(SeparatorQueryParamTest.JavaFramework jf) {
+            return jf != null ? jf.toString() : null;
+        }
+
+    }
+
+    public static class JavaFrameworkConverterProvider implements ParamConverterProvider {
+
+        @Override
+        public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
+            if (SeparatorQueryParamTest.JavaFramework.class.isAssignableFrom(rawType)) {
+                return (ParamConverter<T>) new SeparatorQueryParamTest.JavaFrameworkParamConverter();
+            }
+
+            return null;
+        }
+    }
+
+    @RegisterProvider(JavaFrameworkConverterProvider.class)
+    public interface Client {
+        @GET
+        @Path("/separator/query")
+        String restQuery(@RestQuery @Separator(",") List<String> frameworks);
+
+        @GET
+        @Path("/separator/query")
+        String queryParam(@QueryParam("frameworks") @Separator(",") List<String> frameworks);
+
+        @GET
+        @Path("/separator/query")
+        String queryParamConvertible(@RestQuery("frameworks") @Separator(",") List<JavaFramework> frameworks);
+
+        @GET
+        @Path("/separator/query")
+        String mixed(@RestQuery @Separator(",") List<JavaFramework> frameworks, @RestQuery List<String> javaVersions);
+    }
+
+    Client createClient() {
+        return RestClientBuilder.newBuilder().baseUri(baseUri).build(Client.class);
+    }
+
+    @Path("/separator")
+    @ApplicationScoped
+    public static class Resource {
+
+        @GET
+        @Path("/query")
+        public String query(@Context UriInfo info) {
+            if (info.getQueryParameters().isEmpty())
+                return "none";
+
+            return info.getRequestUri().getRawQuery();
+        }
+    }
+
+}

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/scanning/ClientEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/scanning/ClientEndpointIndexer.java
@@ -162,11 +162,12 @@ public class ClientEndpointIndexer
         DeclaredTypes declaredTypes = getDeclaredTypes(paramType, currentClassInfo, actualEndpointInfo);
         String mimePart = getPartMime(parameterResult.getAnns());
         String partFileName = getPartFileName(parameterResult.getAnns());
+        String separator = getSeparator(parameterResult.getAnns());
         return new MethodParameter(name,
                 elementType, declaredTypes.getDeclaredType(), declaredTypes.getDeclaredUnresolvedType(), signature, type,
                 single,
                 defaultValue, parameterResult.isObtainedAsCollection(), parameterResult.isOptional(), encoded,
-                mimePart, partFileName, null);
+                mimePart, partFileName, separator);
     }
 
     private String getPartFileName(Map<DotName, AnnotationInstance> annotations) {


### PR DESCRIPTION
Implementation Details:

The separator is extracted in `ClientEndpointIndexer#createMethodParameter` and stored in the corresponding `MethodParameter`.
`JaxrsClientReactiveProcessor` then propagates it through the existing parameter-processing chain:
`addQueryParam`
  → `addWebTargetParam`
  → `addWebTargetParamToWebTarget`
Finally, `RestClientBase#convertParamArray` converts each parameter value and, when a separator is specified, joins the converted values before passing them to `WebTarget#queryParam`.
This keeps the behavior scoped to the individual query parameter, avoids introducing mutable separator state in `UriBuilderImpl`, and does not require any changes to the **Jakarta REST API**. It also ensures that values are joined after applying any registered ParamConverter.
