### PR TITLE
[3.x] Allow excluding a class from the reflection-free Jackson optimization

### DIFF
--- a/docs/src/main/asciidoc/rest.adoc
+++ b/docs/src/main/asciidoc/rest.adoc
@@ -1762,6 +1762,26 @@ Developers can further customize JSON processing by implementing the `ObjectMapp
 Reflection-free serializers are not compatible with Kotlin classes, since they break Kotlin-specific features such as default parameter values and non-null type enforcement. As a result, reflection-free serializers are not generated for Kotlin classes.
 ====
 
+To exclude a single class from this optimization, annotate it with `@io.quarkus.resteasy.reactive.jackson.DisableReflectionFreeSerialization`:
+
+[source,java]
+----
+@DisableReflectionFreeSerialization
+public class Person {
+    // ...
+}
+----
+
+No serializer and no deserializer is generated for the annotated class, so Jackson falls back to its standard reflection-based processing for it, while every other class of the application keeps using its generated serializer and deserializer.
+This includes the classes that reference the annotated class in one of their fields: they are still optimized, and only the annotated field value is processed by Jackson itself.
+
+Use this annotation when a class relies on a Jackson feature that the generated serializers do not reproduce faithfully, so that you can keep the optimization enabled for the rest of the application instead of turning it off altogether.
+
+[NOTE]
+====
+The annotation is not inherited: annotating a class does not exclude its subclasses.
+====
+
 ===== Completely customized per method serialization/deserialization
 
 There are times when you need to completely customize the serialization/deserialization of a POJO on a per Jakarta REST method basis or on a per Jakarta REST resource basis. For such use cases, you can use the `@io.quarkus.resteasy.reactive.jackson.CustomSerialization` and `@io.quarkus.resteasy.reactive.jackson.CustomDeserialization` annotations in the REST method or in the REST resource at class level. These annotations allow you to fully configure the `com.fasterxml.jackson.databind.ObjectWriter`/`com.fasterxml.jackson.databind.ObjectReader`.

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -69,6 +69,7 @@ import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.resteasy.reactive.jackson.DisableReflectionFreeSerialization;
 import io.quarkus.resteasy.reactive.jackson.SecureField;
 
 public abstract class JacksonCodeGenerator {
@@ -77,6 +78,8 @@ public abstract class JacksonCodeGenerator {
 
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
     private static final DotName KOTLIN_METADATA = DotName.createSimple("kotlin.Metadata");
+    private static final DotName DISABLE_REFLECTION_FREE_SERIALIZATION = DotName
+            .createSimple(DisableReflectionFreeSerialization.class);
 
     private static final Set<String> UNSUPPORTED_JAKARTA_PERSISTENCE_ANNOTATIONS = Set.of(
             "jakarta.persistence.Transient",
@@ -154,6 +157,12 @@ public abstract class JacksonCodeGenerator {
     private Optional<String> create(ClassInfo classInfo) {
         String beanClassName = classInfo.name().toString();
         if (vetoedClass(classInfo, beanClassName) || !generatedClassNames.add(beanClassName)) {
+            return Optional.empty();
+        }
+        if (classInfo.hasDeclaredAnnotation(DISABLE_REFLECTION_FREE_SERIALIZATION)) {
+            log.debugf("Skipping generation of reflection-free Jackson serializer for class %s" +
+                    " because it is annotated with @%s", beanClassName,
+                    DisableReflectionFreeSerialization.class.getSimpleName());
             return Optional.empty();
         }
         Optional<String> unknownAnnotation = findUnknownAnnotation(classInfo);

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/DisableReflectionFreeSerializationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/DisableReflectionFreeSerializationTest.java
@@ -1,0 +1,239 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.quarkus.resteasy.reactive.jackson.DisableReflectionFreeSerialization;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Verifies that {@link DisableReflectionFreeSerialization} excludes a single class from the reflection-free
+ * optimization, while the other classes of the same application keep using their generated serializers and
+ * deserializers.
+ * <p>
+ * Each DTO captures the stack trace of the thread that is (de)serializing it, which tells the two code paths apart: the
+ * generated classes are named after the DTO plus a {@code $quarkusjackson(de)serializer} suffix, whereas Jackson's
+ * reflection-based path goes through its own {@code Bean(De)Serializer}.
+ */
+public class DisableReflectionFreeSerializationTest {
+
+    private static final String GENERATED_SERIALIZER = "$quarkusjacksonserializer";
+    private static final String GENERATED_DESERIALIZER = "$quarkusjacksondeserializer";
+    private static final String REFLECTION_BASED_SERIALIZER = "BeanSerializer";
+    private static final String REFLECTION_BASED_DESERIALIZER = "BeanDeserializer";
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(TestResource.class, OptimizedDto.class, ExcludedDto.class)
+                            .addAsResource(new StringAsset(
+                                    "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true\n"),
+                                    "application.properties");
+                }
+            });
+
+    @Test
+    public void testOptimizedClassIsSerializedByGeneratedSerializer() {
+        assertThat(serializationStackTraceOf("/test/optimized"))
+                .anyMatch(frame -> frame.contains(GENERATED_SERIALIZER))
+                .noneMatch(frame -> frame.contains(REFLECTION_BASED_SERIALIZER));
+    }
+
+    @Test
+    public void testExcludedClassIsSerializedByJackson() {
+        assertThat(serializationStackTraceOf("/test/excluded"))
+                .anyMatch(frame -> frame.contains(REFLECTION_BASED_SERIALIZER))
+                .noneMatch(frame -> frame.contains(GENERATED_SERIALIZER));
+    }
+
+    @Test
+    public void testOptimizedClassIsDeserializedByGeneratedDeserializer() {
+        assertThat(deserializationStackTraceOf("/test/optimized"))
+                .anyMatch(frame -> frame.contains(GENERATED_DESERIALIZER))
+                .noneMatch(frame -> frame.contains(REFLECTION_BASED_DESERIALIZER));
+    }
+
+    @Test
+    public void testExcludedClassIsDeserializedByJackson() {
+        assertThat(deserializationStackTraceOf("/test/excluded"))
+                .anyMatch(frame -> frame.contains(REFLECTION_BASED_DESERIALIZER))
+                .noneMatch(frame -> frame.contains(GENERATED_DESERIALIZER));
+    }
+
+    @Test
+    public void testExcludedClassIsStillProcessedCorrectly() {
+        given()
+                .accept(MediaType.APPLICATION_JSON)
+                .get("/test/excluded")
+                .then()
+                .statusCode(200)
+                .body("name", Matchers.is("excluded"));
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"name\":\"hello\"}")
+                .post("/test/excluded/name")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("hello"));
+    }
+
+    private static List<String> serializationStackTraceOf(String path) {
+        return given()
+                .accept(MediaType.APPLICATION_JSON)
+                .get(path)
+                .then()
+                .statusCode(200)
+                .extract().body().jsonPath().getList("stackTrace", String.class);
+    }
+
+    private static List<String> deserializationStackTraceOf(String path) {
+        String[] frames = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"name\":\"hello\"}")
+                .post(path)
+                .then()
+                .statusCode(200)
+                .extract().body().as(String[].class);
+        return Arrays.asList(frames);
+    }
+
+    private static List<String> captureStackTrace() {
+        return StackWalker.getInstance()
+                .walk(frames -> frames.limit(30)
+                        .map(frame -> frame.getClassName() + "." + frame.getMethodName())
+                        .collect(Collectors.toList()));
+    }
+
+    @Path("/test")
+    public static class TestResource {
+
+        @GET
+        @Path("/optimized")
+        @Produces(MediaType.APPLICATION_JSON)
+        public OptimizedDto getOptimized() {
+            return new OptimizedDto("optimized");
+        }
+
+        @GET
+        @Path("/excluded")
+        @Produces(MediaType.APPLICATION_JSON)
+        public ExcludedDto getExcluded() {
+            return new ExcludedDto("excluded");
+        }
+
+        @POST
+        @Path("/optimized")
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        public List<String> postOptimized(OptimizedDto dto) {
+            return dto.deserializationTrace();
+        }
+
+        @POST
+        @Path("/excluded")
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        public List<String> postExcluded(ExcludedDto dto) {
+            return dto.deserializationTrace();
+        }
+
+        @POST
+        @Path("/excluded/name")
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.TEXT_PLAIN)
+        public String postExcludedName(ExcludedDto dto) {
+            return dto.getName();
+        }
+    }
+
+    public static class OptimizedDto {
+
+        private final AtomicReference<List<String>> stacktrace = new AtomicReference<>();
+        private List<String> deserializationTrace;
+        private String name;
+
+        public OptimizedDto() {
+        }
+
+        public OptimizedDto(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+            this.deserializationTrace = captureStackTrace();
+        }
+
+        @JsonProperty
+        public List<String> getStackTrace() {
+            return stacktrace.updateAndGet(current -> current != null ? current : captureStackTrace());
+        }
+
+        List<String> deserializationTrace() {
+            return deserializationTrace;
+        }
+    }
+
+    @DisableReflectionFreeSerialization
+    public static class ExcludedDto {
+
+        private final AtomicReference<List<String>> stacktrace = new AtomicReference<>();
+        private List<String> deserializationTrace;
+        private String name;
+
+        public ExcludedDto() {
+        }
+
+        public ExcludedDto(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+            this.deserializationTrace = captureStackTrace();
+        }
+
+        @JsonProperty
+        public List<String> getStackTrace() {
+            return stacktrace.updateAndGet(current -> current != null ? current : captureStackTrace());
+        }
+
+        List<String> deserializationTrace() {
+            return deserializationTrace;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/DisableReflectionFreeSerialization.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/DisableReflectionFreeSerialization.java
@@ -1,0 +1,24 @@
+package io.quarkus.resteasy.reactive.jackson;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Excludes the annotated class from the reflection-free Jackson optimization enabled by the
+ * {@code quarkus.rest.jackson.optimization.enable-reflection-free-serializers} configuration property.
+ * <p>
+ * No serializer and no deserializer are generated at build time for the annotated class, so Jackson falls back to its
+ * standard reflection-based serialization and deserialization for it. All other classes keep using their generated
+ * serializers and deserializers, including the ones that reference the annotated class in one of their fields.
+ * <p>
+ * This is useful when a class relies on a Jackson feature that the generated serializers do not reproduce faithfully,
+ * and lets an application opt that single class out instead of turning off the optimization altogether.
+ * <p>
+ * The annotation is not inherited: annotating a class does not exclude its subclasses.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface DisableReflectionFreeSerialization {
+}


### PR DESCRIPTION
The reflection-free Jackson optimization is an all-or-nothing switch today: if a single class in an application relies on a Jackson feature that the generated serializers do not reproduce faithfully, the only remedy is to turn `quarkus.rest.jackson.optimization.enable-reflection-free-serializers` off and lose the optimization everywhere.

This adds `@DisableReflectionFreeSerialization`, a class-level annotation that opts a single class out. No serializer and no deserializer is generated for the annotated class, so Jackson falls back to its standard reflection-based processing for it, while the rest of the application keeps its generated ones (including classes that reference the annotated class in a field, since nested values are already resolved through the SerializerProvider and DeserializationContext at runtime).

The annotation is a marker with no members, and it is not inherited: annotating a class does not exclude its subclasses.