### PR TITLE
Manage jsoup version in the bom

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -223,6 +223,7 @@
         <!-- Dev UI -->
         <importmap.version>2.0.0</importmap.version>
         <webauthn4j.version>0.30.3.RELEASE</webauthn4j.version>
+        <jsoup.version>1.23.1</jsoup.version>
     </properties>
 
     <pluginRepositories>
@@ -6706,6 +6707,11 @@
                 <groupId>org.aesh</groupId>
                 <artifactId>terminal-ssh</artifactId>
                 <version>${aesh-readline.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jsoup</groupId>
+                <artifactId>jsoup</artifactId>
+                <version>${jsoup.version}</version>
             </dependency>
 
             <!-- Apache SSHD Netty transport (sshd-core and sshd-common already managed) -->


### PR DESCRIPTION
This is used by several camel extensions and langchain4j extensions.
Also resolves https://nvd.nist.gov/vuln/detail/cve-2026-71497