### PR TITLE
Do not generate reflection-free Jackson (de)serializers for Map and Collection subtypes

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -367,7 +367,23 @@ public abstract class JacksonCodeGenerator {
     }
 
     protected boolean shouldGenerateCodeFor(ClassInfo classInfo) {
-        return !classInfo.isEnum() && !classInfo.hasDeclaredAnnotation(KOTLIN_METADATA);
+        return !classInfo.isEnum() && !classInfo.hasDeclaredAnnotation(KOTLIN_METADATA)
+                && !isMapOrCollectionSubtype(classInfo);
+    }
+
+    /**
+     * Jackson (de)serializes a Map or Collection subtype through its container shape and ignores any
+     * bean properties the class declares, so the bean-style (de)serializers generated here would change
+     * semantics and silently drop the container content. Leave those classes to Jackson.
+     */
+    private boolean isMapOrCollectionSubtype(ClassInfo classInfo) {
+        String typeName = classInfo.name().toString();
+        if (isAssignableTo(typeName, MAP_NAME) || isAssignableTo(typeName, COLLECTION_NAME)) {
+            log.debugf("Skipping serializer generation for class '%s' because it is a Map or Collection subtype",
+                    typeName);
+            return true;
+        }
+        return false;
     }
 
     protected static boolean isClassFormatShapeArray(ClassInfo classInfo) {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
@@ -1452,6 +1452,36 @@ public abstract class AbstractSimpleJsonTest {
     }
 
     @Test
+    void testMapSubclassWithProperty() {
+        // Jackson (de)serializes a Map subclass through its map shape, ignoring bean properties, so the
+        // generated (de)serializers must not handle it: they would bind only the bean properties and
+        // silently drop every map entry
+        RestAssured
+                .with()
+                .body("{\"declared\":\"d\",\"extra\":1}")
+                .contentType("application/json")
+                .post("/simple/map-subclass-with-property")
+                .then()
+                .statusCode(200)
+                .body("declared", CoreMatchers.is("d"))
+                .body("extra", CoreMatchers.is(1));
+    }
+
+    @Test
+    void testCollectionSubclassWithProperty() {
+        // Jackson (de)serializes a Collection subclass through its array shape, ignoring bean
+        // properties, so the generated (de)serializers must not handle it either
+        RestAssured
+                .with()
+                .body("[\"one\",\"two\"]")
+                .contentType("application/json")
+                .post("/simple/collection-subclass-with-property")
+                .then()
+                .statusCode(200)
+                .body(CoreMatchers.equalTo("[\"one\",\"two\"]"));
+    }
+
+    @Test
     void testJsonCreatorWithPolymorphicProperty() {
         // A @JsonCreator parameter with a polymorphic (@JsonTypeInfo) type cannot be handled by the
         // generated reflection-free deserializer and must fall back to the reflection-based one

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/CollectionSubclassWithProperty.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/CollectionSubclassWithProperty.java
@@ -1,0 +1,20 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import java.util.ArrayList;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CollectionSubclassWithProperty extends ArrayList<String> {
+
+    private String declared;
+
+    @JsonProperty("declared")
+    public String getDeclared() {
+        return declared;
+    }
+
+    @JsonProperty("declared")
+    public void setDeclared(String declared) {
+        this.declared = declared;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/MapSubclassWithProperty.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/MapSubclassWithProperty.java
@@ -1,0 +1,20 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import java.util.HashMap;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MapSubclassWithProperty extends HashMap<String, Object> {
+
+    private String declared;
+
+    @JsonProperty("declared")
+    public String getDeclared() {
+        return declared;
+    }
+
+    @JsonProperty("declared")
+    public void setDeclared(String declared) {
+        this.declared = declared;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
@@ -807,6 +807,22 @@ public class SimpleJsonResource extends SuperClass<Person> {
     }
 
     @POST
+    @Path("/collection-subclass-with-property")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public CollectionSubclassWithProperty echoCollectionSubclassWithProperty(CollectionSubclassWithProperty obj) {
+        return obj;
+    }
+
+    @POST
+    @Path("/map-subclass-with-property")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public MapSubclassWithProperty echoMapSubclassWithProperty(MapSubclassWithProperty obj) {
+        return obj;
+    }
+
+    @POST
     @Path("/polymorphic-creator-property")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
@@ -42,7 +42,9 @@ public class SimpleJsonTest extends AbstractSimpleJsonTest {
                                     PolymorphicItemResponse.class, PolymorphicItem.class,
                                     SensorMetadata.class, SensorMetadata.ComponentMetadata.class, SensorUnit.class,
                                     FinalCollectionHolder.class, RequiredCreatorProperty.class,
-                                    PolymorphicCreatorProperty.class, NoArgConstructorPojo.class,
+                                    PolymorphicCreatorProperty.class, MapSubclassWithProperty.class,
+                                    CollectionSubclassWithProperty.class,
+                                    NoArgConstructorPojo.class,
                                     MultiConstructorPojo.class, NoMatchingCtorPojo.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
@@ -45,7 +45,9 @@ public class SimpleJsonWithReflectionFreeSerializersTest extends AbstractSimpleJ
                                     PolymorphicItemResponse.class, PolymorphicItem.class,
                                     SensorMetadata.class, SensorMetadata.ComponentMetadata.class, SensorUnit.class,
                                     FinalCollectionHolder.class, RequiredCreatorProperty.class,
-                                    PolymorphicCreatorProperty.class, NoArgConstructorPojo.class,
+                                    PolymorphicCreatorProperty.class, MapSubclassWithProperty.class,
+                                    CollectionSubclassWithProperty.class,
+                                    NoArgConstructorPojo.class,
                                     MultiConstructorPojo.class, NoMatchingCtorPojo.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +


### PR DESCRIPTION
Fixes #56064

Jackson (de)serializes a class assignable to `Map` or `Collection` through its container shape and ignores any bean properties the class declares. The generated bean-style (de)serializers did the opposite.

The fix opts out of generation for those classes in `JacksonCodeGenerator.shouldGenerateCodeFor`, using the existing `isAssignableTo` walker (the factories run on the computing index, so JDK supertypes like `java.util.HashMap` resolve), and leaves them to Jackson's own container (de)serializers. Falling back is the same treatment already given to enums, Kotlin classes, and classes with unsupported annotations.