### PR TITLE
Bump smallrye-certificate-generator to 1.1.2

### DIFF
--- a/extensions/tls-registry/cli/src/test/java/io/quarkus/tls/cli/CaGenerationTest.java
+++ b/extensions/tls-registry/cli/src/test/java/io/quarkus/tls/cli/CaGenerationTest.java
@@ -8,19 +8,13 @@ import java.security.cert.X509Certificate;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.smallrye.certs.ca.CaGenerator;
 
 public class CaGenerationTest {
 
-    // Disabled on Windows: CaGenerator does not close the keystore output stream
-    // (https://github.com/smallrye/smallrye-certificate-generator/issues/92), which keeps the .p12 file
-    // locked so @TempDir cleanup fails there. Revert this annotation once that issue is fixed.
     @Test
-    @DisabledOnOs(OS.WINDOWS)
     public void testCaGeneration(@TempDir Path tempDir) throws Exception {
         File caFile = tempDir.resolve("quarkus-dev-root-ca.pem").toFile();
         File pkFile = tempDir.resolve("quarkus-dev-root-key.pem").toFile();

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <perfmark.version>0.27.0</perfmark.version><!-- dependency of io.grpc:grpc-core not managed in io.grpc:grpc-bom -->
 
         <!-- Used in the build parent and test BOM (for the JUnit plugin) and in the BOM (for the API) -->
-        <smallrye-certificate-generator.version>1.1.1</smallrye-certificate-generator.version>
+        <smallrye-certificate-generator.version>1.1.2</smallrye-certificate-generator.version>
 
         <!-- TestNG version: we don't enforce it in the BOM as it is mostly used in the MP TCKs and we need to use the version from the TCKs -->
         <testng.version>7.8.0</testng.version>


### PR DESCRIPTION
- Bumps SmallRye Certificate Generator to 1.1.2 to include the https://github.com/smallrye/smallrye-certificate-generator/pull/93 fix 
- Follow-up #56067 