### PR TITLE
[3.39] Do not set an invalid country code when generating the Quarkus Dev CA

### DIFF
--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/GenerateCACommand.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/GenerateCACommand.java
@@ -51,11 +51,20 @@ public class GenerateCACommand implements Callable<Integer> {
             }
         }
 
+        generateCA(CA_FILE, PK_FILE, KEYSTORE_FILE);
+
+        return 0;
+    }
+
+    // Visible for testing
+    void generateCA(File caFile, File pkFile, File keystoreFile) throws Exception {
         String username = System.getProperty("user.name", "");
-        CaGenerator generator = new CaGenerator(CA_FILE, PK_FILE, KEYSTORE_FILE, "quarkus");
+        CaGenerator generator = new CaGenerator(caFile, pkFile, keystoreFile, "quarkus");
+        // The country (C) attribute must be a valid 2-letter ISO 3166-1 code, so it is left unset here
+        // (there is no meaningful country for the Quarkus Dev CA).
         generator
                 .generate("quarkus-dev-root-ca", "Quarkus Development (" + username + ")", "Quarkus Development",
-                        "home", "world", "universe");
+                        "home", "world", null);
         if (install) {
             LOGGER.info("🔥 Installing the CA certificate in the system truststore...");
             generator.installToSystem();
@@ -69,8 +78,6 @@ public class GenerateCACommand implements Callable<Integer> {
         }
 
         LOGGER.info("✅ Quarkus Dev CA certificate generated and installed");
-
-        return 0;
     }
 
     private boolean hasExpired() throws Exception {

--- a/extensions/tls-registry/cli/src/test/java/io/quarkus/tls/cli/CaGenerationTest.java
+++ b/extensions/tls-registry/cli/src/test/java/io/quarkus/tls/cli/CaGenerationTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.tls.cli;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.smallrye.certs.ca.CaGenerator;
+
+public class CaGenerationTest {
+
+    @Test
+    public void testCaGeneration(@TempDir Path tempDir) throws Exception {
+        File caFile = tempDir.resolve("quarkus-dev-root-ca.pem").toFile();
+        File pkFile = tempDir.resolve("quarkus-dev-root-key.pem").toFile();
+        File keystoreFile = tempDir.resolve("quarkus-dev-keystore.p12").toFile();
+
+        GenerateCACommand command = new GenerateCACommand();
+        command.generateCA(caFile, pkFile, keystoreFile);
+
+        Assertions.assertTrue(caFile.isFile());
+        Assertions.assertTrue(pkFile.isFile());
+        Assertions.assertTrue(keystoreFile.isFile());
+
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        try (FileInputStream fis = new FileInputStream(keystoreFile)) {
+            ks.load(fis, "quarkus".toCharArray());
+        }
+        X509Certificate cert = (X509Certificate) ks.getCertificate(CaGenerator.KEYSTORE_CERT_ENTRY);
+        Assertions.assertNotNull(cert);
+        // The generated CA must carry a well-formed X.500 subject.
+        Assertions.assertTrue(cert.getSubjectX500Principal().getName().contains("CN=quarkus-dev-root-ca"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <perfmark.version>0.27.0</perfmark.version><!-- dependency of io.grpc:grpc-core not managed in io.grpc:grpc-bom -->
 
         <!-- Used in the build parent and test BOM (for the JUnit plugin) and in the BOM (for the API) -->
-        <smallrye-certificate-generator.version>0.9.3</smallrye-certificate-generator.version>
+        <smallrye-certificate-generator.version>0.9.4</smallrye-certificate-generator.version>
 
         <!-- TestNG version: we don't enforce it in the BOM as it is mostly used in the MP TCKs and we need to use the version from the TCKs -->
         <testng.version>7.8.0</testng.version>


### PR DESCRIPTION
BouncyCastle 1.85 enforces that the X.520 country (C) attribute is a valid 2-letter ISO 3166-1 code. The 'generate-quarkus-ca' CLI command passed 'universe' as the country, which now fails with:
```
  IllegalArgumentException: country code attribute 2.5.4.6 must be exactly 2 characters per ISO 3166-1 / X.520, got 8: 'universe'
```
Drop the invalid country attribute (it is optional and there is no meaningful country for the Quarkus Dev CA). The CA generation logic is extracted into a package-private method and covered by a regression test.

- Also upgrade smallrye-certificate-generator to 0.9.4 to fix https://github.com/smallrye/smallrye-certificate-generator/issues/92 