### PR TITLE
[3.39] Handle string JSON-RPC ids and always respond on the Dev MCP endpoint (3.39 backport)

### DIFF
--- a/extensions/devui/deployment/src/test/java/io/quarkus/devui/devmcp/DevMcpTest.java
+++ b/extensions/devui/deployment/src/test/java/io/quarkus/devui/devmcp/DevMcpTest.java
@@ -361,6 +361,111 @@ public class DevMcpTest {
     }
 
     @Test
+    public void testStringIdIsHandled() {
+        // Per JSON-RPC 2.0 and the MCP spec the id may be a String. A String id must be handled correctly and
+        // echoed back as-is, rather than causing a ClassCastException that leaves the client hanging.
+        String jsonBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": "abc-123",
+                      "method": "tools/list"
+                    }
+                """;
+
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .log().all()
+                .body("id", CoreMatchers.equalTo("abc-123"))
+                .body("jsonrpc", CoreMatchers.equalTo("2.0"))
+                .body("result.tools.name", CoreMatchers.hasItem("devui-logstream_getLogger"));
+
+    }
+
+    @Test
+    public void testStringIdIsHandledForToolsCall() {
+        // A String id must also survive a tools/call, which is wrapped in a CallToolResult and takes a different
+        // response path than tools/list. The id must still be echoed back as-is.
+        String jsonBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": "call-abc-123",
+                      "method": "tools/call",
+                      "params": {
+                        "name": "devui-logstream_getLogger",
+                        "arguments": {
+                          "loggerName": "io.quarkus"
+                        }
+                      }
+                    }
+                """;
+
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .log().all()
+                .body("id", CoreMatchers.equalTo("call-abc-123"))
+                .body("jsonrpc", CoreMatchers.equalTo("2.0"))
+                .body("result.content.type", CoreMatchers.hasItem("text"))
+                .body("result.content.text", CoreMatchers.notNullValue());
+
+    }
+
+    @Test
+    public void testMalformedJsonReturnsParseError() {
+        // A malformed request must never leave the client hanging; it must produce a JSON-RPC parse error response.
+        String jsonBody = "{ this is not valid json ";
+
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .log().all()
+                .body("jsonrpc", CoreMatchers.equalTo("2.0"))
+                .body("error.code", CoreMatchers.equalTo(-32700));
+
+    }
+
+    @Test
+    public void testMissingMethodReturnsInvalidRequest() {
+        // A request without a method is not a valid Request object and must produce an Invalid Request error.
+        String jsonBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 42
+                    }
+                """;
+
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .log().all()
+                .body("id", CoreMatchers.equalTo(42))
+                .body("jsonrpc", CoreMatchers.equalTo("2.0"))
+                .body("error.code", CoreMatchers.equalTo(-32600));
+
+    }
+
+    @Test
     public void testResourcesReadWithInvalidUri() {
         String jsonBody = """
                     {

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/comms/JsonRpcRouter.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/comms/JsonRpcRouter.java
@@ -38,7 +38,7 @@ import io.vertx.core.http.ServerWebSocket;
  */
 public class JsonRpcRouter {
 
-    private final Map<Integer, Cancellable> activeSubscriptions = new ConcurrentHashMap<>();
+    private final Map<Object, Cancellable> activeSubscriptions = new ConcurrentHashMap<>();
 
     // Map json-rpc method to java in runtime classpath
     private Map<String, JsonRpcMethod> runtimeMethodsMap;
@@ -240,8 +240,10 @@ public class JsonRpcRouter {
                                 && map.containsKey("response") && map.get("alreadySerialized").equals("true")) {
                             Object response = map.get("response");
 
-                            // The message response was already serialized, write text directly to socket
-                            jrrw.write("{\"id\":" + jsonRpcRequest.getId() + ",\"result\":{\"messageType\":\""
+                            // The message response was already serialized, write text directly to socket.
+                            // Serialize the id through the mapper so a String id is quoted correctly.
+                            String serializedId = codec.getJsonMapper().toString(jsonRpcRequest.getId(), false);
+                            jrrw.write("{\"id\":" + serializedId + ",\"result\":{\"messageType\":\""
                                     + map.get("messageType") + "\",\"object\":" + response + "}}");
                         } else {
                             codec.writeResponse(jrrw, jsonRpcRequest.getId(), item, MessageType.Response);

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcCodec.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcCodec.java
@@ -28,21 +28,29 @@ public final class JsonRpcCodec {
         return jsonRpcRequestCreator.mcpCreate((JsonObject) jsonMapper.fromString(json, Object.class));
     }
 
-    public void writeResponse(JsonRpcResponseWriter writer, int id, Object object, MessageType messageType) {
+    public void writeResponse(JsonRpcResponseWriter writer, Object id, Object object, MessageType messageType) {
         Object decoratedObject = writer.decorateObject(object, messageType);
         writeResponse(writer, new JsonRpcResponse(id, decoratedObject));
     }
 
-    public void writeMethodNotFoundResponse(JsonRpcResponseWriter writer, int id, String jsonRpcMethodName) {
+    public void writeMethodNotFoundResponse(JsonRpcResponseWriter writer, Object id, String jsonRpcMethodName) {
         writeResponse(writer, new JsonRpcResponse(id,
                 new JsonRpcResponse.Error(METHOD_NOT_FOUND, "Method [" + jsonRpcMethodName + "] not found")));
     }
 
-    public void writeErrorResponse(JsonRpcResponseWriter writer, int id, String jsonRpcMethodName, Throwable exception) {
+    public void writeErrorResponse(JsonRpcResponseWriter writer, Object id, String jsonRpcMethodName, Throwable exception) {
         LOG.error("Error in JsonRPC Call", exception);
         writeResponse(writer, new JsonRpcResponse(id,
                 new JsonRpcResponse.Error(INTERNAL_ERROR,
                         "Method [" + jsonRpcMethodName + "] failed: " + exception.getMessage())));
+    }
+
+    /**
+     * Writes a JSON-RPC error response with an explicit error code, used when a request cannot be parsed or is not a
+     * valid Request object. This must always write something back so a client never hangs waiting for a response.
+     */
+    public void writeErrorResponse(JsonRpcResponseWriter writer, Object id, int code, String message) {
+        writeResponse(writer, new JsonRpcResponse(id, new JsonRpcResponse.Error(code, message)));
     }
 
     private void writeResponse(JsonRpcResponseWriter writer, JsonRpcResponse response) {

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcRequest.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcRequest.java
@@ -5,7 +5,8 @@ import java.util.Map;
 import io.quarkus.devui.runtime.jsonrpc.json.JsonMapper;
 
 public final class JsonRpcRequest {
-    private int id;
+    // Per JSON-RPC 2.0 the id may be a String or a Number (or absent for notifications), so it is kept as an Object.
+    private Object id;
     private String jsonrpc = JsonRpcKeys.VERSION;
     private String method;
     private Map<String, Object> params;
@@ -15,11 +16,11 @@ public final class JsonRpcRequest {
         this.jsonMapper = jsonMapper;
     }
 
-    public int getId() {
+    public Object getId() {
         return id;
     }
 
-    public void setId(int id) {
+    public void setId(Object id) {
         this.id = id;
     }
 

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcRequestCreator.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcRequestCreator.java
@@ -45,6 +45,10 @@ public class JsonRpcRequestCreator {
      * @return JsonRpcRequest the remapped request
      */
     private JsonRpcRequest remap(JsonRpcRequest jsonRpcRequest) {
+        // A request without a method is not a valid Request object; leave it untouched so the caller can report it.
+        if (jsonRpcRequest.getMethod() == null) {
+            return jsonRpcRequest;
+        }
         if (jsonRpcRequest.getMethod().equalsIgnoreCase(TOOLS_SLASH_CALL)) {
 
             Map params = jsonRpcRequest.getParams();
@@ -70,7 +74,8 @@ public class JsonRpcRequestCreator {
     private JsonRpcRequest createWithFilter(JsonObject jsonObject, String... filter) {
         JsonRpcRequest jsonRpcRequest = new JsonRpcRequest(this.jsonMapper);
         if (jsonObject.containsKey(ID)) {
-            jsonRpcRequest.setId(jsonObject.getInteger(ID));
+            // Per JSON-RPC 2.0 the id may be a String or a Number; keep whatever the client sent.
+            jsonRpcRequest.setId(jsonObject.getValue(ID));
         }
         if (jsonObject.containsKey(JSONRPC)) {
             jsonRpcRequest.setJsonrpc(jsonObject.getString(JSONRPC));

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcResponse.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcResponse.java
@@ -4,18 +4,18 @@ import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.VERSION;
 
 public final class JsonRpcResponse {
 
-    // Public for serialization
-    public final int id;
+    // Public for serialization. Per JSON-RPC 2.0 the id may be a String or a Number (or null), so it is kept as an Object.
+    public final Object id;
     public final Object result;
     public final Error error;
 
-    public JsonRpcResponse(int id, Object result) {
+    public JsonRpcResponse(Object id, Object result) {
         this.id = id;
         this.result = result;
         this.error = null;
     }
 
-    public JsonRpcResponse(int id, Error error) {
+    public JsonRpcResponse(Object id, Error error) {
         this.id = id;
         this.result = null;
         this.error = error;

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpHttpHandler.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpHttpHandler.java
@@ -1,8 +1,14 @@
 package io.quarkus.devui.runtime.mcp;
 
+import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.INTERNAL_ERROR;
+import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.INVALID_REQUEST;
+import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.PARSE_ERROR;
+
 import java.util.Map;
 
 import jakarta.enterprise.inject.spi.CDI;
+
+import org.jboss.logging.Logger;
 
 import io.quarkus.devui.runtime.comms.JsonRpcRouter;
 import io.quarkus.devui.runtime.comms.MessageType;
@@ -19,6 +25,8 @@ import io.vertx.ext.web.RoutingContext;
  * Alternative Json RPC communication using Streamable HTTP for MCP
  */
 public class McpHttpHandler implements Handler<RoutingContext> {
+    private static final Logger LOG = Logger.getLogger(McpHttpHandler.class);
+
     private final String quarkusVersion;
     private final JsonMapper jsonMapper;
     private final JsonRpcCodec codec;
@@ -86,42 +94,71 @@ public class McpHttpHandler implements Handler<RoutingContext> {
         ctx.request().handler(buf -> sb.append(buf.toString()));
 
         ctx.request().endHandler(v -> {
-            JsonRpcRouter jsonRpcRouter = CDI.current().select(JsonRpcRouter.class).get();
             String input = sb.toString();
 
-            JsonRpcRequest jsonRpcRequest = codec.readMCPRequest(input);
+            // Parse the request first. A spec-legal request (e.g. a String id) or malformed JSON must never leave the
+            // client hanging with no response: on any parse failure we write a JSON-RPC error back instead.
+            JsonRpcRequest jsonRpcRequest;
+            try {
+                jsonRpcRequest = codec.readMCPRequest(input);
+            } catch (Exception e) {
+                LOG.error("Unable to parse MCP JSON-RPC request", e);
+                McpResponseWriter writer = new McpResponseWriter(ctx.response(), this.jsonMapper, "");
+                // The id cannot be trusted from an unparseable request, so it is reported as null per the spec.
+                codec.writeErrorResponse(writer, null, PARSE_ERROR,
+                        "Unable to parse JSON-RPC request: " + e.getMessage());
+                return;
+            }
 
             String methodName = jsonRpcRequest.getMethod();
-            McpResponseWriter writer = new McpResponseWriter(ctx.response(), this.jsonMapper, methodName);
-            // First see if this a protocol specific method
+            if (methodName == null) {
+                McpResponseWriter writer = new McpResponseWriter(ctx.response(), this.jsonMapper, "");
+                codec.writeErrorResponse(writer, jsonRpcRequest.getId(), INVALID_REQUEST,
+                        "Request is missing the 'method' field");
+                return;
+            }
 
-            if (methodName.equalsIgnoreCase(McpBuiltinMethods.INITIALIZE)) {
-                // This is a MCP server that initialize
-                this.routeToMCPInitialize(jsonRpcRequest, codec, writer);
-            } else if (methodName.startsWith(McpBuiltinMethods.NOTIFICATION)) {
-                // This is a MCP notification
-                this.routeToMCPNotification(jsonRpcRequest, codec, writer);
-            } else if (methodName.equalsIgnoreCase(McpBuiltinMethods.TOOLS_LIST) ||
-                    methodName.equalsIgnoreCase(McpBuiltinMethods.RESOURCES_LIST)) {
-                jsonRpcRequest.setMethod(methodName.replace(SLASH, UNDERSCORE));
-                // Make sure that parameters is empty as expected.
-                jsonRpcRequest.setParams(null);
-                jsonRpcRouter.route(jsonRpcRequest, writer);
-            } else if (methodName.equalsIgnoreCase(McpBuiltinMethods.RESOURCES_READ)) {
-                jsonRpcRequest.setMethod(methodName.replace(SLASH, UNDERSCORE));
-                // Make sure that the only parameter is uri (as expected).
-                String uri = jsonRpcRequest.getParam("uri", String.class);
-                jsonRpcRequest.getParams().clear();
-                jsonRpcRequest.setParams(Map.of("uri", uri));
-                jsonRpcRouter.route(jsonRpcRequest, writer);
-            } else {
-                if (jsonRpcRouter.isEnabled(jsonRpcRequest)) {
-                    jsonRpcRouter.route(jsonRpcRequest, writer);
-                } else {
-                    codec.writeMethodNotFoundResponse(writer, jsonRpcRequest.getId(), methodName);
-                }
+            McpResponseWriter writer = new McpResponseWriter(ctx.response(), this.jsonMapper, methodName);
+            try {
+                routeMcpRequest(jsonRpcRequest, methodName, writer);
+            } catch (Exception e) {
+                LOG.error("Error handling MCP JSON-RPC request", e);
+                codec.writeErrorResponse(writer, jsonRpcRequest.getId(), INTERNAL_ERROR,
+                        "Failed to handle JSON-RPC request: " + e.getMessage());
             }
         });
+    }
+
+    private void routeMcpRequest(JsonRpcRequest jsonRpcRequest, String methodName, McpResponseWriter writer) {
+        JsonRpcRouter jsonRpcRouter = CDI.current().select(JsonRpcRouter.class).get();
+        // First see if this a protocol specific method
+
+        if (methodName.equalsIgnoreCase(McpBuiltinMethods.INITIALIZE)) {
+            // This is a MCP server that initialize
+            this.routeToMCPInitialize(jsonRpcRequest, codec, writer);
+        } else if (methodName.startsWith(McpBuiltinMethods.NOTIFICATION)) {
+            // This is a MCP notification
+            this.routeToMCPNotification(jsonRpcRequest, codec, writer);
+        } else if (methodName.equalsIgnoreCase(McpBuiltinMethods.TOOLS_LIST) ||
+                methodName.equalsIgnoreCase(McpBuiltinMethods.RESOURCES_LIST)) {
+            jsonRpcRequest.setMethod(methodName.replace(SLASH, UNDERSCORE));
+            // Make sure that parameters is empty as expected.
+            jsonRpcRequest.setParams(null);
+            jsonRpcRouter.route(jsonRpcRequest, writer);
+        } else if (methodName.equalsIgnoreCase(McpBuiltinMethods.RESOURCES_READ)) {
+            jsonRpcRequest.setMethod(methodName.replace(SLASH, UNDERSCORE));
+            // Make sure that the only parameter is uri (as expected).
+            String uri = jsonRpcRequest.getParam("uri", String.class);
+            jsonRpcRequest.getParams().clear();
+            jsonRpcRequest.setParams(Map.of("uri", uri));
+            jsonRpcRouter.route(jsonRpcRequest, writer);
+        } else {
+            if (jsonRpcRouter.isEnabled(jsonRpcRequest)) {
+                jsonRpcRouter.route(jsonRpcRequest, writer);
+            } else {
+                codec.writeMethodNotFoundResponse(writer, jsonRpcRequest.getId(), methodName);
+            }
+        }
     }
 
     private void routeToMCPInitialize(JsonRpcRequest jsonRpcRequest, JsonRpcCodec codec, McpResponseWriter writer) {

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpResponseWriter.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpResponseWriter.java
@@ -27,7 +27,9 @@ public class McpResponseWriter implements JsonRpcResponseWriter {
         String output = message + "\n\n";
         int length = output.getBytes(StandardCharsets.UTF_8).length;
 
-        if (!response.closed()) {
+        // Guard on both closed() and ended(): a response may already be ended (e.g. by a route that both wrote a
+        // reply and then failed) without being closed yet, and calling end() again would throw.
+        if (!response.closed() && !response.ended()) {
             response.putHeader("Content-Type", "application/json")
                     .putHeader("Content-Length", String.valueOf(length))
                     .end(output);


### PR DESCRIPTION
Backport of #56017 to the 3.39 branch for the upcoming 3.40 LTS.

The original change did not apply cleanly because the Dev UI/Dev MCP JSON-RPC code was refactored on main (split into the `devjsonrpc` and `devmcp` extensions). On 3.39 it still lives in the `quarkus-devui` runtime module, so the fix has been reapplied by hand rather than cherry-picked.

A spec-legal string `id` (allowed by JSON-RPC 2.0 and the MCP spec) threw a `ClassCastException` on the Vert.x event loop before any response was written, leaving the client hanging until its own timeout. The `id` is now carried as an `Object` through the request/response model and codec, and the MCP handler now guards parsing and routing so any unparseable or invalid request always yields a JSON-RPC error response instead of silently failing.

Fixes #56009