### PR TITLE
Fail the build when unsupported Spring Security annotations are used

### DIFF
--- a/extensions/spring-security/deployment/src/main/java/io/quarkus/spring/security/deployment/DotNames.java
+++ b/extensions/spring-security/deployment/src/main/java/io/quarkus/spring/security/deployment/DotNames.java
@@ -19,6 +19,16 @@ public final class DotNames {
     static final Set<DotName> SUPPORTED_SPRING_SECURITY_ANNOTATIONS = new HashSet<>(
             Arrays.asList(SPRING_SECURED, SPRING_PRE_AUTHORIZE));
 
+    static final DotName SPRING_POST_AUTHORIZE = DotName
+            .createSimple("org.springframework.security.access.prepost.PostAuthorize");
+    static final DotName SPRING_PRE_FILTER = DotName
+            .createSimple("org.springframework.security.access.prepost.PreFilter");
+    static final DotName SPRING_POST_FILTER = DotName
+            .createSimple("org.springframework.security.access.prepost.PostFilter");
+
+    static final Set<DotName> UNSUPPORTED_SPRING_SECURITY_ANNOTATIONS = new HashSet<>(
+            Arrays.asList(SPRING_POST_AUTHORIZE, SPRING_PRE_FILTER, SPRING_POST_FILTER));
+
     private DotNames() {
     }
 }

--- a/extensions/spring-security/deployment/src/main/java/io/quarkus/spring/security/deployment/SpringSecurityProcessor.java
+++ b/extensions/spring-security/deployment/src/main/java/io/quarkus/spring/security/deployment/SpringSecurityProcessor.java
@@ -4,6 +4,7 @@ import static io.quarkus.security.spi.SecurityTransformerBuildItem.createSecurit
 
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -35,10 +36,12 @@ import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.security.deployment.AdditionalSecurityCheckBuildItem;
 import io.quarkus.security.runtime.SecurityCheckRecorder;
 import io.quarkus.security.spi.SecurityTransformer;
@@ -63,6 +66,30 @@ class SpringSecurityProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(Feature.SPRING_SECURITY);
+    }
+
+    @BuildStep
+    @Produce(ServiceStartBuildItem.class)
+    void detectUnsupportedSpringSecurityAnnotations(CombinedIndexBuildItem index) {
+        for (DotName unsupported : DotNames.UNSUPPORTED_SPRING_SECURITY_ANNOTATIONS) {
+            Collection<AnnotationInstance> instances = index.getIndex().getAnnotations(unsupported);
+            if (!instances.isEmpty()) {
+                AnnotationInstance first = instances.iterator().next();
+                AnnotationTarget target = first.target();
+                String location;
+                if (target.kind() == AnnotationTarget.Kind.METHOD) {
+                    MethodInfo method = target.asMethod();
+                    location = "method '" + method.name() + "' of class '" + method.declaringClass().name() + "'";
+                } else {
+                    location = "class '" + target.asClass().name() + "'";
+                }
+                throw new IllegalArgumentException(
+                        "Quarkus does not support the @" + unsupported.withoutPackagePrefix()
+                                + " annotation, found on " + location
+                                + ". Only @Secured and @PreAuthorize are supported."
+                                + " See https://quarkus.io/guides/spring-security#supported-spring-security-annotations");
+            }
+        }
     }
 
     @BuildStep

--- a/extensions/spring-security/deployment/src/test/java/io/quarkus/spring/security/deployment/UnsupportedPostAuthorizeAnnotationTest.java
+++ b/extensions/spring-security/deployment/src/test/java/io/quarkus/spring/security/deployment/UnsupportedPostAuthorizeAnnotationTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.spring.security.deployment;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.security.access.prepost.PostAuthorize;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class UnsupportedPostAuthorizeAnnotationTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(BeanWithPostAuthorize.class, PostAuthorize.class))
+            .setExpectedException(IllegalArgumentException.class);
+
+    @Test
+    public void shouldNotBeCalled() {
+        Assertions.fail();
+    }
+
+    @ApplicationScoped
+    static class BeanWithPostAuthorize {
+
+        @PostAuthorize("returnObject.owner == authentication.name")
+        public String getData() {
+            return "data";
+        }
+    }
+}

--- a/extensions/spring-security/deployment/src/test/java/io/quarkus/spring/security/deployment/UnsupportedPostFilterAnnotationTest.java
+++ b/extensions/spring-security/deployment/src/test/java/io/quarkus/spring/security/deployment/UnsupportedPostFilterAnnotationTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.spring.security.deployment;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.security.access.prepost.PostFilter;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class UnsupportedPostFilterAnnotationTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(BeanWithPostFilter.class, PostFilter.class))
+            .setExpectedException(IllegalArgumentException.class);
+
+    @Test
+    public void shouldNotBeCalled() {
+        Assertions.fail();
+    }
+
+    @ApplicationScoped
+    static class BeanWithPostFilter {
+
+        @PostFilter("filterObject.length() > 3")
+        public List<String> filterResults() {
+            return List.of("a", "abcd", "ab", "abcde");
+        }
+    }
+}

--- a/extensions/spring-security/deployment/src/test/java/io/quarkus/spring/security/deployment/UnsupportedPreFilterAnnotationTest.java
+++ b/extensions/spring-security/deployment/src/test/java/io/quarkus/spring/security/deployment/UnsupportedPreFilterAnnotationTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.spring.security.deployment;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.security.access.prepost.PreFilter;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class UnsupportedPreFilterAnnotationTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(BeanWithPreFilter.class, PreFilter.class))
+            .setExpectedException(IllegalArgumentException.class);
+
+    @Test
+    public void shouldNotBeCalled() {
+        Assertions.fail();
+    }
+
+    @ApplicationScoped
+    static class BeanWithPreFilter {
+
+        @PreFilter("filterObject.length() > 3")
+        public List<String> filterData(List<String> data) {
+            return data;
+        }
+    }
+}

--- a/extensions/spring-security/deployment/src/test/java/org/springframework/security/access/prepost/PostAuthorize.java
+++ b/extensions/spring-security/deployment/src/test/java/org/springframework/security/access/prepost/PostAuthorize.java
@@ -1,0 +1,12 @@
+package org.springframework.security.access.prepost;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PostAuthorize {
+    String value();
+}

--- a/extensions/spring-security/deployment/src/test/java/org/springframework/security/access/prepost/PostFilter.java
+++ b/extensions/spring-security/deployment/src/test/java/org/springframework/security/access/prepost/PostFilter.java
@@ -1,0 +1,12 @@
+package org.springframework.security.access.prepost;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PostFilter {
+    String value();
+}

--- a/extensions/spring-security/deployment/src/test/java/org/springframework/security/access/prepost/PreFilter.java
+++ b/extensions/spring-security/deployment/src/test/java/org/springframework/security/access/prepost/PreFilter.java
@@ -1,0 +1,12 @@
+package org.springframework.security.access.prepost;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PreFilter {
+    String value();
+}


### PR DESCRIPTION
Add a build step that detects `@PostAuthorize`, `@PreFilter` and `@PostFilter` annotations and fails with a clear error message pointing to the supported annotations documentation.

- Fixes: #56070 

cc @sberyozkin @Michael-JRead
