### PR TITLE
Re-enable Develocity build scan publishing for pull requests

### DIFF
--- a/.github/workflows/develocity-publish-build-scans.yml
+++ b/.github/workflows/develocity-publish-build-scans.yml
@@ -1,11 +1,9 @@
 name: Develocity - Publish Maven Build Scans
 
-# CI disabled for Vert.x 5 experimental branch - uncomment the 'on' triggers below to re-enable
-#on:
-#  workflow_run:
-#    workflows: [ "Quarkus CI" ]
-#    types: [ completed ]
-on: [workflow_dispatch]
+on:
+  workflow_run:
+    workflows: [ "Quarkus CI" ]
+    types: [ completed ]
 
 defaults:
   run:


### PR DESCRIPTION
## Problem

Build scans of pull request builds issued from forked repositories are no longer published to ge.quarkus.io. 
<img width="1253" height="702" alt="Screenshot 2026-08-19 at 11 54 08 AM" src="https://github.com/user-attachments/assets/6c3a2a60-058e-4330-a285-9bc84b9d1c28" />


## Cause

The `workflow_run` trigger of `develocity-publish-build-scans.yml` is commented out. It was disabled in a31e3266d2 for the Vert.x 5 branch and never restored — 9ba477d01c re-enabled only `ci-sanity-check.yml` and `vale.yml`.

That commit is from March 27, and got merged into `main` on June 26, when the 4.0 line was promoted.

## Fix

Restore the trigger block as it was before a31e3266d2.
