### PR TITLE
[3.39] Revert "Disable the Quarkus Dev CA generation test on Windows"

### DIFF
--- a/extensions/tls-registry/cli/src/test/java/io/quarkus/tls/cli/CaGenerationTest.java
+++ b/extensions/tls-registry/cli/src/test/java/io/quarkus/tls/cli/CaGenerationTest.java
@@ -8,19 +8,13 @@ import java.security.cert.X509Certificate;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.smallrye.certs.ca.CaGenerator;
 
 public class CaGenerationTest {
 
-    // Disabled on Windows: CaGenerator does not close the keystore output stream
-    // (https://github.com/smallrye/smallrye-certificate-generator/issues/92), which keeps the .p12 file
-    // locked so @TempDir cleanup fails there. Revert this annotation once that issue is fixed.
     @Test
-    @DisabledOnOs(OS.WINDOWS)
     public void testCaGeneration(@TempDir Path tempDir) throws Exception {
         File caFile = tempDir.resolve("quarkus-dev-root-ca.pem").toFile();
         File pkFile = tempDir.resolve("quarkus-dev-root-key.pem").toFile();


### PR DESCRIPTION
- This reverts the commit that disabled the test in Windows fixed in f4a652ae9bf6dd48a717b55b8877006f81f269b1