### PR TITLE
Bump apicurio-registry.version from 3.1.7 to 3.3.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -198,7 +198,7 @@
         <log4j2-jboss-logmanager.version>2.0.1.Final</log4j2-jboss-logmanager.version>
         <log4j2-api.version>2.26.1</log4j2-api.version>
         <avro.version>1.12.1</avro.version>
-        <apicurio-registry.version>3.1.7</apicurio-registry.version>
+        <apicurio-registry.version>3.3.1</apicurio-registry.version>
         <testcontainers.version>2.0.5</testcontainers.version> <!-- Make sure to also update docker-java.version to match its needs -->
         <docker-java.version>3.7.1</docker-java.version> <!-- must be the version Testcontainers use: https://central.sonatype.com/artifact/org.testcontainers/testcontainers -->
         <!-- Check the compatibility matrix (https://github.com/opensearch-project/opensearch-testcontainers) before upgrading: -->

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -149,7 +149,7 @@
         <!-- Dev Services Images -->
         <!-- TODO switch to apache/activemq-artemis to match the artemis version-->
         <amqp.image>quay.io/arkmq-org/arkmq-org-broker:artemis.2.55.0</amqp.image>
-        <apicurio-registry.image>quay.io/apicurio/apicurio-registry:3.1.7</apicurio-registry.image>
+        <apicurio-registry.image>quay.io/apicurio/apicurio-registry:3.3.1</apicurio-registry.image>
         <narayana-lra.image>quay.io/jbosstm/lra-coordinator:latest</narayana-lra.image>
         <rabbitmq.image>docker.io/library/rabbitmq:3.12-management</rabbitmq.image>
         <pulsar.image>docker.io/apachepulsar/pulsar:3.2.4</pulsar.image>


### PR DESCRIPTION
Bump Apicurio Registry from 3.1.7 to 3.3.1.

Updates both the dependency version in the BOM and the Dev Services container image tag.