### PR TITLE
Document that CORS cannot be configured both programmatically and with properties

### DIFF
--- a/docs/src/main/asciidoc/security-cors.adoc
+++ b/docs/src/main/asciidoc/security-cors.adoc
@@ -102,6 +102,11 @@ quarkus.http.cors.enabled=true
 [[cors-filter-programmatic-set-up]]
 == Configuring the CORS filter programmatically
 
+[NOTE]
+====
+Configure the CORS filter by using <<cors-filter,configuration properties>> or programmatically, but not both.
+====
+
 To enforce CORS policies in your application, enable the Quarkus CORS filter with the `io.quarkus.vertx.http.security.HttpSecurity` CDI event:
 
 [source,java]


### PR DESCRIPTION
The CORS guide documents two ways to configure the CORS filter, configuration properties and the `HttpSecurity` CDI event, but it never says the two are mutually exclusive. A reader who follows both sections gets an `IllegalStateException` at startup, and nothing in the guide warns them.

This adds a one-sentence note to the "Configuring the CORS filter programmatically" section:

Configure the CORS filter by using configuration properties or programmatically, but not both.

The constraint is enforced in `HttpSecurityImpl.cors(CORS)`, which throws `IllegalStateException("CORS cannot be configured both programmatically and in the 'application.properties' file")` when any of `access-control-allow-credentials`, `access-control-max-age`, `headers`, `methods`, or `exposed-headers` is already present in the properties config.

The note sits in the programmatic section only, per review feedback: that is the path that throws, and a reader who has already built a programmatic setup is unlikely to forget it and then arrive in the properties section.

On the wording: the note deliberately stops at the constraint. It names no properties and describes no consequence. That came out of SME review on the downstream Red Hat build of Quarkus documentation, where this note was added first. Listing the five properties invites readers to treat every other combination as supported, and stating the consequence in hedged terms ("can prevent the application from starting") reads as though combining the two sometimes works.

Docs only, no code change.
