### PR TITLE
Don't descend into nested git checkouts when scanning for config-doc target directories

### DIFF
--- a/devtools/config-doc-maven-plugin/pom.xml
+++ b/devtools/config-doc-maven-plugin/pom.xml
@@ -184,5 +184,15 @@
             <artifactId>maven-repository-metadata</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/devtools/config-doc-maven-plugin/src/main/java/io/quarkus/maven/config/doc/GenerateConfigDocMojo.java
+++ b/devtools/config-doc-maven-plugin/src/main/java/io/quarkus/maven/config/doc/GenerateConfigDocMojo.java
@@ -271,7 +271,7 @@ public class GenerateConfigDocMojo extends AbstractMojo {
         }
     }
 
-    private static List<Path> findTargetDirectories(Path scanDirectory) throws MojoExecutionException {
+    static List<Path> findTargetDirectories(Path scanDirectory) throws MojoExecutionException {
         try {
             List<Path> targets = new ArrayList<>();
 
@@ -288,6 +288,14 @@ public class GenerateConfigDocMojo extends AbstractMojo {
 
                         // a target directory can contain target directories for test projects
                         // so let's make sure we ignore whatever is nested in a target
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+
+                    // a directory containing a .git file or directory is the root of a separate checkout
+                    // (e.g. a git worktree for another branch kept inside the project directory); its
+                    // target/ directories belong to a different build and must not be merged into this one.
+                    // this doesn't apply to the scan root itself, which is normally the project's own repo root.
+                    if (!dir.equals(scanDirectory) && Files.exists(dir.resolve(".git"))) {
                         return FileVisitResult.SKIP_SUBTREE;
                     }
 

--- a/devtools/config-doc-maven-plugin/src/test/java/io/quarkus/maven/config/doc/GenerateConfigDocMojoTest.java
+++ b/devtools/config-doc-maven-plugin/src/test/java/io/quarkus/maven/config/doc/GenerateConfigDocMojoTest.java
@@ -1,0 +1,94 @@
+package io.quarkus.maven.config.doc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class GenerateConfigDocMojoTest {
+
+    @Test
+    void findsTargetDirectoryOfARealModule(@TempDir Path root) throws IOException, MojoExecutionException {
+        Path moduleTarget = createModuleWithTarget(root, "module-a");
+
+        List<Path> found = GenerateConfigDocMojo.findTargetDirectories(root);
+
+        assertThat(found).containsExactly(moduleTarget);
+    }
+
+    @Test
+    void scanRootBeingAGitCheckoutDoesNotHideItsOwnModules(@TempDir Path root)
+            throws IOException, MojoExecutionException {
+        // the scan root is normally the project's own repo root, which of course has a .git directory;
+        // that must not cause the whole scan to be treated as "nested" and skipped
+        Files.createDirectories(root.resolve(".git"));
+        Path moduleTarget = createModuleWithTarget(root, "module-a");
+
+        List<Path> found = GenerateConfigDocMojo.findTargetDirectories(root);
+
+        assertThat(found).containsExactly(moduleTarget);
+    }
+
+    @Test
+    void ignoresTargetDirectoriesInsideNestedGitCheckouts(@TempDir Path root)
+            throws IOException, MojoExecutionException {
+        Path realModuleTarget = createModuleWithTarget(root, "module-a");
+
+        // e.g. a git worktree for another branch, kept inside the project directory,
+        // that still has stale build output from a previous build
+        Path nestedCheckout = root.resolve(".claude").resolve("worktrees").resolve("stale-branch");
+        Files.createDirectories(nestedCheckout.resolve(".git"));
+        createModuleWithTarget(nestedCheckout, "module-a");
+
+        List<Path> found = GenerateConfigDocMojo.findTargetDirectories(root);
+
+        assertThat(found).containsExactly(realModuleTarget);
+    }
+
+    @Test
+    void ignoresNestedGitCheckoutMarkedByAGitFile(@TempDir Path root) throws IOException, MojoExecutionException {
+        // git worktrees use a `.git` *file* (not a directory) pointing at the real git dir
+        Path realModuleTarget = createModuleWithTarget(root, "module-a");
+
+        Path worktree = root.resolve(".claude").resolve("worktrees").resolve("issue-1234");
+        Files.createDirectories(worktree);
+        Files.writeString(worktree.resolve(".git"), "gitdir: /somewhere/else\n");
+        createModuleWithTarget(worktree, "module-a");
+
+        List<Path> found = GenerateConfigDocMojo.findTargetDirectories(root);
+
+        assertThat(found).containsExactly(realModuleTarget);
+    }
+
+    @Test
+    void ignoresTargetDirectoriesDeeplyNestedInsideAGitCheckout(@TempDir Path root)
+            throws IOException, MojoExecutionException {
+        // mirrors the real-world case: the .git marker is several directories above the
+        // polluting target/ dir, e.g. .claude/worktrees/<branch>/model-providers/<ext>/runtime/target
+        Path realModuleTarget = createModuleWithTarget(root, "module-a");
+
+        Path worktreeRoot = root.resolve(".claude").resolve("worktrees").resolve("issue-2221");
+        Files.createDirectories(worktreeRoot.resolve(".git"));
+        Path deeplyNestedModuleParent = worktreeRoot.resolve("model-providers").resolve("openai")
+                .resolve("openai-vanilla");
+        createModuleWithTarget(deeplyNestedModuleParent, "runtime");
+
+        List<Path> found = GenerateConfigDocMojo.findTargetDirectories(root);
+
+        assertThat(found).containsExactly(realModuleTarget);
+    }
+
+    private static Path createModuleWithTarget(Path parent, String moduleName) throws IOException {
+        Path moduleDir = parent.resolve(moduleName);
+        Path target = moduleDir.resolve("target");
+        Files.createDirectories(target);
+        Files.createFile(moduleDir.resolve("pom.xml"));
+        return target;
+    }
+}


### PR DESCRIPTION
- Closes: https://github.com/quarkusio/quarkus/issues/56104