### PR TITLE
[3.27] Set a default GraphQL query depth limit of 10 to prevent DoS

### DIFF
--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLConfig.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLConfig.java
@@ -177,8 +177,9 @@ public interface SmallRyeGraphQLConfig {
     OptionalInt instrumentationQueryComplexity();
 
     /**
-     * Abort a query if the total depth of the query exceeds the defined limit. Default to no limit
+     * Abort a query if the total depth of the query exceeds the defined limit.
      */
+    @WithDefault("10")
     OptionalInt instrumentationQueryDepth();
 
     /**


### PR DESCRIPTION
Backport of https://github.com/quarkusio/quarkus/pull/55361 to 3.27