### PR TITLE
[3.27] Fix access log cookie masking to check all cookie pairs

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/AllRequestHeadersAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/AllRequestHeadersAttribute.java
@@ -92,15 +92,24 @@ public class AllRequestHeadersAttribute implements ExchangeAttribute {
     }
 
     private String maskCookieHeaderValue(String headerValue) {
-        int idx = headerValue.indexOf('=');
-
-        final String cookieName = idx > 0 ? headerValue.substring(0, idx) : null;
-
-        if (cookieName != null && maskedCookies.contains(cookieName.toLowerCase())) {
-            return cookieName + "=...";
+        if (maskedCookies.isEmpty()) {
+            return headerValue;
         }
 
-        return headerValue;
+        final StringJoiner joiner = new StringJoiner("; ");
+        for (String pair : headerValue.split(";")) {
+            String trimmed = pair.trim();
+            int idx = trimmed.indexOf('=');
+            String cookieName = idx > 0 ? trimmed.substring(0, idx).trim() : null;
+
+            if (cookieName != null && maskedCookies.contains(cookieName.toLowerCase())) {
+                joiner.add(cookieName + "=...");
+            } else {
+                joiner.add(trimmed);
+            }
+        }
+
+        return joiner.toString();
     }
 
     @Override

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/attribute/AllRequestHeadersAttributeTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/attribute/AllRequestHeadersAttributeTest.java
@@ -2,6 +2,8 @@ package io.quarkus.vertx.http.runtime.attribute;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 import io.vertx.core.MultiMap;
@@ -38,6 +40,50 @@ class AllRequestHeadersAttributeTest {
         headers.add("authorization", "token");
         String attribute = new AllRequestHeadersAttribute().readAttribute(headers);
         assertEquals("authorization: ...", attribute);
+    }
+
+    @Test
+    void testMaskedCookieWhenFirst() {
+        AllRequestHeadersAttribute attr = new AllRequestHeadersAttribute(
+                Set.of(), Set.of("Session"));
+
+        MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+        headers.add("Cookie", "Session=encrypted; visitcount=1");
+
+        assertEquals("Cookie: Session=...; visitcount=1", attr.readAttribute(headers));
+    }
+
+    @Test
+    void testMaskedCookieWhenNotFirst() {
+        AllRequestHeadersAttribute attr = new AllRequestHeadersAttribute(
+                Set.of(), Set.of("Session"));
+
+        MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+        headers.add("Cookie", "visitcount=1; Session=encrypted");
+
+        assertEquals("Cookie: visitcount=1; Session=...", attr.readAttribute(headers));
+    }
+
+    @Test
+    void testMultipleMaskedCookies() {
+        AllRequestHeadersAttribute attr = new AllRequestHeadersAttribute(
+                Set.of(), Set.of("Session", "Token"));
+
+        MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+        headers.add("Cookie", "visitcount=1; Session=encrypted; Token=secret");
+
+        assertEquals("Cookie: visitcount=1; Session=...; Token=...", attr.readAttribute(headers));
+    }
+
+    @Test
+    void testNoMaskedCookiesConfigured() {
+        AllRequestHeadersAttribute attr = new AllRequestHeadersAttribute(
+                Set.of(), Set.of());
+
+        MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+        headers.add("Cookie", "Session=encrypted; visitcount=1");
+
+        assertEquals("Cookie: Session=encrypted; visitcount=1", attr.readAttribute(headers));
     }
 
 }


### PR DESCRIPTION
backport of https://github.com/quarkusio/quarkus/pull/55644/ to 3.27