### PR TITLE
Move SSH enabled config to build time and gate all processor build steps

### DIFF
--- a/docs/src/main/asciidoc/aesh.adoc
+++ b/docs/src/main/asciidoc/aesh.adoc
@@ -857,7 +857,7 @@ quarkus.aesh.ssh.password=mysecret
 # Path to the host key file (default: hostkey.ser)
 quarkus.aesh.ssh.host-key-file=hostkey.ser
 
-# Enable or disable the SSH server (default: true)
+# Enable or disable the SSH server at build time (default: true)
 quarkus.aesh.ssh.enabled=true
 ----
 

--- a/extensions/aesh/README.md
+++ b/extensions/aesh/README.md
@@ -279,7 +279,7 @@ Connect with `ssh -p 2222 localhost`. Configure with:
 quarkus.aesh.ssh.port=2222
 quarkus.aesh.ssh.host=localhost
 quarkus.aesh.ssh.password=mysecret
-quarkus.aesh.ssh.enabled=true
+quarkus.aesh.ssh.enabled=true  # build-time property
 ```
 
 > **Note:** These features are intended for development. Secure them appropriately in production.

--- a/extensions/aesh/ssh/deployment/src/main/java/io/quarkus/aesh/ssh/deployment/AeshSshBuildTimeConfig.java
+++ b/extensions/aesh/ssh/deployment/src/main/java/io/quarkus/aesh/ssh/deployment/AeshSshBuildTimeConfig.java
@@ -11,6 +11,12 @@ import io.smallrye.config.WithName;
 public interface AeshSshBuildTimeConfig {
 
     /**
+     * Whether the SSH terminal server is enabled.
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+    /**
      * Whether the health check is published when the smallrye-health extension is present.
      */
     @WithName("health.enabled")

--- a/extensions/aesh/ssh/deployment/src/main/java/io/quarkus/aesh/ssh/deployment/AeshSshProcessor.java
+++ b/extensions/aesh/ssh/deployment/src/main/java/io/quarkus/aesh/ssh/deployment/AeshSshProcessor.java
@@ -23,11 +23,15 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 
 class AeshSshProcessor {
 
     private static final Logger LOG = Logger.getLogger(AeshSshProcessor.class);
+
+    private static final DotName SSH_SERVER_LIFECYCLE_CLASS = DotName
+            .createSimple(SshServerLifecycle.class);
 
     private static final DotName HEALTH_CHECK_CLASS = DotName
             .createSimple("io.quarkus.aesh.ssh.runtime.health.AeshSshHealthCheck");
@@ -38,13 +42,32 @@ class AeshSshProcessor {
     }
 
     @BuildStep
-    AdditionalBeanBuildItem registerBeans() {
-        return AdditionalBeanBuildItem.unremovableOf(SshServerLifecycle.class);
+    AdditionalBeanBuildItem registerBeans(AeshSshBuildTimeConfig config) {
+        if (config.enabled()) {
+            return AdditionalBeanBuildItem.unremovableOf(SshServerLifecycle.class);
+        }
+        return null;
     }
 
     @BuildStep
-    AeshRemoteTransportBuildItem remoteTransport() {
-        return new AeshRemoteTransportBuildItem("ssh");
+    void disableBeansIfNotEnabled(AeshSshBuildTimeConfig config,
+            BuildProducer<AnnotationsTransformerBuildItem> transformers) {
+        if (!config.enabled()) {
+            // Veto the SSH server lifecycle bean so Arc does not discover
+            // it via classpath scanning when SSH is disabled.
+            transformers.produce(new AnnotationsTransformerBuildItem(
+                    AnnotationTransformation.forClasses()
+                            .whenClass(c -> c.name().equals(SSH_SERVER_LIFECYCLE_CLASS))
+                            .transform(ctx -> ctx.add(Vetoed.class))));
+        }
+    }
+
+    @BuildStep
+    AeshRemoteTransportBuildItem remoteTransport(AeshSshBuildTimeConfig config) {
+        if (config.enabled()) {
+            return new AeshRemoteTransportBuildItem("ssh");
+        }
+        return null;
     }
 
     @BuildStep
@@ -54,13 +77,17 @@ class AeshSshProcessor {
         }
         return new HealthBuildItem(
                 "io.quarkus.aesh.ssh.runtime.health.AeshSshHealthCheck",
-                buildTimeConfig.healthEnabled());
+                buildTimeConfig.enabled() && buildTimeConfig.healthEnabled());
     }
 
     @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
-    void nativeImageConfiguration(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClasses,
+    void nativeImageConfiguration(AeshSshBuildTimeConfig config,
+            BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClasses,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<NativeImageProxyDefinitionBuildItem> proxyDefinitions) {
+        if (!config.enabled()) {
+            return;
+        }
         // MontgomeryCurve creates KeyPairGenerator instances (containing SecureRandom)
         // in its enum constants' static initializer. GraalVM does not allow Random
         // instances in the image heap, so defer to runtime.
@@ -111,8 +138,8 @@ class AeshSshProcessor {
 
     @BuildStep
     @Produce(ArtifactResultBuildItem.class)
-    void warnIfInsecureInProduction(LaunchModeBuildItem launchMode) {
-        if (launchMode.getLaunchMode() == io.quarkus.runtime.LaunchMode.NORMAL) {
+    void warnIfInsecureInProduction(AeshSshBuildTimeConfig config, LaunchModeBuildItem launchMode) {
+        if (config.enabled() && launchMode.getLaunchMode() == LaunchMode.NORMAL) {
             LOG.warn("Aesh SSH extension is included in a production build. " +
                     "Ensure authentication is configured via 'quarkus.aesh.ssh.password' or " +
                     "'quarkus.aesh.ssh.authorized-keys-file', or disable with " +
@@ -125,11 +152,13 @@ class AeshSshProcessor {
     void disableHealthCheckIfNotNeeded(AeshSshBuildTimeConfig buildTimeConfig,
             Capabilities capabilities,
             BuildProducer<AnnotationsTransformerBuildItem> transformers) {
-        // Veto the health check class if the SmallRye Health extension is not
-        // present or if health checks are disabled by config. This prevents Arc
-        // from trying to load the class (which implements HealthCheck and would
-        // fail with NoClassDefFoundError when the health extension is absent).
-        if (!capabilities.isPresent(Capability.SMALLRYE_HEALTH) || !buildTimeConfig.healthEnabled()) {
+        // Veto the health check class if SSH is disabled, the SmallRye Health
+        // extension is not present, or health checks are disabled by config.
+        // This prevents Arc from trying to load the class (which implements
+        // HealthCheck and would fail with NoClassDefFoundError when the health
+        // extension is absent).
+        if (!buildTimeConfig.enabled() || !capabilities.isPresent(Capability.SMALLRYE_HEALTH)
+                || !buildTimeConfig.healthEnabled()) {
             transformers.produce(new AnnotationsTransformerBuildItem(
                     AnnotationTransformation.forClasses()
                             .whenClass(c -> c.name().equals(HEALTH_CHECK_CLASS))

--- a/extensions/aesh/ssh/deployment/src/test/java/io/quarkus/aesh/ssh/deployment/AeshSshDisabledTest.java
+++ b/extensions/aesh/ssh/deployment/src/test/java/io/quarkus/aesh/ssh/deployment/AeshSshDisabledTest.java
@@ -14,8 +14,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 
 /**
- * Verifies that setting {@code quarkus.aesh.ssh.enabled=false} prevents the
- * SSH server from starting.
+ * Verifies that setting {@code quarkus.aesh.ssh.enabled=false} at build time
+ * prevents the SSH server beans from being registered and the SSH server
+ * from starting.
  */
 public class AeshSshDisabledTest {
 
@@ -31,7 +32,10 @@ public class AeshSshDisabledTest {
 
     @Test
     public void testSshServerNotStarted() {
-        // The SSH port should not be listening when disabled
+        // The SSH port should not be listening when disabled at build time.
+        // With enabled=false, SshServerLifecycle is not registered as a bean
+        // and no AeshRemoteTransportBuildItem is produced, so the local
+        // console is not suppressed either.
         Assertions.assertThatThrownBy(() -> {
             try (Socket socket = new Socket("localhost", SSH_PORT)) {
                 // should not connect

--- a/extensions/aesh/ssh/runtime/src/main/java/io/quarkus/aesh/ssh/runtime/AeshSshConfig.java
+++ b/extensions/aesh/ssh/runtime/src/main/java/io/quarkus/aesh/ssh/runtime/AeshSshConfig.java
@@ -16,12 +16,6 @@ import io.smallrye.config.WithDefault;
 public interface AeshSshConfig {
 
     /**
-     * Whether the SSH terminal server is enabled.
-     */
-    @WithDefault("true")
-    boolean enabled();
-
-    /**
      * SSH server port.
      */
     @WithDefault("2222")

--- a/extensions/aesh/ssh/runtime/src/main/java/io/quarkus/aesh/ssh/runtime/SshServerLifecycle.java
+++ b/extensions/aesh/ssh/runtime/src/main/java/io/quarkus/aesh/ssh/runtime/SshServerLifecycle.java
@@ -56,11 +56,6 @@ public class SshServerLifecycle implements TransportSessionInfo {
     private volatile ScheduledExecutorService idleScheduler;
 
     void onStart(@Observes StartupEvent event) throws Exception {
-        if (!config.enabled()) {
-            LOG.info("Aesh SSH server is disabled");
-            return;
-        }
-
         // In native images, security providers registered during build-time
         // class initialization are not preserved. Re-register them at runtime
         // so SSHD can use them for key generation and crypto operations.

--- a/extensions/aesh/ssh/runtime/src/main/java/io/quarkus/aesh/ssh/runtime/health/AeshSshHealthCheck.java
+++ b/extensions/aesh/ssh/runtime/src/main/java/io/quarkus/aesh/ssh/runtime/health/AeshSshHealthCheck.java
@@ -11,6 +11,13 @@ import org.eclipse.microprofile.health.Readiness;
 import io.quarkus.aesh.ssh.runtime.AeshSshConfig;
 import io.quarkus.aesh.ssh.runtime.SshServerLifecycle;
 
+/**
+ * Health check for the Aesh SSH server.
+ * <p>
+ * This bean is only registered when {@code quarkus.aesh.ssh.enabled=true}
+ * (the default) and the SmallRye Health extension is present. The processor
+ * vetoes this class otherwise, so there is no need for a runtime enabled check.
+ */
 @Readiness
 @ApplicationScoped
 public class AeshSshHealthCheck implements HealthCheck {
@@ -25,10 +32,6 @@ public class AeshSshHealthCheck implements HealthCheck {
     public HealthCheckResponse call() {
         HealthCheckResponseBuilder builder = HealthCheckResponse
                 .named("Aesh SSH server health check");
-
-        if (!config.enabled()) {
-            return builder.up().withData("server", "disabled").build();
-        }
 
         if (sshServer.isRunning()) {
             return builder.up()

--- a/extensions/aesh/websocket/deployment/src/main/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketProcessor.java
+++ b/extensions/aesh/websocket/deployment/src/main/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketProcessor.java
@@ -27,6 +27,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 import io.quarkus.websockets.next.HttpUpgradeCheck;
 import io.quarkus.websockets.next.WebSocket;
@@ -162,7 +163,7 @@ class AeshWebSocketProcessor {
     @Produce(ArtifactResultBuildItem.class)
     void warnIfInsecureInProduction(AeshWebSocketConfig config,
             LaunchModeBuildItem launchMode) {
-        if (config.enabled() && launchMode.getLaunchMode() == io.quarkus.runtime.LaunchMode.NORMAL) {
+        if (config.enabled() && launchMode.getLaunchMode() == LaunchMode.NORMAL) {
             if (config.rolesAllowed().isEmpty() && !config.authenticated()) {
                 LOG.warn("Aesh WebSocket terminal is enabled in production without " +
                         "authentication. Set 'quarkus.aesh.websocket.roles-allowed' or " +


### PR DESCRIPTION
The SSH module's 'enabled' property was a runtime config in AeshSshConfig, but the processor unconditionally produced AeshRemoteTransportBuildItem and registered SshServerLifecycle at build time regardless of the enabled state. This caused the core AeshProcessor to suppress the local console whenever the SSH module was on the classpath, even with enabled=false.

Move 'enabled' from AeshSshConfig (RUN_TIME) to AeshSshBuildTimeConfig (BUILD_TIME), matching the WebSocket module's pattern.

