### PR TITLE
Centralize UserContextInternal cast into QuarkusHttpUser.setUser()

### DIFF
--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/SecurityContextFilter.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/SecurityContextFilter.java
@@ -106,9 +106,7 @@ public class SecurityContextFilter implements ContainerRequestFilter {
                 return Uni.createFrom().nullItem();
             }
         };
-        // TODO: see if we can find a better way for setting a user on a RoutingContext user context
-        ((io.vertx.ext.web.impl.UserContextInternal) routingContext.userContext())
-                .setUser(new QuarkusHttpUser(newIdentity));
+        QuarkusHttpUser.setUser(routingContext, new QuarkusHttpUser(newIdentity));
         currentIdentityAssociation.setIdentity(newIdentity);
     }
 }

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/SecurityContextOverrideHandler.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/SecurityContextOverrideHandler.java
@@ -26,7 +26,6 @@ import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.impl.UserContextInternal;
 
 public class SecurityContextOverrideHandler implements ServerRestHandler {
 
@@ -121,8 +120,7 @@ public class SecurityContextOverrideHandler implements ServerRestHandler {
                         }
                     };
                     if (routingContext != null) {
-                        ((UserContextInternal) routingContext.userContext())
-                                .setUser(new QuarkusHttpUser(newIdentity));
+                        QuarkusHttpUser.setUser(routingContext, new QuarkusHttpUser(newIdentity));
                     }
                     return newIdentity;
                 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -438,8 +438,7 @@ public class HttpSecurityRecorder {
                             public void accept(SecurityIdentity identity, Throwable throwable, Boolean aBoolean) {
                                 if (identity != null) {
                                     //when the result is evaluated we set the user, even if it is evaluated lazily
-                                    ((io.vertx.ext.web.impl.UserContextInternal) event.userContext())
-                                            .setUser(new QuarkusHttpUser(identity));
+                                    QuarkusHttpUser.setUser(event, new QuarkusHttpUser(identity));
                                 } else if (throwable != null) {
                                     //handle the auth failure
                                     //this can be customised

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/QuarkusHttpUser.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/QuarkusHttpUser.java
@@ -9,6 +9,7 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.impl.UserContextInternal;
 
 /**
  * Basic vert.x user representation
@@ -108,14 +109,21 @@ public class QuarkusHttpUser implements User {
         return Uni.createFrom().nullItem();
     }
 
+    /**
+     * Sets the Vert.x {@link User} on the routing context without touching the deferred identity.
+     */
+    public static void setUser(RoutingContext routingContext, User user) {
+        ((UserContextInternal) routingContext.userContext()).setUser(user);
+    }
+
     static Uni<SecurityIdentity> setIdentity(Uni<SecurityIdentity> identityUni, RoutingContext routingContext) {
-        ((io.vertx.ext.web.impl.UserContextInternal) routingContext.userContext()).setUser(null);
+        setUser(routingContext, null);
         routingContext.put(QuarkusHttpUser.DEFERRED_IDENTITY_KEY, identityUni);
         return identityUni;
     }
 
     public static SecurityIdentity setIdentity(SecurityIdentity identity, RoutingContext routingContext) {
-        ((io.vertx.ext.web.impl.UserContextInternal) routingContext.userContext()).setUser(new QuarkusHttpUser(identity));
+        setUser(routingContext, new QuarkusHttpUser(identity));
         routingContext.put(QuarkusHttpUser.DEFERRED_IDENTITY_KEY, Uni.createFrom().item(identity));
         return identity;
     }

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/security/QuarkusHttpUserTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/security/QuarkusHttpUserTest.java
@@ -26,6 +26,7 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.impl.UserContextInternal;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -137,8 +138,28 @@ class QuarkusHttpUserTest {
     }
 
     @Test
+    void setUserDelegatesToUserContextInternal() {
+        UserContextInternal userContext = mock(UserContextInternal.class);
+        when(routingContext.userContext()).thenReturn(userContext);
+
+        QuarkusHttpUser.setUser(routingContext, user);
+
+        verify(userContext).setUser(user);
+    }
+
+    @Test
+    void setUserWithNullClearsUser() {
+        UserContextInternal userContext = mock(UserContextInternal.class);
+        when(routingContext.userContext()).thenReturn(userContext);
+
+        QuarkusHttpUser.setUser(routingContext, null);
+
+        verify(userContext).setUser(null);
+    }
+
+    @Test
     void setIdentityWithSecurityIdentitySetsUserAndDeferredKey() {
-        io.vertx.ext.web.impl.UserContextInternal userContext = mock(io.vertx.ext.web.impl.UserContextInternal.class);
+        UserContextInternal userContext = mock(UserContextInternal.class);
         when(routingContext.userContext()).thenReturn(userContext);
 
         SecurityIdentity result = QuarkusHttpUser.setIdentity(securityIdentity, routingContext);

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/SecuritySupport.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/SecuritySupport.java
@@ -18,7 +18,6 @@ import io.quarkus.websockets.next.WebSocketServerException;
 import io.quarkus.websockets.next.runtime.spi.security.WebSocketIdentityUpdateRequest;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.impl.UserContextInternal;
 
 public final class SecuritySupport {
 
@@ -121,8 +120,7 @@ public final class SecuritySupport {
         onClose(); // cancel previous timer that closes connection when identity expired
         this.identity = updatedIdentity;
         // this shouldn't be necessary (and probably isn't) but updating ctx it just to stay on the safe side
-        UserContextInternal userContextInternal = (UserContextInternal) this.routingContext.userContext();
-        userContextInternal.setUser(new QuarkusHttpUser(updatedIdentity));
+        QuarkusHttpUser.setUser(this.routingContext, new QuarkusHttpUser(updatedIdentity));
         this.onClose = closeConnectionWhenIdentityExpired(routingContext, connection, updatedIdentity);
         if (connection.isClosed()) {
             // it could be that while we were updating identity, connection has been closed


### PR DESCRIPTION
Centralize `UserContextInternal` cast into `QuarkusHttpUser.setUser()`

This is a cleanup as part of https://github.com/quarkusio/quarkus/issues/51959
