### PR TITLE
Register terminal provider SPI and defer FFM init for native images

### DIFF
--- a/extensions/aesh/deployment/src/main/java/io/quarkus/aesh/deployment/AeshNativeImageProcessor.java
+++ b/extensions/aesh/deployment/src/main/java/io/quarkus/aesh/deployment/AeshNativeImageProcessor.java
@@ -21,10 +21,13 @@ import org.jboss.logging.Logger;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.FfmDowncallBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.FfmType;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 
@@ -33,26 +36,63 @@ class AeshNativeImageProcessor {
     private static final Logger LOGGER = Logger.getLogger(AeshNativeImageProcessor.class);
 
     /**
-     * Registers aesh metadata discovery resources for native images.
+     * Registers aesh service providers and resources for native images.
      * <p>
      * Aesh discovers {@code MetadataRegistry} implementations via a resource file
      * ({@code META-INF/aesh/registry}) before falling back to ServiceLoader.
-     * Registering the resource file is sufficient and avoids ServiceLoader overhead
-     * at startup.
+     * <p>
+     * Terminal providers ({@code TerminalProvider}) are discovered via ServiceLoader
+     * to create the correct terminal connection (FFM-based PTY, exec-based PTY, etc.).
+     * Without explicit registration, Quarkus's disabled auto-service-loader-registration
+     * prevents terminal provider discovery, causing aesh-readline to fall back to
+     * ExternalTerminal which uses buffered System.out and has no raw terminal mode.
      */
     @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
-    void registerMetadataProviders(BuildProducer<ServiceProviderBuildItem> serviceProviders,
+    void registerServiceProviders(BuildProducer<ServiceProviderBuildItem> serviceProviders,
             BuildProducer<NativeImageResourceBuildItem> nativeResources) {
         serviceProviders.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
                 "org.aesh.command.metadata.CommandMetadataProvider"));
+        serviceProviders.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "org.aesh.terminal.provider.TerminalProvider"));
         nativeResources.produce(new NativeImageResourceBuildItem("META-INF/aesh/registry"));
+    }
+
+    /**
+     * Registers FFM downcall signatures used by aesh-readline's {@code LibC} class
+     * for POSIX terminal access (tcgetattr, tcsetattr, ioctl, read, poll, etc.).
+     * <p>
+     * GraalVM native image requires explicit registration of all FFM downcall
+     * signatures. Without this, the FFM terminal provider fails at runtime with
+     * {@code MissingForeignRegistrationError} and falls back to ExecPty.
+     */
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    void registerFfmDowncalls(BuildProducer<FfmDowncallBuildItem> downcalls) {
+        // int isatty(int fd) — no captureCallState
+        downcalls.produce(new FfmDowncallBuildItem(FfmType.INT, FfmType.INT));
+        // int open(const char *pathname, int flags) — with captureCallState
+        downcalls.produce(new FfmDowncallBuildItem(FfmType.INT, FfmType.ADDRESS, FfmType.INT));
+        // int close(int fd) — with captureCallState
+        downcalls.produce(new FfmDowncallBuildItem(FfmType.INT, FfmType.INT));
+        // ssize_t read(int fd, void *buf, size_t count) — with captureCallState
+        downcalls.produce(new FfmDowncallBuildItem(FfmType.LONG, FfmType.INT, FfmType.ADDRESS, FfmType.LONG));
+        // int poll(struct pollfd *fds, nfds_t nfds, int timeout) — Linux: nfds_t=long
+        downcalls.produce(new FfmDowncallBuildItem(FfmType.INT, FfmType.ADDRESS, FfmType.LONG, FfmType.INT));
+        // int poll(struct pollfd *fds, nfds_t nfds, int timeout) — macOS: nfds_t=int
+        downcalls.produce(new FfmDowncallBuildItem(FfmType.INT, FfmType.ADDRESS, FfmType.INT, FfmType.INT));
+        // int tcgetattr(int fd, struct termios *termios_p) — with captureCallState
+        downcalls.produce(new FfmDowncallBuildItem(FfmType.INT, FfmType.INT, FfmType.ADDRESS));
+        // int tcsetattr(int fd, int actions, const struct termios *termios_p)
+        downcalls.produce(new FfmDowncallBuildItem(FfmType.INT, FfmType.INT, FfmType.INT, FfmType.ADDRESS));
+        // int ioctl(int fd, unsigned long request, void *arg) — variadic
+        downcalls.produce(new FfmDowncallBuildItem(FfmType.INT, FfmType.INT, FfmType.LONG, FfmType.ADDRESS));
     }
 
     @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
     void reflectionConfiguration(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchies,
-            BuildProducer<NativeImageProxyDefinitionBuildItem> nativeImageProxies) {
+            BuildProducer<NativeImageProxyDefinitionBuildItem> nativeImageProxies,
+            BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClasses) {
         IndexView index = combinedIndexBuildItem.getIndex();
 
         Collection<DotName> annotationsToAnalyze = Arrays.asList(
@@ -138,6 +178,34 @@ class AeshNativeImageProcessor {
                 "org.aesh.command.impl.parser.AeshOptionParser",
                 "org.aesh.AeshConsoleRunner$ExitCommand")
                 .build());
+
+        // FfmTerminalProvider loads FfmPty via Class.forName() (multi-release JAR,
+        // Java 22+). Register it for reflection so it can be instantiated in native.
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(
+                "org.aesh.terminal.tty.impl.FfmPty")
+                .methods().build());
+
+        // FFM terminal classes use java.lang.foreign.Linker in static initializers
+        // to create downcall handles for POSIX functions (tcgetattr, ioctl, etc.)
+        // and Windows console functions (GetStdHandle, etc.). These must be
+        // initialized at runtime, not captured at build time inside the container
+        // which has no TTY and may produce stale FFM state.
+        runtimeInitializedClasses.produce(new RuntimeInitializedClassBuildItem(
+                "org.aesh.terminal.tty.impl.LibC"));
+        runtimeInitializedClasses.produce(new RuntimeInitializedClassBuildItem(
+                "org.aesh.terminal.tty.impl.PosixConstants"));
+        runtimeInitializedClasses.produce(new RuntimeInitializedClassBuildItem(
+                "org.aesh.terminal.tty.impl.FfmPty"));
+        runtimeInitializedClasses.produce(new RuntimeInitializedClassBuildItem(
+                "org.aesh.terminal.tty.impl.WinConsoleNative"));
+        runtimeInitializedClasses.produce(new RuntimeInitializedClassBuildItem(
+                "org.aesh.terminal.tty.impl.WinSysTerminal"));
+        runtimeInitializedClasses.produce(new RuntimeInitializedClassBuildItem(
+                "org.aesh.terminal.tty.impl.WinSysTerminal$Handles"));
+        runtimeInitializedClasses.produce(new RuntimeInitializedClassBuildItem(
+                "org.aesh.terminal.tty.impl.AbstractWindowsTerminal"));
+        runtimeInitializedClasses.produce(new RuntimeInitializedClassBuildItem(
+                "org.aesh.terminal.tty.impl.AbstractWindowsTerminal$ConsoleOutput"));
     }
 
 }


### PR DESCRIPTION
Quarkus disables automatic ServiceLoader registration by default, but the aesh extension did not explicitly register the TerminalProvider SPI. This prevented aesh-readline from discovering terminal providers (FFM, ExecPty) in native images, causing it to fall back to ExternalTerminal which uses buffered System.out without raw terminal mode. The result was missing prompts and broken tab completion in native executables.

Register org.aesh.terminal.provider.TerminalProvider via ServiceProviderBuildItem so all terminal providers are discoverable.

Fixes: https://github.com/Hyperfoil/h5m/issues/267

