### PR TITLE
Tweak Gradle plugin build properties

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/TasksConfigurationCacheCompatibilityTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/TasksConfigurationCacheCompatibilityTest.java
@@ -73,12 +73,12 @@ public class TasksConfigurationCacheCompatibilityTest {
         FileUtils.copyDirectory(new File(url.toURI()), testProjectDir.toFile());
         FileUtils.copyFile(new File("../gradle.properties"), testProjectDir.resolve("gradle.properties").toFile());
 
-        buildResult(":help", "--configuration-cache");
+        buildResult(":help", "--configuration-cache", "-Dorg.gradle.unsafe.isolated-projects=true");
 
-        BuildResult firstBuild = buildResult(taskName, "-Dorg.gradle.unsafe.isolated-projects=true");
+        BuildResult firstBuild = buildResult(taskName, "--configuration-cache", "-Dorg.gradle.unsafe.isolated-projects=true");
         assertTrue(firstBuild.getOutput().contains("Configuration cache entry stored"));
 
-        BuildResult secondBuild = buildResult(taskName, "-Dorg.gradle.unsafe.isolated-projects=true");
+        BuildResult secondBuild = buildResult(taskName, "--configuration-cache", "-Dorg.gradle.unsafe.isolated-projects=true");
         assertTrue(secondBuild.getOutput().contains("Reusing configuration cache."));
     }
 
@@ -151,6 +151,10 @@ public class TasksConfigurationCacheCompatibilityTest {
 
     private BuildResult buildResult(String task, String configurationCacheCommand) {
         return buildResult(task, List.of(configurationCacheCommand));
+    }
+
+    private BuildResult buildResult(String task, String firstExtraArg, String secondExtraArg) {
+        return buildResult(task, List.of(firstExtraArg, secondExtraArg));
     }
 
     private BuildResult buildResult(String task, List<String> extraArgs) {

--- a/devtools/gradle/gradle.properties
+++ b/devtools/gradle/gradle.properties
@@ -1,1 +1,16 @@
 version = 999-SNAPSHOT
+
+# Enable the Gradle build cache
+org.gradle.caching=true
+# Enable Gradle parallel builds
+org.gradle.parallel=true
+# Configure only necessary Gradle tasks
+org.gradle.configureondemand=true
+# Explicitly disable the configuration cache.
+# The configuration cache can be used explicitly using the `--configuration-cache` option.
+# But enabling the configuration cache by default can be risky, especially in CI environments,
+# because credentials in environment variable, system properties or Gradle properties _may_
+# be persisted to disk and become unintentionally accessible.
+org.gradle.configuration-cache=false
+#org.gradle.configuration-cache-problems=warn
+org.gradle.warning.mode=all


### PR DESCRIPTION
Enable build caching, parallel execution, configuration-on-demand, and full warning reporting for the Gradle plugin build.

Keep the configuration cache disabled by default. It remains available explicitly, but a default cache can persist values observed from credentials or other environment sources.
