### PR TITLE
Make remote-dev session updates consistent

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandler.java
@@ -5,12 +5,13 @@ import java.io.IOException;
 import java.io.ObjectInputFilter;
 import java.io.ObjectInputStream;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Base64;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.jboss.logging.Logger;
 
@@ -37,6 +38,9 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
     public static final String DEV = "/dev";
     public static final String PROBE = "/probe"; //used to check that the server is back up after restart
 
+    private static final long SESSION_TIMEOUT_MILLIS = 60000;
+    private static final ReentrantLock SESSION_OPERATION_LOCK = new ReentrantLock(true);
+
     final String password;
     final Handler<HttpServerRequest> next;
     final HotReplacementContext hotReplacementContext;
@@ -44,10 +48,7 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
 
     //all these are static to allow the handler to be recreated on hot reload
     //which makes lifecycle management a lot easier
-    static volatile String currentSession;
-    //incrementing counter to prevent replay attacks
-    static volatile int currentSessionCounter;
-    static volatile long currentSessionTimeout;
+    static volatile SessionState sessionState = SessionState.inactive();
     static volatile Throwable remoteProblem;
     static volatile boolean checkForChanges;
 
@@ -60,7 +61,8 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
     }
 
     public static void doPreScan() {
-        if (currentSession == null) {
+        SessionState state = sessionState;
+        if (!state.isActive(System.currentTimeMillis())) {
             return;
         }
         synchronized (RemoteSyncHandler.class) {
@@ -77,21 +79,15 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
 
     @Override
     public void handle(HttpServerRequest event) {
-        long time = System.currentTimeMillis();
-        if (time > currentSessionTimeout) {
-            currentSession = null;
-            currentSessionCounter = 0;
-        }
         final String type = event.headers().get(HttpHeaderNames.CONTENT_TYPE);
         if (APPLICATION_QUARKUS.equals(type)) {
-            currentSessionTimeout = time + 60000;
-            VertxCoreRecorder.getVertx().get().executeBlocking(new Callable<Void>() {
+            executeBlocking(new Callable<Void>() {
                 @Override
                 public Void call() {
                     handleRequest(event);
                     return null;
                 }
-            }, false);
+            });
             return;
         }
         next.handle(event);
@@ -125,35 +121,37 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
         event.bodyHandler(new Handler<Buffer>() {
             @Override
             public void handle(Buffer b) {
-                if (checkSession(event, b.getBytes())) {
-                    return;
-                }
-                VertxCoreRecorder.getVertx().get().executeBlocking(new Callable<Void>() {
+                executeBlocking(new Callable<Void>() {
                     @Override
                     public Void call() {
                         try {
-                            Throwable problem = (Throwable) createFilteredObjectInputStream(b.getBytes())
-                                    .readObject();
-                            //update the problem if it has changed
-                            if (problem != null || remoteProblem != null) {
-                                remoteProblem = problem;
-                                hotReplacementContext.setRemoteProblem(problem);
-                            }
-                            synchronized (RemoteSyncHandler.class) {
-                                RemoteSyncHandler.class.notifyAll();
-                                try {
-                                    RemoteSyncHandler.class.wait(10000);
-                                } catch (InterruptedException e) {
-                                    log.debug("interrupted", e);
+                            withAuthenticatedSession(event, b.getBytes(), () -> {
+                                Throwable problem;
+                                try (ObjectInputStream input = createFilteredObjectInputStream(b.getBytes())) {
+                                    problem = (Throwable) input.readObject();
                                 }
-                                if (checkForChanges) {
-                                    checkForChanges = false;
-                                    event.response().setStatusCode(200);
-                                } else {
-                                    event.response().setStatusCode(204);
+                                //update the problem if it has changed
+                                if (problem != null || remoteProblem != null) {
+                                    remoteProblem = problem;
+                                    hotReplacementContext.setRemoteProblem(problem);
                                 }
-                                event.response().end();
-                            }
+                                synchronized (RemoteSyncHandler.class) {
+                                    RemoteSyncHandler.class.notifyAll();
+                                    try {
+                                        RemoteSyncHandler.class.wait(10000);
+                                    } catch (InterruptedException e) {
+                                        Thread.currentThread().interrupt();
+                                        log.debug("interrupted", e);
+                                    }
+                                    if (checkForChanges) {
+                                        checkForChanges = false;
+                                        event.response().setStatusCode(200);
+                                    } else {
+                                        event.response().setStatusCode(204);
+                                    }
+                                    event.response().end();
+                                }
+                            });
                         } catch (RejectedExecutionException e) {
                             //everything is shut down
                             //likely in the middle of a restart
@@ -164,7 +162,7 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
                         }
                         return null;
                     }
-                }, false);
+                });
             }
         }).exceptionHandler(new Handler<Throwable>() {
             @Override
@@ -179,36 +177,10 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
         event.bodyHandler(new Handler<Buffer>() {
             @Override
             public void handle(Buffer b) {
-                try {
-
-                    String rp = event.headers().get(QUARKUS_PASSWORD);
-                    String bodyHash = HashUtil.sha256(b.getBytes());
-                    String compare = HashUtil.sha256(bodyHash + password);
-                    if (!compare.equals(rp)) {
-                        log.error("Incorrect password");
-                        event.response().putHeader(QUARKUS_ERROR, "Incorrect password").setStatusCode(401).end();
-                        return;
-                    }
-                    SecureRandom r = new SecureRandom();
-                    byte[] sessionId = new byte[40];
-                    r.nextBytes(sessionId);
-                    currentSession = Base64.getEncoder().encodeToString(sessionId);
-                    currentSessionCounter = 0;
-                    RemoteDevState state = (RemoteDevState) createFilteredObjectInputStream(b.getBytes())
-                            .readObject();
-                    remoteProblem = state.getAugmentProblem();
-                    if (state.getAugmentProblem() != null) {
-                        hotReplacementContext.setRemoteProblem(state.getAugmentProblem());
-                    }
-                    Set<String> files = hotReplacementContext.syncState(state.getFileHashes());
-                    event.response().headers().set(QUARKUS_SESSION, currentSession);
-                    event.response().end(String.join(";", files));
-
-                } catch (Exception e) {
-                    log.error("Connect failed", e);
-                    event.response().setStatusCode(500).end();
-                }
-
+                executeBlocking(() -> {
+                    processConnect(event, b);
+                    return null;
+                });
             }
         }).exceptionHandler(new Handler<Throwable>() {
             @Override
@@ -219,26 +191,52 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
         }).resume();
     }
 
+    private void processConnect(HttpServerRequest event, Buffer body) {
+        try {
+            String rp = event.headers().get(QUARKUS_PASSWORD);
+            String bodyHash = HashUtil.sha256(body.getBytes());
+            String compare = HashUtil.sha256(bodyHash + password);
+            if (!constantTimeEquals(compare, rp)) {
+                log.error("Incorrect password");
+                event.response().putHeader(QUARKUS_ERROR, "Incorrect password").setStatusCode(401).end();
+                return;
+            }
+            SESSION_OPERATION_LOCK.lock();
+            try {
+                RemoteDevState state;
+                try (ObjectInputStream input = createFilteredObjectInputStream(body.getBytes())) {
+                    state = (RemoteDevState) input.readObject();
+                }
+                Set<String> files = hotReplacementContext.syncState(state.getFileHashes());
+                if (state.getAugmentProblem() != null) {
+                    hotReplacementContext.setRemoteProblem(state.getAugmentProblem());
+                }
+                SecureRandom r = new SecureRandom();
+                byte[] sessionId = new byte[40];
+                r.nextBytes(sessionId);
+                String session = Base64.getEncoder().encodeToString(sessionId);
+                sessionState = new SessionState(session, 0,
+                        System.currentTimeMillis() + SESSION_TIMEOUT_MILLIS);
+                remoteProblem = state.getAugmentProblem();
+                event.response().headers().set(QUARKUS_SESSION, session);
+                event.response().end(String.join(";", files));
+            } finally {
+                SESSION_OPERATION_LOCK.unlock();
+            }
+        } catch (Exception e) {
+            log.error("Connect failed", e);
+            event.response().setStatusCode(500).end();
+        }
+    }
+
     private void handlePut(HttpServerRequest event) {
         event.bodyHandler(new Handler<Buffer>() {
             @Override
             public void handle(Buffer buffer) {
-                if (checkSession(event, buffer.getBytes())) {
-                    return;
-                }
-                try {
-                    String path = stripRootPath(event.path());
-                    hotReplacementContext.updateFile(path, buffer.getBytes());
-                } catch (IllegalArgumentException e) {
-                    log.warn("Rejected remote-dev file update", e);
-                    event.response().setStatusCode(400).end();
-                    return;
-                } catch (Exception e) {
-                    log.error("Failed to update file", e);
-                    event.response().setStatusCode(500).end();
-                    return;
-                }
-                event.response().end();
+                executeBlocking(() -> {
+                    processPut(event, buffer);
+                    return null;
+                });
             }
         }).exceptionHandler(new Handler<Throwable>() {
             @Override
@@ -250,6 +248,24 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
         }).resume();
     }
 
+    private void processPut(HttpServerRequest event, Buffer buffer) {
+        try {
+            if (withAuthenticatedSession(event, buffer.getBytes(),
+                    () -> hotReplacementContext.updateFile(stripRootPath(event.path()), buffer.getBytes()))) {
+                return;
+            }
+        } catch (IllegalArgumentException e) {
+            log.warn("Rejected remote-dev file update", e);
+            event.response().setStatusCode(400).end();
+            return;
+        } catch (Exception e) {
+            log.error("Failed to update file", e);
+            event.response().setStatusCode(500).end();
+            return;
+        }
+        event.response().end();
+    }
+
     private String stripRootPath(String path) {
         return path.startsWith(rootPath)
                 ? path.substring(rootPath.length())
@@ -257,10 +273,11 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
     }
 
     private void handleDelete(HttpServerRequest event) {
-        if (checkSession(event, event.path().getBytes(StandardCharsets.UTF_8)))
-            return;
         try {
-            hotReplacementContext.deleteFile(stripRootPath(event.path()));
+            if (withAuthenticatedSession(event, event.path().getBytes(StandardCharsets.UTF_8),
+                    () -> hotReplacementContext.deleteFile(stripRootPath(event.path())))) {
+                return;
+            }
             event.response().end();
         } catch (IllegalArgumentException e) {
             log.warn("Rejected remote-dev file deletion", e);
@@ -271,7 +288,8 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
         }
     }
 
-    private boolean checkSession(HttpServerRequest event, byte[] data) {
+    private boolean withAuthenticatedSession(HttpServerRequest event, byte[] data, CheckedOperation operation)
+            throws Exception {
         String ses = event.headers().get(QUARKUS_SESSION);
         String sessionCount = event.headers().get(QUARKUS_SESSION_COUNT);
         if (sessionCount == null) {
@@ -281,16 +299,19 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
             event.response().setStatusCode(203).end();
             return true;
         }
-        int sc = Integer.parseInt(sessionCount);
-        if (!Objects.equals(ses, currentSession) ||
-                sc <= currentSessionCounter) {
-            log.error("Invalid session");
-            //not really sure what status code makes sense here
-            //Non-Authoritative Information seems as good as any
+        final int sc;
+        try {
+            sc = Integer.parseInt(sessionCount);
+        } catch (NumberFormatException e) {
+            log.error("Invalid session count");
             event.response().setStatusCode(203).end();
             return true;
         }
-        currentSessionCounter = sc;
+        if (sc <= 0) {
+            log.error("Invalid session count");
+            event.response().setStatusCode(203).end();
+            return true;
+        }
 
         String dataHash = "";
         if (data != null) {
@@ -298,12 +319,70 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
         }
         String rp = event.headers().get(QUARKUS_PASSWORD);
         String compare = HashUtil.sha256(dataHash + ses + sc + password);
-        if (!compare.equals(rp)) {
+        if (!constantTimeEquals(compare, rp)) {
             log.error("Incorrect password");
             event.response().setStatusCode(401).end();
             return true;
         }
-        return false;
+        SESSION_OPERATION_LOCK.lock();
+        try {
+            long now = System.currentTimeMillis();
+            SessionState current = sessionState;
+            if (!current.isActive(now)) {
+                sessionState = SessionState.inactive();
+                log.error("Invalid session");
+                event.response().setStatusCode(203).end();
+                return true;
+            }
+            if (!current.id().equals(ses) || sc <= current.acceptedCounter()) {
+                log.error("Invalid session");
+                //not really sure what status code makes sense here
+                //Non-Authoritative Information seems as good as any
+                event.response().setStatusCode(203).end();
+                return true;
+            }
+            sessionState = new SessionState(current.id(), sc, now + SESSION_TIMEOUT_MILLIS);
+            operation.run();
+            return false;
+        } finally {
+            SESSION_OPERATION_LOCK.unlock();
+        }
+    }
+
+    private static boolean constantTimeEquals(String expected, String actual) {
+        byte[] expectedBytes = expected.getBytes(StandardCharsets.US_ASCII);
+        byte[] actualBytes = new byte[expectedBytes.length];
+        boolean valid = actual != null && actual.length() == expectedBytes.length;
+        if (valid) {
+            for (int i = 0; i < actual.length(); i++) {
+                char value = actual.charAt(i);
+                if (Character.digit(value, 16) == -1) {
+                    valid = false;
+                }
+                actualBytes[i] = (byte) value;
+            }
+        }
+        return MessageDigest.isEqual(expectedBytes, actualBytes) & valid;
+    }
+
+    void executeBlocking(Callable<Void> action) {
+        VertxCoreRecorder.getVertx().get().executeBlocking(action, false);
+    }
+
+    @FunctionalInterface
+    private interface CheckedOperation {
+        void run() throws Exception;
+    }
+
+    record SessionState(String id, int acceptedCounter, long expiresAt) {
+
+        static SessionState inactive() {
+            return new SessionState(null, 0, 0);
+        }
+
+        boolean isActive(long now) {
+            return id != null && now <= expiresAt;
+        }
     }
 
     /**

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandlerTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandlerTest.java
@@ -1,19 +1,34 @@
 package io.quarkus.vertx.http.runtime.devmode;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.dev.spi.HotReplacementContext;
+import io.quarkus.dev.spi.RemoteDevState;
 import io.quarkus.runtime.util.HashUtil;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -28,9 +43,7 @@ class RemoteSyncHandlerTest {
 
     @AfterEach
     void resetRemoteSyncState() {
-        RemoteSyncHandler.currentSession = null;
-        RemoteSyncHandler.currentSessionCounter = 0;
-        RemoteSyncHandler.currentSessionTimeout = 0;
+        RemoteSyncHandler.sessionState = RemoteSyncHandler.SessionState.inactive();
         RemoteSyncHandler.remoteProblem = null;
         RemoteSyncHandler.checkForChanges = false;
     }
@@ -39,8 +52,7 @@ class RemoteSyncHandlerTest {
     void putStripsConfiguredRootPathBeforeUpdatingFile() throws Exception {
         byte[] data = "content".getBytes(StandardCharsets.UTF_8);
         var context = mock(HotReplacementContext.class);
-        var handler = new RemoteSyncHandler(PASSWORD, ignored -> {
-        }, context, "/root");
+        var handler = handler(context);
 
         invokeHandlePut(handler, request("/root/app/classes/com/acme/Foo.class", data));
 
@@ -51,8 +63,7 @@ class RemoteSyncHandlerTest {
     void putLeavesPathUnchangedWhenRootPathDoesNotMatch() throws Exception {
         byte[] data = "content".getBytes(StandardCharsets.UTF_8);
         var context = mock(HotReplacementContext.class);
-        var handler = new RemoteSyncHandler(PASSWORD, ignored -> {
-        }, context, "/root");
+        var handler = handler(context);
 
         invokeHandlePut(handler, request("/other/app/classes/com/acme/Foo.class", data));
 
@@ -62,8 +73,7 @@ class RemoteSyncHandlerTest {
     @Test
     void deletePassesRawRequestPathToUpdateFile() throws Exception {
         var context = mock(HotReplacementContext.class);
-        var handler = new RemoteSyncHandler(PASSWORD, ignored -> {
-        }, context, "/root");
+        var handler = handler(context);
 
         invokeHandleDelete(handler, request("/root/app/classes/com/acme/Foo.class", null));
 
@@ -76,8 +86,7 @@ class RemoteSyncHandlerTest {
         var context = mock(HotReplacementContext.class);
         doThrow(new IllegalArgumentException("outside root")).when(context)
                 .updateFile("/app/classes/com/acme/Foo.class", data);
-        var handler = new RemoteSyncHandler(PASSWORD, ignored -> {
-        }, context, "/root");
+        var handler = handler(context);
         HttpServerRequest request = request("/root/app/classes/com/acme/Foo.class", data);
 
         invokeHandlePut(handler, request);
@@ -91,8 +100,7 @@ class RemoteSyncHandlerTest {
         var context = mock(HotReplacementContext.class);
         doThrow(new IllegalArgumentException("outside root")).when(context)
                 .deleteFile("/app/classes/com/acme/Foo.class");
-        var handler = new RemoteSyncHandler(PASSWORD, ignored -> {
-        }, context, "/root");
+        var handler = handler(context);
         HttpServerRequest request = request("/root/app/classes/com/acme/Foo.class", null);
 
         invokeHandleDelete(handler, request);
@@ -107,8 +115,7 @@ class RemoteSyncHandlerTest {
         var context = mock(HotReplacementContext.class);
         doThrow(new IllegalStateException("write failed")).when(context)
                 .updateFile("/app/classes/com/acme/Foo.class", data);
-        var handler = new RemoteSyncHandler(PASSWORD, ignored -> {
-        }, context, "/root");
+        var handler = handler(context);
         HttpServerRequest request = request("/root/app/classes/com/acme/Foo.class", data);
 
         invokeHandlePut(handler, request);
@@ -122,8 +129,7 @@ class RemoteSyncHandlerTest {
         var context = mock(HotReplacementContext.class);
         doThrow(new IllegalStateException("delete failed")).when(context)
                 .deleteFile("/app/classes/com/acme/Foo.class");
-        var handler = new RemoteSyncHandler(PASSWORD, ignored -> {
-        }, context, "/root");
+        var handler = handler(context);
         HttpServerRequest request = request("/root/app/classes/com/acme/Foo.class", null);
 
         invokeHandleDelete(handler, request);
@@ -132,16 +138,293 @@ class RemoteSyncHandlerTest {
         verify(request.response()).end();
     }
 
+    @Test
+    void invalidAuthenticatorDoesNotConsumeAHigherCounterOrRefreshTheSession() throws Exception {
+        byte[] data = "content".getBytes(StandardCharsets.UTF_8);
+        var context = mock(HotReplacementContext.class);
+        var handler = handler(context);
+        long timeout = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1);
+        RemoteSyncHandler.sessionState = new RemoteSyncHandler.SessionState(SESSION, 0, timeout);
+        HttpServerRequest rejected = request("/root/app/classes/com/acme/Foo.class", data,
+                SESSION, 100, "incorrect");
+
+        invokeHandlePut(handler, rejected);
+
+        verify(rejected.response()).setStatusCode(401);
+        assertThat(RemoteSyncHandler.sessionState)
+                .isEqualTo(new RemoteSyncHandler.SessionState(SESSION, 0, timeout));
+
+        HttpServerRequest accepted = request("/root/app/classes/com/acme/Foo.class", data,
+                SESSION, 1, authenticator(data, SESSION, 1));
+        invokeHandlePut(handler, accepted);
+
+        verify(context).updateFile("/app/classes/com/acme/Foo.class", data);
+        assertThat(RemoteSyncHandler.sessionState.acceptedCounter()).isEqualTo(1);
+        assertThat(RemoteSyncHandler.sessionState.expiresAt()).isGreaterThan(timeout);
+    }
+
+    @Test
+    void malformedCounterIsRejectedWithoutMutatingTheSession() throws Exception {
+        byte[] data = "content".getBytes(StandardCharsets.UTF_8);
+        var context = mock(HotReplacementContext.class);
+        var handler = handler(context);
+        long timeout = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1);
+        RemoteSyncHandler.SessionState expected = new RemoteSyncHandler.SessionState(SESSION, 0, timeout);
+        for (String invalidCount : new String[] { null, "", " ", "not-a-number", "2147483648", "-1", "0" }) {
+            RemoteSyncHandler.sessionState = expected;
+            HttpServerRequest request = request("/root/app/classes/com/acme/Foo.class", data,
+                    SESSION, invalidCount, "irrelevant");
+
+            invokeHandlePut(handler, request);
+
+            verify(request.response()).setStatusCode(203);
+            assertThat(RemoteSyncHandler.sessionState).isEqualTo(expected);
+        }
+        verify(context, never()).updateFile(any(), any());
+    }
+
+    @Test
+    void malformedAuthenticatorsAreRejectedWithoutMutatingTheSession() throws Exception {
+        byte[] data = "content".getBytes(StandardCharsets.UTF_8);
+        var context = mock(HotReplacementContext.class);
+        var handler = handler(context);
+        long timeout = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1);
+        RemoteSyncHandler.SessionState expected = new RemoteSyncHandler.SessionState(SESSION, 0, timeout);
+        for (String invalidAuthenticator : new String[] { null, "", "short", "g".repeat(64) }) {
+            RemoteSyncHandler.sessionState = expected;
+            HttpServerRequest request = request("/root/app/classes/com/acme/Foo.class", data,
+                    SESSION, "1", invalidAuthenticator);
+
+            invokeHandlePut(handler, request);
+
+            verify(request.response()).setStatusCode(401);
+            assertThat(RemoteSyncHandler.sessionState).isEqualTo(expected);
+        }
+        verify(context, never()).updateFile(any(), any());
+    }
+
+    @Test
+    void onlyOneConcurrentRequestCanCommitTheSameCounter() throws Exception {
+        byte[] data = "content".getBytes(StandardCharsets.UTF_8);
+        var context = mock(HotReplacementContext.class);
+        var handler = handler(context);
+        RemoteSyncHandler.sessionState = new RemoteSyncHandler.SessionState(
+                SESSION, 0, System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1));
+        HttpServerRequest first = request("/root/app/classes/com/acme/First.class", data,
+                SESSION, 1, authenticator(data, SESSION, 1));
+        HttpServerRequest second = request("/root/app/classes/com/acme/Second.class", data,
+                SESSION, 1, authenticator(data, SESSION, 1));
+        CountDownLatch start = new CountDownLatch(1);
+        var executor = Executors.newFixedThreadPool(2);
+        try {
+            var firstResult = executor.submit(() -> {
+                start.await();
+                invokeHandlePut(handler, first);
+                return responseHasStatus(first, 203);
+            });
+            var secondResult = executor.submit(() -> {
+                start.await();
+                invokeHandlePut(handler, second);
+                return responseHasStatus(second, 203);
+            });
+            start.countDown();
+
+            assertThat(List.of(firstResult.get(10, TimeUnit.SECONDS), secondResult.get(10, TimeUnit.SECONDS)))
+                    .containsExactlyInAnyOrder(false, true);
+            assertThat(RemoteSyncHandler.sessionState.acceptedCounter()).isEqualTo(1);
+            verify(context).updateFile(any(), any());
+        } finally {
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    @Test
+    void acceptedCountersAndTheirMutationsRemainOrdered() throws Exception {
+        byte[] data = "content".getBytes(StandardCharsets.UTF_8);
+        var context = mock(HotReplacementContext.class);
+        CountDownLatch firstMutationEntered = new CountDownLatch(1);
+        CountDownLatch releaseFirstMutation = new CountDownLatch(1);
+        List<String> mutations = new CopyOnWriteArrayList<>();
+        doAnswer(invocation -> {
+            String path = invocation.getArgument(0);
+            mutations.add(path);
+            if (path.contains("First")) {
+                firstMutationEntered.countDown();
+                assertThat(releaseFirstMutation.await(10, TimeUnit.SECONDS)).isTrue();
+            }
+            return null;
+        }).when(context).updateFile(any(), any());
+        var handler = handler(context);
+        RemoteSyncHandler.sessionState = new RemoteSyncHandler.SessionState(
+                SESSION, 9, System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1));
+        HttpServerRequest first = request("/root/app/classes/com/acme/First.class", data,
+                SESSION, 10, authenticator(data, SESSION, 10));
+        HttpServerRequest second = request("/root/app/classes/com/acme/Second.class", data,
+                SESSION, 11, authenticator(data, SESSION, 11));
+        CountDownLatch secondFinished = new CountDownLatch(1);
+        var executor = Executors.newFixedThreadPool(2);
+        try {
+            var firstResult = executor.submit(() -> {
+                invokeHandlePut(handler, first);
+                return null;
+            });
+            assertThat(firstMutationEntered.await(10, TimeUnit.SECONDS)).isTrue();
+            var secondResult = executor.submit(() -> {
+                try {
+                    invokeHandlePut(handler, second);
+                } finally {
+                    secondFinished.countDown();
+                }
+                return null;
+            });
+
+            assertThat(secondFinished.await(200, TimeUnit.MILLISECONDS)).isFalse();
+            releaseFirstMutation.countDown();
+            firstResult.get(10, TimeUnit.SECONDS);
+            secondResult.get(10, TimeUnit.SECONDS);
+
+            assertThat(mutations).containsExactly(
+                    "/app/classes/com/acme/First.class",
+                    "/app/classes/com/acme/Second.class");
+            assertThat(RemoteSyncHandler.sessionState.acceptedCounter()).isEqualTo(11);
+        } finally {
+            releaseFirstMutation.countDown();
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    @Test
+    void sessionReplacementWaitsForAnAcceptedOldSessionMutation() throws Exception {
+        byte[] data = "content".getBytes(StandardCharsets.UTF_8);
+        byte[] connectBody = serialized(new RemoteDevState(Map.of(), null));
+        var context = mock(HotReplacementContext.class);
+        CountDownLatch mutationEntered = new CountDownLatch(1);
+        CountDownLatch releaseMutation = new CountDownLatch(1);
+        CountDownLatch syncStarted = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            mutationEntered.countDown();
+            assertThat(releaseMutation.await(10, TimeUnit.SECONDS)).isTrue();
+            return null;
+        }).when(context).updateFile(any(), any());
+        when(context.syncState(any())).thenAnswer(invocation -> {
+            syncStarted.countDown();
+            return Set.of();
+        });
+        var handler = handler(context);
+        RemoteSyncHandler.sessionState = new RemoteSyncHandler.SessionState(
+                SESSION, 0, System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1));
+        HttpServerRequest oldSessionPut = request("/root/app/classes/com/acme/Old.class", data,
+                SESSION, 1, authenticator(data, SESSION, 1));
+        HttpServerRequest connect = connectRequest(connectBody);
+        var executor = Executors.newFixedThreadPool(2);
+        try {
+            var putResult = executor.submit(() -> {
+                invokeHandlePut(handler, oldSessionPut);
+                return null;
+            });
+            assertThat(mutationEntered.await(10, TimeUnit.SECONDS)).isTrue();
+            var connectResult = executor.submit(() -> {
+                invoke(handler, "handleConnect", connect);
+                return null;
+            });
+
+            assertThat(syncStarted.await(200, TimeUnit.MILLISECONDS)).isFalse();
+            assertThat(RemoteSyncHandler.sessionState.id()).isEqualTo(SESSION);
+            releaseMutation.countDown();
+            putResult.get(10, TimeUnit.SECONDS);
+            connectResult.get(10, TimeUnit.SECONDS);
+
+            assertThat(RemoteSyncHandler.sessionState.id()).isNotEqualTo(SESSION);
+            HttpServerRequest stalePut = request("/root/app/classes/com/acme/Stale.class", data,
+                    SESSION, 2, authenticator(data, SESSION, 2));
+            invokeHandlePut(handler, stalePut);
+            verify(stalePut.response()).setStatusCode(203);
+            verify(context).updateFile(any(), any());
+        } finally {
+            releaseMutation.countDown();
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    @Test
+    void failedConnectDoesNotReplaceTheUsableSession() throws Exception {
+        byte[] body = serialized(new RemoteDevState(Map.of("app/application.jar", "hash"), null));
+        var context = mock(HotReplacementContext.class);
+        doThrow(new IllegalStateException("sync failed")).when(context).syncState(any());
+        var handler = handler(context);
+        long timeout = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1);
+        RemoteSyncHandler.SessionState previous = new RemoteSyncHandler.SessionState(SESSION, 7, timeout);
+        RemoteSyncHandler.sessionState = previous;
+        HttpServerRequest request = connectRequest(body);
+
+        invoke(handler, "handleConnect", request);
+
+        verify(request.response()).setStatusCode(500);
+        assertThat(RemoteSyncHandler.sessionState).isEqualTo(previous);
+    }
+
+    @Test
+    void expiredSessionIsClearedAsOneRejectedTransition() throws Exception {
+        byte[] data = "content".getBytes(StandardCharsets.UTF_8);
+        var handler = handler(mock(HotReplacementContext.class));
+        RemoteSyncHandler.sessionState = new RemoteSyncHandler.SessionState(SESSION, 7, 1);
+        HttpServerRequest request = request("/root/app/classes/com/acme/Foo.class", data,
+                SESSION, 8, authenticator(data, SESSION, 8));
+
+        invokeHandlePut(handler, request);
+
+        verify(request.response()).setStatusCode(203);
+        assertThat(RemoteSyncHandler.sessionState).isEqualTo(RemoteSyncHandler.SessionState.inactive());
+    }
+
     private HttpServerRequest request(String path, byte[] body) {
-        RemoteSyncHandler.currentSession = SESSION;
-        RemoteSyncHandler.currentSessionCounter = 0;
+        RemoteSyncHandler.sessionState = new RemoteSyncHandler.SessionState(
+                SESSION, 0, System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1));
+        byte[] passwordHashInput = body == null ? path.getBytes(StandardCharsets.UTF_8) : body;
+        return request(path, body, SESSION, 1, authenticator(passwordHashInput, SESSION, 1));
+    }
+
+    private RemoteSyncHandler handler(HotReplacementContext context) {
+        return new RemoteSyncHandler(PASSWORD, ignored -> {
+        }, context, "/root") {
+            @Override
+            void executeBlocking(Callable<Void> action) {
+                try {
+                    action.call();
+                } catch (RuntimeException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        };
+    }
+
+    private HttpServerRequest request(String path, byte[] body, String session, int sessionCounter, String password) {
+        return request(path, body, session, Integer.toString(sessionCounter), password);
+    }
+
+    private HttpServerRequest request(String path, byte[] body, String session, String sessionCounter, String password) {
         var request = mock(HttpServerRequest.class);
         var response = mock(HttpServerResponse.class);
         when(request.path()).thenReturn(path);
         when(request.response()).thenReturn(response);
         when(response.setStatusCode(400)).thenReturn(response);
+        when(response.setStatusCode(401)).thenReturn(response);
+        when(response.setStatusCode(203)).thenReturn(response);
         when(response.setStatusCode(500)).thenReturn(response);
-        when(request.headers()).thenReturn(headers(path, body));
+        MultiMap headers = MultiMap.caseInsensitiveMultiMap()
+                .add(RemoteSyncHandler.QUARKUS_SESSION, session);
+        if (sessionCounter != null) {
+            headers.add(RemoteSyncHandler.QUARKUS_SESSION_COUNT, sessionCounter);
+        }
+        if (password != null) {
+            headers.add(RemoteSyncHandler.QUARKUS_PASSWORD, password);
+        }
+        when(request.headers()).thenReturn(headers);
         when(request.bodyHandler(any())).thenAnswer(invocation -> {
             Handler<Buffer> bodyHandler = invocation.getArgument(0);
             bodyHandler.handle(Buffer.buffer(body));
@@ -152,14 +435,35 @@ class RemoteSyncHandlerTest {
         return request;
     }
 
-    private MultiMap headers(String path, byte[] body) {
-        var sessionCounter = 1;
-        var passwordHashInput = body == null ? path.getBytes(StandardCharsets.UTF_8) : body;
-        return MultiMap.caseInsensitiveMultiMap()
-                .add(RemoteSyncHandler.QUARKUS_SESSION, SESSION)
-                .add(RemoteSyncHandler.QUARKUS_SESSION_COUNT, String.valueOf(sessionCounter))
+    private HttpServerRequest connectRequest(byte[] body) {
+        var request = mock(HttpServerRequest.class);
+        var response = mock(HttpServerResponse.class);
+        when(request.response()).thenReturn(response);
+        when(response.setStatusCode(500)).thenReturn(response);
+        when(response.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+        when(request.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap()
                 .add(RemoteSyncHandler.QUARKUS_PASSWORD,
-                        HashUtil.sha256(HashUtil.sha256(passwordHashInput) + SESSION + sessionCounter + PASSWORD));
+                        HashUtil.sha256(HashUtil.sha256(body) + PASSWORD)));
+        when(request.bodyHandler(any())).thenAnswer(invocation -> {
+            Handler<Buffer> bodyHandler = invocation.getArgument(0);
+            bodyHandler.handle(Buffer.buffer(body));
+            return request;
+        });
+        when(request.exceptionHandler(any())).thenReturn(request);
+        when(request.resume()).thenReturn(request);
+        return request;
+    }
+
+    private String authenticator(byte[] body, String session, int sessionCounter) {
+        return HashUtil.sha256(HashUtil.sha256(body) + session + sessionCounter + PASSWORD);
+    }
+
+    private byte[] serialized(Object value) throws Exception {
+        var bytes = new ByteArrayOutputStream();
+        try (var output = new ObjectOutputStream(bytes)) {
+            output.writeObject(value);
+        }
+        return bytes.toByteArray();
     }
 
     private void invokeHandlePut(RemoteSyncHandler handler, HttpServerRequest request) throws Exception {
@@ -168,6 +472,12 @@ class RemoteSyncHandlerTest {
 
     private void invokeHandleDelete(RemoteSyncHandler handler, HttpServerRequest request) throws Exception {
         invoke(handler, "handleDelete", request);
+    }
+
+    private boolean responseHasStatus(HttpServerRequest request, int status) {
+        return mockingDetails(request.response()).getInvocations().stream()
+                .anyMatch(invocation -> invocation.getMethod().getName().equals("setStatusCode")
+                        && invocation.getArgument(0).equals(status));
     }
 
     private void invoke(RemoteSyncHandler handler, String methodName, HttpServerRequest request) throws Exception {


### PR DESCRIPTION
Remote-dev session identity, request counters, expiry, and file operations were updated independently. Overlapping requests could advance counters out of order, displace a usable session when a connection failed, or apply file changes in a different order from the client.

Model session data as one immutable value and serialize session replacement, request validation, and mutation. Move blocking request work off the event loop and cover malformed metadata, overlapping counters, ordered mutations, replacement, and expiry.
