### PR TITLE
Deprecate legacy Gradle extension configuration accessors

### DIFF
--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
@@ -46,18 +46,34 @@ public class QuarkusExtensionConfiguration {
         dependencyCondition = project.getObjects().listProperty(String.class);
     }
 
+    /**
+     * @deprecated Use {@code getDisableValidation().set(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setDisableValidation(boolean disableValidation) {
-        this.disableValidation.set(disableValidation);
+        getDisableValidation().set(disableValidation);
     }
 
-    public Property<Boolean> isValidationDisabled() {
+    public Property<Boolean> getDisableValidation() {
         return disableValidation;
+    }
+
+    /**
+     * @deprecated Use {@link #getDisableValidation()} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public Property<Boolean> isValidationDisabled() {
+        return getDisableValidation();
     }
 
     public Property<String> getDeploymentArtifact() {
         return deploymentArtifact;
     }
 
+    /**
+     * @deprecated Use {@code getDeploymentArtifact().set(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setDeploymentArtifact(String deploymentArtifact) {
         this.deploymentArtifact.set(deploymentArtifact);
     }
@@ -66,6 +82,10 @@ public class QuarkusExtensionConfiguration {
         return deploymentModule;
     }
 
+    /**
+     * @deprecated Use {@code getDeploymentModule().set(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setDeploymentModule(String deploymentModule) {
         this.deploymentModule.set(deploymentModule);
     }
@@ -74,6 +94,10 @@ public class QuarkusExtensionConfiguration {
         return excludedArtifacts;
     }
 
+    /**
+     * @deprecated Use {@code getExcludedArtifacts().addAll(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setExcludedArtifacts(List<String> excludedArtifacts) {
         this.excludedArtifacts.addAll(excludedArtifacts);
     }
@@ -82,6 +106,10 @@ public class QuarkusExtensionConfiguration {
         return parentFirstArtifacts;
     }
 
+    /**
+     * @deprecated Use {@code getParentFirstArtifacts().addAll(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setParentFirstArtifacts(List<String> parentFirstArtifacts) {
         this.parentFirstArtifacts.addAll(parentFirstArtifacts);
     }
@@ -90,6 +118,10 @@ public class QuarkusExtensionConfiguration {
         return runnerParentFirstArtifacts;
     }
 
+    /**
+     * @deprecated Use {@code getRunnerParentFirstArtifacts().addAll(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setRunnerParentFirstArtifacts(List<String> runnerParentFirstArtifacts) {
         this.runnerParentFirstArtifacts.addAll(runnerParentFirstArtifacts);
     }
@@ -98,6 +130,10 @@ public class QuarkusExtensionConfiguration {
         return lesserPriorityArtifacts;
     }
 
+    /**
+     * @deprecated Use {@code getLesserPriorityArtifacts().addAll(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setLesserPriorityArtifacts(List<String> lesserPriorityArtifacts) {
         this.lesserPriorityArtifacts.addAll(lesserPriorityArtifacts);
     }
@@ -106,6 +142,10 @@ public class QuarkusExtensionConfiguration {
         return conditionalDependencies;
     }
 
+    /**
+     * @deprecated Use {@code getConditionalDependencies().addAll(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setConditionalDependencies(List<String> conditionalDependencies) {
         this.conditionalDependencies.addAll(conditionalDependencies);
     }
@@ -114,6 +154,10 @@ public class QuarkusExtensionConfiguration {
         return conditionalDevDependencies;
     }
 
+    /**
+     * @deprecated Use {@code getConditionalDevDependencies().addAll(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setConditionalDevDependencies(List<String> conditionalDependencies) {
         this.conditionalDevDependencies.addAll(conditionalDependencies);
     }
@@ -122,6 +166,10 @@ public class QuarkusExtensionConfiguration {
         return dependencyCondition;
     }
 
+    /**
+     * @deprecated Use {@code getDependencyConditions().addAll(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setDependencyConditions(List<String> dependencyCondition) {
         this.dependencyCondition.addAll(dependencyCondition);
     }

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
@@ -49,7 +49,7 @@ public class QuarkusExtensionConfiguration {
     /**
      * @deprecated Use {@code getDisableValidation().set(...)} instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "4.0", forRemoval = true)
     public void setDisableValidation(boolean disableValidation) {
         getDisableValidation().set(disableValidation);
     }
@@ -61,7 +61,7 @@ public class QuarkusExtensionConfiguration {
     /**
      * @deprecated Use {@link #getDisableValidation()} instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "4.0", forRemoval = true)
     public Property<Boolean> isValidationDisabled() {
         return getDisableValidation();
     }
@@ -73,7 +73,7 @@ public class QuarkusExtensionConfiguration {
     /**
      * @deprecated Use {@code getDeploymentArtifact().set(...)} instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "4.0", forRemoval = true)
     public void setDeploymentArtifact(String deploymentArtifact) {
         this.deploymentArtifact.set(deploymentArtifact);
     }
@@ -85,7 +85,7 @@ public class QuarkusExtensionConfiguration {
     /**
      * @deprecated Use {@code getDeploymentModule().set(...)} instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "4.0", forRemoval = true)
     public void setDeploymentModule(String deploymentModule) {
         this.deploymentModule.set(deploymentModule);
     }
@@ -97,7 +97,7 @@ public class QuarkusExtensionConfiguration {
     /**
      * @deprecated Use {@code getExcludedArtifacts().addAll(...)} instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "4.0", forRemoval = true)
     public void setExcludedArtifacts(List<String> excludedArtifacts) {
         this.excludedArtifacts.addAll(excludedArtifacts);
     }
@@ -109,7 +109,7 @@ public class QuarkusExtensionConfiguration {
     /**
      * @deprecated Use {@code getParentFirstArtifacts().addAll(...)} instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "4.0", forRemoval = true)
     public void setParentFirstArtifacts(List<String> parentFirstArtifacts) {
         this.parentFirstArtifacts.addAll(parentFirstArtifacts);
     }
@@ -121,7 +121,7 @@ public class QuarkusExtensionConfiguration {
     /**
      * @deprecated Use {@code getRunnerParentFirstArtifacts().addAll(...)} instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "4.0", forRemoval = true)
     public void setRunnerParentFirstArtifacts(List<String> runnerParentFirstArtifacts) {
         this.runnerParentFirstArtifacts.addAll(runnerParentFirstArtifacts);
     }
@@ -133,7 +133,7 @@ public class QuarkusExtensionConfiguration {
     /**
      * @deprecated Use {@code getLesserPriorityArtifacts().addAll(...)} instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "4.0", forRemoval = true)
     public void setLesserPriorityArtifacts(List<String> lesserPriorityArtifacts) {
         this.lesserPriorityArtifacts.addAll(lesserPriorityArtifacts);
     }
@@ -145,7 +145,7 @@ public class QuarkusExtensionConfiguration {
     /**
      * @deprecated Use {@code getConditionalDependencies().addAll(...)} instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "4.0", forRemoval = true)
     public void setConditionalDependencies(List<String> conditionalDependencies) {
         this.conditionalDependencies.addAll(conditionalDependencies);
     }
@@ -157,7 +157,7 @@ public class QuarkusExtensionConfiguration {
     /**
      * @deprecated Use {@code getConditionalDevDependencies().addAll(...)} instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "4.0", forRemoval = true)
     public void setConditionalDevDependencies(List<String> conditionalDependencies) {
         this.conditionalDevDependencies.addAll(conditionalDependencies);
     }
@@ -169,7 +169,7 @@ public class QuarkusExtensionConfiguration {
     /**
      * @deprecated Use {@code getDependencyConditions().addAll(...)} instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "4.0", forRemoval = true)
     public void setDependencyConditions(List<String> dependencyCondition) {
         this.dependencyCondition.addAll(dependencyCondition);
     }

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ValidateExtensionTask.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ValidateExtensionTask.java
@@ -43,7 +43,7 @@ public class ValidateExtensionTask extends DefaultTask {
 
         this.project = getProject();
         this.runtimeModuleClasspath = runtimeModuleClasspath;
-        this.onlyIf(t -> !quarkusExtensionConfiguration.isValidationDisabled().get());
+        this.onlyIf(t -> !quarkusExtensionConfiguration.getDisableValidation().get());
 
         // Calling this method tells Gradle that it should not fail the build. Side effect is that the configuration
         // cache will be at least degraded, but the build will not fail.

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/QuarkusExtensionPluginTest.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/QuarkusExtensionPluginTest.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Properties;
 
 import org.assertj.core.api.Assertions;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
@@ -36,6 +38,16 @@ public class QuarkusExtensionPluginTest {
         File settingFile = new File(testProjectDir, "settings.gradle");
         String settingsContent = "rootProject.name = 'test'";
         TestUtils.writeFile(settingFile, settingsContent);
+    }
+
+    @Test
+    public void disableValidationShouldExposeManagedProperty() {
+        Project project = ProjectBuilder.builder().build();
+        QuarkusExtensionConfiguration configuration = new QuarkusExtensionConfiguration(project);
+
+        configuration.getDisableValidation().set(true);
+
+        assertThat(configuration.isValidationDisabled().get()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
Extension configuration is moving to the managed Gradle `Property` and `ListProperty` accessors. Retain the setter-style methods and `isValidationDisabled()` for compatibility, but deprecate them in favor of the corresponding property getters.

This keeps existing extension builds working while they migrate to the managed properties.