### PR TITLE
Rework Gradle application model task wiring

### DIFF
--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/Util.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/Util.java
@@ -1,0 +1,4 @@
+package io.quarkus.extension.gradle.tasks;
+
+public class Util {
+}

--- a/devtools/gradle/gradle-model/build.gradle.kts
+++ b/devtools/gradle/gradle-model/build.gradle.kts
@@ -34,6 +34,11 @@ tasks.withType<Jar>().configureEach {
     isReproducibleFileOrder = true
 }
 
+tasks.test {
+    // Required by Gradle's ProjectBuilder on strongly encapsulated JDKs.
+    jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
+}
+
 publishing {
     publications.create<MavenPublication>("maven") {
         artifactId = "quarkus-gradle-model"

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/config/CurrentProjectDescriptorBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/config/CurrentProjectDescriptorBuilder.java
@@ -1,0 +1,179 @@
+package io.quarkus.gradle.model.config;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.gradle.api.Project;
+import org.gradle.api.internal.file.copy.DefaultCopySpec;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.SourceSetOutput;
+import org.gradle.api.tasks.bundling.Jar;
+import org.gradle.api.tasks.testing.Test;
+
+import io.quarkus.bootstrap.workspace.ArtifactSources;
+import io.quarkus.bootstrap.workspace.DefaultArtifactSources;
+import io.quarkus.bootstrap.workspace.LazySourceDir;
+import io.quarkus.bootstrap.workspace.SourceDir;
+import io.quarkus.bootstrap.workspace.WorkspaceModule;
+import io.quarkus.bootstrap.workspace.WorkspaceModuleId;
+import io.quarkus.gradle.tooling.DefaultProjectDescriptor;
+
+public final class CurrentProjectDescriptorBuilder {
+
+    private CurrentProjectDescriptorBuilder() {
+    }
+
+    public static Provider<DefaultProjectDescriptor> buildForCurrentProject(Project project) {
+        WorkspaceModule.Mutable module = moduleBuilder(project);
+        initModuleAfterEvaluation(project, module);
+        return project.getProviders().provider(() -> {
+            refreshModuleId(project, module);
+            return new DefaultProjectDescriptor(module);
+        });
+    }
+
+    private static WorkspaceModule.Mutable moduleBuilder(Project project) {
+        return WorkspaceModule.builder()
+                .setModuleId(WorkspaceModuleId.of(String.valueOf(project.getGroup()), project.getName(),
+                        String.valueOf(project.getVersion())))
+                .setModuleDir(project.getLayout().getProjectDirectory().getAsFile().toPath())
+                .setBuildDir(project.getLayout().getBuildDirectory().get().getAsFile().toPath())
+                .setBuildFile(project.getBuildFile().toPath());
+    }
+
+    private static void initModuleAfterEvaluation(Project project, WorkspaceModule.Mutable module) {
+        if (project.getState().getExecuted()) {
+            refreshModuleId(project, module);
+            initSourceDirs(project, module);
+        } else {
+            project.afterEvaluate(evaluated -> {
+                refreshModuleId(evaluated, module);
+                initSourceDirs(evaluated, module);
+            });
+        }
+    }
+
+    private static void refreshModuleId(Project project, WorkspaceModule.Mutable module) {
+        module.setModuleId(WorkspaceModuleId.of(String.valueOf(project.getGroup()), project.getName(),
+                String.valueOf(project.getVersion())));
+    }
+
+    private static void initSourceDirs(Project project, WorkspaceModule.Mutable result) {
+        final SourceSetContainer srcSets = project.getExtensions().findByType(SourceSetContainer.class);
+        if (srcSets == null) {
+            return;
+        }
+        project.getTasks().withType(Jar.class).configureEach(jarTask -> {
+            final String classifier = jarTask.getArchiveClassifier().get();
+
+            final List<File> classesDirs = new ArrayList<>(2);
+            final List<File> resourcesOutputDirs = new ArrayList<>(2);
+            collectSourceSetOutput(((DefaultCopySpec) jarTask.getRootSpec()), classesDirs, resourcesOutputDirs);
+
+            final List<SourceDir> sourceDirs = new ArrayList<>();
+            final List<SourceDir> resourceDirs = new ArrayList<>(2);
+            for (SourceSet srcSet : srcSets) {
+                for (var classesDir : srcSet.getOutput().getClassesDirs().getFiles()) {
+                    if (classesDirs.contains(classesDir)) {
+                        for (var srcDir : srcSet.getAllJava().getSrcDirs()) {
+                            sourceDirs.add(new LazySourceDir(srcDir.toPath(), classesDir.toPath(),
+                                    findGeneratedSourceDir(classesDir, srcSet)));
+                        }
+                    }
+                }
+
+                if (resourcesOutputDirs.contains(srcSet.getOutput().getResourcesDir())) {
+                    var resourcesTarget = srcSet.getOutput().getResourcesDir().toPath();
+                    for (var dir : srcSet.getResources().getSrcDirs()) {
+                        resourceDirs.add(new LazySourceDir(dir.toPath(), resourcesTarget));
+                    }
+                }
+            }
+
+            if (!sourceDirs.isEmpty() || !resourceDirs.isEmpty()) {
+                result.addArtifactSources(new DefaultArtifactSources(classifier, sourceDirs, resourceDirs));
+            }
+        });
+
+        project.getTasks().withType(Test.class).configureEach(testTask -> {
+            for (SourceSet srcSet : srcSets) {
+                String classifier = null;
+                List<SourceDir> testSourcesDirs = new ArrayList<>(6);
+                List<SourceDir> testResourcesDirs = new ArrayList<>(2);
+                for (var classesDir : srcSet.getOutput().getClassesDirs().getFiles()) {
+                    if (testTask.getTestClassesDirs().contains(classesDir)) {
+                        if (classifier == null) {
+                            classifier = sourceSetNameToClassifier(srcSet.getName());
+                            if (result.hasSources(classifier)) {
+                                break;
+                            }
+                        }
+                        for (var srcDir : srcSet.getAllJava().getSrcDirs()) {
+                            testSourcesDirs.add(new LazySourceDir(srcDir.toPath(), classesDir.toPath(),
+                                    findGeneratedSourceDir(classesDir, srcSet)));
+                        }
+                    }
+                }
+                if (classifier != null && !testSourcesDirs.isEmpty()) {
+                    if (srcSet.getOutput().getResourcesDir() != null) {
+                        final Path resourcesOutputDir = srcSet.getOutput().getResourcesDir().toPath();
+                        for (var dir : srcSet.getResources().getSrcDirs()) {
+                            testResourcesDirs.add(new LazySourceDir(dir.toPath(), resourcesOutputDir));
+                        }
+                    }
+                    result.addArtifactSources(new DefaultArtifactSources(classifier, testSourcesDirs, testResourcesDirs));
+                }
+            }
+        });
+    }
+
+    private static String sourceSetNameToClassifier(String sourceSetName) {
+        if (SourceSet.TEST_SOURCE_SET_NAME.equals(sourceSetName)) {
+            return ArtifactSources.TEST;
+        }
+        var sb = new StringBuilder(sourceSetName.length() + 2);
+        for (int i = 0; i < sourceSetName.length(); ++i) {
+            char original = sourceSetName.charAt(i);
+            char lowerCase = Character.toLowerCase(original);
+            if (original != lowerCase) {
+                sb.append('-');
+            }
+            sb.append(lowerCase);
+        }
+        return sb.toString();
+    }
+
+    private static Path findGeneratedSourceDir(File classesDir, SourceSet sourceSet) {
+        if (classesDir.getParentFile() == null) {
+            return null;
+        }
+        String language = classesDir.getParentFile().getName();
+        String sourceSetName = classesDir.getName();
+        for (File generatedDir : sourceSet.getOutput().getGeneratedSourcesDirs().getFiles()) {
+            if (generatedDir.getParentFile() == null) {
+                continue;
+            }
+            if (generatedDir.getName().equals(sourceSetName)
+                    && generatedDir.getParentFile().getName().equals(language)) {
+                return generatedDir.toPath();
+            }
+        }
+        return null;
+    }
+
+    private static void collectSourceSetOutput(DefaultCopySpec spec, List<File> classesDir, List<File> resourcesDir) {
+        for (var paths : spec.getSourcePaths()) {
+            if (paths instanceof SourceSetOutput sso) {
+                classesDir.addAll(sso.getClassesDirs().getFiles());
+                resourcesDir.add(sso.getResourcesDir());
+            }
+        }
+        for (var child : spec.getChildren()) {
+            collectSourceSetOutput((DefaultCopySpec) child, classesDir, resourcesDir);
+        }
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/config/ExtensionVariantConstants.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/config/ExtensionVariantConstants.java
@@ -1,0 +1,23 @@
+package io.quarkus.gradle.model.config;
+
+import org.gradle.api.attributes.Attribute;
+
+public final class ExtensionVariantConstants {
+
+    public static final String EXTENSION_DEPLOYMENT_PLUGIN_ID = "io.quarkus.extension.deployment";
+    public static final String EXTENSION_DEPLOYMENT_MARKER_ELEMENTS_CONFIGURATION_NAME = "quarkusExtensionDeploymentMarkerElements";
+    public static final String EXTENSION_DEPLOYMENT_MARKER_TASK_NAME = "quarkusExtensionDeploymentMarker";
+    public static final String EXTENSION_DEPLOYMENT_MARKER_CATEGORY = "quarkus-extension-deployment-marker";
+    public static final String EXTENSION_DEPLOYMENT_DEPENDENCY_ELEMENTS_CONFIGURATION_NAME = "quarkusExtensionDeploymentDependencyElements";
+    public static final String EXTENSION_DEPLOYMENT_DEPENDENCY_CATEGORY = "quarkus-extension-deployment-dependency";
+    public static final Attribute<Boolean> EXTENSION_RUNTIME_ATTRIBUTE = Attribute.of("io.quarkus.extension.runtime",
+            Boolean.class);
+    public static final Attribute<Boolean> EXTENSION_DEPLOYMENT_ATTRIBUTE = Attribute.of(EXTENSION_DEPLOYMENT_PLUGIN_ID,
+            Boolean.class);
+    public static final Attribute<Boolean> EXTENSION_DEPLOYMENT_DEPENDENCY_ATTRIBUTE = Attribute.of(
+            EXTENSION_DEPLOYMENT_PLUGIN_ID + ".dependency", Boolean.class);
+    public static final String QUARKUS_ANNOTATION_PROCESSOR = "io.quarkus:quarkus-extension-processor";
+
+    private ExtensionVariantConstants() {
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/config/LocalComponentOutputViews.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/config/LocalComponentOutputViews.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.quarkus.gradle.model.config;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.gradle.api.artifacts.ArtifactView;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
+import org.gradle.api.attributes.LibraryElements;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+
+public final class LocalComponentOutputViews {
+
+    private final ArtifactView classes;
+    private final ArtifactView resources;
+    private final ArtifactView jars;
+
+    private LocalComponentOutputViews(ObjectFactory objects, Configuration configuration) {
+        classes = artifactView(objects, configuration, LibraryElements.CLASSES,
+                ArtifactTypeDefinition.JVM_CLASS_DIRECTORY);
+        resources = artifactView(objects, configuration, LibraryElements.RESOURCES,
+                ArtifactTypeDefinition.JVM_RESOURCES_DIRECTORY);
+        jars = artifactView(objects, configuration, LibraryElements.JAR,
+                ArtifactTypeDefinition.JAR_TYPE);
+    }
+
+    public static LocalComponentOutputViews of(ObjectFactory objects, Configuration configuration) {
+        return new LocalComponentOutputViews(objects, configuration);
+    }
+
+    public ArtifactView classes() {
+        return classes;
+    }
+
+    public ArtifactView resources() {
+        return resources;
+    }
+
+    public ArtifactView jars() {
+        return jars;
+    }
+
+    public Provider<Set<ResolvedArtifactResult>> classArtifacts() {
+        return classes.getArtifacts().getResolvedArtifacts();
+    }
+
+    public Provider<Set<ResolvedArtifactResult>> resourceArtifacts() {
+        return resources.getArtifacts().getResolvedArtifacts();
+    }
+
+    public Provider<Set<ResolvedArtifactResult>> jarArtifacts() {
+        return jars.getArtifacts().getResolvedArtifacts();
+    }
+
+    public FileCollection classFiles() {
+        return classes.getFiles();
+    }
+
+    public FileCollection resourceFiles() {
+        return resources.getFiles();
+    }
+
+    public FileCollection jarFiles() {
+        return jars.getFiles();
+    }
+
+    public Provider<Set<File>> jarFilesWithoutOutputVariants(ProviderFactory providers) {
+        return providers.provider(() -> {
+            Set<String> componentsWithOutputVariants = new HashSet<>();
+            collectComponentIds(classArtifacts().get(), componentsWithOutputVariants);
+            collectComponentIds(resourceArtifacts().get(), componentsWithOutputVariants);
+            Set<File> jarFiles = new LinkedHashSet<>();
+            for (ResolvedArtifactResult artifact : jarArtifacts().get()) {
+                if (!componentsWithOutputVariants.contains(componentId(artifact))) {
+                    jarFiles.add(artifact.getFile());
+                }
+            }
+            return jarFiles;
+        });
+    }
+
+    private static ArtifactView artifactView(ObjectFactory objects, Configuration configuration,
+            String libraryElements, String artifactType) {
+        return configuration.getIncoming().artifactView(view -> {
+            view.withVariantReselection();
+            view.lenient(true);
+            view.attributes(attributes -> {
+                attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+                        objects.named(LibraryElements.class, libraryElements));
+                attributes.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, artifactType);
+            });
+        });
+    }
+
+    private static void collectComponentIds(Set<ResolvedArtifactResult> artifacts, Set<String> target) {
+        for (ResolvedArtifactResult artifact : artifacts) {
+            target.add(componentId(artifact));
+        }
+    }
+
+    private static String componentId(ResolvedArtifactResult artifact) {
+        return artifact.getId().getComponentIdentifier().getDisplayName();
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/config/QuarkusExtensionAnnotationProcessorConfigurator.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/config/QuarkusExtensionAnnotationProcessorConfigurator.java
@@ -1,0 +1,114 @@
+package io.quarkus.gradle.model.config;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.DependencySet;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.attributes.Category;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.provider.ListProperty;
+
+public final class QuarkusExtensionAnnotationProcessorConfigurator {
+
+    private static final String QUARKUS_CORE_GROUP = "io.quarkus";
+    private static final String QUARKUS_CORE_NAME = "quarkus-core";
+    private static final String QUARKUS_ANNOTATION_PROCESSOR = "io.quarkus:quarkus-extension-processor";
+    private static final Set<String> QUARKUS_PLATFORM_GROUPS = Set.of("io.quarkus", "io.quarkus.platform");
+
+    private final Function<Project, String> quarkusCoreVersionResolver;
+
+    public QuarkusExtensionAnnotationProcessorConfigurator() {
+        this(QuarkusExtensionAnnotationProcessorConfigurator::resolveQuarkusCoreVersionFromCompileClasspath);
+    }
+
+    public QuarkusExtensionAnnotationProcessorConfigurator(Function<Project, String> quarkusCoreVersionResolver) {
+        this.quarkusCoreVersionResolver = quarkusCoreVersionResolver;
+    }
+
+    public void configure(Project project) {
+        DependencySet annotationProcessorDependencies = project.getConfigurations()
+                .getByName(JavaPlugin.ANNOTATION_PROCESSOR_CONFIGURATION_NAME)
+                .getDependencies();
+        annotationProcessorDependencies.addAllLater(quarkusPlatformDependencies(project));
+        annotationProcessorDependencies.addAllLater(annotationProcessorDependency(project));
+    }
+
+    private ListProperty<Dependency> quarkusPlatformDependencies(Project project) {
+        ListProperty<Dependency> dependencyListProperty = project.getObjects().listProperty(Dependency.class);
+        return dependencyListProperty.value(project.provider(() -> project.getConfigurations()
+                .getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME)
+                .getAllDependencies()
+                .stream()
+                .filter(QuarkusExtensionAnnotationProcessorConfigurator::isQuarkusPlatform)
+                .map(Dependency::copy)
+                .collect(Collectors.toList())));
+    }
+
+    private ListProperty<Dependency> annotationProcessorDependency(Project project) {
+        ListProperty<Dependency> dependencyListProperty = project.getObjects().listProperty(Dependency.class);
+        return dependencyListProperty.value(project.provider(() -> {
+            if (hasQuarkusPlatform(project)) {
+                return List.of(project.getDependencies().create(QUARKUS_ANNOTATION_PROCESSOR));
+            }
+
+            project.getLogger().debug(
+                    "No Quarkus platform dependency found; resolving the compile classpath to determine the quarkus-core version.");
+            String quarkusCoreVersion = quarkusCoreVersionResolver.apply(project);
+            if (quarkusCoreVersion != null && !quarkusCoreVersion.isEmpty()) {
+                return List.of(project.getDependencies().create(QUARKUS_ANNOTATION_PROCESSOR + ':' + quarkusCoreVersion));
+            }
+            return List.of();
+        }));
+    }
+
+    private boolean hasQuarkusPlatform(Project project) {
+        return project.getConfigurations()
+                .getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME)
+                .getAllDependencies()
+                .stream()
+                .anyMatch(QuarkusExtensionAnnotationProcessorConfigurator::isQuarkusPlatform);
+    }
+
+    private static boolean isQuarkusPlatform(Dependency dependency) {
+        return dependency instanceof ModuleDependency moduleDependency
+                && isEnforcedPlatform(moduleDependency)
+                && QUARKUS_PLATFORM_GROUPS.contains(dependency.getGroup());
+    }
+
+    private static boolean isEnforcedPlatform(ModuleDependency module) {
+        final Category category = module.getAttributes().getAttribute(Category.CATEGORY_ATTRIBUTE);
+        return category != null && (Category.ENFORCED_PLATFORM.equals(category.getName())
+                || Category.REGULAR_PLATFORM.equals(category.getName()));
+    }
+
+    private static String resolveQuarkusCoreVersionFromCompileClasspath(Project project) {
+        Configuration compileClasspath = project.getConfigurations()
+                .getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME);
+        Configuration compileClasspathCopy = project.getConfigurations()
+                .detachedConfiguration(compileClasspath.getAllDependencies()
+                        .stream()
+                        .map(Dependency::copy)
+                        .toArray(Dependency[]::new));
+        compileClasspathCopy.getDependencyConstraints().addAll(compileClasspath.getAllDependencyConstraints());
+        Set<ResolvedArtifact> compileClasspathArtifacts = compileClasspathCopy
+                .getResolvedConfiguration()
+                .getResolvedArtifacts();
+
+        for (ResolvedArtifact artifact : compileClasspathArtifacts) {
+            ModuleVersionIdentifier id = artifact.getModuleVersion().getId();
+            if (QUARKUS_CORE_GROUP.equals(id.getGroup()) && QUARKUS_CORE_NAME.equals(id.getName())
+                    && !id.getVersion().isEmpty()) {
+                return id.getVersion();
+            }
+        }
+        return null;
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/config/StrictApplicationDeploymentClasspathBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/config/StrictApplicationDeploymentClasspathBuilder.java
@@ -1,0 +1,209 @@
+package io.quarkus.gradle.model.config;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.artifacts.result.ResolvedDependencyResult;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.provider.ListProperty;
+
+import io.quarkus.bootstrap.BootstrapConstants;
+import io.quarkus.gradle.dependency.ApplicationDeploymentClasspathBuilder;
+import io.quarkus.gradle.dependency.QuarkusComponentVariants;
+import io.quarkus.gradle.tooling.ToolingUtils;
+import io.quarkus.runtime.LaunchMode;
+
+@SuppressWarnings("UnstableApiUsage")
+public final class StrictApplicationDeploymentClasspathBuilder {
+
+    private final Project project;
+    private final LaunchMode mode;
+    private final String runtimeConfigurationName;
+    private final String platformConfigurationName;
+    private final String platformPropertiesConfigurationName;
+    private final String deploymentConfigurationName;
+    private final String compileOnlyConfigurationName;
+
+    public static void initConfigurations(Project project) {
+        var configurations = project.getConfigurations();
+        configurations.maybeCreate(ToolingUtils.DEV_MODE_CONFIGURATION_NAME)
+                .extendsFrom(configurations.getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME));
+        maybeCreateLegacyBaseConfiguration(project, LaunchMode.TEST, JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+        maybeCreateLegacyBaseConfiguration(project, LaunchMode.NORMAL, JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+        maybeCreateLegacyBaseConfiguration(project, LaunchMode.DEVELOPMENT, ToolingUtils.DEV_MODE_CONFIGURATION_NAME,
+                JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME, JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+    }
+
+    private static void maybeCreateLegacyBaseConfiguration(Project project, LaunchMode mode, String... parents) {
+        String name = ApplicationDeploymentClasspathBuilder.getBaseRuntimeConfigName(mode);
+        if (project.getConfigurations().findByName(name) != null) {
+            return;
+        }
+        project.getConfigurations().resolvable(name, configuration -> {
+            configuration.setCanBeConsumed(false);
+            for (String parent : parents) {
+                configuration.extendsFrom(project.getConfigurations().getByName(parent));
+            }
+            QuarkusComponentVariants.setConditionalAttributes(configuration, project, mode);
+        });
+    }
+
+    public StrictApplicationDeploymentClasspathBuilder(Project project, LaunchMode mode, String configurationNamePrefix) {
+        this.project = project;
+        this.mode = mode;
+        runtimeConfigurationName = configurationNamePrefix + launchModeAlias(mode) + "RuntimeClasspathConfiguration";
+        platformConfigurationName = ToolingUtils.toPlatformConfigurationName(runtimeConfigurationName);
+        platformPropertiesConfigurationName = configurationNamePrefix + launchModeAlias(mode) + "PlatformProperties";
+        deploymentConfigurationName = ToolingUtils.toDeploymentConfigurationName(runtimeConfigurationName);
+        compileOnlyConfigurationName = configurationNamePrefix + launchModeAlias(mode) + "CompileOnlyConfiguration";
+
+        setUpPlatformConfiguration();
+        setUpPlatformPropertiesConfiguration();
+        setUpRuntimeConfiguration();
+        setUpDeploymentConfiguration();
+        setUpCompileOnlyConfiguration();
+    }
+
+    private void setUpPlatformConfiguration() {
+        if (project.getConfigurations().findByName(platformConfigurationName) != null) {
+            return;
+        }
+        project.getConfigurations().resolvable(platformConfigurationName, configuration -> {
+            configuration.setCanBeConsumed(false);
+            ListProperty<Dependency> dependencies = project.getObjects().listProperty(Dependency.class);
+            configuration.getDependencies().addAllLater(dependencies.value(project.provider(() -> project.getConfigurations()
+                    .getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME)
+                    .getAllDependencies()
+                    .stream()
+                    .filter(dependency -> dependency instanceof ModuleDependency moduleDependency
+                            && ToolingUtils.isEnforcedPlatform(moduleDependency))
+                    .collect(Collectors.toList()))));
+        });
+    }
+
+    private void setUpPlatformPropertiesConfiguration() {
+        if (project.getConfigurations().findByName(platformPropertiesConfigurationName) != null) {
+            return;
+        }
+        project.getConfigurations().resolvable(platformPropertiesConfigurationName, configuration -> {
+            configuration.setCanBeConsumed(false);
+            configuration.setTransitive(false);
+            DependencyHandler dependencies = project.getDependencies();
+            // Platform BOMs constrain their descriptor and properties modules but do not resolve those artifacts.
+            configuration.getDependencies().addAllLater(getPlatformConfiguration().getIncoming().getResolutionResult()
+                    .getRootComponent()
+                    .map(root -> root.getDependencies().stream()
+                            .filter(ResolvedDependencyResult.class::isInstance)
+                            .map(ResolvedDependencyResult.class::cast)
+                            .map(dependency -> dependency.getSelected().getId())
+                            .filter(ModuleComponentIdentifier.class::isInstance)
+                            .map(ModuleComponentIdentifier.class::cast)
+                            .flatMap(platform -> platformArtifactDependencyNotations(platform).stream())
+                            .distinct()
+                            .sorted()
+                            .map(dependencies::create)
+                            .toList()));
+        });
+    }
+
+    private static List<String> platformArtifactDependencyNotations(ModuleComponentIdentifier platform) {
+        String groupAndArtifact = platform.getGroup() + ":" + platform.getModule();
+        String version = platform.getVersion();
+        return List.of(
+                groupAndArtifact + BootstrapConstants.PLATFORM_DESCRIPTOR_ARTIFACT_ID_SUFFIX + ":" + version + ":" + version
+                        + "@json",
+                groupAndArtifact + BootstrapConstants.PLATFORM_PROPERTIES_ARTIFACT_ID_SUFFIX + ":" + version + "@properties");
+    }
+
+    private void setUpRuntimeConfiguration() {
+        if (project.getConfigurations().findByName(runtimeConfigurationName) != null) {
+            return;
+        }
+        project.getConfigurations().resolvable(runtimeConfigurationName, configuration -> {
+            configuration.setCanBeConsumed(false);
+            for (String configurationName : originalRuntimeConfigurationNames(mode)) {
+                configuration.extendsFrom(project.getConfigurations().getByName(configurationName));
+            }
+            QuarkusComponentVariants.setConditionalAttributes(configuration, project, mode);
+        });
+    }
+
+    private void setUpDeploymentConfiguration() {
+        if (project.getConfigurations().findByName(deploymentConfigurationName) != null) {
+            return;
+        }
+        project.getConfigurations().resolvable(deploymentConfigurationName, configuration -> {
+            configuration.setCanBeConsumed(false);
+            configuration.extendsFrom(getRuntimeConfigurationWithoutResolvingDeployment(), getPlatformConfiguration());
+            configuration.shouldResolveConsistentlyWith(getRuntimeConfigurationWithoutResolvingDeployment());
+            QuarkusComponentVariants.setDeploymentAndConditionalAttributes(configuration, project, mode);
+        });
+    }
+
+    private void setUpCompileOnlyConfiguration() {
+        if (project.getConfigurations().findByName(compileOnlyConfigurationName) != null) {
+            return;
+        }
+        project.getConfigurations().resolvable(compileOnlyConfigurationName, configuration -> {
+            configuration.setCanBeConsumed(false);
+            configuration.extendsFrom(getPlatformConfiguration(),
+                    project.getConfigurations().getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME));
+            configuration.shouldResolveConsistentlyWith(getDeploymentConfiguration());
+            QuarkusComponentVariants.setCommonAttributes(configuration.getAttributes(), project.getObjects());
+        });
+    }
+
+    public FileCollection getOriginalRuntimeClasspathAsInput() {
+        return project.files(originalRuntimeConfigurationNames(mode).stream()
+                .map(name -> project.getConfigurations().getByName(name))
+                .toArray());
+    }
+
+    public Configuration getPlatformConfiguration() {
+        return project.getConfigurations().getByName(platformConfigurationName);
+    }
+
+    public Configuration getPlatformPropertiesConfiguration() {
+        return project.getConfigurations().getByName(platformPropertiesConfigurationName);
+    }
+
+    public Configuration getRuntimeConfigurationWithoutResolvingDeployment() {
+        return project.getConfigurations().getByName(runtimeConfigurationName);
+    }
+
+    public Configuration getDeploymentConfiguration() {
+        return project.getConfigurations().getByName(deploymentConfigurationName);
+    }
+
+    public Configuration getCompileOnlyWithoutResolvingDeployment() {
+        return project.getConfigurations().getByName(compileOnlyConfigurationName);
+    }
+
+    private static List<String> originalRuntimeConfigurationNames(LaunchMode mode) {
+        return switch (mode) {
+            case TEST -> List.of(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+            case NORMAL -> List.of(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+            case DEVELOPMENT -> List.of(
+                    ToolingUtils.DEV_MODE_CONFIGURATION_NAME,
+                    JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME,
+                    JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+            default -> throw new IllegalArgumentException("Unsupported launch mode: " + mode);
+        };
+    }
+
+    private static String launchModeAlias(LaunchMode mode) {
+        return switch (mode) {
+            case DEVELOPMENT -> "Dev";
+            case TEST -> "Test";
+            case NORMAL -> "Prod";
+            default -> throw new IllegalArgumentException("Unsupported launch mode: " + mode);
+        };
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/ApplicationModelBuilderSupport.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/ApplicationModelBuilderSupport.java
@@ -1,0 +1,138 @@
+package io.quarkus.gradle.model.pom;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Properties;
+import java.util.Set;
+
+import io.quarkus.bootstrap.BootstrapConstants;
+import io.quarkus.bootstrap.model.ApplicationModelBuilder;
+import io.quarkus.bootstrap.model.CapabilityContract;
+import io.quarkus.bootstrap.workspace.SourceDir;
+import io.quarkus.fs.util.ZipUtils;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
+import io.quarkus.paths.PathList;
+import io.quarkus.runtime.util.HashUtil;
+
+public final class ApplicationModelBuilderSupport {
+
+    private ApplicationModelBuilderSupport() {
+    }
+
+    public static boolean isFlagOn(byte walkingFlags, byte flag) {
+        return (walkingFlags & flag) > 0;
+    }
+
+    public static byte clearFlag(byte flags, byte flag) {
+        if ((flags & flag) > 0) {
+            flags ^= flag;
+        }
+        return flags;
+    }
+
+    public static void collectDestinationDirs(Collection<SourceDir> sources, PathList.Builder paths) {
+        for (SourceDir src : sources) {
+            Path path = src.getOutputDir();
+            if (paths.contains(path) || !Files.exists(path)) {
+                continue;
+            }
+            paths.add(path);
+        }
+    }
+
+    public static void addFileDependencies(ApplicationModelBuilder modelBuilder, Set<File> fileDependencies) {
+        for (File file : fileDependencies) {
+            if (!file.exists()) {
+                continue;
+            }
+            ResolvedDependencyBuilder artifactBuilder = toFileDependency(file);
+            processQuarkusDependency(artifactBuilder, modelBuilder);
+            modelBuilder.addDependency(artifactBuilder);
+        }
+    }
+
+    public static ResolvedDependencyBuilder toFileDependency(File file) {
+        String parentPath = file.getParent();
+        String group = HashUtil.sha1(parentPath == null ? file.getName() : parentPath);
+        String name = file.getName();
+        String type = ArtifactCoords.TYPE_JAR;
+        if (!file.isDirectory()) {
+            int dot = file.getName().lastIndexOf('.');
+            if (dot > 0) {
+                name = file.getName().substring(0, dot);
+                type = file.getName().substring(dot + 1);
+            }
+        }
+        return ResolvedDependencyBuilder.newInstance()
+                .setGroupId(group)
+                .setArtifactId(name)
+                .setType(type)
+                .setVersion(String.valueOf(file.lastModified()))
+                .setResolvedPath(file.toPath())
+                .setDirect(true)
+                .setRuntimeCp()
+                .setDeploymentCp();
+    }
+
+    public static boolean processQuarkusDependency(ResolvedDependencyBuilder artifactBuilder,
+            ApplicationModelBuilder modelBuilder) {
+        for (Path artifactPath : artifactBuilder.getResolvedPaths()) {
+            if (!Files.exists(artifactPath) || !artifactBuilder.getType().equals(ArtifactCoords.TYPE_JAR)) {
+                break;
+            }
+            if (Files.isDirectory(artifactPath)) {
+                return processQuarkusDir(artifactBuilder, artifactPath.resolve(BootstrapConstants.META_INF), modelBuilder);
+            }
+            try (FileSystem artifactFs = ZipUtils.newFileSystem(artifactPath)) {
+                return processQuarkusDir(artifactBuilder, artifactFs.getPath(BootstrapConstants.META_INF), modelBuilder);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to process " + artifactPath, e);
+            }
+        }
+        return false;
+    }
+
+    private static boolean processQuarkusDir(ResolvedDependencyBuilder artifactBuilder, Path quarkusDir,
+            ApplicationModelBuilder modelBuilder) {
+        if (!Files.exists(quarkusDir)) {
+            return false;
+        }
+        Path quarkusDescr = quarkusDir.resolve(BootstrapConstants.DESCRIPTOR_FILE_NAME);
+        if (!Files.exists(quarkusDescr)) {
+            return false;
+        }
+        Properties extProps = readDescriptor(quarkusDescr);
+        if (extProps == null) {
+            return false;
+        }
+        artifactBuilder.setRuntimeExtensionArtifact();
+        modelBuilder.handleExtensionProperties(extProps, artifactBuilder.getKey());
+
+        String providesCapabilities = extProps.getProperty(BootstrapConstants.PROP_PROVIDES_CAPABILITIES);
+        if (providesCapabilities != null) {
+            modelBuilder.addExtensionCapabilities(
+                    CapabilityContract.of(artifactBuilder.toGACTVString(), providesCapabilities, null));
+        }
+        return true;
+    }
+
+    private static Properties readDescriptor(Path path) {
+        if (!Files.exists(path)) {
+            return null;
+        }
+        Properties rtProps = new Properties();
+        try (BufferedReader reader = Files.newBufferedReader(path)) {
+            rtProps.load(reader);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to load extension description " + path, e);
+        }
+        return rtProps;
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/DeclaredDependency.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/DeclaredDependency.java
@@ -1,0 +1,59 @@
+package io.quarkus.gradle.model.pom;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+import io.quarkus.maven.dependency.ArtifactCoords;
+
+public class DeclaredDependency implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final String groupId;
+    private final String artifactId;
+    private final String classifier;
+    private final String type;
+    private final String version;
+    private final String scope;
+    private final boolean optional;
+
+    DeclaredDependency(org.apache.maven.model.Dependency dep) {
+        this.groupId = dep.getGroupId();
+        this.artifactId = dep.getArtifactId();
+        this.classifier = StrictDependencyDataCollector.defaultIfNull(dep.getClassifier(), ArtifactCoords.DEFAULT_CLASSIFIER);
+        this.type = StrictDependencyDataCollector.defaultIfNull(dep.getType(), ArtifactCoords.TYPE_JAR);
+        this.version = dep.getVersion();
+        this.scope = StrictDependencyDataCollector.defaultIfNull(dep.getScope(),
+                io.quarkus.maven.dependency.Dependency.SCOPE_COMPILE);
+        this.optional = Boolean.parseBoolean(dep.getOptional());
+    }
+
+    String getGroupId() {
+        return groupId;
+    }
+
+    String getArtifactId() {
+        return artifactId;
+    }
+
+    String getClassifier() {
+        return classifier;
+    }
+
+    String getType() {
+        return type;
+    }
+
+    String getVersion() {
+        return version;
+    }
+
+    String getScope() {
+        return scope;
+    }
+
+    boolean isOptional() {
+        return optional;
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/DeclaredDependencyEnrichmentMode.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/DeclaredDependencyEnrichmentMode.java
@@ -1,0 +1,6 @@
+package io.quarkus.gradle.model.pom;
+
+public enum DeclaredDependencyEnrichmentMode {
+    NONE,
+    SELECTED_MODULE_POMS
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/DeclaredDepsResult.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/DeclaredDepsResult.java
@@ -1,0 +1,34 @@
+package io.quarkus.gradle.model.pom;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.List;
+
+public class DeclaredDepsResult implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final List<DeclaredDependency> declaredDependencies;
+    private final boolean resolved;
+
+    private DeclaredDepsResult(List<DeclaredDependency> declaredDependencies, boolean resolved) {
+        this.declaredDependencies = declaredDependencies;
+        this.resolved = resolved;
+    }
+
+    public static DeclaredDepsResult resolved(List<DeclaredDependency> declaredDependencies) {
+        return new DeclaredDepsResult(declaredDependencies, true);
+    }
+
+    public static DeclaredDepsResult unresolved() {
+        return new DeclaredDepsResult(List.of(), false);
+    }
+
+    public List<DeclaredDependency> getDeclaredDependencies() {
+        return declaredDependencies;
+    }
+
+    public boolean isResolved() {
+        return resolved;
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/ExternalModuleDeclaredDependencyInput.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/ExternalModuleDeclaredDependencyInput.java
@@ -1,0 +1,91 @@
+package io.quarkus.gradle.model.pom;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Objects;
+
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.GAV;
+
+@SuppressWarnings("ClassCanBeRecord") // Gradle doesn't like records in this case
+public class ExternalModuleDeclaredDependencyInput
+        implements Serializable, Comparable<ExternalModuleDeclaredDependencyInput> {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final ArtifactKey artifactKey;
+    private final GAV pomGav;
+
+    public ExternalModuleDeclaredDependencyInput(ArtifactKey artifactKey, GAV pomGav) {
+        this.artifactKey = Objects.requireNonNull(artifactKey, "artifactKey cannot be null");
+        this.pomGav = Objects.requireNonNull(pomGav, "pomGav cannot be null");
+    }
+
+    static ExternalModuleDeclaredDependencyInput from(
+            ResolvedArtifactResult artifact,
+            ModuleComponentIdentifier moduleId) {
+        return new ExternalModuleDeclaredDependencyInput(
+                StrictDependencyDataCollector.resolveArtifactKey(artifact, moduleId),
+                new GAV(moduleId.getGroup(), moduleId.getModule(), moduleId.getVersion()));
+    }
+
+    @Internal
+    public ArtifactKey getArtifactKey() {
+        return artifactKey;
+    }
+
+    @Internal
+    public GAV getPomGav() {
+        return pomGav;
+    }
+
+    @Input
+    public String getArtifactGroupId() {
+        return artifactKey.getGroupId();
+    }
+
+    @Input
+    public String getArtifactId() {
+        return artifactKey.getArtifactId();
+    }
+
+    @Input
+    public String getArtifactClassifier() {
+        return StrictDependencyDataCollector.defaultIfNull(artifactKey.getClassifier(), "");
+    }
+
+    @Input
+    public String getArtifactType() {
+        return StrictDependencyDataCollector.defaultIfNull(artifactKey.getType(), "");
+    }
+
+    @Input
+    public String getPomGroupId() {
+        return pomGav.getGroupId();
+    }
+
+    @Input
+    public String getPomArtifactId() {
+        return pomGav.getArtifactId();
+    }
+
+    @Input
+    public String getPomVersion() {
+        return pomGav.getVersion();
+    }
+
+    @Override
+    public int compareTo(ExternalModuleDeclaredDependencyInput other) {
+        int result = artifactKey.compareTo(other.artifactKey);
+        if (result != 0) {
+            return result;
+        }
+        return pomGav.toString().compareTo(other.pomGav.toString());
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/KnownPomResolver.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/KnownPomResolver.java
@@ -1,0 +1,153 @@
+package io.quarkus.gradle.model.pom;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.maven.model.building.ModelSource2;
+import org.apache.maven.model.resolution.UnresolvableModelException;
+
+import io.quarkus.maven.dependency.GAV;
+
+public final class KnownPomResolver implements PomResolver {
+
+    private final Map<GAV, Optional<File>> pomCache = new ConcurrentHashMap<>();
+    private final Map<GAV, File> resolvedPomFiles;
+    private final ArrayList<File> repositoryRoots;
+
+    public KnownPomResolver(Map<GAV, File> resolvedPomFiles, Collection<GAV> missingPoms,
+            Collection<File> repositoryRoots) {
+        this.resolvedPomFiles = Map.copyOf(resolvedPomFiles);
+        this.repositoryRoots = new ArrayList<>(repositoryRoots);
+        resolvedPomFiles.forEach((gav, file) -> pomCache.put(gav, Optional.of(file)));
+        missingPoms.forEach(gav -> pomCache.putIfAbsent(gav, Optional.empty()));
+    }
+
+    public static KnownPomResolver fromPomClosure(Map<GAV, File> resolvedPomFiles, Collection<GAV> missingPoms,
+            Collection<File> repositoryRoots) {
+        return new KnownPomResolver(resolvedPomFiles, missingPoms, repositoryRoots);
+    }
+
+    @Override
+    public void prefetchPoms(Collection<GAV> gavs) {
+        gavs.stream()
+                .filter(gav -> !pomCache.containsKey(gav))
+                .forEach(gav -> pomCache.putIfAbsent(gav, resolvePomFromKnownRepositories(gav)));
+    }
+
+    @Override
+    public boolean hasPomResult(GAV gav) {
+        return pomCache.containsKey(gav);
+    }
+
+    @Override
+    public ModelSource2 resolvePom(GAV gav) throws UnresolvableModelException {
+        File pomFile = pomCache.computeIfAbsent(gav, this::resolvePomFromKnownRepositories).orElse(null);
+        if (pomFile == null) {
+            throw new UnresolvableModelException(
+                    "Could not resolve POM for " + gav.getGroupId() + ":" + gav.getArtifactId() + ":" + gav.getVersion(),
+                    gav.getGroupId(), gav.getArtifactId(), gav.getVersion());
+        }
+        return new FileModelSource(pomFile);
+    }
+
+    private Optional<File> resolvePomFromKnownRepositories(GAV gav) {
+        File resolved = resolvedPomFiles.get(gav);
+        if (resolved != null) {
+            return Optional.of(resolved);
+        }
+
+        String targetSuffix = repositoryPomPath(gav);
+        for (File repositoryRoot : repositoryRoots) {
+            Path candidate = repositoryRoot.toPath().resolve(targetSuffix);
+            if (candidate.toFile().isFile()) {
+                return Optional.of(candidate.toFile());
+            }
+            Optional<File> gradleCachePom = findGradleCachePom(repositoryRoot.toPath(), gav);
+            if (gradleCachePom.isPresent()) {
+                return gradleCachePom;
+            }
+        }
+
+        for (var entry : resolvedPomFiles.entrySet()) {
+            Path knownPom = entry.getValue().toPath();
+            String knownSuffix = repositoryPomPath(entry.getKey());
+            if (!knownPom.endsWith(knownSuffix)) {
+                continue;
+            }
+            Path repositoryRoot = knownPom;
+            for (int i = 0; i < Path.of(knownSuffix).getNameCount(); i++) {
+                repositoryRoot = repositoryRoot.getParent();
+            }
+            Path candidate = repositoryRoot.resolve(targetSuffix);
+            if (candidate.toFile().isFile()) {
+                return Optional.of(candidate.toFile());
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<File> findGradleCachePom(Path repositoryRoot, GAV gav) {
+        Path moduleDirectory = repositoryRoot
+                .resolve(gav.getGroupId())
+                .resolve(gav.getArtifactId())
+                .resolve(gav.getVersion());
+        if (!moduleDirectory.toFile().isDirectory()) {
+            return Optional.empty();
+        }
+        File[] hashDirectories = moduleDirectory.toFile().listFiles(File::isDirectory);
+        if (hashDirectories == null) {
+            return Optional.empty();
+        }
+        String pomFileName = gav.getArtifactId() + "-" + gav.getVersion() + ".pom";
+        File resolvedPom = null;
+        for (File hashDirectory : hashDirectories) {
+            File candidate = hashDirectory.toPath().resolve(pomFileName).toFile();
+            if (candidate.isFile()) {
+                if (resolvedPom != null) {
+                    return Optional.empty();
+                }
+                resolvedPom = candidate;
+            }
+        }
+        return Optional.ofNullable(resolvedPom);
+    }
+
+    private static String repositoryPomPath(GAV gav) {
+        return gav.getGroupId().replace('.', File.separatorChar)
+                + File.separator + gav.getArtifactId()
+                + File.separator + gav.getVersion()
+                + File.separator + gav.getArtifactId() + "-" + gav.getVersion() + ".pom";
+    }
+
+    private record FileModelSource(File file) implements ModelSource2 {
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return new FileInputStream(file);
+        }
+
+        @Override
+        public String getLocation() {
+            return file.getAbsolutePath();
+        }
+
+        @Override
+        public ModelSource2 getRelatedSource(String relPath) {
+            return null;
+        }
+
+        @Override
+        public URI getLocationURI() {
+            return file.toURI();
+        }
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/MavenEffectiveModelResolver.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/MavenEffectiveModelResolver.java
@@ -1,0 +1,77 @@
+package io.quarkus.gradle.model.pom;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Parent;
+import org.apache.maven.model.Repository;
+import org.apache.maven.model.building.DefaultModelBuilder;
+import org.apache.maven.model.building.DefaultModelBuilderFactory;
+import org.apache.maven.model.building.DefaultModelBuildingRequest;
+import org.apache.maven.model.building.ModelBuildingException;
+import org.apache.maven.model.building.ModelBuildingRequest;
+import org.apache.maven.model.building.ModelSource2;
+import org.apache.maven.model.resolution.ModelResolver;
+import org.apache.maven.model.resolution.UnresolvableModelException;
+
+import io.quarkus.maven.dependency.GAV;
+
+class MavenEffectiveModelResolver {
+
+    private final PomResolver pomResolver;
+    private final Supplier<Map<String, String>> systemProperties;
+    private final ModelResolver modelResolver;
+    private final DefaultModelBuilder modelBuilder;
+
+    MavenEffectiveModelResolver(PomResolver pomResolver, Supplier<Map<String, String>> systemProperties) {
+        this.pomResolver = pomResolver;
+        this.systemProperties = systemProperties;
+        this.modelResolver = new PomBackedModelResolver(pomResolver);
+        this.modelBuilder = new DefaultModelBuilderFactory().newInstance();
+    }
+
+    Model resolveEffectiveModel(String groupId, String artifactId, String version)
+            throws UnresolvableModelException, ModelBuildingException {
+        var request = new DefaultModelBuildingRequest();
+        request.setModelSource(pomResolver.resolvePom(new GAV(groupId, artifactId, version)));
+        request.setModelResolver(modelResolver);
+        request.getSystemProperties().putAll(systemProperties.get());
+        request.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
+        return modelBuilder.build(request).getEffectiveModel();
+    }
+
+    private record PomBackedModelResolver(PomResolver pomResolver) implements ModelResolver {
+        @Override
+        public ModelSource2 resolveModel(String groupId, String artifactId, String version)
+                throws UnresolvableModelException {
+            return pomResolver.resolvePom(new GAV(groupId, artifactId, version));
+        }
+
+        @Override
+        public ModelSource2 resolveModel(Parent parent) throws UnresolvableModelException {
+            return resolveModel(parent.getGroupId(), parent.getArtifactId(), parent.getVersion());
+        }
+
+        @Override
+        public ModelSource2 resolveModel(Dependency dependency) throws UnresolvableModelException {
+            return resolveModel(dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion());
+        }
+
+        @Override
+        public void addRepository(Repository repository) {
+            // The Gradle-backed resolver intentionally uses repositories configured in Gradle.
+        }
+
+        @Override
+        public void addRepository(Repository repository, boolean replace) {
+            // The Gradle-backed resolver intentionally uses repositories configured in Gradle.
+        }
+
+        @Override
+        public ModelResolver newCopy() {
+            return this;
+        }
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/PomClosureResult.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/PomClosureResult.java
@@ -1,0 +1,46 @@
+package io.quarkus.gradle.model.pom;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import io.quarkus.maven.dependency.GAV;
+
+public final class PomClosureResult {
+
+    private final Map<GAV, File> resolvedPoms;
+    private final Set<GAV> missingPoms;
+
+    public PomClosureResult(Map<GAV, File> resolvedPoms, Set<GAV> missingPoms) {
+        this.resolvedPoms = Map.copyOf(resolvedPoms);
+        this.missingPoms = Set.copyOf(missingPoms);
+    }
+
+    public static PomClosureResult from(Map<GAV, Optional<File>> pomResults) {
+        Map<GAV, File> resolved = new TreeMap<>(PomClosureResult::compare);
+        Set<GAV> missing = new TreeSet<>(PomClosureResult::compare);
+        pomResults.forEach((gav, file) -> {
+            if (file.isPresent()) {
+                resolved.put(gav, file.get());
+            } else {
+                missing.add(gav);
+            }
+        });
+        return new PomClosureResult(resolved, missing);
+    }
+
+    public Map<GAV, File> resolvedPoms() {
+        return resolvedPoms;
+    }
+
+    public Set<GAV> missingPoms() {
+        return missingPoms;
+    }
+
+    private static int compare(GAV left, GAV right) {
+        return left.toString().compareTo(right.toString());
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/PomClosureResultCodec.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/PomClosureResultCodec.java
@@ -1,0 +1,106 @@
+package io.quarkus.gradle.model.pom;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import io.quarkus.bootstrap.util.PropertyUtils;
+import io.quarkus.maven.dependency.GAV;
+
+public final class PomClosureResultCodec {
+
+    private static final String COUNT = "count";
+    private static final String PREFIX = "entry.";
+    private static final String GAV = ".gav";
+    private static final String RESOLVED = ".resolved";
+    private static final String FILE = ".file";
+
+    private PomClosureResultCodec() {
+    }
+
+    public static void write(PomClosureResult result, Path file) throws IOException {
+        Files.createDirectories(file.getParent());
+        PropertyUtils.store(toProperties(result), file);
+    }
+
+    public static PomClosureResult read(Path file) throws IOException {
+        Properties properties = new Properties();
+        try (InputStream input = Files.newInputStream(file)) {
+            properties.load(input);
+        }
+        int count = requiredInt(properties, COUNT);
+        Map<GAV, java.io.File> resolved = new TreeMap<>(PomClosureResultCodec::compare);
+        Set<GAV> missing = new TreeSet<>(PomClosureResultCodec::compare);
+        for (int i = 0; i < count; i++) {
+            String prefix = PREFIX + i;
+            GAV gav = parseGav(required(properties, prefix + GAV));
+            boolean resolvedEntry = Boolean.parseBoolean(required(properties, prefix + RESOLVED));
+            if (resolvedEntry) {
+                resolved.put(gav, Path.of(required(properties, prefix + FILE)).toFile());
+            } else {
+                missing.add(gav);
+            }
+        }
+        return new PomClosureResult(resolved, missing);
+    }
+
+    private static Properties toProperties(PomClosureResult result) {
+        Properties properties = new Properties();
+        int index = 0;
+        Map<GAV, java.io.File> resolved = new TreeMap<>(PomClosureResultCodec::compare);
+        resolved.putAll(result.resolvedPoms());
+        for (Map.Entry<GAV, java.io.File> entry : resolved.entrySet()) {
+            writeEntry(properties, index++, entry.getKey(), true, entry.getValue());
+        }
+        Set<GAV> missing = new TreeSet<>(PomClosureResultCodec::compare);
+        missing.addAll(result.missingPoms());
+        for (GAV gav : missing) {
+            writeEntry(properties, index++, gav, false, null);
+        }
+        properties.setProperty(COUNT, Integer.toString(index));
+        return properties;
+    }
+
+    private static void writeEntry(Properties properties, int index, GAV gav, boolean resolved, java.io.File file) {
+        String prefix = PREFIX + index;
+        properties.setProperty(prefix + GAV, gav.toString());
+        properties.setProperty(prefix + RESOLVED, Boolean.toString(resolved));
+        if (resolved) {
+            properties.setProperty(prefix + FILE, file.getAbsolutePath());
+        }
+    }
+
+    private static int requiredInt(Properties properties, String key) {
+        try {
+            return Integer.parseInt(required(properties, key));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("POM closure property '" + key + "' must be an integer", e);
+        }
+    }
+
+    private static String required(Properties properties, String key) {
+        String value = properties.getProperty(key);
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("POM closure file is missing property '" + key + "'");
+        }
+        return value;
+    }
+
+    private static GAV parseGav(String value) {
+        String[] parts = value.split(":", -1);
+        if (parts.length != 3 || parts[0].isBlank() || parts[1].isBlank() || parts[2].isBlank()) {
+            throw new IllegalArgumentException("POM closure GAV must have format groupId:artifactId:version: " + value);
+        }
+        return new GAV(parts[0], parts[1], parts[2]);
+    }
+
+    private static int compare(GAV left, GAV right) {
+        return left.toString().compareTo(right.toString());
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/PomClosureTaskInput.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/PomClosureTaskInput.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.quarkus.gradle.model.pom;
+
+import java.io.File;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+
+import io.quarkus.maven.dependency.GAV;
+
+@SuppressWarnings("ClassCanBeRecord") // Gradle doesn't like records in this case
+public final class PomClosureTaskInput implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final Map<String, String> resolvedPomFilesByGav;
+    private final List<String> missingPomGavs;
+    private final List<File> resolvedPomFiles;
+
+    private PomClosureTaskInput(Map<String, String> resolvedPomFilesByGav, List<String> missingPomGavs,
+            List<File> resolvedPomFiles) {
+        this.resolvedPomFilesByGav = Map.copyOf(resolvedPomFilesByGav);
+        this.missingPomGavs = List.copyOf(missingPomGavs);
+        this.resolvedPomFiles = List.copyOf(resolvedPomFiles);
+    }
+
+    public static PomClosureTaskInput from(PomClosureResult result) {
+        Map<String, String> resolved = new TreeMap<>();
+        result.resolvedPoms()
+                .forEach((gav, file) -> resolved.put(gav.toString(), file.getAbsolutePath()));
+        List<String> missing = result.missingPoms().stream()
+                .map(GAV::toString)
+                .sorted()
+                .toList();
+        List<File> files = resolved.values().stream()
+                .map(File::new)
+                .toList();
+        return new PomClosureTaskInput(resolved, missing, files);
+    }
+
+    @Input
+    public Map<String, String> getResolvedPomFilesByGav() {
+        return resolvedPomFilesByGav;
+    }
+
+    @Input
+    public List<String> getMissingPomGavs() {
+        return missingPomGavs;
+    }
+
+    @Classpath
+    public List<File> getResolvedPomFiles() {
+        return resolvedPomFiles;
+    }
+
+    @Internal
+    public PomClosureResult getResult() {
+        Map<GAV, File> resolved = new TreeMap<>((left, right) -> left.toString().compareTo(right.toString()));
+        resolvedPomFilesByGav.forEach((gav, file) -> resolved.put(parseGav(gav), new File(file)));
+        Set<GAV> missing = new TreeSet<>((left, right) -> left.toString().compareTo(right.toString()));
+        missingPomGavs.stream().map(PomClosureTaskInput::parseGav).forEach(missing::add);
+        return new PomClosureResult(resolved, missing);
+    }
+
+    private static GAV parseGav(String value) {
+        String[] parts = value.split(":", -1);
+        if (parts.length != 3 || parts[0].isBlank() || parts[1].isBlank() || parts[2].isBlank()) {
+            throw new IllegalArgumentException("POM closure GAV must have format groupId:artifactId:version: " + value);
+        }
+        return new GAV(parts[0], parts[1], parts[2]);
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/PomResolver.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/PomResolver.java
@@ -1,0 +1,29 @@
+package io.quarkus.gradle.model.pom;
+
+import java.util.Collection;
+
+import org.apache.maven.model.building.ModelSource2;
+import org.apache.maven.model.resolution.UnresolvableModelException;
+
+import io.quarkus.maven.dependency.GAV;
+
+public interface PomResolver {
+
+    ModelSource2 resolvePom(GAV gav) throws UnresolvableModelException;
+
+    /**
+     * Gives Gradle-backed resolvers a chance to populate their cache with several POM lookup results at once.
+     */
+    default void prefetchPoms(Collection<GAV> gavs) {
+    }
+
+    /**
+     * Returns whether this resolver already has a resolved or known-missing result for the given POM.
+     * <p>
+     * Resolvers that do not maintain an explicit cache return {@code true} so callers fall back to direct
+     * {@link #resolvePom(GAV)} calls instead of trying to prefetch unsupported lookups.
+     */
+    default boolean hasPomResult(GAV gav) {
+        return true;
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/StrictDependencyDataCollector.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/pom/StrictDependencyDataCollector.java
@@ -1,0 +1,277 @@
+package io.quarkus.gradle.model.pom;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.building.ModelBuildingException;
+import org.apache.maven.model.building.ModelSource2;
+import org.apache.maven.model.resolution.UnresolvableModelException;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
+import org.gradle.api.logging.Logger;
+
+import io.quarkus.bootstrap.model.ApplicationModelBuilder;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.DependencyBuilder;
+import io.quarkus.maven.dependency.DependencyFlags;
+import io.quarkus.maven.dependency.GAV;
+import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
+
+public class StrictDependencyDataCollector {
+
+    private static final String SCOPE_TEST = "test";
+
+    private final PomResolver pomResolver;
+    private final Supplier<Map<String, String>> systemProperties;
+    private final Map<DeclaredDepsCacheKey, DeclaredDepsResult> declaredDependenciesCache = new ConcurrentHashMap<>();
+
+    public StrictDependencyDataCollector(PomResolver pomResolver, Supplier<Map<String, String>> systemProperties) {
+        this.pomResolver = Objects.requireNonNull(pomResolver, "pomResolver cannot be null");
+        this.systemProperties = Objects.requireNonNull(systemProperties, "systemProperties cannot be null");
+    }
+
+    /**
+     * Sets direct dependencies for the given dependency builder based on the provided declared dependencies.
+     * <p>
+     * The intention here is to use this method right before we build the model, making sure that the modelBuilder
+     * hass all the info about all dependencies, so we can properly set the flags for direct dependencies (e.g.
+     * MISSING_FROM_APPLICATION).
+     */
+    public static void setDirectDeps(
+            ResolvedDependencyBuilder depBuilder,
+            ApplicationModelBuilder modelBuilder,
+            Map<ArtifactKey, DeclaredDepsResult> declaredDependencies, Logger logger) {
+        final DeclaredDepsResult declaredDepsResult = declaredDependencies.get(depBuilder.getKey());
+        if (declaredDepsResult == null || !declaredDepsResult.isResolved()) {
+            logger.info("Declared dependencies not found for {}", depBuilder.getArtifactCoords().toGACTVString());
+            return;
+        }
+        final List<DeclaredDependency> declaredDeps = declaredDepsResult.getDeclaredDependencies();
+
+        final List<io.quarkus.maven.dependency.Dependency> directDeps = new ArrayList<>(declaredDeps.size());
+        final List<ArtifactCoords> depCoords = new ArrayList<>(declaredDeps.size());
+
+        for (var declaredDep : declaredDeps) {
+            var builder = DependencyBuilder.newInstance()
+                    .setGroupId(declaredDep.getGroupId())
+                    .setArtifactId(declaredDep.getArtifactId())
+                    .setClassifier(defaultIfNull(declaredDep.getClassifier(), ArtifactCoords.DEFAULT_CLASSIFIER))
+                    .setType(defaultIfNull(declaredDep.getType(), ArtifactCoords.TYPE_JAR))
+                    .setVersion(declaredDep.getVersion());
+
+            if (declaredDep.getScope() != null) {
+                builder.setScope(declaredDep.getScope());
+            }
+
+            var appDep = modelBuilder.getDependency(builder.getKey());
+            if (appDep == null) {
+                builder.setFlags(DependencyFlags.MISSING_FROM_APPLICATION);
+            } else {
+                builder.setVersion(appDep.getVersion())
+                        .setFlags(appDep.getFlags());
+            }
+
+            builder.setOptional(declaredDep.isOptional())
+                    .setFlags(DependencyFlags.DIRECT);
+
+            var directDep = builder.build();
+            directDeps.add(directDep);
+
+            if (appDep != null) {
+                depCoords.add(toPlainArtifactCoords(directDep));
+            }
+        }
+
+        depBuilder.setDependencies(depCoords)
+                .setDirectDependencies(directDeps);
+    }
+
+    public static List<ExternalModuleDeclaredDependencyInput> externalModuleDeclaredDependencyInputs(
+            Collection<ResolvedArtifactResult> artifacts) {
+        List<ExternalModuleDeclaredDependencyInput> moduleInputs = new ArrayList<>();
+        for (ResolvedArtifactResult artifact : artifacts) {
+            var componentId = artifact.getId().getComponentIdentifier();
+            if (componentId instanceof ModuleComponentIdentifier moduleId) {
+                moduleInputs.add(ExternalModuleDeclaredDependencyInput.from(artifact, moduleId));
+            }
+        }
+        moduleInputs.sort(ExternalModuleDeclaredDependencyInput::compareTo);
+        return List.copyOf(moduleInputs);
+    }
+
+    public Map<ArtifactKey, DeclaredDepsResult> collectExternalDeclaredDependencies(Logger logger,
+            List<ExternalModuleDeclaredDependencyInput> moduleInputs) {
+        Map<ArtifactKey, DeclaredDepsResult> result = new ConcurrentHashMap<>();
+        collectDeclaredDependencies(logger, moduleInputs, result);
+        return result;
+    }
+
+    private void collectDeclaredDependencies(Logger logger,
+            List<ExternalModuleDeclaredDependencyInput> moduleInputs,
+            Map<ArtifactKey, DeclaredDepsResult> result) {
+        collectDeclaredDependenciesWithPomResolution(logger, moduleInputs, result);
+    }
+
+    /**
+     * Builds Maven effective models from Gradle-resolved POMs and records their declared dependency edges.
+     * <p>
+     * The first iteration prefetches the POMs for the modules selected by Gradle. Maven model building may then request
+     * parent POMs or imported BOM POMs that were not part of that initial set. Those requests are recorded, prefetched
+     * through Gradle as a batch, and retried until no new POMs are discovered. Missing POMs are cached as unresolved
+     * results so the loop terminates without repeated resolution attempts.
+     * <p>
+     * This intentionally follows Gradle's resolved module graph for the modules being enriched, while using Maven model
+     * parsing only to recover information Gradle does not expose directly: which dependencies were declared by a POM, with
+     * their Maven scopes and optional markers. Consumer-side Gradle constraints, platforms, and conflict resolution are
+     * applied later when {@link #setDirectDeps(ResolvedDependencyBuilder, ApplicationModelBuilder, Map, Logger)} maps the
+     * declared edges back onto the Gradle-built application model.
+     */
+    private void collectDeclaredDependenciesWithPomResolution(
+            Logger logger,
+            List<ExternalModuleDeclaredDependencyInput> moduleInputs,
+            Map<ArtifactKey, DeclaredDepsResult> result) {
+        pomResolver.prefetchPoms(moduleInputs.stream()
+                .map(ExternalModuleDeclaredDependencyInput::getPomGav)
+                .toList());
+
+        List<ExternalModuleDeclaredDependencyInput> pending = new ArrayList<>();
+        for (ExternalModuleDeclaredDependencyInput moduleInput : moduleInputs) {
+            DeclaredDepsResult cached = declaredDependenciesCache.get(declaredDepsCacheKey(moduleInput));
+            if (cached == null) {
+                pending.add(moduleInput);
+            } else {
+                result.put(moduleInput.getArtifactKey(), cached);
+            }
+        }
+
+        while (!pending.isEmpty()) {
+            Set<GAV> missingPoms = new LinkedHashSet<>();
+            List<ExternalModuleDeclaredDependencyInput> retry = new ArrayList<>();
+
+            for (ExternalModuleDeclaredDependencyInput moduleInput : pending) {
+                DeclaredDepsResult resolved = collectDeclaredFromModule(logger, moduleInput, missingPoms);
+                if (resolved == null) {
+                    retry.add(moduleInput);
+                } else {
+                    declaredDependenciesCache.putIfAbsent(declaredDepsCacheKey(moduleInput), resolved);
+                    result.put(moduleInput.getArtifactKey(), resolved);
+                }
+            }
+
+            if (missingPoms.isEmpty()) {
+                for (ExternalModuleDeclaredDependencyInput moduleInput : retry) {
+                    DeclaredDepsResult unresolved = DeclaredDepsResult.unresolved();
+                    declaredDependenciesCache.putIfAbsent(declaredDepsCacheKey(moduleInput), unresolved);
+                    result.put(moduleInput.getArtifactKey(), unresolved);
+                }
+                return;
+            }
+
+            pomResolver.prefetchPoms(missingPoms);
+            pending = retry;
+        }
+    }
+
+    private DeclaredDepsResult collectDeclaredFromModule(
+            Logger logger,
+            ExternalModuleDeclaredDependencyInput moduleInput,
+            Set<GAV> missingPoms) {
+        GAV pomGav = moduleInput.getPomGav();
+        var recordingPomResolver = new RecordingPomResolver(pomResolver);
+        try {
+            var effectiveModelResolver = new MavenEffectiveModelResolver(recordingPomResolver, systemProperties);
+            var effectiveModel = effectiveModelResolver.resolveEffectiveModel(
+                    pomGav.getGroupId(), pomGav.getArtifactId(), pomGav.getVersion());
+            return DeclaredDepsResult.resolved(toDeclaredDependencies(effectiveModel));
+        } catch (UnresolvableModelException | ModelBuildingException e) {
+            Set<GAV> requestedPoms = recordingPomResolver.getRequestedPoms();
+            if (!requestedPoms.isEmpty()) {
+                missingPoms.addAll(requestedPoms);
+                return null;
+            }
+            logger.warn("Unable to resolve effective model for {}:{}:{}: {}",
+                    pomGav.getGroupId(), pomGav.getArtifactId(), pomGav.getVersion(), e.getMessage());
+            return DeclaredDepsResult.unresolved();
+        }
+    }
+
+    private static DeclaredDepsCacheKey declaredDepsCacheKey(ExternalModuleDeclaredDependencyInput moduleInput) {
+        return new DeclaredDepsCacheKey(moduleInput.getArtifactKey(), moduleInput.getPomGav(), false);
+    }
+
+    private record DeclaredDepsCacheKey(ArtifactKey artifactKey, GAV pomGav, boolean includeTestScopes) {
+    }
+
+    private static final class RecordingPomResolver implements PomResolver {
+
+        private final PomResolver delegate;
+        private final Set<GAV> requestedPoms = new LinkedHashSet<>();
+
+        private RecordingPomResolver(PomResolver delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public ModelSource2 resolvePom(GAV gav) throws UnresolvableModelException {
+            if (!delegate.hasPomResult(gav)) {
+                requestedPoms.add(gav);
+                throw new UnresolvableModelException("POM not prefetched for " + gav,
+                        gav.getGroupId(), gav.getArtifactId(), gav.getVersion());
+            }
+            return delegate.resolvePom(gav);
+        }
+
+        private Set<GAV> getRequestedPoms() {
+            return requestedPoms;
+        }
+    }
+
+    private static List<DeclaredDependency> toDeclaredDependencies(Model model) {
+        final List<DeclaredDependency> declaredDeps = new ArrayList<>();
+        for (org.apache.maven.model.Dependency dep : model.getDependencies()) {
+            if (!SCOPE_TEST.equals(dep.getScope())) {
+                declaredDeps.add(new DeclaredDependency(dep));
+            }
+        }
+        return declaredDeps;
+    }
+
+    static String resolveArtifactType(ResolvedArtifactResult artifact) {
+        return artifact.getVariant().getAttributes().getAttribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE);
+    }
+
+    static ArtifactKey resolveArtifactKey(ResolvedArtifactResult artifact, ModuleComponentIdentifier moduleId) {
+        return ArtifactKey.of(moduleId.getGroup(), moduleId.getModule(),
+                resolveClassifier(moduleId.getModule(), moduleId.getVersion(), artifact.getFile()),
+                resolveArtifactType(artifact));
+    }
+
+    private static String resolveClassifier(String artifactId, String version, java.io.File file) {
+        String artifactIdVersion = version == null || version.isEmpty() || "unspecified".equals(version)
+                ? artifactId
+                : artifactId + "-" + version;
+        if ((file.getName().endsWith(".jar") || file.getName().endsWith(".pom") || file.getName().endsWith(".exe"))
+                && file.getName().startsWith(artifactIdVersion + "-")) {
+            return file.getName().substring(artifactIdVersion.length() + 1, file.getName().length() - 4);
+        }
+        return "";
+    }
+
+    private static ArtifactCoords toPlainArtifactCoords(io.quarkus.maven.dependency.Dependency dep) {
+        return ArtifactCoords.of(dep.getGroupId(), dep.getArtifactId(), dep.getClassifier(), dep.getType(), dep.getVersion());
+    }
+
+    static String defaultIfNull(String value, String fallback) {
+        return value == null ? fallback : value;
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/GenerateApplicationModelTask.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/GenerateApplicationModelTask.java
@@ -1,0 +1,52 @@
+package io.quarkus.gradle.model.tasks;
+
+import javax.inject.Inject;
+
+import io.quarkus.runtime.LaunchMode;
+
+/**
+ * Shared task type for Gradle plugins that need to serialize a Quarkus application model for a specific launch mode.
+ */
+public abstract class GenerateApplicationModelTask extends QuarkusApplicationModelTask {
+
+    @Inject
+    public GenerateApplicationModelTask(LaunchMode launchMode) {
+        getLaunchMode().set(launchMode);
+        getApplicationModel().convention(getLaunchMode()
+                .flatMap(mode -> getProject().getLayout().getBuildDirectory()
+                        .file(applicationModelPath(mode, false))));
+    }
+
+    public static String taskName(LaunchMode launchMode) {
+        return switch (launchMode) {
+            case NORMAL -> "quarkusGenerateAppModel";
+            case DEVELOPMENT -> "quarkusGenerateDevAppModel";
+            case TEST -> "quarkusGenerateTestAppModel";
+            default -> throw new IllegalArgumentException("Unsupported launch mode " + launchMode);
+        };
+    }
+
+    static String applicationModelPath(LaunchMode launchMode, boolean buildModel) {
+        return switch (launchMode) {
+            case TEST -> {
+                if (buildModel) {
+                    throw new IllegalArgumentException("BUILD_MODEL mode is not supported for LaunchMode.TEST");
+                }
+                yield "quarkus/application-model/quarkus-app-test-model.dat";
+            }
+            case DEVELOPMENT -> {
+                if (buildModel) {
+                    throw new IllegalArgumentException("BUILD_MODEL mode is not supported for LaunchMode.DEVELOPMENT");
+                }
+                yield "quarkus/application-model/quarkus-app-dev-model.dat";
+            }
+            case NORMAL -> {
+                yield buildModel ? "quarkus/application-model/quarkus-app-model-build.dat"
+                        : "quarkus/application-model/quarkus-app-model.dat";
+            }
+            case RUN -> {
+                throw new IllegalArgumentException("RUN mode is not supported for application model generation");
+            }
+        };
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/GeneratePomClosureTask.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/GeneratePomClosureTask.java
@@ -1,0 +1,30 @@
+package io.quarkus.gradle.model.tasks;
+
+import java.io.IOException;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
+
+import io.quarkus.gradle.model.pom.PomClosureResultCodec;
+import io.quarkus.gradle.model.pom.PomClosureTaskInput;
+
+@DisableCachingByDefault(because = "The closure records absolute paths into Gradle's dependency cache")
+public abstract class GeneratePomClosureTask extends DefaultTask {
+
+    @Nested
+    public abstract Property<PomClosureTaskInput> getPomClosureInput();
+
+    @OutputFile
+    public abstract RegularFileProperty getPomClosureFile();
+
+    @TaskAction
+    public void execute() throws IOException {
+        PomClosureResultCodec.write(getPomClosureInput().get().getResult(),
+                getPomClosureFile().get().getAsFile().toPath());
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/GradlePomClosureResolver.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/GradlePomClosureResolver.java
@@ -1,0 +1,254 @@
+package io.quarkus.gradle.model.tasks;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+import org.apache.maven.model.building.ModelSource2;
+import org.apache.maven.model.resolution.UnresolvableModelException;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.maven.MavenModule;
+import org.gradle.maven.MavenPomArtifact;
+
+import io.quarkus.gradle.model.pom.PomResolver;
+import io.quarkus.maven.dependency.GAV;
+
+public class GradlePomClosureResolver implements PomResolver {
+
+    private final DependencyHandler dependencies;
+    private final Map<GAV, Optional<File>> pomCache = new ConcurrentHashMap<>();
+    private final Map<GAV, File> resolvedPomFiles;
+    private final List<File> repositoryRoots;
+
+    /**
+     * Creates a resolver that starts from modeled POM files but falls back to Gradle artifact resolution for missing POMs.
+     * This is intended for legacy/tooling compatibility and dedicated POM-closure producer tasks.
+     */
+    public static GradlePomClosureResolver withGradleArtifactResolution(Map<GAV, File> resolvedPomFiles,
+            DependencyHandler dependencies, Collection<File> repositoryRoots) {
+        return new GradlePomClosureResolver(resolvedPomFiles, dependencies, repositoryRoots);
+    }
+
+    private GradlePomClosureResolver(Map<GAV, File> resolvedPomFiles, DependencyHandler dependencies,
+            Collection<File> repositoryRoots) {
+        this.dependencies = dependencies;
+        this.resolvedPomFiles = Map.copyOf(resolvedPomFiles);
+        this.repositoryRoots = new ArrayList<>(repositoryRoots);
+        resolvedPomFiles.forEach((gav, file) -> pomCache.put(gav, Optional.of(file)));
+    }
+
+    public Map<GAV, Optional<File>> getPomResults() {
+        return Map.copyOf(pomCache);
+    }
+
+    public void prefetchPoms(Stream<ModuleComponentIdentifier> moduleIds) {
+        Set<ModuleComponentIdentifier> unresolvedModuleIds = new HashSet<>();
+        moduleIds.filter(moduleId -> !pomCache.containsKey(toGav(moduleId)))
+                .forEach(unresolvedModuleIds::add);
+        if (unresolvedModuleIds.isEmpty()) {
+            return;
+        }
+        if (dependencies == null) {
+            unresolvedModuleIds.stream()
+                    .map(GradlePomClosureResolver::toGav)
+                    .forEach(gav -> pomCache.putIfAbsent(gav, resolvePomFromKnownRepositories(gav)));
+            return;
+        }
+
+        @SuppressWarnings("unchecked")
+        var result = dependencies.createArtifactResolutionQuery()
+                .forComponents(unresolvedModuleIds)
+                .withArtifacts(MavenModule.class, MavenPomArtifact.class)
+                .execute();
+
+        Set<GAV> unresolvedGavs = new HashSet<>();
+        unresolvedModuleIds.stream()
+                .map(GradlePomClosureResolver::toGav)
+                .forEach(unresolvedGavs::add);
+        for (var component : result.getResolvedComponents()) {
+            ComponentIdentifier componentId = component.getId();
+            if (componentId instanceof ModuleComponentIdentifier moduleId) {
+                Optional<File> pom = Optional.empty();
+                for (var artifactResult : component.getArtifacts(MavenPomArtifact.class)) {
+                    if (artifactResult instanceof ResolvedArtifactResult resolved) {
+                        pom = Optional.of(resolved.getFile());
+                        break;
+                    }
+                }
+                var gav = toGav(moduleId);
+                pomCache.putIfAbsent(gav, pom);
+                unresolvedGavs.remove(gav);
+            }
+        }
+
+        for (var unresolvedGav : unresolvedGavs) {
+            pomCache.putIfAbsent(unresolvedGav, Optional.empty());
+        }
+    }
+
+    @Override
+    public void prefetchPoms(Collection<GAV> gavs) {
+        Set<GAV> unresolvedGavs = new HashSet<>();
+        gavs.stream()
+                .filter(gav -> !pomCache.containsKey(gav))
+                .forEach(unresolvedGavs::add);
+        if (unresolvedGavs.isEmpty()) {
+            return;
+        }
+
+        for (GAV gav : unresolvedGavs) {
+            pomCache.putIfAbsent(gav, dependencies == null ? resolvePomFromKnownRepositories(gav) : resolvePomViaQuery(gav));
+        }
+    }
+
+    @Override
+    public boolean hasPomResult(GAV gav) {
+        return pomCache.containsKey(gav);
+    }
+
+    @Override
+    public ModelSource2 resolvePom(GAV gav) throws UnresolvableModelException {
+        File pomFile = pomCache
+                .computeIfAbsent(gav, this::resolvePomViaQuery)
+                .orElse(null);
+
+        if (pomFile == null) {
+            throw new UnresolvableModelException(
+                    "Could not resolve POM for " + gav.getGroupId() + ":" + gav.getArtifactId() + ":" + gav.getVersion(),
+                    gav.getGroupId(), gav.getArtifactId(), gav.getVersion());
+        }
+
+        return new FileModelSource(pomFile);
+    }
+
+    private Optional<File> resolvePomViaQuery(GAV gav) {
+        if (dependencies == null) {
+            return resolvePomFromKnownRepositories(gav);
+        }
+        @SuppressWarnings("unchecked")
+        var componentId = dependencies.createArtifactResolutionQuery()
+                .forModule(gav.getGroupId(), gav.getArtifactId(), gav.getVersion())
+                .withArtifacts(MavenModule.class, MavenPomArtifact.class)
+                .execute();
+
+        for (var component : componentId.getResolvedComponents()) {
+            for (var artifactResult : component.getArtifacts(MavenPomArtifact.class)) {
+                if (artifactResult instanceof ResolvedArtifactResult resolved) {
+                    return Optional.of(resolved.getFile());
+                }
+            }
+        }
+        return resolvePomFromKnownRepositories(gav);
+    }
+
+    private Optional<File> resolvePomFromKnownRepositories(GAV gav) {
+        File resolved = resolvedPomFiles.get(gav);
+        if (resolved != null) {
+            return Optional.of(resolved);
+        }
+
+        String targetSuffix = repositoryPomPath(gav);
+        for (File repositoryRoot : repositoryRoots) {
+            Path candidate = repositoryRoot.toPath().resolve(targetSuffix);
+            if (candidate.toFile().isFile()) {
+                return Optional.of(candidate.toFile());
+            }
+            Optional<File> gradleCachePom = findGradleCachePom(repositoryRoot.toPath(), gav);
+            if (gradleCachePom.isPresent()) {
+                return gradleCachePom;
+            }
+        }
+
+        for (var entry : resolvedPomFiles.entrySet()) {
+            Path knownPom = entry.getValue().toPath();
+            String knownSuffix = repositoryPomPath(entry.getKey());
+            if (!knownPom.endsWith(knownSuffix)) {
+                continue;
+            }
+            Path repositoryRoot = knownPom;
+            for (int i = 0; i < Path.of(knownSuffix).getNameCount(); i++) {
+                repositoryRoot = repositoryRoot.getParent();
+            }
+            Path candidate = repositoryRoot.resolve(targetSuffix);
+            if (candidate.toFile().isFile()) {
+                return Optional.of(candidate.toFile());
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<File> findGradleCachePom(Path repositoryRoot, GAV gav) {
+        Path moduleDirectory = repositoryRoot
+                .resolve(gav.getGroupId())
+                .resolve(gav.getArtifactId())
+                .resolve(gav.getVersion());
+        if (!moduleDirectory.toFile().isDirectory()) {
+            return Optional.empty();
+        }
+        File[] hashDirectories = moduleDirectory.toFile().listFiles(File::isDirectory);
+        if (hashDirectories == null) {
+            return Optional.empty();
+        }
+        String pomFileName = gav.getArtifactId() + "-" + gav.getVersion() + ".pom";
+        File resolvedPom = null;
+        for (File hashDirectory : hashDirectories) {
+            File candidate = hashDirectory.toPath().resolve(pomFileName).toFile();
+            if (candidate.isFile()) {
+                if (resolvedPom != null) {
+                    return Optional.empty();
+                }
+                resolvedPom = candidate;
+            }
+        }
+        return Optional.ofNullable(resolvedPom);
+    }
+
+    private static String repositoryPomPath(GAV gav) {
+        return gav.getGroupId().replace('.', File.separatorChar)
+                + File.separator + gav.getArtifactId()
+                + File.separator + gav.getVersion()
+                + File.separator + gav.getArtifactId() + "-" + gav.getVersion() + ".pom";
+    }
+
+    private static GAV toGav(ModuleComponentIdentifier moduleId) {
+        return new GAV(moduleId.getGroup(), moduleId.getModule(), moduleId.getVersion());
+    }
+
+    private record FileModelSource(File file) implements ModelSource2 {
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return new FileInputStream(file);
+        }
+
+        @Override
+        public String getLocation() {
+            return file.getAbsolutePath();
+        }
+
+        @Override
+        public ModelSource2 getRelatedSource(String relPath) {
+            return null;
+        }
+
+        @Override
+        public URI getLocationURI() {
+            return file.toURI();
+        }
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/IsolatedApplicationModelTaskConfigurator.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/IsolatedApplicationModelTaskConfigurator.java
@@ -1,0 +1,46 @@
+package io.quarkus.gradle.model.tasks;
+
+import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.TaskProvider;
+
+import io.quarkus.gradle.model.config.LocalComponentOutputViews;
+import io.quarkus.gradle.model.config.StrictApplicationDeploymentClasspathBuilder;
+import io.quarkus.gradle.model.pom.DeclaredDependencyEnrichmentMode;
+import io.quarkus.gradle.tooling.DefaultProjectDescriptor;
+import io.quarkus.runtime.LaunchMode;
+
+public final class IsolatedApplicationModelTaskConfigurator {
+
+    private IsolatedApplicationModelTaskConfigurator() {
+    }
+
+    /**
+     * Registers an application-model task path that avoids configuration-time producer-project model access.
+     * <p>
+     * This path uses Gradle artifact views to capture local component class/resource outputs. It intentionally avoids
+     * declared dependency enrichment until the deployment classpath resolver is isolated-project safe for that path.
+     */
+    public static TaskProvider<GenerateApplicationModelTask> registerGenerateApplicationModelTask(Project project,
+            Provider<DefaultProjectDescriptor> projectDescriptor,
+            StrictApplicationDeploymentClasspathBuilder classpath,
+            LaunchMode launchMode,
+            LocalComponentOutputViews localComponentOutputs) {
+        var appModelTask = project.getTasks().register(GenerateApplicationModelTask.taskName(launchMode),
+                GenerateApplicationModelTask.class, launchMode);
+        appModelTask.configure(task -> {
+            StrictApplicationModelTaskConfigurator.configureNoLiveProjectDeclaredDependencies(project, task,
+                    projectDescriptor, classpath, launchMode, false);
+            task.getDeclaredDependencyEnrichmentMode().set(DeclaredDependencyEnrichmentMode.NONE);
+            configureLocalComponentOutputs(task, localComponentOutputs);
+        });
+        return appModelTask;
+    }
+
+    private static void configureLocalComponentOutputs(QuarkusApplicationModelTask task,
+            LocalComponentOutputViews localComponentOutputs) {
+        task.getLocalClassOutputArtifacts().set(localComponentOutputs.classArtifacts());
+        task.getLocalResourceOutputArtifacts().set(localComponentOutputs.resourceArtifacts());
+        task.getLocalComponentOutputFiles().from(localComponentOutputs.classFiles(), localComponentOutputs.resourceFiles());
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/QuarkusApplicationModelTask.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/QuarkusApplicationModelTask.java
@@ -1,0 +1,635 @@
+package io.quarkus.gradle.model.tasks;
+
+import static io.quarkus.gradle.model.pom.ApplicationModelBuilderSupport.addFileDependencies;
+import static io.quarkus.gradle.model.pom.ApplicationModelBuilderSupport.clearFlag;
+import static io.quarkus.gradle.model.pom.ApplicationModelBuilderSupport.collectDestinationDirs;
+import static io.quarkus.gradle.model.pom.ApplicationModelBuilderSupport.isFlagOn;
+import static io.quarkus.gradle.model.pom.ApplicationModelBuilderSupport.processQuarkusDependency;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.result.DependencyResult;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.artifacts.result.ResolvedDependencyResult;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.CompileClasspath;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
+
+import io.quarkus.bootstrap.model.ApplicationModelBuilder;
+import io.quarkus.bootstrap.model.DefaultApplicationModel;
+import io.quarkus.bootstrap.workspace.WorkspaceModule;
+import io.quarkus.bootstrap.workspace.WorkspaceModuleId;
+import io.quarkus.gradle.model.pom.DeclaredDependencyEnrichmentMode;
+import io.quarkus.gradle.model.pom.DeclaredDepsResult;
+import io.quarkus.gradle.model.pom.KnownPomResolver;
+import io.quarkus.gradle.model.pom.PomClosureResult;
+import io.quarkus.gradle.model.pom.PomClosureResultCodec;
+import io.quarkus.gradle.model.pom.StrictDependencyDataCollector;
+import io.quarkus.gradle.tooling.DefaultProjectDescriptor;
+import io.quarkus.gradle.tooling.ProjectDescriptor;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactDependency;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.DependencyFlags;
+import io.quarkus.maven.dependency.GACTV;
+import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
+import io.quarkus.paths.PathList;
+import io.quarkus.runtime.LaunchMode;
+
+@DisableCachingByDefault(because = "The serialized application model contains resolved file-system paths and is not relocatable")
+public abstract class QuarkusApplicationModelTask extends QuarkusBaseTask {
+
+    /* @formatter:off */
+    private static final byte COLLECT_TOP_EXTENSION_RUNTIME_NODES = 0b001;
+    private static final byte COLLECT_DIRECT_DEPS =                 0b010;
+    private static final byte COLLECT_RELOADABLE_MODULES =          0b100;
+    /* @formatter:on */
+
+    private final QuarkusResolvedClasspath compileOnlyClasspath;
+    private final QuarkusResolvedClasspath deploymentClasspath;
+
+    @Internal
+    public abstract RegularFileProperty getProjectBuildFile();
+
+    /**
+     * Used just to track original classpath as an input, since resolving quarkus classpath is kinda expensive,
+     * and we don't want to do that if task is up-to-date
+     */
+    @CompileClasspath
+    public abstract ConfigurableFileCollection getOriginalClasspath();
+
+    /**
+     * Tracks deployment artifacts as a Gradle-native file input for local up-to-date checks.
+     * The resolved graph itself is consumed through the lazy resolution-result properties below.
+     */
+    @CompileClasspath
+    public abstract ConfigurableFileCollection getDeploymentClasspathFiles();
+
+    @Internal
+    public abstract SetProperty<ResolvedArtifactResult> getLocalClassOutputArtifacts();
+
+    @Internal
+    public abstract SetProperty<ResolvedArtifactResult> getLocalResourceOutputArtifacts();
+
+    @CompileClasspath
+    public abstract ConfigurableFileCollection getLocalComponentOutputFiles();
+
+    @Nested
+    public abstract QuarkusResolvedClasspath getPlatformConfiguration();
+
+    @Nested
+    public abstract QuarkusResolvedClasspath getAppClasspath();
+
+    @Internal
+    public QuarkusResolvedClasspath getDeploymentClasspath() {
+        return deploymentClasspath;
+    }
+
+    @Internal
+    public QuarkusResolvedClasspath getCompileOnlyClasspath() {
+        return compileOnlyClasspath;
+    }
+
+    @Nested
+    public abstract QuarkusPlatformInfo getPlatformInfo();
+
+    @Input
+    public abstract Property<LaunchMode> getLaunchMode();
+
+    @Input
+    public abstract Property<String> getTypeModel();
+
+    /**
+     * If any project task changes, we will invalidate this task anyway
+     */
+    @Input
+    public abstract Property<DefaultProjectDescriptor> getProjectDescriptor();
+
+    @Internal
+    public abstract MapProperty<ArtifactKey, DeclaredDepsResult> getDeclaredDependencies();
+
+    @Input
+    public abstract Property<DeclaredDependencyEnrichmentMode> getDeclaredDependencyEnrichmentMode();
+
+    @InputFile
+    @Optional
+    @PathSensitive(PathSensitivity.NONE)
+    public abstract RegularFileProperty getPomClosureFile();
+
+    @OutputFile
+    public abstract RegularFileProperty getApplicationModel();
+
+    public QuarkusApplicationModelTask() {
+        compileOnlyClasspath = getObjects().newInstance(QuarkusResolvedClasspath.class);
+        deploymentClasspath = getObjects().newInstance(QuarkusResolvedClasspath.class);
+        getProjectBuildFile().set(getProject().getBuildFile());
+        getLocalClassOutputArtifacts().convention(Set.of());
+        getLocalResourceOutputArtifacts().convention(Set.of());
+        getDeclaredDependencies().convention(Map.of());
+        getDeclaredDependencyEnrichmentMode().convention(DeclaredDependencyEnrichmentMode.SELECTED_MODULE_POMS);
+    }
+
+    @TaskAction
+    public void execute() throws IOException {
+        final DefaultProjectDescriptor projectDescriptor = getProjectDescriptor().get();
+
+        final ResolvedDependencyBuilder appArtifact = getProjectArtifact(projectDescriptor);
+
+        final ApplicationModelBuilder modelBuilder = new ApplicationModelBuilder()
+                .setAppArtifact(appArtifact)
+                .setPlatformImports(getPlatformInfo().resolvePlatformImports())
+                .addReloadableWorkspaceModule(appArtifact.getKey());
+
+        LocalOutputPaths localOutputPaths = localOutputPaths();
+        collectDependencies(getAppClasspath(), modelBuilder, projectDescriptor.getWorkspaceModule(), projectDescriptor,
+                localOutputPaths);
+        collectExtensionDependencies(getDeploymentClasspath(), modelBuilder);
+        collectCompileOnlyDependencies(getCompileOnlyClasspath(), modelBuilder);
+
+        if (getDeclaredDependencyEnrichmentMode().get() == DeclaredDependencyEnrichmentMode.SELECTED_MODULE_POMS) {
+            var declaredDependencies = new HashMap<>(getDeclaredDependencies().get());
+            declaredDependencies.putAll(collectExternalDeclaredDependencies());
+            StrictDependencyDataCollector.setDirectDeps(appArtifact, modelBuilder, declaredDependencies, getLogger());
+            for (ResolvedDependencyBuilder dep : modelBuilder.getDependencies()) {
+                StrictDependencyDataCollector.setDirectDeps(dep, modelBuilder, declaredDependencies, getLogger());
+            }
+        }
+
+        DefaultApplicationModel model = modelBuilder.build();
+        SerializedApplicationModel.write(model, getApplicationModel().get().getAsFile().toPath());
+    }
+
+    private Map<ArtifactKey, DeclaredDepsResult> collectExternalDeclaredDependencies() throws IOException {
+        var collector = new StrictDependencyDataCollector(pomResolver(),
+                getProviderFactory().systemPropertiesPrefixedBy("")::get);
+        return collector.collectExternalDeclaredDependencies(getLogger(),
+                StrictDependencyDataCollector.externalModuleDeclaredDependencyInputs(Stream.concat(
+                        getAppClasspath().getResolvedArtifacts().get().stream(),
+                        getDeploymentClasspath().getResolvedArtifacts().get().stream()).toList()));
+    }
+
+    private KnownPomResolver pomResolver() throws IOException {
+        if (!getPomClosureFile().isPresent()) {
+            return KnownPomResolver.fromPomClosure(Map.of(), Set.of(), getMavenLocalRepositoryRoots());
+        }
+        PomClosureResult pomClosure = PomClosureResultCodec.read(getPomClosureFile().get().getAsFile().toPath());
+        return KnownPomResolver.fromPomClosure(pomClosure.resolvedPoms(), pomClosure.missingPoms(),
+                getMavenLocalRepositoryRoots());
+    }
+
+    private List<File> getMavenLocalRepositoryRoots() {
+        String mavenRepoLocal = getProviderFactory().systemProperty("maven.repo.local").getOrNull();
+        if (mavenRepoLocal == null || mavenRepoLocal.isBlank()) {
+            return List.of();
+        }
+        return List.of(new File(mavenRepoLocal));
+    }
+
+    private ResolvedDependencyBuilder getProjectArtifact(DefaultProjectDescriptor projectDescriptor) {
+        ModuleVersionIdentifier moduleVersion = getAppClasspath().getRoot().get().getModuleVersion();
+        ResolvedDependencyBuilder appArtifact = ResolvedDependencyBuilder.newInstance()
+                .setGroupId(moduleVersion.getGroup())
+                .setArtifactId(moduleVersion.getName())
+                .setVersion(moduleVersion.getVersion());
+
+        WorkspaceModule.Mutable module = projectDescriptor.getWorkspaceModule();
+        // TODO this is necessary for now to set the proper ID, since the group ID and the version don't have proper values in the descriptor
+        module.setModuleId(
+                WorkspaceModuleId.of(appArtifact.getGroupId(), appArtifact.getArtifactId(), appArtifact.getVersion()));
+
+        var mainSources = module.getMainSources();
+        if (mainSources != null) {
+            final PathList.Builder paths = PathList.builder();
+            collectDestinationDirs(module.getMainSources().getSourceDirs(), paths);
+            collectDestinationDirs(module.getMainSources().getResourceDirs(), paths);
+            appArtifact.setResolvedPaths(paths.build());
+            appArtifact.setReloadable().setWorkspaceModule();
+        } else {
+            appArtifact.setResolvedPaths(PathList.empty());
+        }
+
+        return appArtifact.setWorkspaceModule(module);
+    }
+
+    private void collectDependencies(QuarkusResolvedClasspath classpath, ApplicationModelBuilder modelBuilder,
+            WorkspaceModule.Mutable wsModule, ProjectDescriptor projectDescriptor,
+            LocalOutputPaths localOutputPaths) {
+        final Map<ComponentIdentifier, List<QuarkusResolvedArtifact>> artifacts = classpath
+                .resolvedArtifactsByComponentIdentifier();
+
+        Set<File> alreadyCollectedFiles = new HashSet<>(artifacts.size());
+        final Set<ModuleVersionIdentifier> processedModules = new HashSet<>();
+        classpath.getRoot().get().getDependencies().forEach(d -> {
+            if (d instanceof ResolvedDependencyResult resolved) {
+                byte flags = (byte) (COLLECT_TOP_EXTENSION_RUNTIME_NODES | COLLECT_DIRECT_DEPS);
+                final LaunchMode launchMode = getLaunchMode().get();
+                if (!launchMode.equals(LaunchMode.NORMAL)) {
+                    flags |= COLLECT_RELOADABLE_MODULES;
+                }
+                collectDependencies(resolved, modelBuilder, artifacts, wsModule, alreadyCollectedFiles,
+                        processedModules, flags, projectDescriptor, localOutputPaths);
+            }
+        });
+        Set<File> fileDependencies = new HashSet<>(classpath.getAllResolvedFiles().getFiles());
+
+        fileDependencies.removeAll(alreadyCollectedFiles);
+        addFileDependencies(modelBuilder, fileDependencies);
+    }
+
+    private static void collectDependencies(
+            ResolvedDependencyResult resolvedDependency,
+            ApplicationModelBuilder modelBuilder,
+            Map<ComponentIdentifier, List<QuarkusResolvedArtifact>> resolvedArtifacts,
+            WorkspaceModule.Mutable parentModule,
+            Set<File> collectedArtifactFiles,
+            Set<ModuleVersionIdentifier> processedModules,
+            byte flags,
+            ProjectDescriptor projectDescriptor,
+            LocalOutputPaths localOutputPaths) {
+        final ModuleVersionIdentifier moduleId = getModuleVersion(resolvedDependency);
+        if (!processedModules.add(moduleId)) {
+            return;
+        }
+        var projectModule = projectDescriptor
+                .getWorkspaceModuleOrNull(WorkspaceModuleId.of(moduleId.getGroup(), moduleId.getName(), moduleId.getVersion()));
+        boolean localWorkspaceModule = projectModule != null
+                || localOutputPaths.hasComponent(resolvedDependency.getSelected().getId());
+        final List<QuarkusResolvedArtifact> artifacts = getResolvedModuleArtifacts(resolvedArtifacts,
+                resolvedDependency.getSelected().getId());
+        if (artifacts.isEmpty()) {
+            final byte finalFlags = flags;
+            final WorkspaceModule.Mutable currentProjectModule = projectModule;
+            resolvedDependency.getSelected().getDependencies().forEach((Consumer<DependencyResult>) dependencyResult -> {
+                if (dependencyResult instanceof ResolvedDependencyResult result) {
+                    collectDependencies(result, modelBuilder, resolvedArtifacts,
+                            currentProjectModule,
+                            collectedArtifactFiles,
+                            processedModules, finalFlags, projectDescriptor, localOutputPaths);
+                }
+            });
+            return;
+        }
+
+        byte newFlags = flags;
+        for (QuarkusResolvedArtifact artifact : artifacts) {
+            collectedArtifactFiles.add(artifact.file);
+            final ArtifactKey artifactKey = getKey(
+                    moduleId.getGroup(),
+                    moduleId.getName(),
+                    moduleId.getVersion(),
+                    artifact.file,
+                    artifact.type);
+            if (!isDependency(artifact)
+                    || modelBuilder.getDependency(artifactKey) != null
+                    // test fixtures depend on the default jar artifact, which could be the root one
+                    || isApplicationRoot(modelBuilder, artifactKey)) {
+                continue;
+            }
+
+            final ArtifactCoords depCoords = new GACTV(artifactKey, moduleId.getVersion());
+            ResolvedDependencyBuilder depBuilder = ResolvedDependencyBuilder.newInstance()
+                    .setCoords(depCoords)
+                    .setRuntimeCp()
+                    .setDeploymentCp()
+                    .setResolvedPaths(localResolvedPathsOrArtifactPath(localOutputPaths, artifact, artifactKey))
+                    .setWorkspaceModule(projectModule);
+            if (projectModule == null && localWorkspaceModule) {
+                depBuilder.setWorkspaceModule();
+            }
+            if (isFlagOn(flags, COLLECT_DIRECT_DEPS)) {
+                depBuilder.setDirect(true);
+                newFlags = clearFlag(newFlags, COLLECT_DIRECT_DEPS);
+            }
+            if (parentModule != null) {
+                parentModule.addDependency(new ArtifactDependency(depCoords));
+            }
+
+            if (processQuarkusDependency(depBuilder, modelBuilder)) {
+                if (isFlagOn(flags, COLLECT_TOP_EXTENSION_RUNTIME_NODES)) {
+                    depBuilder.setFlags(DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT);
+                    newFlags = clearFlag(newFlags, COLLECT_TOP_EXTENSION_RUNTIME_NODES);
+                }
+            }
+            if (isFlagOn(flags, COLLECT_RELOADABLE_MODULES)) {
+                if (!depBuilder.isRuntimeExtensionArtifact()
+                        && localWorkspaceModule) {
+                    depBuilder.setReloadable();
+                    modelBuilder.addReloadableWorkspaceModule(artifactKey);
+                } else {
+                    newFlags = clearFlag(newFlags, COLLECT_RELOADABLE_MODULES);
+                }
+            }
+            modelBuilder.addDependency(depBuilder);
+        }
+
+        flags = newFlags;
+        for (DependencyResult dependency : resolvedDependency.getSelected().getDependencies()) {
+            if (dependency instanceof ResolvedDependencyResult result) {
+                collectDependencies(result, modelBuilder, resolvedArtifacts, projectModule,
+                        collectedArtifactFiles,
+                        processedModules, flags, projectDescriptor, localOutputPaths);
+            }
+        }
+    }
+
+    private LocalOutputPaths localOutputPaths() {
+        Map<LocalOutputKey, PathList.Builder> builders = new LinkedHashMap<>();
+        collectLocalOutputPaths(getLocalClassOutputArtifacts().get(), builders);
+        collectLocalOutputPaths(getLocalResourceOutputArtifacts().get(), builders);
+        Map<LocalOutputKey, PathList> paths = new LinkedHashMap<>();
+        builders.forEach((key, builder) -> paths.put(key, builder.build()));
+        return new LocalOutputPaths(paths);
+    }
+
+    private static void collectLocalOutputPaths(Set<ResolvedArtifactResult> artifacts,
+            Map<LocalOutputKey, PathList.Builder> pathsByVariant) {
+        for (ResolvedArtifactResult artifact : artifacts) {
+            pathsByVariant.computeIfAbsent(LocalOutputKey.of(artifact), ignored -> PathList.builder())
+                    .add(artifact.getFile().toPath());
+        }
+    }
+
+    private static PathList localResolvedPathsOrArtifactPath(LocalOutputPaths localOutputPaths,
+            QuarkusResolvedArtifact artifact,
+            ArtifactKey artifactKey) {
+        PathList paths = localOutputPaths.get(artifact, artifactKey);
+        return paths == null ? PathList.of(artifact.file.toPath()) : paths;
+    }
+
+    private record LocalOutputKey(ComponentIdentifier componentIdentifier, String classifier) {
+
+        static LocalOutputKey of(ResolvedArtifactResult artifact) {
+            return new LocalOutputKey(artifact.getId().getComponentIdentifier(), classifierFromOutputPath(artifact));
+        }
+
+        static LocalOutputKey of(QuarkusResolvedArtifact artifact, ArtifactKey artifactKey) {
+            return new LocalOutputKey(artifact.id.getComponentIdentifier(), artifactKey.getClassifier());
+        }
+
+        private static String classifierFromOutputPath(ResolvedArtifactResult artifact) {
+            String sourceSetName = artifact.getFile().getName();
+            if (SourceSet.MAIN_SOURCE_SET_NAME.equals(sourceSetName)) {
+                return ArtifactCoords.DEFAULT_CLASSIFIER;
+            }
+            return camelCaseToKebabCase(sourceSetName);
+        }
+
+        private static String camelCaseToKebabCase(String value) {
+            StringBuilder result = new StringBuilder(value.length());
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                if (Character.isUpperCase(c)) {
+                    if (i > 0) {
+                        result.append('-');
+                    }
+                    result.append(Character.toLowerCase(c));
+                } else {
+                    result.append(c);
+                }
+            }
+            return result.toString();
+        }
+    }
+
+    private record LocalOutputPaths(Map<LocalOutputKey, PathList> pathsByVariant) {
+
+        PathList get(QuarkusResolvedArtifact artifact, ArtifactKey artifactKey) {
+            return pathsByVariant.get(LocalOutputKey.of(artifact, artifactKey));
+        }
+
+        boolean hasComponent(ComponentIdentifier componentIdentifier) {
+            for (LocalOutputKey key : pathsByVariant.keySet()) {
+                if (key.componentIdentifier().equals(componentIdentifier)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private static boolean isApplicationRoot(ApplicationModelBuilder modelBuilder, ArtifactKey artifactKey) {
+        return modelBuilder.getApplicationArtifact().getKey().equals(artifactKey);
+    }
+
+    private static ModuleVersionIdentifier getModuleVersion(ResolvedDependencyResult resolvedDependency) {
+        return Objects.requireNonNull(resolvedDependency.getSelected().getModuleVersion());
+    }
+
+    private static ArtifactKey getKey(String groupId, String artifactId, String version, File file, String type) {
+        return ArtifactKey.of(groupId, artifactId, resolveClassifier(artifactId, version, file), type);
+    }
+
+    private static String resolveClassifier(String artifactId, String version, File file) {
+        String artifactIdVersion = version == null || version.isEmpty() || "unspecified".equals(version)
+                ? artifactId
+                : artifactId + "-" + version;
+        if ((file.getName().endsWith(".jar") || file.getName().endsWith(".pom") || file.getName().endsWith(".exe"))
+                && file.getName().startsWith(artifactIdVersion + "-")) {
+            return file.getName().substring(artifactIdVersion.length() + 1, file.getName().length() - 4);
+        }
+        return "";
+    }
+
+    private static boolean isDependency(QuarkusResolvedArtifact a) {
+        return a.file.getName().endsWith(ArtifactCoords.TYPE_JAR)
+                || a.file.getName().endsWith(".exe")
+                || a.file.isDirectory();
+    }
+
+    private static void collectExtensionDependencies(QuarkusResolvedClasspath classpath, ApplicationModelBuilder modelBuilder) {
+        Map<ComponentIdentifier, List<QuarkusResolvedArtifact>> artifacts = classpath.resolvedArtifactsByComponentIdentifier();
+        final Set<ModuleVersionIdentifier> processedModules = new HashSet<>();
+        classpath.getRoot().get().getDependencies().forEach(d -> {
+            if (d instanceof ResolvedDependencyResult result) {
+                collectExtensionDependencies(result, modelBuilder, artifacts, processedModules, false);
+            }
+        });
+    }
+
+    private static void collectExtensionDependencies(
+            ResolvedDependencyResult resolvedDependency,
+            ApplicationModelBuilder modelBuilder,
+            Map<ComponentIdentifier, List<QuarkusResolvedArtifact>> resolvedArtifacts,
+            Set<ModuleVersionIdentifier> processedModules,
+            boolean clearReloadableFlag) {
+        final ModuleVersionIdentifier moduleId = getModuleVersion(resolvedDependency);
+        if (!processedModules.add(moduleId)) {
+            if (clearReloadableFlag) {
+                clearReloadableWorkspaceModule(resolvedDependency, modelBuilder, resolvedArtifacts);
+            }
+            return;
+        }
+        List<QuarkusResolvedArtifact> artifacts = getResolvedModuleArtifacts(resolvedArtifacts,
+                resolvedDependency.getSelected().getId());
+        if (artifacts.isEmpty()) {
+            return;
+        }
+
+        final ModuleVersionIdentifier moduleVersionIdentifier = getModuleVersion(resolvedDependency);
+        boolean clearReloadableFlagChildren = clearReloadableFlag;
+        for (QuarkusResolvedArtifact artifact : artifacts) {
+            ArtifactKey artifactKey = getKey(
+                    moduleVersionIdentifier.getGroup(),
+                    moduleVersionIdentifier.getName(),
+                    moduleVersionIdentifier.getVersion(),
+                    artifact.file,
+                    artifact.type);
+            if (!isDependency(artifact)
+                    // test fixtures depend on the default jar artifact, which could be the root one
+                    || isApplicationRoot(modelBuilder, artifactKey)) {
+                continue;
+            }
+
+            ResolvedDependencyBuilder dep = modelBuilder.getDependency(artifactKey);
+            if (dep == null) {
+                ArtifactCoords artifactCoords = new GACTV(artifactKey, moduleVersionIdentifier.getVersion());
+                dep = toDependency(artifactCoords, artifact.file);
+                modelBuilder.addDependency(dep);
+            }
+            dep.setDeploymentCp();
+            if (clearReloadableFlag) {
+                clearReloadableWorkspaceModule(modelBuilder, dep);
+            } else if (!dep.isReloadable()) {
+                clearReloadableFlagChildren = true;
+            }
+        }
+
+        for (DependencyResult d : resolvedDependency.getSelected().getDependencies()) {
+            if (d instanceof ResolvedDependencyResult result) {
+                collectExtensionDependencies(result, modelBuilder, resolvedArtifacts, processedModules,
+                        clearReloadableFlagChildren);
+            }
+        }
+    }
+
+    private static void clearReloadableWorkspaceModule(
+            ResolvedDependencyResult resolvedDependency,
+            ApplicationModelBuilder modelBuilder,
+            Map<ComponentIdentifier, List<QuarkusResolvedArtifact>> resolvedArtifacts) {
+        final ModuleVersionIdentifier moduleVersionIdentifier = getModuleVersion(resolvedDependency);
+        for (QuarkusResolvedArtifact artifact : getResolvedModuleArtifacts(resolvedArtifacts,
+                resolvedDependency.getSelected().getId())) {
+            ArtifactKey artifactKey = getKey(
+                    moduleVersionIdentifier.getGroup(),
+                    moduleVersionIdentifier.getName(),
+                    moduleVersionIdentifier.getVersion(),
+                    artifact.file,
+                    artifact.type);
+            ResolvedDependencyBuilder dep = modelBuilder.getDependency(artifactKey);
+            if (dep != null) {
+                clearReloadableWorkspaceModule(modelBuilder, dep);
+            }
+        }
+    }
+
+    private static void clearReloadableWorkspaceModule(ApplicationModelBuilder modelBuilder, ResolvedDependencyBuilder dep) {
+        dep.clearFlag(DependencyFlags.RELOADABLE);
+        modelBuilder.removeReloadableWorkspaceModule(dep.getKey());
+    }
+
+    private static void collectCompileOnlyDependencies(QuarkusResolvedClasspath classpath,
+            ApplicationModelBuilder modelBuilder) {
+        final Map<ComponentIdentifier, List<QuarkusResolvedArtifact>> artifacts = classpath
+                .resolvedArtifactsByComponentIdentifier();
+        final Set<ModuleVersionIdentifier> processedModules = new HashSet<>();
+        classpath.getRoot().get().getDependencies().forEach(d -> {
+            if (d instanceof ResolvedDependencyResult resolved) {
+                collectCompileOnlyDependencies(resolved, modelBuilder, artifacts, processedModules);
+            }
+        });
+    }
+
+    private static void collectCompileOnlyDependencies(
+            ResolvedDependencyResult resolvedDependency,
+            ApplicationModelBuilder modelBuilder,
+            Map<ComponentIdentifier, List<QuarkusResolvedArtifact>> resolvedArtifacts,
+            Set<ModuleVersionIdentifier> processedModules) {
+        final ModuleVersionIdentifier moduleId = getModuleVersion(resolvedDependency);
+        if (!processedModules.add(moduleId)) {
+            return;
+        }
+        final List<QuarkusResolvedArtifact> artifacts = getResolvedModuleArtifacts(resolvedArtifacts,
+                resolvedDependency.getSelected().getId());
+        if (artifacts.isEmpty()) {
+            return;
+        }
+
+        boolean skip = true;
+        for (QuarkusResolvedArtifact artifact : artifacts) {
+            if (!isDependency(artifact)) {
+                continue;
+            }
+            final ArtifactKey artifactKey = getKey(
+                    moduleId.getGroup(),
+                    moduleId.getName(),
+                    moduleId.getVersion(),
+                    artifact.file,
+                    artifact.type);
+            if (isApplicationRoot(modelBuilder, artifactKey)) {
+                continue;
+            }
+
+            ResolvedDependencyBuilder dep = modelBuilder.getDependency(artifactKey);
+            if (dep == null) {
+                ArtifactCoords artifactCoords = new GACTV(artifactKey, moduleId.getVersion());
+                dep = toDependency(artifactCoords, artifact.file);
+                modelBuilder.addDependency(dep);
+            }
+            if (!dep.isFlagSet(DependencyFlags.COMPILE_ONLY)) {
+                skip = false;
+                dep.setFlags(DependencyFlags.COMPILE_ONLY);
+            }
+        }
+
+        if (!skip) {
+            for (DependencyResult dependency : resolvedDependency.getSelected().getDependencies()) {
+                if (dependency instanceof ResolvedDependencyResult result) {
+                    collectCompileOnlyDependencies(result, modelBuilder, resolvedArtifacts, processedModules);
+                }
+            }
+        }
+    }
+
+    private static List<QuarkusResolvedArtifact> getResolvedModuleArtifacts(
+            Map<ComponentIdentifier, List<QuarkusResolvedArtifact>> artifacts, ComponentIdentifier moduleId) {
+        return artifacts.getOrDefault(moduleId, List.of());
+    }
+
+    static ResolvedDependencyBuilder toDependency(ArtifactCoords artifactCoords, File file, int... flags) {
+        int allFlags = 0;
+        for (int f : flags) {
+            allFlags |= f;
+        }
+        return ResolvedDependencyBuilder.newInstance()
+                .setCoords(artifactCoords)
+                .setResolvedPaths(PathList.of(file.toPath()))
+                .setFlags(allFlags);
+    }
+
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/QuarkusBaseTask.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/QuarkusBaseTask.java
@@ -1,0 +1,44 @@
+package io.quarkus.gradle.model.tasks;
+
+import javax.inject.Inject;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+
+public abstract class QuarkusBaseTask extends DefaultTask {
+
+    protected QuarkusBaseTask() {
+        getProjectName().set(getProject().getName());
+        getProjectGroup().set(getProject().getGroup().toString());
+        // Should NOT capture project-version here, because that can likely be configured
+        // after this constructor runs.
+        var description = getProject().getDescription();
+        if (description != null) {
+            getProjectDescription().set(description);
+        }
+    }
+
+    @Input
+    protected abstract Property<String> getProjectName();
+
+    @Input
+    @Optional
+    protected abstract Property<String> getProjectDescription();
+
+    @Input
+    protected abstract Property<String> getProjectGroup();
+
+    @Inject
+    public abstract ProviderFactory getProviderFactory();
+
+    @Inject
+    public abstract DependencyHandler getDependencyHandler();
+
+    @Inject
+    public abstract ObjectFactory getObjects();
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/QuarkusPlatformInfo.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/QuarkusPlatformInfo.java
@@ -1,0 +1,48 @@
+package io.quarkus.gradle.model.tasks;
+
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Internal;
+import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
+
+import io.quarkus.bootstrap.model.PlatformImportsImpl;
+import io.quarkus.bootstrap.resolver.AppModelResolverException;
+import io.quarkus.maven.dependency.ArtifactCoords;
+
+public abstract class QuarkusPlatformInfo {
+
+    static final String PLATFORM_DESCRIPTOR_ARTIFACT_TYPE = "json";
+    static final String PLATFORM_PROPERTIES_ARTIFACT_TYPE = "properties";
+
+    /**
+     * Internal since we track defined dependencies via {@link QuarkusApplicationModelTask#getOriginalClasspath}
+     */
+    @Internal
+    public abstract SetProperty<ResolvedArtifactResult> getResolvedArtifacts();
+
+    PlatformImportsImpl resolvePlatformImports() {
+        final PlatformImportsImpl result = new PlatformImportsImpl();
+        for (var artifact : getResolvedArtifacts().get()) {
+            var compId = ((ModuleComponentArtifactIdentifier) artifact.getId()).getComponentIdentifier();
+            final String artifactId = artifact.getFile().getName();
+            if (artifactId.endsWith(".json")) {
+                result.addPlatformDescriptor(compId.getGroup(), compId.getModuleIdentifier().getName(),
+                        compId.getVersion(), PLATFORM_DESCRIPTOR_ARTIFACT_TYPE, compId.getVersion());
+            } else if (artifactId.endsWith(".properties")) {
+                try {
+                    result.addPlatformProperties(compId.getGroup(), compId.getModuleIdentifier().getName(),
+                            ArtifactCoords.DEFAULT_CLASSIFIER, PLATFORM_PROPERTIES_ARTIFACT_TYPE, compId.getVersion(),
+                            artifact.getFile().toPath());
+                } catch (AppModelResolverException e) {
+                    throw new RuntimeException("Failed to add platform properties " + artifact, e);
+                }
+            }
+        }
+        return result;
+    }
+
+    public void configureFrom(Configuration configuration) {
+        getResolvedArtifacts().set(configuration.getIncoming().getArtifacts().getResolvedArtifacts());
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/QuarkusResolvedArtifact.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/QuarkusResolvedArtifact.java
@@ -1,0 +1,21 @@
+package io.quarkus.gradle.model.tasks;
+
+import java.io.File;
+import java.io.Serializable;
+
+import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
+
+class QuarkusResolvedArtifact implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    final ComponentArtifactIdentifier id;
+    final String type;
+    final File file;
+
+    QuarkusResolvedArtifact(ComponentArtifactIdentifier id, File file, String type) {
+        this.id = id;
+        this.type = type;
+        this.file = file;
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/QuarkusResolvedClasspath.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/QuarkusResolvedClasspath.java
@@ -1,0 +1,74 @@
+package io.quarkus.gradle.model.tasks;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ResolvableDependencies;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Internal;
+
+/**
+ * See example https://docs.gradle.org/current/samples/sample_tasks_with_dependency_resolution_result_inputs.html,
+ * to better understand how this works.
+ */
+public abstract class QuarkusResolvedClasspath {
+
+    /**
+     * Internal since we track defined dependencies via {@link QuarkusApplicationModelTask#getOriginalClasspath}
+     */
+    @Internal
+    public abstract Property<ResolvedComponentResult> getRoot();
+
+    /**
+     * Internal since we track defined dependencies via {@link QuarkusApplicationModelTask#getOriginalClasspath}
+     */
+    @Internal
+    public abstract SetProperty<ResolvedArtifactResult> getResolvedArtifacts();
+
+    /**
+     * Internal since we track defined dependencies via {@link QuarkusApplicationModelTask#getOriginalClasspath}
+     */
+    @Internal
+    public abstract ConfigurableFileCollection getResolvedArtifactFiles();
+
+    @Internal
+    FileCollection getAllResolvedFiles() {
+        return getResolvedArtifactFiles();
+    }
+
+    Map<ComponentIdentifier, List<QuarkusResolvedArtifact>> resolvedArtifactsByComponentIdentifier() {
+        return getQuarkusResolvedArtifacts().stream()
+                .collect(Collectors.groupingBy(artifact -> artifact.id.getComponentIdentifier()));
+    }
+
+    private List<QuarkusResolvedArtifact> getQuarkusResolvedArtifacts() {
+        return getResolvedArtifacts().get().stream()
+                .map(this::toResolvedArtifact)
+                .collect(toList());
+    }
+
+    private QuarkusResolvedArtifact toResolvedArtifact(ResolvedArtifactResult result) {
+        String type = result.getVariant().getAttributes().getAttribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE);
+        return new QuarkusResolvedArtifact(result.getId(), result.getFile(), type);
+    }
+
+    public void configureFrom(Configuration configuration) {
+        ResolvableDependencies resolvableDependencies = configuration.getIncoming();
+        getRoot().set(resolvableDependencies.getResolutionResult().getRootComponent());
+        var artifacts = resolvableDependencies.getArtifacts();
+        getResolvedArtifacts().set(artifacts.getResolvedArtifacts());
+        getResolvedArtifactFiles().from(artifacts.getArtifactFiles());
+    }
+
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/SerializedApplicationModel.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/SerializedApplicationModel.java
@@ -1,0 +1,18 @@
+package io.quarkus.gradle.model.tasks;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import io.quarkus.bootstrap.app.ApplicationModelSerializer;
+import io.quarkus.bootstrap.model.ApplicationModel;
+
+public final class SerializedApplicationModel {
+
+    private SerializedApplicationModel() {
+    }
+
+    public static Path write(ApplicationModel appModel, Path serializedModelPath) throws IOException {
+        ApplicationModelSerializer.serialize(appModel, serializedModelPath);
+        return serializedModelPath;
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/StrictApplicationModelTaskConfigurator.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/model/tasks/StrictApplicationModelTaskConfigurator.java
@@ -1,0 +1,37 @@
+package io.quarkus.gradle.model.tasks;
+
+import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
+
+import io.quarkus.gradle.model.config.StrictApplicationDeploymentClasspathBuilder;
+import io.quarkus.gradle.tooling.DefaultProjectDescriptor;
+import io.quarkus.runtime.LaunchMode;
+
+public final class StrictApplicationModelTaskConfigurator {
+
+    private StrictApplicationModelTaskConfigurator() {
+    }
+
+    /**
+     * Configures an application-model task without reading live Gradle project models for declared dependency enrichment.
+     */
+    public static void configureNoLiveProjectDeclaredDependencies(Project project, QuarkusApplicationModelTask task,
+            Provider<DefaultProjectDescriptor> projectDescriptor,
+            StrictApplicationDeploymentClasspathBuilder classpath,
+            LaunchMode launchMode, boolean buildModel) {
+        task.getProjectDescriptor().set(projectDescriptor);
+        task.getLaunchMode().set(launchMode);
+        task.getTypeModel().set(task.getPath());
+        task.getApplicationModel()
+                .set(project.getLayout().getBuildDirectory().file(GenerateApplicationModelTask.applicationModelPath(launchMode,
+                        buildModel)));
+        task.getOriginalClasspath().setFrom(classpath.getOriginalRuntimeClasspathAsInput());
+        task.getAppClasspath().configureFrom(classpath.getRuntimeConfigurationWithoutResolvingDeployment());
+        task.getPlatformConfiguration().configureFrom(classpath.getPlatformConfiguration());
+        task.getPlatformInfo().configureFrom(classpath.getPlatformPropertiesConfiguration());
+        task.getCompileOnlyClasspath().configureFrom(classpath.getCompileOnlyWithoutResolvingDeployment());
+        task.getDeploymentClasspath().configureFrom(classpath.getDeploymentConfiguration());
+        task.getDeploymentClasspathFiles()
+                .from(classpath.getDeploymentConfiguration().getIncoming().getArtifacts().getArtifactFiles());
+    }
+}

--- a/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/model/config/CurrentProjectDescriptorBuilderTest.java
+++ b/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/model/config/CurrentProjectDescriptorBuilderTest.java
@@ -1,0 +1,96 @@
+package io.quarkus.gradle.model.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import org.gradle.api.Project;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkus.bootstrap.workspace.ArtifactSources;
+import io.quarkus.gradle.tooling.DefaultProjectDescriptor;
+
+class CurrentProjectDescriptorBuilderTest {
+
+    @TempDir
+    Path projectDir;
+
+    @Test
+    void providerRefreshesCoordinatesAndCapturesCurrentProjectSourcesAfterEvaluation() {
+        Project project = ProjectBuilder.builder()
+                .withName("sample-app")
+                .withProjectDir(projectDir.toFile())
+                .build();
+        Path effectiveProjectDir = project.getLayout().getProjectDirectory().getAsFile().toPath();
+        project.getPlugins().apply(JavaPlugin.class);
+        var descriptor = CurrentProjectDescriptorBuilder.buildForCurrentProject(project);
+
+        project.setGroup("org.acme");
+        project.setVersion("1.0");
+        project.getTasks().named(JavaPlugin.JAR_TASK_NAME).get();
+        ((ProjectInternal) project).evaluate();
+
+        DefaultProjectDescriptor result = descriptor.get();
+
+        assertThat(result.getWorkspaceModule().getId().toString()).isEqualTo("org.acme:sample-app:1.0");
+        assertThat(result.getWorkspaceModule().getModuleDir()).isEqualTo(effectiveProjectDir.toFile());
+        assertThat(result.getWorkspaceModule().getBuildDir())
+                .isEqualTo(project.getLayout().getBuildDirectory().get().getAsFile());
+        assertThat(result.getWorkspaceModule().hasMainSources()).isTrue();
+        assertThat(result.getWorkspaceModule().getSourceClassifiers()).contains(ArtifactSources.MAIN);
+        assertThat(result.getWorkspaceModule().getMainSources().getSourceDirs())
+                .singleElement()
+                .satisfies(sourceDir -> {
+                    assertThat(sourceDir.getDir()).isEqualTo(effectiveProjectDir.resolve("src/main/java"));
+                    assertThat(sourceDir.getOutputDir()).isEqualTo(effectiveProjectDir.resolve("build/classes/java/main"));
+                    assertThat(sourceDir.getAptSourcesDir())
+                            .isEqualTo(effectiveProjectDir.resolve("build/generated/sources/annotationProcessor/java/main"));
+                });
+        assertThat(result.getWorkspaceModule().getMainSources().getResourceDirs())
+                .singleElement()
+                .satisfies(resourceDir -> {
+                    assertThat(resourceDir.getDir()).isEqualTo(effectiveProjectDir.resolve("src/main/resources"));
+                    assertThat(resourceDir.getOutputDir()).isEqualTo(effectiveProjectDir.resolve("build/resources/main"));
+                    assertThat(resourceDir.getAptSourcesDir()).isNull();
+                });
+    }
+
+    @Test
+    void providerCapturesCustomTestSuiteClassifierWithoutRequiringProjectGraphWalk() {
+        Project project = ProjectBuilder.builder()
+                .withName("sample-app")
+                .withProjectDir(projectDir.toFile())
+                .build();
+        Path effectiveProjectDir = project.getLayout().getProjectDirectory().getAsFile().toPath();
+        project.getPlugins().apply(JavaPlugin.class);
+        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+        var integrationTest = sourceSets.create("integrationTest");
+        project.getTasks().register("integrationTest", org.gradle.api.tasks.testing.Test.class, test -> {
+            test.setTestClassesDirs(integrationTest.getOutput().getClassesDirs());
+            test.setClasspath(integrationTest.getRuntimeClasspath());
+        });
+
+        var descriptor = CurrentProjectDescriptorBuilder.buildForCurrentProject(project);
+        project.getTasks().named("integrationTest").get();
+        ((ProjectInternal) project).evaluate();
+
+        DefaultProjectDescriptor result = descriptor.get();
+
+        assertThat(result.getWorkspaceModule().getSourceClassifiers()).contains("integration-test");
+        assertThat(result.getWorkspaceModule().getSources("integration-test").getSourceDirs())
+                .singleElement()
+                .satisfies(sourceDir -> {
+                    assertThat(sourceDir.getDir()).isEqualTo(effectiveProjectDir.resolve("src/integrationTest/java"));
+                    assertThat(sourceDir.getOutputDir())
+                            .isEqualTo(effectiveProjectDir.resolve("build/classes/java/integrationTest"));
+                    assertThat(sourceDir.getAptSourcesDir())
+                            .isEqualTo(effectiveProjectDir.resolve(
+                                    "build/generated/sources/annotationProcessor/java/integrationTest"));
+                });
+    }
+}

--- a/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/model/pom/KnownPomResolverTest.java
+++ b/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/model/pom/KnownPomResolverTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.quarkus.gradle.model.pom;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.maven.model.resolution.UnresolvableModelException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkus.maven.dependency.GAV;
+
+class KnownPomResolverTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void shouldFailClosedForAmbiguousGradleCachePoms() throws IOException {
+        installGradleCachePom("first-hash");
+        installGradleCachePom("second-hash");
+        GAV sample = new GAV("org.acme", "sample", "1.0");
+        KnownPomResolver resolver = KnownPomResolver.fromPomClosure(
+                Map.of(), Set.of(), List.of(tempDir.toFile()));
+
+        assertThatThrownBy(() -> resolver.resolvePom(sample))
+                .isInstanceOf(UnresolvableModelException.class)
+                .hasMessageContaining("Could not resolve POM for org.acme:sample:1.0");
+    }
+
+    private void installGradleCachePom(String hash) throws IOException {
+        Path artifactDirectory = tempDir.resolve("org.acme").resolve("sample").resolve("1.0").resolve(hash);
+        Files.createDirectories(artifactDirectory);
+        Files.writeString(artifactDirectory.resolve("sample-1.0.pom"), "<project/>", StandardCharsets.UTF_8);
+    }
+}

--- a/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/model/pom/MavenEffectiveModelResolverTest.java
+++ b/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/model/pom/MavenEffectiveModelResolverTest.java
@@ -1,0 +1,162 @@
+package io.quarkus.gradle.model.pom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.apache.maven.model.building.ModelSource2;
+import org.apache.maven.model.resolution.UnresolvableModelException;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.maven.dependency.GAV;
+
+class MavenEffectiveModelResolverTest {
+
+    @Test
+    void shouldResolveEffectiveModelThroughPomResolver() throws Exception {
+        var resolver = new MavenEffectiveModelResolver(new InMemoryPomResolver(Map.of(
+                new GAV("org.acme", "parent", "1.0"), pom("""
+                        <project>
+                          <modelVersion>4.0.0</modelVersion>
+                          <groupId>org.acme</groupId>
+                          <artifactId>parent</artifactId>
+                          <version>1.0</version>
+                          <packaging>pom</packaging>
+                          <properties>
+                            <runtime.version>3.0</runtime.version>
+                          </properties>
+                          <dependencyManagement>
+                            <dependencies>
+                              <dependency>
+                                <groupId>org.acme</groupId>
+                                <artifactId>managed-lib</artifactId>
+                                <version>2.0</version>
+                              </dependency>
+                            </dependencies>
+                          </dependencyManagement>
+                        </project>
+                        """),
+                new GAV("org.acme", "acme-bom", "1.0"), pom("""
+                        <project>
+                          <modelVersion>4.0.0</modelVersion>
+                          <groupId>org.acme</groupId>
+                          <artifactId>acme-bom</artifactId>
+                          <version>1.0</version>
+                          <packaging>pom</packaging>
+                          <dependencyManagement>
+                            <dependencies>
+                              <dependency>
+                                <groupId>org.acme</groupId>
+                                <artifactId>bom-managed-lib</artifactId>
+                                <version>4.0</version>
+                              </dependency>
+                            </dependencies>
+                          </dependencyManagement>
+                        </project>
+                        """),
+                new GAV("org.acme", "app", "1.0"), pom("""
+                        <project>
+                          <modelVersion>4.0.0</modelVersion>
+                          <parent>
+                            <groupId>org.acme</groupId>
+                            <artifactId>parent</artifactId>
+                            <version>1.0</version>
+                          </parent>
+                          <artifactId>app</artifactId>
+                          <dependencyManagement>
+                            <dependencies>
+                              <dependency>
+                                <groupId>org.acme</groupId>
+                                <artifactId>acme-bom</artifactId>
+                                <version>1.0</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                              </dependency>
+                            </dependencies>
+                          </dependencyManagement>
+                          <dependencies>
+                            <dependency>
+                              <groupId>org.acme</groupId>
+                              <artifactId>managed-lib</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.acme</groupId>
+                              <artifactId>bom-managed-lib</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.acme</groupId>
+                              <artifactId>runtime-lib</artifactId>
+                              <version>${runtime.version}</version>
+                              <scope>runtime</scope>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.acme</groupId>
+                              <artifactId>system-property-lib</artifactId>
+                              <version>${external.version}</version>
+                            </dependency>
+                          </dependencies>
+                        </project>
+                        """))), () -> Map.of("external.version", "5.0"));
+
+        var effectiveModel = resolver.resolveEffectiveModel("org.acme", "app", "1.0");
+
+        assertThat(effectiveModel.getDependencies())
+                .extracting(dependency -> dependency.getGroupId()
+                        + ":" + dependency.getArtifactId()
+                        + ":" + dependency.getVersion()
+                        + ":" + dependency.getScope())
+                .containsExactly(
+                        "org.acme:managed-lib:2.0:compile",
+                        "org.acme:bom-managed-lib:4.0:compile",
+                        "org.acme:runtime-lib:3.0:runtime",
+                        "org.acme:system-property-lib:5.0:compile");
+    }
+
+    private record InMemoryPomResolver(Map<GAV, String> poms) implements PomResolver {
+
+        @Override
+        public ModelSource2 resolvePom(GAV gav) throws UnresolvableModelException {
+            String pom = poms.get(gav);
+            if (pom == null) {
+                throw new UnresolvableModelException("Could not resolve POM for " + gav,
+                        gav.getGroupId(), gav.getArtifactId(), gav.getVersion());
+            }
+            return new StringModelSource(gav, pom);
+        }
+    }
+
+    private record StringModelSource(GAV gav, String pom) implements ModelSource2 {
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return new ByteArrayInputStream(pom.getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public String getLocation() {
+            return gav.toString();
+        }
+
+        @Override
+        public ModelSource2 getRelatedSource(String relPath) {
+            return null;
+        }
+
+        @Override
+        public URI getLocationURI() {
+            return URI.create("memory:/" + gav.getGroupId() + "/" + gav.getArtifactId() + "/" + gav.getVersion());
+        }
+    }
+
+    private static String pom(String body) {
+        return body.replace("<project>", "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" "
+                + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+                + "xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 "
+                + "https://maven.apache.org/xsd/maven-4.0.0.xsd\">");
+    }
+}

--- a/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/model/pom/StrictDependencyDataCollectorTest.java
+++ b/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/model/pom/StrictDependencyDataCollectorTest.java
@@ -1,0 +1,680 @@
+package io.quarkus.gradle.model.pom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarOutputStream;
+
+import org.apache.maven.model.building.ModelSource2;
+import org.apache.maven.model.resolution.UnresolvableModelException;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.plugins.JavaLibraryPlugin;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkus.gradle.model.tasks.GradlePomClosureResolver;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.GAV;
+
+class StrictDependencyDataCollectorTest {
+
+    // Gradle dependency resolution can keep files from the synthetic Maven repository locked on Windows.
+    @TempDir(cleanup = CleanupMode.NEVER)
+    Path tempDir;
+
+    @Test
+    void shouldCollectDependenciesFromEffectiveMavenModel() throws IOException {
+        Path repository = tempDir.resolve("repo");
+        installPom(repository, "org.acme", "parent", "1.0", pom("""
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.acme</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <properties>
+                    <optional.version>3.0</optional.version>
+                  </properties>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.acme</groupId>
+                        <artifactId>managed-lib</artifactId>
+                        <version>2.0</version>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                </project>
+                """));
+        installPom(repository, "org.acme", "acme-bom", "1.0", pom("""
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.acme</groupId>
+                  <artifactId>acme-bom</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.acme</groupId>
+                        <artifactId>bom-managed-lib</artifactId>
+                        <version>4.0</version>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                </project>
+                """));
+        installJar(repository, "org.acme", "app-lib", "1.0", pom("""
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>org.acme</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1.0</version>
+                  </parent>
+                  <artifactId>app-lib</artifactId>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.acme</groupId>
+                        <artifactId>acme-bom</artifactId>
+                        <version>1.0</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.acme</groupId>
+                      <artifactId>managed-lib</artifactId>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.acme</groupId>
+                      <artifactId>bom-managed-lib</artifactId>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.acme</groupId>
+                      <artifactId>optional-lib</artifactId>
+                      <version>${optional.version}</version>
+                      <scope>runtime</scope>
+                      <optional>true</optional>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.acme</groupId>
+                      <artifactId>test-lib</artifactId>
+                      <version>5.0</version>
+                      <scope>test</scope>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """));
+        installJar(repository, "org.acme", "managed-lib", "2.0", simplePom("org.acme", "managed-lib", "2.0"));
+        installJar(repository, "org.acme", "bom-managed-lib", "4.0", simplePom("org.acme", "bom-managed-lib", "4.0"));
+
+        Project project = createProject(repository);
+        project.getDependencies().add("implementation", "org.acme:app-lib:1.0");
+
+        Map<ArtifactKey, DeclaredDepsResult> declaredDependencies = collectDeclaredDependencies(project, "runtimeClasspath");
+
+        assertThat(declaredDependencies)
+                .containsKey(ArtifactKey.of("org.acme", "app-lib", "", "jar"));
+        assertThat(declaredDependencies.get(ArtifactKey.of("org.acme", "app-lib", "", "jar"))
+                .getDeclaredDependencies())
+                .extracting(StrictDependencyDataCollectorTest::dependencySnapshot)
+                .containsExactlyInAnyOrder(
+                        "org.acme:managed-lib:2.0::jar:compile:false",
+                        "org.acme:bom-managed-lib:4.0::jar:compile:false",
+                        "org.acme:optional-lib:3.0::jar:runtime:true");
+    }
+
+    @Test
+    void shouldCollectExternalDeclaredDependenciesFromModeledInputs() {
+        StrictDependencyDataCollector collector = new StrictDependencyDataCollector(
+                new InMemoryPomResolver(effectiveModelPoms()),
+                () -> Map.of("external.version", "5.0"));
+
+        Map<ArtifactKey, DeclaredDepsResult> declaredDependencies = collector.collectExternalDeclaredDependencies(
+                mock(Logger.class),
+                List.of(new ExternalModuleDeclaredDependencyInput(
+                        ArtifactKey.of("org.acme", "app", "", "jar"),
+                        new GAV("org.acme", "app", "1.0"))));
+
+        assertThat(declaredDependencies)
+                .containsOnlyKeys(ArtifactKey.of("org.acme", "app", "", "jar"));
+        assertThat(declaredDependencies.get(ArtifactKey.of("org.acme", "app", "", "jar")).getDeclaredDependencies())
+                .extracting(StrictDependencyDataCollectorTest::dependencySnapshot)
+                .containsExactlyInAnyOrder(
+                        "org.acme:managed-lib:2.0::jar:compile:false",
+                        "org.acme:bom-managed-lib:4.0::jar:compile:false",
+                        "org.acme:runtime-lib:3.0::jar:runtime:false",
+                        "org.acme:system-property-lib:5.0::jar:compile:false");
+    }
+
+    @Test
+    void shouldBatchPrefetchSharedParentPomDiscoveredDuringModelBuilding() {
+        GAV firstApp = new GAV("org.acme", "first-app", "1.0");
+        GAV secondApp = new GAV("org.acme", "second-app", "1.0");
+        GAV parent = new GAV("org.acme", "parent", "1.0");
+        BatchingInMemoryPomResolver pomResolver = new BatchingInMemoryPomResolver(Map.of(
+                parent, pom("""
+                        <project>
+                          <modelVersion>4.0.0</modelVersion>
+                          <groupId>org.acme</groupId>
+                          <artifactId>parent</artifactId>
+                          <version>1.0</version>
+                          <packaging>pom</packaging>
+                          <properties>
+                            <shared.version>2.0</shared.version>
+                          </properties>
+                        </project>
+                        """),
+                firstApp, childWithParentPom("first-app", """
+                        <dependencies>
+                          <dependency>
+                            <groupId>org.acme</groupId>
+                            <artifactId>shared-lib</artifactId>
+                            <version>${shared.version}</version>
+                          </dependency>
+                        </dependencies>
+                        """),
+                secondApp, childWithParentPom("second-app", """
+                        <dependencies>
+                          <dependency>
+                            <groupId>org.acme</groupId>
+                            <artifactId>shared-lib</artifactId>
+                            <version>${shared.version}</version>
+                          </dependency>
+                        </dependencies>
+                        """)));
+        StrictDependencyDataCollector collector = new StrictDependencyDataCollector(
+                pomResolver,
+                Map::of);
+
+        Map<ArtifactKey, DeclaredDepsResult> declaredDependencies = collector.collectExternalDeclaredDependencies(
+                mock(Logger.class),
+                List.of(
+                        new ExternalModuleDeclaredDependencyInput(
+                                ArtifactKey.of("org.acme", "first-app", "", "jar"), firstApp),
+                        new ExternalModuleDeclaredDependencyInput(
+                                ArtifactKey.of("org.acme", "second-app", "", "jar"), secondApp)));
+
+        assertThat(declaredDependencies.values())
+                .allSatisfy(result -> assertThat(result.getDeclaredDependencies())
+                        .extracting(StrictDependencyDataCollectorTest::dependencySnapshot)
+                        .containsExactly("org.acme:shared-lib:2.0::jar:compile:false"));
+        assertThat(pomResolver.prefetchBatches())
+                .containsExactly(
+                        List.of(firstApp, secondApp),
+                        List.of(parent));
+    }
+
+    @Test
+    void shouldBatchPrefetchNestedImportedPomRequestsAcrossIterations() {
+        GAV app = new GAV("org.acme", "app", "1.0");
+        GAV parent = new GAV("org.acme", "parent", "1.0");
+        GAV bom = new GAV("org.acme", "acme-bom", "1.0");
+        BatchingInMemoryPomResolver pomResolver = new BatchingInMemoryPomResolver(Map.of(
+                app, childWithParentPom("app", """
+                        <dependencies>
+                          <dependency>
+                            <groupId>org.acme</groupId>
+                            <artifactId>managed-lib</artifactId>
+                          </dependency>
+                        </dependencies>
+                        """),
+                parent, pom("""
+                        <project>
+                          <modelVersion>4.0.0</modelVersion>
+                          <groupId>org.acme</groupId>
+                          <artifactId>parent</artifactId>
+                          <version>1.0</version>
+                          <packaging>pom</packaging>
+                          <dependencyManagement>
+                            <dependencies>
+                              <dependency>
+                                <groupId>org.acme</groupId>
+                                <artifactId>acme-bom</artifactId>
+                                <version>1.0</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                              </dependency>
+                            </dependencies>
+                          </dependencyManagement>
+                        </project>
+                        """),
+                bom, pom("""
+                        <project>
+                          <modelVersion>4.0.0</modelVersion>
+                          <groupId>org.acme</groupId>
+                          <artifactId>acme-bom</artifactId>
+                          <version>1.0</version>
+                          <packaging>pom</packaging>
+                          <dependencyManagement>
+                            <dependencies>
+                              <dependency>
+                                <groupId>org.acme</groupId>
+                                <artifactId>managed-lib</artifactId>
+                                <version>3.0</version>
+                              </dependency>
+                            </dependencies>
+                          </dependencyManagement>
+                        </project>
+                        """)));
+        StrictDependencyDataCollector collector = new StrictDependencyDataCollector(
+                pomResolver,
+                Map::of);
+
+        Map<ArtifactKey, DeclaredDepsResult> declaredDependencies = collector.collectExternalDeclaredDependencies(
+                mock(Logger.class),
+                List.of(new ExternalModuleDeclaredDependencyInput(
+                        ArtifactKey.of("org.acme", "app", "", "jar"), app)));
+
+        assertThat(declaredDependencies.get(ArtifactKey.of("org.acme", "app", "", "jar")).getDeclaredDependencies())
+                .extracting(StrictDependencyDataCollectorTest::dependencySnapshot)
+                .containsExactly("org.acme:managed-lib:3.0::jar:compile:false");
+        assertThat(pomResolver.prefetchBatches())
+                .containsExactly(
+                        List.of(app),
+                        List.of(parent),
+                        List.of(bom));
+    }
+
+    @Test
+    void shouldStopBatchPrefetchRetriesWhenDiscoveredParentPomIsMissing() {
+        GAV app = new GAV("org.acme", "app", "1.0");
+        GAV parent = new GAV("org.acme", "missing-parent", "1.0");
+        BatchingInMemoryPomResolver pomResolver = new BatchingInMemoryPomResolver(Map.of(
+                app, pom("""
+                        <project>
+                          <modelVersion>4.0.0</modelVersion>
+                          <parent>
+                            <groupId>org.acme</groupId>
+                            <artifactId>missing-parent</artifactId>
+                            <version>1.0</version>
+                          </parent>
+                          <artifactId>app</artifactId>
+                        </project>
+                        """)));
+        StrictDependencyDataCollector collector = new StrictDependencyDataCollector(
+                pomResolver,
+                Map::of);
+
+        Map<ArtifactKey, DeclaredDepsResult> declaredDependencies = collector.collectExternalDeclaredDependencies(
+                mock(Logger.class),
+                List.of(new ExternalModuleDeclaredDependencyInput(
+                        ArtifactKey.of("org.acme", "app", "", "jar"), app)));
+
+        assertThat(declaredDependencies.get(ArtifactKey.of("org.acme", "app", "", "jar")).isResolved()).isFalse();
+        assertThat(pomResolver.prefetchBatches())
+                .containsExactly(
+                        List.of(app),
+                        List.of(parent));
+    }
+
+    @Test
+    void shouldKeepArtifactKeySeparateFromPomLookupGav() {
+        StrictDependencyDataCollector collector = new StrictDependencyDataCollector(
+                new InMemoryPomResolver(Map.of(new GAV("org.acme", "app", "1.0"),
+                        simplePom("org.acme", "app", "1.0"))),
+                Map::of);
+        ArtifactKey classifiedKey = ArtifactKey.of("org.acme", "app", "tests", "jar");
+
+        Map<ArtifactKey, DeclaredDepsResult> declaredDependencies = collector.collectExternalDeclaredDependencies(
+                mock(Logger.class),
+                List.of(new ExternalModuleDeclaredDependencyInput(classifiedKey, new GAV("org.acme", "app", "1.0"))));
+
+        assertThat(declaredDependencies).containsOnlyKeys(classifiedKey);
+        assertThat(declaredDependencies.get(classifiedKey).isResolved()).isTrue();
+    }
+
+    @Test
+    void shouldCacheExternalDeclaredDependenciesByPomGav() {
+        StrictDependencyDataCollector collector = new StrictDependencyDataCollector(
+                new InMemoryPomResolver(Map.of(
+                        new GAV("org.acme", "app", "1.0"), pom("""
+                                <project>
+                                  <modelVersion>4.0.0</modelVersion>
+                                  <groupId>org.acme</groupId>
+                                  <artifactId>app</artifactId>
+                                  <version>1.0</version>
+                                  <dependencies>
+                                    <dependency>
+                                      <groupId>org.acme</groupId>
+                                      <artifactId>first-version-lib</artifactId>
+                                      <version>1.0</version>
+                                    </dependency>
+                                  </dependencies>
+                                </project>
+                                """),
+                        new GAV("org.acme", "app", "2.0"), pom("""
+                                <project>
+                                  <modelVersion>4.0.0</modelVersion>
+                                  <groupId>org.acme</groupId>
+                                  <artifactId>app</artifactId>
+                                  <version>2.0</version>
+                                  <dependencies>
+                                    <dependency>
+                                      <groupId>org.acme</groupId>
+                                      <artifactId>second-version-lib</artifactId>
+                                      <version>2.0</version>
+                                    </dependency>
+                                  </dependencies>
+                                </project>
+                                """))),
+                Map::of);
+        ArtifactKey key = ArtifactKey.of("org.acme", "app", "", "jar");
+
+        collector.collectExternalDeclaredDependencies(
+                mock(Logger.class),
+                List.of(new ExternalModuleDeclaredDependencyInput(key, new GAV("org.acme", "app", "1.0"))));
+        Map<ArtifactKey, DeclaredDepsResult> secondVersion = collector.collectExternalDeclaredDependencies(
+                mock(Logger.class),
+                List.of(new ExternalModuleDeclaredDependencyInput(key, new GAV("org.acme", "app", "2.0"))));
+
+        assertThat(secondVersion.get(key).getDeclaredDependencies())
+                .extracting(StrictDependencyDataCollectorTest::dependencySnapshot)
+                .containsExactly("org.acme:second-version-lib:2.0::jar:compile:false");
+    }
+
+    @Test
+    void shouldReturnUnresolvedExternalDeclaredDependenciesWhenPomIsMissing() {
+        StrictDependencyDataCollector collector = new StrictDependencyDataCollector(
+                new InMemoryPomResolver(Map.of()),
+                Map::of);
+        ArtifactKey key = ArtifactKey.of("org.acme", "missing", "", "jar");
+
+        Map<ArtifactKey, DeclaredDepsResult> declaredDependencies = collector.collectExternalDeclaredDependencies(
+                mock(Logger.class),
+                List.of(new ExternalModuleDeclaredDependencyInput(key, new GAV("org.acme", "missing", "1.0"))));
+
+        assertThat(declaredDependencies).containsOnlyKeys(key);
+        assertThat(declaredDependencies.get(key).isResolved()).isFalse();
+        assertThat(declaredDependencies.get(key).getDeclaredDependencies()).isEmpty();
+    }
+
+    private Map<ArtifactKey, DeclaredDepsResult> collectDeclaredDependencies(Project project, String configurationName) {
+        Configuration configuration = project.getConfigurations().getByName(configurationName);
+        return new StrictDependencyDataCollector(
+                GradlePomClosureResolver
+                        .withGradleArtifactResolution(Collections.emptyMap(), project.getDependencies(), new ArrayList<>()),
+                () -> Map.copyOf(System.getProperties().entrySet().stream()
+                        .collect(java.util.stream.Collectors.toMap(
+                                entry -> String.valueOf(entry.getKey()),
+                                entry -> String.valueOf(entry.getValue())))))
+                .collectExternalDeclaredDependencies(mock(Logger.class),
+                        StrictDependencyDataCollector.externalModuleDeclaredDependencyInputs(
+                                configuration.getIncoming().getArtifacts().getResolvedArtifacts().get()));
+    }
+
+    private Project createProject(Path repository) throws IOException {
+        Path projectDirectory = tempDir.resolve("project-" + System.nanoTime());
+        Files.createDirectories(projectDirectory);
+        Project project = ProjectBuilder.builder()
+                .withName("app")
+                .withProjectDir(projectDirectory.toFile())
+                .build();
+        project.setGroup("org.acme");
+        project.setVersion("1.0");
+        project.getPluginManager().apply(JavaLibraryPlugin.class);
+        project.getRepositories().maven(repo -> repo.setUrl(repository.toUri()));
+        return project;
+    }
+
+    private static String dependencySnapshot(DeclaredDependency dependency) {
+        return dependency.getGroupId()
+                + ":" + dependency.getArtifactId()
+                + ":" + dependency.getVersion()
+                + ":" + dependency.getClassifier()
+                + ":" + dependency.getType()
+                + ":" + dependency.getScope()
+                + ":" + dependency.isOptional();
+    }
+
+    private static Map<GAV, String> effectiveModelPoms() {
+        return Map.of(
+                new GAV("org.acme", "parent", "1.0"), pom("""
+                        <project>
+                          <modelVersion>4.0.0</modelVersion>
+                          <groupId>org.acme</groupId>
+                          <artifactId>parent</artifactId>
+                          <version>1.0</version>
+                          <packaging>pom</packaging>
+                          <properties>
+                            <runtime.version>3.0</runtime.version>
+                          </properties>
+                          <dependencyManagement>
+                            <dependencies>
+                              <dependency>
+                                <groupId>org.acme</groupId>
+                                <artifactId>managed-lib</artifactId>
+                                <version>2.0</version>
+                              </dependency>
+                            </dependencies>
+                          </dependencyManagement>
+                        </project>
+                        """),
+                new GAV("org.acme", "acme-bom", "1.0"), pom("""
+                        <project>
+                          <modelVersion>4.0.0</modelVersion>
+                          <groupId>org.acme</groupId>
+                          <artifactId>acme-bom</artifactId>
+                          <version>1.0</version>
+                          <packaging>pom</packaging>
+                          <dependencyManagement>
+                            <dependencies>
+                              <dependency>
+                                <groupId>org.acme</groupId>
+                                <artifactId>bom-managed-lib</artifactId>
+                                <version>4.0</version>
+                              </dependency>
+                            </dependencies>
+                          </dependencyManagement>
+                        </project>
+                        """),
+                new GAV("org.acme", "app", "1.0"), pom("""
+                        <project>
+                          <modelVersion>4.0.0</modelVersion>
+                          <parent>
+                            <groupId>org.acme</groupId>
+                            <artifactId>parent</artifactId>
+                            <version>1.0</version>
+                          </parent>
+                          <artifactId>app</artifactId>
+                          <dependencyManagement>
+                            <dependencies>
+                              <dependency>
+                                <groupId>org.acme</groupId>
+                                <artifactId>acme-bom</artifactId>
+                                <version>1.0</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                              </dependency>
+                            </dependencies>
+                          </dependencyManagement>
+                          <dependencies>
+                            <dependency>
+                              <groupId>org.acme</groupId>
+                              <artifactId>managed-lib</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.acme</groupId>
+                              <artifactId>bom-managed-lib</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.acme</groupId>
+                              <artifactId>runtime-lib</artifactId>
+                              <version>${runtime.version}</version>
+                              <scope>runtime</scope>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.acme</groupId>
+                              <artifactId>system-property-lib</artifactId>
+                              <version>${external.version}</version>
+                            </dependency>
+                          </dependencies>
+                        </project>
+                        """));
+    }
+
+    private static void installJar(Path repository, String groupId, String artifactId, String version, String pom)
+            throws IOException {
+        Path artifactDirectory = artifactDirectory(repository, groupId, artifactId, version);
+        Files.createDirectories(artifactDirectory);
+        Files.writeString(artifactDirectory.resolve(artifactId + "-" + version + ".pom"), pom, StandardCharsets.UTF_8);
+        try (OutputStream output = Files.newOutputStream(artifactDirectory.resolve(artifactId + "-" + version + ".jar"));
+                JarOutputStream ignore = new JarOutputStream(output)) {
+        }
+    }
+
+    private static void installPom(Path repository, String groupId, String artifactId, String version, String pom)
+            throws IOException {
+        Path artifactDirectory = artifactDirectory(repository, groupId, artifactId, version);
+        Files.createDirectories(artifactDirectory);
+        Files.writeString(artifactDirectory.resolve(artifactId + "-" + version + ".pom"), pom, StandardCharsets.UTF_8);
+    }
+
+    private static Path artifactDirectory(Path repository, String groupId, String artifactId, String version) {
+        return repository.resolve(groupId.replace('.', '/')).resolve(artifactId).resolve(version);
+    }
+
+    private static String simplePom(String groupId, String artifactId, String version) {
+        return pom("""
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>%s</groupId>
+                  <artifactId>%s</artifactId>
+                  <version>%s</version>
+                </project>
+                """.formatted(groupId, artifactId, version));
+    }
+
+    private static String childWithParentPom(String artifactId, String body) {
+        return pom("""
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>org.acme</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1.0</version>
+                  </parent>
+                  <artifactId>%s</artifactId>
+                  %s
+                </project>
+                """.formatted(artifactId, body));
+    }
+
+    private static String pom(String body) {
+        return body.replace("<project>", "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" "
+                + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+                + "xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 "
+                + "https://maven.apache.org/xsd/maven-4.0.0.xsd\">");
+    }
+
+    private record InMemoryPomResolver(Map<GAV, String> poms) implements PomResolver {
+
+        @Override
+        public ModelSource2 resolvePom(GAV gav) throws UnresolvableModelException {
+            String pom = poms.get(gav);
+            if (pom == null) {
+                throw new UnresolvableModelException("Could not resolve POM for " + gav,
+                        gav.getGroupId(), gav.getArtifactId(), gav.getVersion());
+            }
+            return new StringModelSource(gav, pom);
+        }
+    }
+
+    private static final class BatchingInMemoryPomResolver implements PomResolver {
+
+        private final Map<GAV, String> repository;
+        private final Map<GAV, String> cache = new LinkedHashMap<>();
+        private final Set<GAV> missing = new LinkedHashSet<>();
+        private final List<List<GAV>> prefetchBatches = new ArrayList<>();
+
+        private BatchingInMemoryPomResolver(Map<GAV, String> repository) {
+            this.repository = repository;
+        }
+
+        @Override
+        public void prefetchPoms(Collection<GAV> gavs) {
+            List<GAV> uncached = gavs.stream()
+                    .filter(gav -> !hasPomResult(gav))
+                    .sorted((left, right) -> left.toString().compareTo(right.toString()))
+                    .toList();
+            if (uncached.isEmpty()) {
+                return;
+            }
+            prefetchBatches.add(uncached);
+            for (GAV gav : uncached) {
+                String pom = repository.get(gav);
+                if (pom == null) {
+                    missing.add(gav);
+                } else {
+                    cache.put(gav, pom);
+                }
+            }
+        }
+
+        @Override
+        public boolean hasPomResult(GAV gav) {
+            return cache.containsKey(gav) || missing.contains(gav);
+        }
+
+        @Override
+        public ModelSource2 resolvePom(GAV gav) throws UnresolvableModelException {
+            String pom = cache.get(gav);
+            if (pom == null) {
+                throw new UnresolvableModelException("Could not resolve POM for " + gav,
+                        gav.getGroupId(), gav.getArtifactId(), gav.getVersion());
+            }
+            return new StringModelSource(gav, pom);
+        }
+
+        private List<List<GAV>> prefetchBatches() {
+            return prefetchBatches;
+        }
+    }
+
+    private record StringModelSource(GAV gav, String pom) implements ModelSource2 {
+
+        @Override
+        public InputStream getInputStream() {
+            return new ByteArrayInputStream(pom.getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public String getLocation() {
+            return gav.toString();
+        }
+
+        @Override
+        public ModelSource2 getRelatedSource(String relPath) {
+            return null;
+        }
+
+        @Override
+        public URI getLocationURI() {
+            return URI.create("memory:/" + gav.getGroupId() + "/" + gav.getArtifactId() + "/" + gav.getVersion());
+        }
+    }
+}

--- a/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/model/tasks/ApplicationModelTaskConfiguratorTest.java
+++ b/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/model/tasks/ApplicationModelTaskConfiguratorTest.java
@@ -1,0 +1,89 @@
+package io.quarkus.gradle.model.tasks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.gradle.model.config.LocalComponentOutputViews;
+import io.quarkus.gradle.model.config.StrictApplicationDeploymentClasspathBuilder;
+import io.quarkus.gradle.model.pom.DeclaredDependencyEnrichmentMode;
+import io.quarkus.gradle.tooling.DefaultProjectDescriptor;
+import io.quarkus.runtime.LaunchMode;
+
+class ApplicationModelTaskConfiguratorTest {
+
+    @Test
+    void strictConfiguratorWiresModelTaskWithoutLiveProjectDeclaredDependencyEnrichment() {
+        Project project = configuredJavaProject();
+        var classpath = new StrictApplicationDeploymentClasspathBuilder(project, LaunchMode.NORMAL, "quarkusApplication");
+        GenerateApplicationModelTask task = project.getTasks()
+                .create("quarkusApplicationModel", GenerateApplicationModelTask.class, LaunchMode.NORMAL);
+        DefaultProjectDescriptor projectDescriptor = new DefaultProjectDescriptor(null);
+
+        StrictApplicationModelTaskConfigurator.configureNoLiveProjectDeclaredDependencies(project, task,
+                project.provider(() -> projectDescriptor), classpath, LaunchMode.NORMAL, false);
+
+        assertThat(task.getProjectDescriptor().get()).isSameAs(projectDescriptor);
+        assertThat(task.getLaunchMode().get()).isEqualTo(LaunchMode.NORMAL);
+        assertThat(task.getTypeModel().get()).isEqualTo(":quarkusApplicationModel");
+        assertThat(task.getDeclaredDependencyEnrichmentMode().get())
+                .isEqualTo(DeclaredDependencyEnrichmentMode.SELECTED_MODULE_POMS);
+        assertThat(task.getApplicationModel().get().getAsFile())
+                .isEqualTo(project.getLayout().getBuildDirectory()
+                        .file("quarkus/application-model/quarkus-app-model.dat").get().getAsFile());
+        assertThat(task.getOriginalClasspath()).containsExactlyInAnyOrderElementsOf(
+                project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
+        assertThat(task.getLocalClassOutputArtifacts().get()).isEmpty();
+        assertThat(task.getLocalResourceOutputArtifacts().get()).isEmpty();
+        assertThat(task.getLocalComponentOutputFiles()).isEmpty();
+    }
+
+    @Test
+    void strictConfiguratorSupportsBuildModelOutputForNormalMode() {
+        Project project = configuredJavaProject();
+        var classpath = new StrictApplicationDeploymentClasspathBuilder(project, LaunchMode.NORMAL, "quarkusApplication");
+        GenerateApplicationModelTask task = project.getTasks()
+                .create("quarkusApplicationBuildModel", GenerateApplicationModelTask.class, LaunchMode.NORMAL);
+
+        StrictApplicationModelTaskConfigurator.configureNoLiveProjectDeclaredDependencies(project, task,
+                project.provider(() -> new DefaultProjectDescriptor(null)), classpath, LaunchMode.NORMAL, true);
+
+        assertThat(task.getApplicationModel().get().getAsFile())
+                .isEqualTo(project.getLayout().getBuildDirectory()
+                        .file("quarkus/application-model/quarkus-app-model-build.dat").get().getAsFile());
+    }
+
+    @Test
+    void isolatedConfiguratorRegistersTaskWithLocalOutputArtifactsAndNoDeclaredDependencyEnrichment() {
+        Project project = configuredJavaProject();
+        var classpath = new StrictApplicationDeploymentClasspathBuilder(project, LaunchMode.DEVELOPMENT, "quarkusApplication");
+        var localOutputs = LocalComponentOutputViews.of(project.getObjects(),
+                classpath.getRuntimeConfigurationWithoutResolvingDeployment());
+
+        var taskProvider = IsolatedApplicationModelTaskConfigurator.registerGenerateApplicationModelTask(project,
+                project.provider(() -> new DefaultProjectDescriptor(null)), classpath, LaunchMode.DEVELOPMENT, localOutputs);
+
+        GenerateApplicationModelTask task = taskProvider.get();
+        assertThat(task.getName()).isEqualTo("quarkusGenerateDevAppModel");
+        assertThat(task.getLaunchMode().get()).isEqualTo(LaunchMode.DEVELOPMENT);
+        assertThat(task.getDeclaredDependencyEnrichmentMode().get()).isEqualTo(DeclaredDependencyEnrichmentMode.NONE);
+        assertThat(task.getApplicationModel().get().getAsFile())
+                .isEqualTo(project.getLayout().getBuildDirectory()
+                        .file("quarkus/application-model/quarkus-app-dev-model.dat").get().getAsFile());
+        assertThat(task.getLocalClassOutputArtifacts().get()).isEqualTo(Set.of());
+        assertThat(task.getLocalResourceOutputArtifacts().get()).isEqualTo(Set.of());
+        assertThat(task.getLocalComponentOutputFiles()).isEmpty();
+    }
+
+    private static Project configuredJavaProject() {
+        Project project = ProjectBuilder.builder().build();
+        project.getPlugins().apply(JavaPlugin.class);
+        StrictApplicationDeploymentClasspathBuilder.initConfigurations(project);
+        return project;
+    }
+}

--- a/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/model/tasks/GradlePomClosureResolverTest.java
+++ b/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/model/tasks/GradlePomClosureResolverTest.java
@@ -1,0 +1,311 @@
+package io.quarkus.gradle.model.tasks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import org.apache.maven.model.resolution.UnresolvableModelException;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.artifacts.query.ArtifactResolutionQuery;
+import org.gradle.api.artifacts.result.ArtifactResolutionResult;
+import org.gradle.api.artifacts.result.ComponentArtifactsResult;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.maven.MavenModule;
+import org.gradle.maven.MavenPomArtifact;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentMatchers;
+
+import io.quarkus.maven.dependency.GAV;
+
+class GradlePomClosureResolverTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldPrefetchPomsForMultipleModulesInOneQuery() throws Exception {
+        Path firstPom = writePom("first");
+        Path secondPom = writePom("second");
+        var firstModule = moduleId("org.acme", "first", "1.0");
+        var secondModule = moduleId("org.acme", "second", "1.0");
+        ArtifactResolutionQuery query = mock(ArtifactResolutionQuery.class);
+        AtomicReference<List<ModuleComponentIdentifier>> requestedModuleIds = new AtomicReference<>();
+        when(query.forComponents(ArgumentMatchers.<Iterable<? extends ComponentIdentifier>> any()))
+                .thenAnswer(invocation -> {
+                    Iterable<?> requested = invocation.getArgument(0);
+                    List<ModuleComponentIdentifier> snapshot = new ArrayList<>();
+                    for (Object moduleId : requested) {
+                        snapshot.add((ModuleComponentIdentifier) moduleId);
+                    }
+                    requestedModuleIds.set(snapshot);
+                    return query;
+                });
+        when(query.withArtifacts(MavenModule.class, MavenPomArtifact.class)).thenReturn(query);
+        Set<ComponentArtifactsResult> components = Set.of(
+                component(firstModule, firstPom),
+                component(secondModule, secondPom));
+        ArtifactResolutionResult result = mock(ArtifactResolutionResult.class);
+        when(result.getResolvedComponents()).thenReturn(components);
+        when(query.execute()).thenReturn(result);
+        DependencyHandler dependencies = mock(DependencyHandler.class);
+        when(dependencies.createArtifactResolutionQuery()).thenReturn(query);
+        Project project = mock(Project.class);
+        when(project.getDependencies()).thenReturn(dependencies);
+        GradlePomClosureResolver resolver = GradlePomClosureResolver
+                .withGradleArtifactResolution(Collections.emptyMap(), project.getDependencies(), new ArrayList<>());
+
+        resolver.prefetchPoms(Stream.of(firstModule, secondModule));
+
+        assertThat(resolver.resolvePom(new GAV("org.acme", "first", "1.0")).getLocation())
+                .isEqualTo(firstPom.toAbsolutePath().toString());
+        assertThat(resolver.resolvePom(new GAV("org.acme", "second", "1.0")).getLocation())
+                .isEqualTo(secondPom.toAbsolutePath().toString());
+        assertThat(requestedModuleIds.get())
+                .extracting(ModuleComponentIdentifier::getDisplayName)
+                .containsExactlyInAnyOrder("org.acme:first:1.0", "org.acme:second:1.0");
+        verify(query, never()).forModule(any(), any(), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldPrefetchPomsForMultipleGavsWithModuleQueries() throws Exception {
+        Path firstPom = writePom("first");
+        Path secondPom = writePom("second");
+        var firstModule = moduleId("org.acme", "first", "1.0");
+        var secondModule = moduleId("org.acme", "second", "1.0");
+        ArtifactResolutionQuery query = mock(ArtifactResolutionQuery.class);
+        when(query.forModule("org.acme", "first", "1.0")).thenReturn(query);
+        when(query.forModule("org.acme", "second", "1.0")).thenReturn(query);
+        when(query.withArtifacts(MavenModule.class, MavenPomArtifact.class)).thenReturn(query);
+        ComponentArtifactsResult firstComponent = component(firstModule, firstPom);
+        ComponentArtifactsResult secondComponent = component(secondModule, secondPom);
+        ArtifactResolutionResult firstResult = mock(ArtifactResolutionResult.class);
+        when(firstResult.getResolvedComponents()).thenReturn(Set.of(firstComponent));
+        ArtifactResolutionResult secondResult = mock(ArtifactResolutionResult.class);
+        when(secondResult.getResolvedComponents()).thenReturn(Set.of(secondComponent));
+        when(query.execute()).thenReturn(firstResult, secondResult);
+        DependencyHandler dependencies = mock(DependencyHandler.class);
+        when(dependencies.createArtifactResolutionQuery()).thenReturn(query);
+        Project project = mock(Project.class);
+        when(project.getDependencies()).thenReturn(dependencies);
+        GradlePomClosureResolver resolver = GradlePomClosureResolver
+                .withGradleArtifactResolution(Collections.emptyMap(), project.getDependencies(), new ArrayList<>());
+
+        resolver.prefetchPoms(List.of(
+                new GAV("org.acme", "first", "1.0"),
+                new GAV("org.acme", "second", "1.0")));
+
+        assertThat(resolver.resolvePom(new GAV("org.acme", "first", "1.0")).getLocation())
+                .isEqualTo(firstPom.toAbsolutePath().toString());
+        assertThat(resolver.resolvePom(new GAV("org.acme", "second", "1.0")).getLocation())
+                .isEqualTo(secondPom.toAbsolutePath().toString());
+        verify(query, never()).forComponents(ArgumentMatchers.<Iterable<? extends ComponentIdentifier>> any());
+        verify(query).forModule("org.acme", "first", "1.0");
+        verify(query).forModule("org.acme", "second", "1.0");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldExposeMissingPomAsCachedBatchResult() throws Exception {
+        ArtifactResolutionQuery query = mock(ArtifactResolutionQuery.class);
+        when(query.forModule("org.acme", "missing", "1.0")).thenReturn(query);
+        when(query.withArtifacts(MavenModule.class, MavenPomArtifact.class)).thenReturn(query);
+        ArtifactResolutionResult result = mock(ArtifactResolutionResult.class);
+        when(result.getResolvedComponents()).thenReturn(Set.of());
+        when(query.execute()).thenReturn(result);
+        DependencyHandler dependencies = mock(DependencyHandler.class);
+        when(dependencies.createArtifactResolutionQuery()).thenReturn(query);
+        Project project = mock(Project.class);
+        when(project.getDependencies()).thenReturn(dependencies);
+        GradlePomClosureResolver resolver = GradlePomClosureResolver
+                .withGradleArtifactResolution(Collections.emptyMap(), project.getDependencies(), new ArrayList<>());
+        GAV missing = new GAV("org.acme", "missing", "1.0");
+
+        resolver.prefetchPoms(List.of(missing));
+
+        assertThat(resolver.hasPomResult(missing)).isTrue();
+        assertThatThrownBy(() -> resolver.resolvePom(missing))
+                .isInstanceOf(UnresolvableModelException.class)
+                .hasMessageContaining("Could not resolve POM for org.acme:missing:1.0");
+        verify(query, never()).forComponents(ArgumentMatchers.<Iterable<? extends ComponentIdentifier>> any());
+        verify(query, times(1)).forModule("org.acme", "missing", "1.0");
+        verify(query, times(1)).execute();
+    }
+
+    @Test
+    void shouldPrefetchGavPomFromGradleRepository() throws Exception {
+        Path repository = tempDir.resolve("repo");
+        installPom(repository, "org.acme", "sample", "1.0");
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(tempDir.resolve("project").toFile())
+                .build();
+        project.getRepositories().maven(repo -> repo.setUrl(repository.toUri()));
+        GradlePomClosureResolver resolver = GradlePomClosureResolver
+                .withGradleArtifactResolution(Collections.emptyMap(), project.getDependencies(), new ArrayList<>());
+        GAV sample = new GAV("org.acme", "sample", "1.0");
+
+        resolver.prefetchPoms(List.of(sample));
+
+        assertThat(resolver.hasPomResult(sample)).isTrue();
+        assertThat(resolver.resolvePom(sample).getLocation().replace('\\', '/'))
+                .endsWith("org/acme/sample/1.0/sample-1.0.pom");
+    }
+
+    @Test
+    void shouldResolveKnownAndSiblingRepositoryPomsWithoutProjectServices() throws Exception {
+        Path repository = tempDir.resolve("repo");
+        Path samplePom = installPom(repository, "org.acme", "sample", "1.0");
+        Path parentPom = installPom(repository, "org.acme", "parent", "1.0");
+        GAV sample = new GAV("org.acme", "sample", "1.0");
+        GAV parent = new GAV("org.acme", "parent", "1.0");
+        GradlePomClosureResolver resolver = GradlePomClosureResolver
+                .withGradleArtifactResolution(Map.of(sample, samplePom.toFile()), null, Collections.emptyList());
+
+        resolver.prefetchPoms(List.of(sample, parent));
+
+        assertThat(resolver.resolvePom(sample).getLocation()).isEqualTo(samplePom.toAbsolutePath().toString());
+        assertThat(resolver.resolvePom(parent).getLocation()).isEqualTo(parentPom.toAbsolutePath().toString());
+    }
+
+    @Test
+    void shouldFailClosedForAmbiguousGradleCachePoms() throws Exception {
+        Path repository = tempDir.resolve("repo");
+        installGradleCachePom(repository, "first-hash", "org.acme", "sample", "1.0");
+        installGradleCachePom(repository, "second-hash", "org.acme", "sample", "1.0");
+        GAV sample = new GAV("org.acme", "sample", "1.0");
+        GradlePomClosureResolver resolver = GradlePomClosureResolver
+                .withGradleArtifactResolution(Map.of(), null, List.of(repository.toFile()));
+
+        resolver.prefetchPoms(List.of(sample));
+
+        assertThatThrownBy(() -> resolver.resolvePom(sample))
+                .isInstanceOf(UnresolvableModelException.class)
+                .hasMessageContaining("Could not resolve POM for org.acme:sample:1.0");
+    }
+
+    @Test
+    void shouldPreferModeledPomOverAmbiguousGradleCachePoms() throws Exception {
+        Path repository = tempDir.resolve("repo");
+        installGradleCachePom(repository, "first-hash", "org.acme", "sample", "1.0");
+        installGradleCachePom(repository, "second-hash", "org.acme", "sample", "1.0");
+        Path selectedPom = installPom(tempDir.resolve("selected-repository"), "org.acme", "sample", "1.0");
+        GAV sample = new GAV("org.acme", "sample", "1.0");
+        GradlePomClosureResolver resolver = GradlePomClosureResolver
+                .withGradleArtifactResolution(
+                        Map.of(sample, selectedPom.toFile()), null, List.of(repository.toFile()));
+
+        resolver.prefetchPoms(List.of(sample));
+
+        assertThat(resolver.resolvePom(sample).getLocation()).isEqualTo(selectedPom.toAbsolutePath().toString());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldResolvePomWithoutPrefetchAndCacheMisses() throws Exception {
+        ArtifactResolutionQuery query = mock(ArtifactResolutionQuery.class);
+        when(query.forModule("org.acme", "missing", "1.0")).thenReturn(query);
+        when(query.withArtifacts(MavenModule.class, MavenPomArtifact.class)).thenReturn(query);
+        ArtifactResolutionResult result = mock(ArtifactResolutionResult.class);
+        when(result.getResolvedComponents()).thenReturn(Set.of());
+        when(query.execute()).thenReturn(result);
+        DependencyHandler dependencies = mock(DependencyHandler.class);
+        when(dependencies.createArtifactResolutionQuery()).thenReturn(query);
+        Project project = mock(Project.class);
+        when(project.getDependencies()).thenReturn(dependencies);
+        GradlePomClosureResolver resolver = GradlePomClosureResolver
+                .withGradleArtifactResolution(Collections.emptyMap(), project.getDependencies(), new ArrayList<>());
+        GAV missing = new GAV("org.acme", "missing", "1.0");
+
+        assertThatThrownBy(() -> resolver.resolvePom(missing))
+                .isInstanceOf(UnresolvableModelException.class)
+                .hasMessageContaining("Could not resolve POM for org.acme:missing:1.0");
+        assertThatThrownBy(() -> resolver.resolvePom(missing))
+                .isInstanceOf(UnresolvableModelException.class)
+                .hasMessageContaining("Could not resolve POM for org.acme:missing:1.0");
+
+        verify(dependencies, times(1)).createArtifactResolutionQuery();
+        verify(query, times(1)).execute();
+    }
+
+    private Path writePom(String name) throws IOException {
+        Path pom = tempDir.resolve(name + ".pom");
+        Files.writeString(pom, "<project/>", StandardCharsets.UTF_8);
+        return pom;
+    }
+
+    private static Path installPom(Path repository, String groupId, String artifactId, String version) throws IOException {
+        Path artifactDirectory = repository.resolve(groupId.replace('.', '/')).resolve(artifactId).resolve(version);
+        Files.createDirectories(artifactDirectory);
+        Path pom = artifactDirectory.resolve(artifactId + "-" + version + ".pom");
+        Files.writeString(pom,
+                """
+                        <project>
+                          <modelVersion>4.0.0</modelVersion>
+                          <groupId>%s</groupId>
+                          <artifactId>%s</artifactId>
+                          <version>%s</version>
+                        </project>
+                        """.formatted(groupId, artifactId, version),
+                StandardCharsets.UTF_8);
+        return pom;
+    }
+
+    private static void installGradleCachePom(Path repository, String hash, String groupId, String artifactId,
+            String version) throws IOException {
+        Path artifactDirectory = repository.resolve(groupId).resolve(artifactId).resolve(version).resolve(hash);
+        Files.createDirectories(artifactDirectory);
+        Files.writeString(artifactDirectory.resolve(artifactId + "-" + version + ".pom"),
+                """
+                        <project>
+                          <modelVersion>4.0.0</modelVersion>
+                          <groupId>%s</groupId>
+                          <artifactId>%s</artifactId>
+                          <version>%s</version>
+                          <description>%s</description>
+                        </project>
+                        """.formatted(groupId, artifactId, version, hash),
+                StandardCharsets.UTF_8);
+    }
+
+    private static ModuleComponentIdentifier moduleId(String groupId, String artifactId, String version) {
+        var moduleId = mock(ModuleComponentIdentifier.class);
+        when(moduleId.getGroup()).thenReturn(groupId);
+        when(moduleId.getModule()).thenReturn(artifactId);
+        when(moduleId.getVersion()).thenReturn(version);
+        when(moduleId.getDisplayName()).thenReturn(groupId + ":" + artifactId + ":" + version);
+        return moduleId;
+    }
+
+    private static ComponentArtifactsResult component(
+            ModuleComponentIdentifier moduleId, Path pomFile) {
+        ResolvedArtifactResult artifact = mock(ResolvedArtifactResult.class);
+        when(artifact.getFile()).thenReturn(pomFile.toFile());
+        ComponentArtifactsResult component = mock(ComponentArtifactsResult.class);
+        when(component.getId()).thenReturn(moduleId);
+        when(component.getArtifacts(MavenPomArtifact.class)).thenReturn(Set.of(artifact));
+        return component;
+    }
+}

--- a/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/model/tasks/QuarkusPlatformInfoTest.java
+++ b/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/model/tasks/QuarkusPlatformInfoTest.java
@@ -1,0 +1,73 @@
+package io.quarkus.gradle.model.tasks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class QuarkusPlatformInfoTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void shouldUseArtifactExtensionAsPlatformArtifactType() {
+        assertThat(QuarkusPlatformInfo.PLATFORM_DESCRIPTOR_ARTIFACT_TYPE).isEqualTo("json");
+        assertThat(QuarkusPlatformInfo.PLATFORM_PROPERTIES_ARTIFACT_TYPE).isEqualTo("properties");
+    }
+
+    @Test
+    void shouldResolveDescriptorAndPropertiesArtifacts() throws IOException {
+        QuarkusPlatformInfo platformInfo = ProjectBuilder.builder().build().getObjects()
+                .newInstance(QuarkusPlatformInfo.class);
+        platformInfo.getResolvedArtifacts().set(Set.of(
+                artifact("io.quarkus.platform", "acme-quarkus-platform-descriptor", "3.0.0",
+                        writeFile("descriptor.json", "")),
+                artifact("io.quarkus.platform", "acme-quarkus-platform-properties", "3.0.0",
+                        writeFile("properties.properties", "platform.quarkus.sample=value\n"))));
+
+        var platformImports = platformInfo.resolvePlatformImports();
+
+        assertThat(platformImports.getImportedPlatformBoms())
+                .extracting(Object::toString)
+                .containsExactly("io.quarkus.platform:acme::pom:3.0.0");
+        assertThat(platformImports.getPlatformProperties())
+                .containsEntry("platform.quarkus.sample", "value");
+    }
+
+    private Path writeFile(String name, String content) throws IOException {
+        Path file = tempDir.resolve(name);
+        Files.writeString(file, content);
+        return file;
+    }
+
+    private static ResolvedArtifactResult artifact(String group, String moduleName, String version, Path file) {
+        ModuleIdentifier moduleIdentifier = mock(ModuleIdentifier.class);
+        when(moduleIdentifier.getName()).thenReturn(moduleName);
+
+        ModuleComponentIdentifier componentIdentifier = mock(ModuleComponentIdentifier.class);
+        when(componentIdentifier.getGroup()).thenReturn(group);
+        when(componentIdentifier.getModuleIdentifier()).thenReturn(moduleIdentifier);
+        when(componentIdentifier.getVersion()).thenReturn(version);
+
+        ModuleComponentArtifactIdentifier artifactIdentifier = mock(ModuleComponentArtifactIdentifier.class);
+        when(artifactIdentifier.getComponentIdentifier()).thenReturn(componentIdentifier);
+
+        ResolvedArtifactResult artifact = mock(ResolvedArtifactResult.class);
+        when(artifact.getId()).thenReturn(artifactIdentifier);
+        when(artifact.getFile()).thenReturn(file.toFile());
+        return artifact;
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ApplicationModelBuilder.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ApplicationModelBuilder.java
@@ -224,6 +224,11 @@ public class ApplicationModelBuilder {
         return this;
     }
 
+    public ApplicationModelBuilder removeReloadableWorkspaceModule(ArtifactKey key) {
+        this.reloadableWorkspaceModules.remove(key);
+        return this;
+    }
+
     public ApplicationModelBuilder addReloadableWorkspaceModules(Collection<ArtifactKey> key) {
         this.reloadableWorkspaceModules.addAll(key);
         return this;


### PR DESCRIPTION
Move the shared application-model task and support code into `:gradle-model` so the application and extension plugins can consume serialized model outputs without keeping live `Project` state on task actions.

This also folds the declared dependency collector back into the application-model task boundary. That avoids the superseded producer-task design, keeps dependency resolution tied to the consuming task, and removes the Maven model task runner/tooling escape path that was not compatible with the final Gradle-native direction.

As part of the same boundary, remove the Quarkus 4 application-plugin DSL helpers that exposed live Gradle project state, route native arguments through managed extension state, harden shared build services, and model provider-backed environment/system-property reads without making incidental process state part of cache keys.
