### PR TITLE
Add Gradle bootstrap support for new plugins and external build tools

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleApplicationModelSidecar.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleApplicationModelSidecar.java
@@ -1,0 +1,28 @@
+package io.quarkus.bootstrap.model.gradle;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Gradle-specific project and output metadata corresponding to an
+ * {@code ApplicationModel} obtained by the same Tooling API request.
+ * <p>
+ * Paths in this model are Gradle-declared paths. Consumers may use them for
+ * correlation, but must not treat them as IDE output paths.
+ */
+public interface GradleApplicationModelSidecar extends Serializable {
+
+    int CURRENT_SCHEMA_VERSION = 1;
+
+    GradleModelCorrelation getCorrelation();
+
+    GradleProjectIdentity getTargetProject();
+
+    List<? extends GradleProjectComponent> getProjectComponents();
+
+    enum Mode {
+        NORMAL,
+        DEVELOPMENT,
+        TEST
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleApplicationModelSidecarMismatchException.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleApplicationModelSidecarMismatchException.java
@@ -1,0 +1,31 @@
+package io.quarkus.bootstrap.model.gradle;
+
+import java.util.Locale;
+
+/**
+ * Indicates that an IDE sidecar does not correspond to the application model
+ * or Tooling API target with which it was paired.
+ */
+public class GradleApplicationModelSidecarMismatchException extends IllegalArgumentException {
+
+    private static final long serialVersionUID = 356306829480760234L;
+
+    private final Dimension dimension;
+
+    public GradleApplicationModelSidecarMismatchException(Dimension dimension, Object expected, Object actual) {
+        super("Gradle application-model sidecar " + dimension.name().toLowerCase(Locale.ROOT)
+                + " mismatch: expected " + expected + " but was " + actual);
+        this.dimension = dimension;
+    }
+
+    public Dimension getDimension() {
+        return dimension;
+    }
+
+    public enum Dimension {
+        SCHEMA,
+        MODE,
+        TARGET,
+        GRAPH
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleApplicationModelSidecarValidator.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleApplicationModelSidecarValidator.java
@@ -1,0 +1,244 @@
+package io.quarkus.bootstrap.model.gradle;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.model.gradle.GradleApplicationModelSidecarMismatchException.Dimension;
+import io.quarkus.bootstrap.workspace.WorkspaceModule;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.paths.PathCollection;
+
+/**
+ * Validates the externally known dimensions of a paired application model and
+ * Gradle sidecar.
+ */
+public final class GradleApplicationModelSidecarValidator {
+
+    private GradleApplicationModelSidecarValidator() {
+    }
+
+    public static void validate(GradleApplicationModelSidecar sidecar, int expectedSchemaVersion,
+            GradleApplicationModelSidecar.Mode expectedMode, String expectedTargetBuildTreePath,
+            Collection<String> expectedCanonicalGraphFacts) {
+        Objects.requireNonNull(expectedCanonicalGraphFacts, "expectedCanonicalGraphFacts");
+        final GradleModelCorrelation correlation = validateDimensions(sidecar, expectedSchemaVersion, expectedMode,
+                expectedTargetBuildTreePath);
+        final List<String> expectedGraph = canonicalGraph(expectedCanonicalGraphFacts);
+        if (!expectedGraph.equals(correlation.getCanonicalGraphFacts())) {
+            throw mismatch(Dimension.GRAPH, expectedGraph, correlation.getCanonicalGraphFacts());
+        }
+    }
+
+    /**
+     * Validates a sidecar against an application model obtained through the
+     * Tooling API.
+     * <p>
+     * Gradle adapts custom model interfaces to protocol proxies. In
+     * particular, {@link PathCollection#iterator()} and
+     * {@link PathCollection#spliterator()} are not supported by that adapter.
+     * This validation path therefore compares every sidecar path with
+     * {@link PathCollection#contains(Path)} and verifies the collection size,
+     * without attempting to iterate it.
+     */
+    public static void validate(GradleApplicationModelSidecar sidecar, int expectedSchemaVersion,
+            GradleApplicationModelSidecar.Mode expectedMode, String expectedTargetBuildTreePath,
+            ApplicationModel expectedApplicationModel) {
+        Objects.requireNonNull(expectedApplicationModel, "expectedApplicationModel");
+        final GradleModelCorrelation correlation = validateDimensions(sidecar, expectedSchemaVersion, expectedMode,
+                expectedTargetBuildTreePath);
+        validateApplicationModelGraph(correlation.getCanonicalGraphFacts(), expectedApplicationModel);
+    }
+
+    private static GradleModelCorrelation validateDimensions(GradleApplicationModelSidecar sidecar,
+            int expectedSchemaVersion, GradleApplicationModelSidecar.Mode expectedMode,
+            String expectedTargetBuildTreePath) {
+        Objects.requireNonNull(sidecar, "sidecar");
+        Objects.requireNonNull(expectedMode, "expectedMode");
+        Objects.requireNonNull(expectedTargetBuildTreePath, "expectedTargetBuildTreePath");
+
+        final GradleModelCorrelation correlation = Objects.requireNonNull(sidecar.getCorrelation(), "sidecar.correlation");
+        if (correlation.getSchemaVersion() != expectedSchemaVersion) {
+            throw mismatch(Dimension.SCHEMA, expectedSchemaVersion, correlation.getSchemaVersion());
+        }
+        if (correlation.getMode() != expectedMode) {
+            throw mismatch(Dimension.MODE, expectedMode, correlation.getMode());
+        }
+        if (!expectedTargetBuildTreePath.equals(correlation.getTargetBuildTreePath())) {
+            throw mismatch(Dimension.TARGET, expectedTargetBuildTreePath, correlation.getTargetBuildTreePath());
+        }
+        if (!correlation.getTargetBuildTreePath().equals(sidecar.getTargetProject().getBuildTreePath())) {
+            throw mismatch(Dimension.TARGET, sidecar.getTargetProject().getBuildTreePath(),
+                    correlation.getTargetBuildTreePath());
+        }
+        return correlation;
+    }
+
+    private static void validateApplicationModelGraph(List<String> actualFacts, ApplicationModel model) {
+        final List<String> canonicalActualFacts = canonicalGraph(actualFacts);
+        if (!canonicalActualFacts.equals(actualFacts)) {
+            throw mismatch(Dimension.GRAPH, canonicalActualFacts, actualFacts);
+        }
+
+        final Map<EntryKey, List<String>> entries = new LinkedHashMap<>();
+        final List<WorkspaceEdge> edges = new ArrayList<>();
+        try {
+            for (String fact : actualFacts) {
+                if (fact.startsWith("workspace-edge|")) {
+                    edges.add(parseWorkspaceEdge(fact));
+                } else {
+                    final EntryFact entry = parseEntryFact(fact);
+                    entries.computeIfAbsent(entry.key(), ignored -> new ArrayList<>()).add(entry.resolvedPath());
+                }
+            }
+        } catch (RuntimeException e) {
+            throw mismatch(Dimension.GRAPH, "well-formed canonical graph facts", actualFacts);
+        }
+
+        validateEntry(entries, "application", model.getAppArtifact());
+        validateWorkspaceEdges(edges, model.getAppArtifact().getWorkspaceModule());
+        for (ResolvedDependency dependency : model.getDependencies()) {
+            validateEntry(entries, "dependency", dependency);
+            validateWorkspaceEdges(edges, dependency.getWorkspaceModule());
+        }
+        if (!entries.isEmpty() || !edges.isEmpty()) {
+            throw mismatch(Dimension.GRAPH, "no unmatched graph facts",
+                    new GraphRemainder(entries, edges));
+        }
+    }
+
+    private static void validateEntry(Map<EntryKey, List<String>> entries, String kind,
+            ResolvedDependency dependency) {
+        final EntryKey key = new EntryKey(kind, coordinates(dependency), dependency.getFlags());
+        final List<String> paths = entries.remove(key);
+        if (paths == null) {
+            throw mismatch(Dimension.GRAPH, key, "missing");
+        }
+
+        final PathCollection resolvedPaths = dependency.getResolvedPaths();
+        final int resolvedPathCount = resolvedPaths == null ? 0 : resolvedPaths.size();
+        if (resolvedPathCount == 0) {
+            if (!paths.equals(List.of(""))) {
+                throw mismatch(Dimension.GRAPH, List.of(""), paths);
+            }
+            return;
+        }
+        if (paths.size() != resolvedPathCount || paths.stream().anyMatch(String::isEmpty)
+                || paths.stream().distinct().count() != paths.size()) {
+            throw mismatch(Dimension.GRAPH, resolvedPathCount + " distinct non-empty resolved paths", paths);
+        }
+        for (String path : paths) {
+            if (!resolvedPaths.contains(Path.of(path))) {
+                throw mismatch(Dimension.GRAPH, "application-model path", path);
+            }
+        }
+    }
+
+    private static void validateWorkspaceEdges(List<WorkspaceEdge> edges, WorkspaceModule module) {
+        if (module == null) {
+            return;
+        }
+        final String source = moduleId(module);
+        for (Dependency dependency : module.getDirectDependencies()) {
+            final WorkspaceEdge edge = new WorkspaceEdge(source, coordinates(dependency));
+            if (!edges.remove(edge)) {
+                throw mismatch(Dimension.GRAPH, edge, "missing");
+            }
+        }
+    }
+
+    private static EntryFact parseEntryFact(String fact) {
+        int kindEnd = fact.indexOf('|');
+        if (kindEnd <= 0) {
+            throw new IllegalArgumentException("Missing entry kind");
+        }
+        final String kind = fact.substring(0, kindEnd);
+        if (!kind.equals("application") && !kind.equals("dependency")) {
+            throw new IllegalArgumentException("Unknown entry kind");
+        }
+        final LengthPrefixed coordinates = lengthPrefixed(fact, kindEnd + 1);
+        if (coordinates.end() >= fact.length() || fact.charAt(coordinates.end()) != '|') {
+            throw new IllegalArgumentException("Missing flags");
+        }
+        final int flagsEnd = fact.indexOf('|', coordinates.end() + 1);
+        if (flagsEnd < 0) {
+            throw new IllegalArgumentException("Missing resolved path");
+        }
+        final int flags = Integer.parseInt(fact.substring(coordinates.end() + 1, flagsEnd));
+        final LengthPrefixed path = lengthPrefixed(fact, flagsEnd + 1);
+        if (path.end() != fact.length()) {
+            throw new IllegalArgumentException("Unexpected entry suffix");
+        }
+        return new EntryFact(new EntryKey(kind, coordinates.value(), flags), path.value());
+    }
+
+    private static WorkspaceEdge parseWorkspaceEdge(String fact) {
+        final int prefixLength = "workspace-edge|".length();
+        final LengthPrefixed source = lengthPrefixed(fact, prefixLength);
+        if (source.end() >= fact.length() || fact.charAt(source.end()) != '|') {
+            throw new IllegalArgumentException("Missing workspace edge target");
+        }
+        final LengthPrefixed target = lengthPrefixed(fact, source.end() + 1);
+        if (target.end() != fact.length()) {
+            throw new IllegalArgumentException("Unexpected workspace edge suffix");
+        }
+        return new WorkspaceEdge(source.value(), target.value());
+    }
+
+    private static LengthPrefixed lengthPrefixed(String value, int offset) {
+        final int colon = value.indexOf(':', offset);
+        if (colon < 0) {
+            throw new IllegalArgumentException("Missing length separator");
+        }
+        final int length = Integer.parseInt(value.substring(offset, colon));
+        final int start = colon + 1;
+        final int end = start + length;
+        if (length < 0 || end > value.length()) {
+            throw new IllegalArgumentException("Invalid length");
+        }
+        return new LengthPrefixed(value.substring(start, end), end);
+    }
+
+    private static String coordinates(ArtifactCoords dependency) {
+        return dependency.getGroupId() + ':' + dependency.getArtifactId() + ':' + dependency.getClassifier() + ':'
+                + dependency.getType() + ':' + dependency.getVersion();
+    }
+
+    private static String moduleId(WorkspaceModule module) {
+        return module.getId().getGroupId() + ':' + module.getId().getArtifactId() + ':' + module.getId().getVersion();
+    }
+
+    private static List<String> canonicalGraph(Collection<String> facts) {
+        final List<String> canonical = new ArrayList<>(facts);
+        canonical.sort(Comparator.naturalOrder());
+        return List.copyOf(canonical);
+    }
+
+    private static GradleApplicationModelSidecarMismatchException mismatch(Dimension dimension, Object expected,
+            Object actual) {
+        return new GradleApplicationModelSidecarMismatchException(dimension, expected, actual);
+    }
+
+    private record EntryKey(String kind, String coordinates, int flags) {
+    }
+
+    private record EntryFact(EntryKey key, String resolvedPath) {
+    }
+
+    private record WorkspaceEdge(String source, String target) {
+    }
+
+    private record LengthPrefixed(String value, int end) {
+    }
+
+    private record GraphRemainder(Map<EntryKey, List<String>> entries, List<WorkspaceEdge> edges) {
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleLogicalOutput.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleLogicalOutput.java
@@ -1,0 +1,64 @@
+package io.quarkus.bootstrap.model.gradle;
+
+import java.io.Serializable;
+
+/**
+ * Logical class or processed-resource output published by a Gradle producer.
+ */
+public interface GradleLogicalOutput extends Serializable {
+
+    /**
+     * Returns the sidecar-local identity used by producer-published
+     * source-to-output associations.
+     */
+    String getIdentity();
+
+    Kind getKind();
+
+    Scope getScope();
+
+    String getPath();
+
+    /**
+     * Returns the copied selected artifact or capability identity.
+     */
+    String getSelectedArtifactIdentity();
+
+    String getProducerSemanticIdentity();
+
+    String getSourceSet();
+
+    String getJvmFeature();
+
+    String getClassifier();
+
+    Materialization getMaterialization();
+
+    ProducerCategory getProducerCategory();
+
+    GradleModelAssociation getModelAssociation();
+
+    enum Kind {
+        CLASSES,
+        PROCESSED_RESOURCES
+    }
+
+    enum Scope {
+        UNKNOWN,
+        MAIN,
+        TEST
+    }
+
+    enum Materialization {
+        UNKNOWN,
+        REQUIRED,
+        OPTIONAL
+    }
+
+    enum ProducerCategory {
+        UNKNOWN,
+        STANDARD,
+        GENERATED,
+        OPAQUE
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleModelAssociation.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleModelAssociation.java
@@ -1,0 +1,44 @@
+package io.quarkus.bootstrap.model.gradle;
+
+import java.io.Serializable;
+
+/**
+ * Unambiguous association between a Gradle logical output and an occurrence in
+ * the corresponding application model.
+ */
+public interface GradleModelAssociation extends Serializable {
+
+    Kind getKind();
+
+    /**
+     * Returns the surviving application/dependency coordinates, or
+     * {@code null} for an unknown association.
+     */
+    String getArtifactCoordinates();
+
+    /**
+     * Returns the exact resolved path occurrence, or {@code null} for an
+     * unknown association.
+     */
+    String getResolvedPath();
+
+    /**
+     * Returns the producer-published classifier, or {@code null} when it is
+     * unknown.
+     */
+    String getClassifier();
+
+    default boolean isKnown() {
+        return getKind() != Kind.UNKNOWN;
+    }
+
+    default boolean isEligibleForOverlayReplacement() {
+        return isKnown();
+    }
+
+    enum Kind {
+        UNKNOWN,
+        APPLICATION,
+        DEPENDENCY
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleModelCorrelation.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleModelCorrelation.java
@@ -1,0 +1,26 @@
+package io.quarkus.bootstrap.model.gradle;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Canonical inputs used to verify that a sidecar and application model belong
+ * to the same request.
+ * <p>
+ * This descriptor detects accidental mismatches. It is neither a cache key nor
+ * a security boundary.
+ */
+public interface GradleModelCorrelation extends Serializable {
+
+    int getSchemaVersion();
+
+    GradleApplicationModelSidecar.Mode getMode();
+
+    String getTargetBuildTreePath();
+
+    /**
+     * Returns the sorted canonical application-model graph projection.
+     * Consumers recompute these facts from the application model.
+     */
+    List<String> getCanonicalGraphFacts();
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleModelCorrelationSupport.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleModelCorrelationSupport.java
@@ -1,0 +1,67 @@
+package io.quarkus.bootstrap.model.gradle;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.workspace.WorkspaceModule;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.paths.PathCollection;
+
+/**
+ * Produces the neutral application-model projection used to correlate a
+ * Gradle sidecar with its paired model.
+ */
+public final class GradleModelCorrelationSupport {
+
+    private GradleModelCorrelationSupport() {
+    }
+
+    /**
+     * Returns deterministic facts for the application and every dependency,
+     * including coordinates, flags, every exact resolved-path occurrence, and
+     * workspace-module direct edges.
+     */
+    public static List<String> canonicalGraphFacts(ApplicationModel model) {
+        final List<String> facts = new ArrayList<>();
+        addFacts(facts, "application", model.getAppArtifact());
+        addWorkspaceEdges(facts, model.getApplicationModule());
+        for (ResolvedDependency dependency : model.getDependencies()) {
+            addFacts(facts, "dependency", dependency);
+            addWorkspaceEdges(facts, dependency.getWorkspaceModule());
+        }
+        facts.sort(Comparator.naturalOrder());
+        return List.copyOf(facts);
+    }
+
+    private static void addFacts(List<String> facts, String entryKind, ResolvedDependency dependency) {
+        final PathCollection resolvedPaths = dependency.getResolvedPaths();
+        if (resolvedPaths == null || resolvedPaths.isEmpty()) {
+            facts.add(fact(entryKind, dependency, ""));
+            return;
+        }
+        for (Path path : resolvedPaths) {
+            facts.add(fact(entryKind, dependency, path.toString()));
+        }
+    }
+
+    private static String fact(String entryKind, ResolvedDependency dependency, String resolvedPath) {
+        final String coordinates = dependency.toGACTVString();
+        return entryKind + '|' + coordinates.length() + ':' + coordinates + '|' + dependency.getFlags() + '|'
+                + resolvedPath.length() + ':' + resolvedPath;
+    }
+
+    private static void addWorkspaceEdges(List<String> facts, WorkspaceModule module) {
+        if (module == null) {
+            return;
+        }
+        final String source = module.getId().toString();
+        for (Dependency dependency : module.getDirectDependencies()) {
+            final String target = dependency.toGACTVString();
+            facts.add("workspace-edge|" + source.length() + ':' + source + '|' + target.length() + ':' + target);
+        }
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleProjectComponent.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleProjectComponent.java
@@ -1,0 +1,48 @@
+package io.quarkus.bootstrap.model.gradle;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Gradle project component selected into the application graph.
+ */
+public interface GradleProjectComponent extends Serializable {
+
+    GradleProjectIdentity getProjectIdentity();
+
+    /**
+     * Returns the copied Gradle component identity used during resolution.
+     */
+    String getSelectedComponentIdentity();
+
+    Set<Role> getRoles();
+
+    Set<ClasspathAssociation> getClasspathAssociations();
+
+    Set<GraphRelationship> getGraphRelationships();
+
+    List<? extends GradleSourceObservation> getSourceObservations();
+
+    List<? extends GradleLogicalOutput> getLogicalOutputs();
+
+    enum Role {
+        APPLICATION,
+        WORKSPACE_DEPENDENCY,
+        EXTENSION_RUNTIME,
+        EXTENSION_DEPLOYMENT
+    }
+
+    enum ClasspathAssociation {
+        RUNTIME,
+        DEPLOYMENT,
+        COMPILE_ONLY,
+        TEST
+    }
+
+    enum GraphRelationship {
+        DIRECT,
+        TRANSITIVE,
+        WORKSPACE_DIRECT
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleProjectIdentity.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleProjectIdentity.java
@@ -1,0 +1,15 @@
+package io.quarkus.bootstrap.model.gradle;
+
+import java.io.Serializable;
+
+/**
+ * Composite-build-safe identity of a Gradle project.
+ */
+public interface GradleProjectIdentity extends Serializable {
+
+    String getBuildPath();
+
+    String getProjectPath();
+
+    String getBuildTreePath();
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleSourceObservation.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/GradleSourceObservation.java
@@ -1,0 +1,34 @@
+package io.quarkus.bootstrap.model.gradle;
+
+import java.io.Serializable;
+
+/**
+ * Source path published by a Gradle producer.
+ * <p>
+ * A source is associated with a logical output only when the producer
+ * publishes that association. Project membership alone is not sufficient.
+ */
+public interface GradleSourceObservation extends Serializable {
+
+    String getPath();
+
+    Role getRole();
+
+    /**
+     * Returns a producer-published logical output identity, or {@code null}
+     * when the producer did not publish a source-to-output mapping.
+     */
+    String getLogicalOutputIdentity();
+
+    default boolean hasLogicalOutputAssociation() {
+        return getLogicalOutputIdentity() != null;
+    }
+
+    enum Role {
+        UNKNOWN,
+        JAVA,
+        KOTLIN,
+        RESOURCE,
+        GENERATED
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/DefaultGradleApplicationModelSidecar.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/DefaultGradleApplicationModelSidecar.java
@@ -1,0 +1,41 @@
+package io.quarkus.bootstrap.model.gradle.impl;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import io.quarkus.bootstrap.model.gradle.GradleApplicationModelSidecar;
+import io.quarkus.bootstrap.model.gradle.GradleModelCorrelation;
+import io.quarkus.bootstrap.model.gradle.GradleProjectComponent;
+import io.quarkus.bootstrap.model.gradle.GradleProjectIdentity;
+
+public final class DefaultGradleApplicationModelSidecar implements GradleApplicationModelSidecar {
+
+    private static final long serialVersionUID = 6540011924193033765L;
+
+    private final GradleModelCorrelation correlation;
+    private final GradleProjectIdentity targetProject;
+    private final List<? extends GradleProjectComponent> projectComponents;
+
+    public DefaultGradleApplicationModelSidecar(GradleModelCorrelation correlation,
+            GradleProjectIdentity targetProject, Collection<? extends GradleProjectComponent> projectComponents) {
+        this.correlation = Objects.requireNonNull(correlation, "correlation");
+        this.targetProject = Objects.requireNonNull(targetProject, "targetProject");
+        this.projectComponents = List.copyOf(projectComponents);
+    }
+
+    @Override
+    public GradleModelCorrelation getCorrelation() {
+        return correlation;
+    }
+
+    @Override
+    public GradleProjectIdentity getTargetProject() {
+        return targetProject;
+    }
+
+    @Override
+    public List<? extends GradleProjectComponent> getProjectComponents() {
+        return projectComponents;
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/DefaultGradleLogicalOutput.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/DefaultGradleLogicalOutput.java
@@ -1,0 +1,102 @@
+package io.quarkus.bootstrap.model.gradle.impl;
+
+import java.util.Objects;
+
+import io.quarkus.bootstrap.model.gradle.GradleLogicalOutput;
+import io.quarkus.bootstrap.model.gradle.GradleModelAssociation;
+
+public final class DefaultGradleLogicalOutput implements GradleLogicalOutput {
+
+    private static final long serialVersionUID = -7112065215159628735L;
+
+    private final String identity;
+    private final Kind kind;
+    private final Scope scope;
+    private final String path;
+    private final String selectedArtifactIdentity;
+    private final String producerSemanticIdentity;
+    private final String sourceSet;
+    private final String jvmFeature;
+    private final String classifier;
+    private final Materialization materialization;
+    private final ProducerCategory producerCategory;
+    private final GradleModelAssociation modelAssociation;
+
+    public DefaultGradleLogicalOutput(String identity, Kind kind, Scope scope, String path,
+            String selectedArtifactIdentity, String producerSemanticIdentity, String sourceSet, String jvmFeature,
+            String classifier, Materialization materialization, ProducerCategory producerCategory,
+            GradleModelAssociation modelAssociation) {
+        this.identity = Objects.requireNonNull(identity, "identity");
+        this.kind = Objects.requireNonNull(kind, "kind");
+        this.scope = Objects.requireNonNull(scope, "scope");
+        this.path = Objects.requireNonNull(path, "path");
+        this.selectedArtifactIdentity = Objects.requireNonNull(selectedArtifactIdentity, "selectedArtifactIdentity");
+        this.producerSemanticIdentity = producerSemanticIdentity;
+        this.sourceSet = sourceSet;
+        this.jvmFeature = jvmFeature;
+        this.classifier = classifier;
+        this.materialization = Objects.requireNonNull(materialization, "materialization");
+        this.producerCategory = Objects.requireNonNull(producerCategory, "producerCategory");
+        this.modelAssociation = Objects.requireNonNull(modelAssociation, "modelAssociation");
+    }
+
+    @Override
+    public String getIdentity() {
+        return identity;
+    }
+
+    @Override
+    public Kind getKind() {
+        return kind;
+    }
+
+    @Override
+    public Scope getScope() {
+        return scope;
+    }
+
+    @Override
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public String getSelectedArtifactIdentity() {
+        return selectedArtifactIdentity;
+    }
+
+    @Override
+    public String getProducerSemanticIdentity() {
+        return producerSemanticIdentity;
+    }
+
+    @Override
+    public String getSourceSet() {
+        return sourceSet;
+    }
+
+    @Override
+    public String getJvmFeature() {
+        return jvmFeature;
+    }
+
+    @Override
+    public String getClassifier() {
+        return classifier;
+    }
+
+    @Override
+    public Materialization getMaterialization() {
+        return materialization;
+    }
+
+    @Override
+    public ProducerCategory getProducerCategory() {
+        return producerCategory;
+    }
+
+    @Override
+    public GradleModelAssociation getModelAssociation() {
+        return modelAssociation;
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/DefaultGradleModelAssociation.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/DefaultGradleModelAssociation.java
@@ -1,0 +1,54 @@
+package io.quarkus.bootstrap.model.gradle.impl;
+
+import java.util.Objects;
+
+import io.quarkus.bootstrap.model.gradle.GradleModelAssociation;
+
+public final class DefaultGradleModelAssociation implements GradleModelAssociation {
+
+    private static final long serialVersionUID = -7371983253634892542L;
+
+    private final Kind kind;
+    private final String artifactCoordinates;
+    private final String resolvedPath;
+    private final String classifier;
+
+    public DefaultGradleModelAssociation(Kind kind, String artifactCoordinates, String resolvedPath, String classifier) {
+        this.kind = Objects.requireNonNull(kind, "kind");
+        if (kind == Kind.UNKNOWN) {
+            if (artifactCoordinates != null || resolvedPath != null || classifier != null) {
+                throw new IllegalArgumentException("An unknown model association cannot contain model coordinates or paths");
+            }
+        } else {
+            Objects.requireNonNull(artifactCoordinates, "artifactCoordinates");
+            Objects.requireNonNull(resolvedPath, "resolvedPath");
+        }
+        this.artifactCoordinates = artifactCoordinates;
+        this.resolvedPath = resolvedPath;
+        this.classifier = classifier;
+    }
+
+    public static DefaultGradleModelAssociation unknown() {
+        return new DefaultGradleModelAssociation(Kind.UNKNOWN, null, null, null);
+    }
+
+    @Override
+    public Kind getKind() {
+        return kind;
+    }
+
+    @Override
+    public String getArtifactCoordinates() {
+        return artifactCoordinates;
+    }
+
+    @Override
+    public String getResolvedPath() {
+        return resolvedPath;
+    }
+
+    @Override
+    public String getClassifier() {
+        return classifier;
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/DefaultGradleModelCorrelation.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/DefaultGradleModelCorrelation.java
@@ -1,0 +1,56 @@
+package io.quarkus.bootstrap.model.gradle.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+import io.quarkus.bootstrap.model.gradle.GradleApplicationModelSidecar;
+import io.quarkus.bootstrap.model.gradle.GradleModelCorrelation;
+
+public final class DefaultGradleModelCorrelation implements GradleModelCorrelation {
+
+    private static final long serialVersionUID = -4767943016645702070L;
+
+    private final int schemaVersion;
+    private final GradleApplicationModelSidecar.Mode mode;
+    private final String targetBuildTreePath;
+    private final List<String> canonicalGraphFacts;
+
+    public DefaultGradleModelCorrelation(int schemaVersion, GradleApplicationModelSidecar.Mode mode,
+            String targetBuildTreePath, Collection<String> canonicalGraphFacts) {
+        if (schemaVersion < 1) {
+            throw new IllegalArgumentException("schemaVersion must be greater than zero");
+        }
+        this.schemaVersion = schemaVersion;
+        this.mode = Objects.requireNonNull(mode, "mode");
+        this.targetBuildTreePath = Objects.requireNonNull(targetBuildTreePath, "targetBuildTreePath");
+        final List<String> facts = new ArrayList<>(canonicalGraphFacts);
+        for (String fact : facts) {
+            Objects.requireNonNull(fact, "canonicalGraphFacts contains null");
+        }
+        facts.sort(Comparator.naturalOrder());
+        this.canonicalGraphFacts = List.copyOf(facts);
+    }
+
+    @Override
+    public int getSchemaVersion() {
+        return schemaVersion;
+    }
+
+    @Override
+    public GradleApplicationModelSidecar.Mode getMode() {
+        return mode;
+    }
+
+    @Override
+    public String getTargetBuildTreePath() {
+        return targetBuildTreePath;
+    }
+
+    @Override
+    public List<String> getCanonicalGraphFacts() {
+        return canonicalGraphFacts;
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/DefaultGradleProjectComponent.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/DefaultGradleProjectComponent.java
@@ -1,0 +1,83 @@
+package io.quarkus.bootstrap.model.gradle.impl;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import io.quarkus.bootstrap.model.gradle.GradleLogicalOutput;
+import io.quarkus.bootstrap.model.gradle.GradleProjectComponent;
+import io.quarkus.bootstrap.model.gradle.GradleProjectIdentity;
+import io.quarkus.bootstrap.model.gradle.GradleSourceObservation;
+
+public final class DefaultGradleProjectComponent implements GradleProjectComponent {
+
+    private static final long serialVersionUID = -5391398664530192947L;
+
+    private final GradleProjectIdentity projectIdentity;
+    private final String selectedComponentIdentity;
+    private final Set<Role> roles;
+    private final Set<ClasspathAssociation> classpathAssociations;
+    private final Set<GraphRelationship> graphRelationships;
+    private final List<? extends GradleSourceObservation> sourceObservations;
+    private final List<? extends GradleLogicalOutput> logicalOutputs;
+
+    public DefaultGradleProjectComponent(GradleProjectIdentity projectIdentity, String selectedComponentIdentity,
+            Collection<Role> roles, Collection<ClasspathAssociation> classpathAssociations,
+            Collection<GraphRelationship> graphRelationships,
+            Collection<? extends GradleSourceObservation> sourceObservations,
+            Collection<? extends GradleLogicalOutput> logicalOutputs) {
+        this.projectIdentity = Objects.requireNonNull(projectIdentity, "projectIdentity");
+        this.selectedComponentIdentity = Objects.requireNonNull(selectedComponentIdentity, "selectedComponentIdentity");
+        this.roles = immutableEnumSet(roles);
+        this.classpathAssociations = immutableEnumSet(classpathAssociations);
+        this.graphRelationships = immutableEnumSet(graphRelationships);
+        this.sourceObservations = List.copyOf(sourceObservations);
+        this.logicalOutputs = List.copyOf(logicalOutputs);
+    }
+
+    @Override
+    public GradleProjectIdentity getProjectIdentity() {
+        return projectIdentity;
+    }
+
+    @Override
+    public String getSelectedComponentIdentity() {
+        return selectedComponentIdentity;
+    }
+
+    @Override
+    public Set<Role> getRoles() {
+        return roles;
+    }
+
+    @Override
+    public Set<ClasspathAssociation> getClasspathAssociations() {
+        return classpathAssociations;
+    }
+
+    @Override
+    public Set<GraphRelationship> getGraphRelationships() {
+        return graphRelationships;
+    }
+
+    @Override
+    public List<? extends GradleSourceObservation> getSourceObservations() {
+        return sourceObservations;
+    }
+
+    @Override
+    public List<? extends GradleLogicalOutput> getLogicalOutputs() {
+        return logicalOutputs;
+    }
+
+    private static <E extends Enum<E>> Set<E> immutableEnumSet(Collection<E> values) {
+        Objects.requireNonNull(values, "values");
+        if (values.isEmpty()) {
+            return Set.of();
+        }
+        return Collections.unmodifiableSet(EnumSet.copyOf(values));
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/DefaultGradleProjectIdentity.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/DefaultGradleProjectIdentity.java
@@ -1,0 +1,35 @@
+package io.quarkus.bootstrap.model.gradle.impl;
+
+import java.util.Objects;
+
+import io.quarkus.bootstrap.model.gradle.GradleProjectIdentity;
+
+public final class DefaultGradleProjectIdentity implements GradleProjectIdentity {
+
+    private static final long serialVersionUID = -3169557076250064908L;
+
+    private final String buildPath;
+    private final String projectPath;
+    private final String buildTreePath;
+
+    public DefaultGradleProjectIdentity(String buildPath, String projectPath, String buildTreePath) {
+        this.buildPath = Objects.requireNonNull(buildPath, "buildPath");
+        this.projectPath = Objects.requireNonNull(projectPath, "projectPath");
+        this.buildTreePath = Objects.requireNonNull(buildTreePath, "buildTreePath");
+    }
+
+    @Override
+    public String getBuildPath() {
+        return buildPath;
+    }
+
+    @Override
+    public String getProjectPath() {
+        return projectPath;
+    }
+
+    @Override
+    public String getBuildTreePath() {
+        return buildTreePath;
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/DefaultGradleSourceObservation.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/DefaultGradleSourceObservation.java
@@ -1,0 +1,35 @@
+package io.quarkus.bootstrap.model.gradle.impl;
+
+import java.util.Objects;
+
+import io.quarkus.bootstrap.model.gradle.GradleSourceObservation;
+
+public final class DefaultGradleSourceObservation implements GradleSourceObservation {
+
+    private static final long serialVersionUID = 2428088945457434848L;
+
+    private final String path;
+    private final Role role;
+    private final String logicalOutputIdentity;
+
+    public DefaultGradleSourceObservation(String path, Role role, String logicalOutputIdentity) {
+        this.path = Objects.requireNonNull(path, "path");
+        this.role = Objects.requireNonNull(role, "role");
+        this.logicalOutputIdentity = logicalOutputIdentity;
+    }
+
+    @Override
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public Role getRole() {
+        return role;
+    }
+
+    @Override
+    public String getLogicalOutputIdentity() {
+        return logicalOutputIdentity;
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/workspace/DefaultWorkspaceModule.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/workspace/DefaultWorkspaceModule.java
@@ -29,19 +29,37 @@ public class DefaultWorkspaceModule implements WorkspaceModule, Serializable {
         private Builder() {
         }
 
+        /**
+         * Populates this builder from the workspace-module map representation.
+         * <p>
+         * The module ID entry is required. Module directory, build directory, and build-file entries are optional; when
+         * absent, this method does not modify the corresponding builder values. Other supported collection entries are
+         * also applied only when present.
+         *
+         * @param map workspace-module representation
+         * @return this builder
+         */
         @Override
         public Builder fromMap(Map<String, Object> map) {
             setModuleId(WorkspaceModuleId.fromString((String) map.get(BootstrapConstants.MAPPABLE_MODULE_ID)));
-            setModuleDir(Path.of((String) map.get(BootstrapConstants.MAPPABLE_MODULE_DIR)));
-            setBuildDir(Path.of((String) map.get(BootstrapConstants.MAPPABLE_BUILD_DIR)));
+            String moduleDir = (String) map.get(BootstrapConstants.MAPPABLE_MODULE_DIR);
+            if (moduleDir != null) {
+                setModuleDir(Path.of(moduleDir));
+            }
+            String buildDir = (String) map.get(BootstrapConstants.MAPPABLE_BUILD_DIR);
+            if (buildDir != null) {
+                setBuildDir(Path.of(buildDir));
+            }
 
             Collection<String> buildFilesStr = (Collection<String>) map.get(BootstrapConstants.MAPPABLE_BUILD_FILES);
-            final Path[] buildFiles = new Path[buildFilesStr.size()];
-            int i = 0;
-            for (String buildFileStr : buildFilesStr) {
-                buildFiles[i++] = Path.of(buildFileStr);
+            if (buildFilesStr != null) {
+                final Path[] buildFiles = new Path[buildFilesStr.size()];
+                int i = 0;
+                for (String buildFileStr : buildFilesStr) {
+                    buildFiles[i++] = Path.of(buildFileStr);
+                }
+                setBuildFiles(PathList.of(buildFiles));
             }
-            setBuildFiles(PathList.of(buildFiles));
 
             Collection<Map<String, Object>> sourcesMap = (Collection<Map<String, Object>>) map
                     .get(BootstrapConstants.MAPPABLE_ARTIFACT_SOURCES);

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/bootstrap/model/gradle/GradleApplicationModelSidecarTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/bootstrap/model/gradle/GradleApplicationModelSidecarTest.java
@@ -1,0 +1,356 @@
+package io.quarkus.bootstrap.model.gradle;
+
+import static io.quarkus.bootstrap.model.gradle.GradleApplicationModelSidecar.Mode.DEVELOPMENT;
+import static io.quarkus.bootstrap.model.gradle.GradleApplicationModelSidecarMismatchException.Dimension.GRAPH;
+import static io.quarkus.bootstrap.model.gradle.GradleApplicationModelSidecarMismatchException.Dimension.MODE;
+import static io.quarkus.bootstrap.model.gradle.GradleApplicationModelSidecarMismatchException.Dimension.SCHEMA;
+import static io.quarkus.bootstrap.model.gradle.GradleApplicationModelSidecarMismatchException.Dimension.TARGET;
+import static io.quarkus.bootstrap.model.gradle.GradleLogicalOutput.Kind.CLASSES;
+import static io.quarkus.bootstrap.model.gradle.GradleLogicalOutput.Materialization.UNKNOWN;
+import static io.quarkus.bootstrap.model.gradle.GradleLogicalOutput.ProducerCategory.STANDARD;
+import static io.quarkus.bootstrap.model.gradle.GradleLogicalOutput.Scope.MAIN;
+import static io.quarkus.bootstrap.model.gradle.GradleProjectComponent.ClasspathAssociation.RUNTIME;
+import static io.quarkus.bootstrap.model.gradle.GradleProjectComponent.GraphRelationship.DIRECT;
+import static io.quarkus.bootstrap.model.gradle.GradleProjectComponent.Role.WORKSPACE_DEPENDENCY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.model.ApplicationModelBuilder;
+import io.quarkus.bootstrap.model.gradle.impl.DefaultGradleApplicationModelSidecar;
+import io.quarkus.bootstrap.model.gradle.impl.DefaultGradleLogicalOutput;
+import io.quarkus.bootstrap.model.gradle.impl.DefaultGradleModelAssociation;
+import io.quarkus.bootstrap.model.gradle.impl.DefaultGradleModelCorrelation;
+import io.quarkus.bootstrap.model.gradle.impl.DefaultGradleProjectComponent;
+import io.quarkus.bootstrap.model.gradle.impl.DefaultGradleProjectIdentity;
+import io.quarkus.bootstrap.model.gradle.impl.DefaultGradleSourceObservation;
+import io.quarkus.bootstrap.workspace.WorkspaceModule;
+import io.quarkus.bootstrap.workspace.WorkspaceModuleId;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.maven.dependency.DependencyFlags;
+import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
+import io.quarkus.paths.PathCollection;
+import io.quarkus.paths.PathList;
+
+class GradleApplicationModelSidecarTest {
+
+    private static final List<String> GRAPH_FACTS = List.of(
+            "dependency|org.acme:library::jar:1|runtime|/workspace/library/build/classes/java/main",
+            "workspace-edge|org.acme:application::jar:1|org.acme:library::jar:1");
+
+    @Test
+    void preservesImmutableCompositeIdentitiesAndMultipleOutputsAcrossSerialization() throws Exception {
+        final var rootIdentity = new DefaultGradleProjectIdentity(":", ":library", ":library");
+        final var includedIdentity = new DefaultGradleProjectIdentity(":included", ":library", ":included:library");
+        final var components = new ArrayList<GradleProjectComponent>();
+        components.add(component(rootIdentity, "/workspace/library/build/classes/java/main",
+                "/workspace/library/build/classes/kotlin/main"));
+        components.add(component(includedIdentity, "/workspace/included/library/build/classes/java/main"));
+
+        final var sidecar = sidecar(components, GRAPH_FACTS);
+        components.clear();
+
+        assertThat(sidecar.getProjectComponents()).hasSize(2);
+        assertThat(sidecar.getProjectComponents()).extracting(c -> c.getProjectIdentity().getProjectPath())
+                .containsOnly(":library");
+        assertThat(sidecar.getProjectComponents()).extracting(c -> c.getProjectIdentity().getBuildTreePath())
+                .containsExactly(":library", ":included:library");
+        assertThat(sidecar.getProjectComponents().get(0).getLogicalOutputs()).hasSize(2);
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> sidecar.getProjectComponents().clear());
+
+        final GradleApplicationModelSidecar copy = roundTrip(sidecar);
+        assertThat(copy.getProjectComponents()).hasSize(2);
+        assertThat(copy.getProjectComponents().get(0).getLogicalOutputs())
+                .extracting(GradleLogicalOutput::getPath)
+                .containsExactly("/workspace/library/build/classes/java/main",
+                        "/workspace/library/build/classes/kotlin/main");
+        assertThat(copy.getCorrelation().getCanonicalGraphFacts()).containsExactlyElementsOf(GRAPH_FACTS);
+    }
+
+    @Test
+    void keepsUnknownSemanticsAndAmbiguousAssociationsExplicit() {
+        final var identity = new DefaultGradleProjectIdentity(":", ":library", ":library");
+        final var source = new DefaultGradleSourceObservation("/workspace/library/src/main",
+                GradleSourceObservation.Role.UNKNOWN, null);
+        final var output = output("classes-0", "/workspace/library/build/classes/java/main");
+        final var component = new DefaultGradleProjectComponent(identity, "project :library",
+                Set.of(WORKSPACE_DEPENDENCY), Set.of(RUNTIME), Set.of(DIRECT), List.of(source), List.of(output));
+
+        assertThat(source.getRole()).isEqualTo(GradleSourceObservation.Role.UNKNOWN);
+        assertThat(source.hasLogicalOutputAssociation()).isFalse();
+        assertThat(output.getSourceSet()).isNull();
+        assertThat(output.getJvmFeature()).isNull();
+        assertThat(output.getClassifier()).isNull();
+        assertThat(output.getMaterialization()).isEqualTo(UNKNOWN);
+        assertThat(output.getModelAssociation().getKind()).isEqualTo(GradleModelAssociation.Kind.UNKNOWN);
+        assertThat(output.getModelAssociation().isEligibleForOverlayReplacement()).isFalse();
+        assertThat(component.getSourceObservations()).hasSize(1);
+        assertThat(component.getLogicalOutputs()).hasSize(1);
+    }
+
+    @Test
+    void canonicalizesCorrelationAndAcceptsMatchingDimensions() {
+        final var reversedFacts = List.of(GRAPH_FACTS.get(1), GRAPH_FACTS.get(0));
+        final var sidecar = sidecar(List.of(), reversedFacts);
+
+        assertThat(sidecar.getCorrelation().getCanonicalGraphFacts()).containsExactlyElementsOf(GRAPH_FACTS);
+        GradleApplicationModelSidecarValidator.validate(sidecar,
+                GradleApplicationModelSidecar.CURRENT_SCHEMA_VERSION, DEVELOPMENT, ":application", reversedFacts);
+    }
+
+    @Test
+    void reportsTheMismatchedCorrelationDimension() {
+        final var sidecar = sidecar(List.of(), GRAPH_FACTS);
+
+        assertMismatch(sidecar, 2, DEVELOPMENT, ":application", GRAPH_FACTS, SCHEMA);
+        assertMismatch(sidecar, 1, GradleApplicationModelSidecar.Mode.TEST, ":application", GRAPH_FACTS, MODE);
+        assertMismatch(sidecar, 1, DEVELOPMENT, ":other", GRAPH_FACTS, TARGET);
+        assertMismatch(sidecar, 1, DEVELOPMENT, ":application", List.of("different"), GRAPH);
+    }
+
+    @Test
+    void buildsDeterministicCanonicalFactsFromTheApplicationModel() {
+        final Path applicationResources = Path.of("/workspace/application/build/resources/main");
+        final Path applicationClasses = Path.of("/workspace/application/build/classes/java/main");
+        final Path zLibrary = Path.of("/workspace/z-library.jar");
+        final Path aLibraryClasses = Path.of("/workspace/a-library/build/classes/java/main");
+        final var model = new ApplicationModelBuilder()
+                .setAppArtifact(dependency("org.acme", "application", 0,
+                        applicationResources,
+                        applicationClasses))
+                .addDependency(dependency("org.acme", "z-library",
+                        DependencyFlags.RUNTIME_CP | DependencyFlags.DEPLOYMENT_CP,
+                        zLibrary))
+                .addDependency(dependency("org.acme", "a-library",
+                        DependencyFlags.RUNTIME_CP | DependencyFlags.DEPLOYMENT_CP | DependencyFlags.DIRECT,
+                        aLibraryClasses))
+                .build();
+
+        assertThat(GradleModelCorrelationSupport.canonicalGraphFacts(model)).containsExactly(
+                "application|31:org.acme:application::jar:1.0.0|0|" + encodedPath(applicationResources),
+                "application|31:org.acme:application::jar:1.0.0|0|" + encodedPath(applicationClasses),
+                "dependency|29:org.acme:a-library::jar:1.0.0|"
+                        + (DependencyFlags.RUNTIME_CP | DependencyFlags.DEPLOYMENT_CP | DependencyFlags.DIRECT)
+                        + "|" + encodedPath(aLibraryClasses),
+                "dependency|29:org.acme:z-library::jar:1.0.0|"
+                        + (DependencyFlags.RUNTIME_CP | DependencyFlags.DEPLOYMENT_CP)
+                        + "|" + encodedPath(zLibrary));
+    }
+
+    @Test
+    void canonicalFactsIncludeWorkspaceDirectEdges() {
+        final WorkspaceModule.Mutable applicationWorkspace = WorkspaceModule.builder()
+                .setModuleId(WorkspaceModuleId.of("org.acme", "application", "1.0.0"))
+                .addDependency(Dependency.of("org.acme", "library", "1.0.0"));
+        final WorkspaceModule.Mutable libraryWorkspace = WorkspaceModule.builder()
+                .setModuleId(WorkspaceModuleId.of("org.acme", "library", "1.0.0"))
+                .addDependency(Dependency.of("org.acme", "transitive", "1.0.0"));
+        final var model = new ApplicationModelBuilder()
+                .setAppArtifact(dependency("org.acme", "application", 0)
+                        .setWorkspaceModule(applicationWorkspace))
+                .addDependency(dependency("org.acme", "library",
+                        DependencyFlags.RUNTIME_CP | DependencyFlags.DEPLOYMENT_CP)
+                        .setWorkspaceModule(libraryWorkspace))
+                .build();
+
+        assertThat(GradleModelCorrelationSupport.canonicalGraphFacts(model))
+                .contains(
+                        "workspace-edge|26:org.acme:application:1.0.0|27:org.acme:library::jar:1.0.0",
+                        "workspace-edge|22:org.acme:library:1.0.0|30:org.acme:transitive::jar:1.0.0");
+    }
+
+    @Test
+    void validatesToolingProxyPathsWithoutIteration() {
+        final Path applicationPath = Path.of("/workspace/application/build/classes/java/main");
+        final Path libraryPath = Path.of("/workspace/library/build/classes/java/main");
+        final var canonicalModel = correlatedModel(
+                PathList.of(applicationPath), "library",
+                DependencyFlags.RUNTIME_CP | DependencyFlags.DEPLOYMENT_CP,
+                PathList.of(libraryPath), "library");
+        final var proxyModel = correlatedModel(
+                new NonIterablePathCollection(applicationPath), "library",
+                DependencyFlags.RUNTIME_CP | DependencyFlags.DEPLOYMENT_CP,
+                new NonIterablePathCollection(libraryPath), "library");
+        final var sidecar = sidecar(List.of(), GradleModelCorrelationSupport.canonicalGraphFacts(canonicalModel));
+
+        assertThatCode(() -> GradleApplicationModelSidecarValidator.validate(sidecar,
+                GradleApplicationModelSidecar.CURRENT_SCHEMA_VERSION, DEVELOPMENT, ":application", proxyModel))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void proxySafeValidationDetectsCoordinateFlagPathAndWorkspaceEdgeMismatches() {
+        final Path applicationPath = Path.of("/workspace/application/build/classes/java/main");
+        final Path libraryPath = Path.of("/workspace/library/build/classes/java/main");
+        final int flags = DependencyFlags.RUNTIME_CP | DependencyFlags.DEPLOYMENT_CP;
+        final var canonicalModel = correlatedModel(
+                PathList.of(applicationPath), "library", flags, PathList.of(libraryPath), "library");
+        final var sidecar = sidecar(List.of(), GradleModelCorrelationSupport.canonicalGraphFacts(canonicalModel));
+
+        assertApplicationModelMismatch(sidecar,
+                correlatedModel(new NonIterablePathCollection(applicationPath), "otherlib", flags,
+                        new NonIterablePathCollection(libraryPath), "library"));
+        assertApplicationModelMismatch(sidecar,
+                correlatedModel(new NonIterablePathCollection(applicationPath), "library",
+                        flags | DependencyFlags.DIRECT, new NonIterablePathCollection(libraryPath), "library"));
+        assertApplicationModelMismatch(sidecar,
+                correlatedModel(new NonIterablePathCollection(applicationPath), "library", flags,
+                        new NonIterablePathCollection(Path.of("/workspace/library/build/other")), "library"));
+        assertApplicationModelMismatch(sidecar,
+                correlatedModel(new NonIterablePathCollection(applicationPath), "library", flags,
+                        new NonIterablePathCollection(libraryPath), "otherlib"));
+    }
+
+    private static ApplicationModel correlatedModel(
+            PathCollection applicationPaths, String libraryArtifactId, int libraryFlags,
+            PathCollection libraryPaths, String applicationEdgeArtifactId) {
+        final WorkspaceModule.Mutable applicationWorkspace = WorkspaceModule.builder()
+                .setModuleId(WorkspaceModuleId.of("org.acme", "application", "1.0.0"))
+                .addDependency(Dependency.of("org.acme", applicationEdgeArtifactId, "1.0.0"));
+        final WorkspaceModule.Mutable libraryWorkspace = WorkspaceModule.builder()
+                .setModuleId(WorkspaceModuleId.of("org.acme", libraryArtifactId, "1.0.0"));
+        return new ApplicationModelBuilder()
+                .setAppArtifact(dependency("org.acme", "application", 0)
+                        .setResolvedPaths(applicationPaths)
+                        .setWorkspaceModule(applicationWorkspace))
+                .addDependency(dependency("org.acme", libraryArtifactId, libraryFlags)
+                        .setResolvedPaths(libraryPaths)
+                        .setWorkspaceModule(libraryWorkspace))
+                .build();
+    }
+
+    private static void assertApplicationModelMismatch(GradleApplicationModelSidecar sidecar,
+            ApplicationModel model) {
+        assertThatExceptionOfType(GradleApplicationModelSidecarMismatchException.class)
+                .isThrownBy(() -> GradleApplicationModelSidecarValidator.validate(sidecar,
+                        GradleApplicationModelSidecar.CURRENT_SCHEMA_VERSION, DEVELOPMENT, ":application", model))
+                .satisfies(failure -> assertThat(failure.getDimension()).isEqualTo(GRAPH));
+    }
+
+    private static String encodedPath(Path path) {
+        final String value = path.toString();
+        return value.length() + ":" + value;
+    }
+
+    private static DefaultGradleApplicationModelSidecar sidecar(
+            List<? extends GradleProjectComponent> components, List<String> graphFacts) {
+        final var target = new DefaultGradleProjectIdentity(":", ":application", ":application");
+        final var correlation = new DefaultGradleModelCorrelation(
+                GradleApplicationModelSidecar.CURRENT_SCHEMA_VERSION, DEVELOPMENT, target.getBuildTreePath(), graphFacts);
+        return new DefaultGradleApplicationModelSidecar(correlation, target, components);
+    }
+
+    private static DefaultGradleProjectComponent component(GradleProjectIdentity identity, String... outputPaths) {
+        final var outputs = new ArrayList<GradleLogicalOutput>(outputPaths.length);
+        for (int i = 0; i < outputPaths.length; i++) {
+            outputs.add(output("classes-" + i, outputPaths[i]));
+        }
+        return new DefaultGradleProjectComponent(identity, "project " + identity.getBuildTreePath(),
+                Set.of(WORKSPACE_DEPENDENCY), Set.of(RUNTIME), Set.of(DIRECT), List.of(), outputs);
+    }
+
+    private static DefaultGradleLogicalOutput output(String identity, String path) {
+        return new DefaultGradleLogicalOutput(identity, CLASSES, MAIN, path, "classes-directory",
+                null, null, null, null, UNKNOWN, STANDARD, DefaultGradleModelAssociation.unknown());
+    }
+
+    private static ResolvedDependencyBuilder dependency(String groupId, String artifactId, int flags, Path... paths) {
+        return ResolvedDependencyBuilder.newInstance()
+                .setCoords(ArtifactCoords.jar(groupId, artifactId, "1.0.0"))
+                .setFlags(flags)
+                .setResolvedPaths(PathList.of(paths));
+    }
+
+    private static void assertMismatch(GradleApplicationModelSidecar sidecar, int schema,
+            GradleApplicationModelSidecar.Mode mode, String target, List<String> facts,
+            GradleApplicationModelSidecarMismatchException.Dimension dimension) {
+        assertThatExceptionOfType(GradleApplicationModelSidecarMismatchException.class)
+                .isThrownBy(() -> GradleApplicationModelSidecarValidator.validate(sidecar, schema, mode, target, facts))
+                .satisfies(failure -> {
+                    assertThat(failure.getDimension()).isEqualTo(dimension);
+                    assertThat(failure.getMessage()).contains(dimension.name().toLowerCase(), "expected", "but was");
+                });
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T roundTrip(T value) throws IOException, ClassNotFoundException {
+        final byte[] serialized;
+        try (var bytes = new ByteArrayOutputStream(); var output = new ObjectOutputStream(bytes)) {
+            output.writeObject(value);
+            serialized = bytes.toByteArray();
+        }
+        try (var input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            return (T) input.readObject();
+        }
+    }
+
+    private static final class NonIterablePathCollection implements PathCollection {
+
+        private final List<Path> paths;
+
+        private NonIterablePathCollection(Path... paths) {
+            this.paths = List.of(paths);
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return paths.isEmpty();
+        }
+
+        @Override
+        public int size() {
+            return paths.size();
+        }
+
+        @Override
+        public boolean isSinglePath() {
+            return paths.size() == 1;
+        }
+
+        @Override
+        public boolean contains(Path path) {
+            return paths.contains(path);
+        }
+
+        @Override
+        public PathCollection add(Path... paths) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PathCollection addFirst(Path... paths) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PathCollection addAllFirst(Iterable<Path> paths) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Path resolveExistingOrNull(String path) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Iterator<Path> iterator() {
+            throw new UnsupportedOperationException("Tooling API proxy does not support PathCollection iteration");
+        }
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/bootstrap/workspace/DefaultWorkspaceModuleTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/bootstrap/workspace/DefaultWorkspaceModuleTest.java
@@ -1,0 +1,22 @@
+package io.quarkus.bootstrap.workspace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class DefaultWorkspaceModuleTest {
+
+    @Test
+    void roundTripsAnIdentityOnlyWorkspaceModule() {
+        WorkspaceModule original = WorkspaceModule.builder()
+                .setModuleId(WorkspaceModuleId.of("org.acme", "library", "1.0"))
+                .build();
+
+        WorkspaceModule restored = WorkspaceModule.builder().fromMap(original.asMap()).build();
+
+        assertThat(restored.getId()).isEqualTo(original.getId());
+        assertThat(restored.getModuleDir()).isNull();
+        assertThat(restored.getBuildDir()).isNull();
+        assertThat(restored.getBuildFiles()).isEmpty();
+    }
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/utils/BuildToolHelper.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/utils/BuildToolHelper.java
@@ -1,5 +1,6 @@
 package io.quarkus.bootstrap.utils;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -11,6 +12,7 @@ import io.quarkus.bootstrap.app.ApplicationModelSerializer;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.resolver.AppModelResolverException;
 import io.quarkus.bootstrap.resolver.QuarkusGradleModelFactory;
+import io.quarkus.bootstrap.resolver.QuarkusToolingModelResult;
 import io.quarkus.bootstrap.workspace.WorkspaceModule;
 import io.quarkus.maven.dependency.ResolvedDependency;
 
@@ -23,6 +25,7 @@ public class BuildToolHelper {
 
     private final static String[] DEVMODE_REQUIRED_TASKS = new String[] { "classes" };
     private final static String[] TEST_REQUIRED_TASKS = new String[] { "classes", "testClasses", "integrationTestClasses" };
+    private final static String[] STANDALONE_TEST_REQUIRED_TASKS = new String[] { "classes", "testClasses" };
     private final static List<String> ENABLE_JAR_PACKAGING = List.of("-Dorg.gradle.java.compile-classpath-packaging=true");
 
     public enum BuildTool {
@@ -133,8 +136,28 @@ public class BuildToolHelper {
 
     public static ApplicationModel enableGradleAppModelForTest(Path projectRoot)
             throws IOException, AppModelResolverException {
-        // We enable jar packaging since we want test-fixtures as jars
-        return enableGradleAppModel(projectRoot, "TEST", ENABLE_JAR_PACKAGING, TEST_REQUIRED_TASKS);
+        if (!isGradleProject(projectRoot)) {
+            return null;
+        }
+
+        final File projectDir = getBuildFile(projectRoot, BuildTool.GRADLE).toFile();
+        log.infof("Loading Quarkus Gradle test application model for %s", projectRoot);
+        // Probe provider ownership without prerequisites. Legacy test launch keeps its integration-test source-set
+        // behavior, while the standalone plugin requests only the standard source sets it owns.
+        final QuarkusToolingModelResult probe = QuarkusGradleModelFactory.createPaired(
+                projectDir, "TEST", ENABLE_JAR_PACKAGING);
+        final ApplicationModel model;
+        if (probe.getProviderKind() == QuarkusToolingModelResult.ProviderKind.STANDALONE_APPLICATION) {
+            model = QuarkusGradleModelFactory.createPaired(
+                    projectDir, "TEST", ENABLE_JAR_PACKAGING, STANDALONE_TEST_REQUIRED_TASKS)
+                    .getApplicationModel();
+        } else {
+            // We enable jar packaging since legacy test-fixtures are consumed as jars.
+            model = QuarkusGradleModelFactory.create(
+                    projectDir, "TEST", ENABLE_JAR_PACKAGING, TEST_REQUIRED_TASKS);
+        }
+        ApplicationModelSerializer.exportGradleModel(model, true);
+        return model;
     }
 
     public static ApplicationModel enableGradleAppModelForProdMode(Path projectRoot)

--- a/independent-projects/bootstrap/gradle-resolver/pom.xml
+++ b/independent-projects/bootstrap/gradle-resolver/pom.xml
@@ -59,6 +59,11 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusGradleModelFactory.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusGradleModelFactory.java
@@ -38,4 +38,21 @@ public class QuarkusGradleModelFactory {
         }
     }
 
+    public static QuarkusToolingModelResult createPairedForTasks(File projectDir, String... tasks) {
+        return createPaired(projectDir, "DEVELOPMENT", List.of(), tasks);
+    }
+
+    public static QuarkusToolingModelResult createPaired(File projectDir, String mode, List<String> jvmArgs,
+            String... tasks) {
+        try (ProjectConnection connection = GradleConnector.newConnector()
+                .forProjectDirectory(projectDir)
+                .useGradleUserHomeDir(GradleUserHomeLookup.gradleUserHome())
+                .connect()) {
+            return connection.action(new QuarkusToolingModelBuildAction(mode))
+                    .forTasks(tasks)
+                    .addJvmArguments(jvmArgs)
+                    .run();
+        }
+    }
+
 }

--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusToolingModelBuildAction.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusToolingModelBuildAction.java
@@ -1,0 +1,47 @@
+package io.quarkus.bootstrap.resolver;
+
+import java.io.Serializable;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.GradleProject;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.model.gradle.GradleApplicationModelSidecar;
+import io.quarkus.bootstrap.model.gradle.GradleApplicationModelSidecarValidator;
+import io.quarkus.bootstrap.model.gradle.ModelParameter;
+import io.quarkus.bootstrap.resolver.QuarkusToolingModelResult.ProviderKind;
+
+/**
+ * Fetches an application model and the standalone-plugin ownership marker in
+ * one Tooling API invocation.
+ */
+public final class QuarkusToolingModelBuildAction implements BuildAction<QuarkusToolingModelResult>, Serializable {
+
+    private static final long serialVersionUID = -1584626513393139052L;
+
+    private final String mode;
+
+    public QuarkusToolingModelBuildAction(String mode) {
+        this.mode = mode;
+    }
+
+    @Override
+    public QuarkusToolingModelResult execute(BuildController controller) {
+        ApplicationModel applicationModel = controller.getModel(ApplicationModel.class, ModelParameter.class,
+                parameter -> parameter.setMode(mode));
+        GradleApplicationModelSidecar sidecar = controller.findModel(GradleApplicationModelSidecar.class,
+                ModelParameter.class, parameter -> parameter.setMode(mode));
+        if (sidecar == null) {
+            return new QuarkusToolingModelResult(applicationModel, ProviderKind.UNMARKED_COMPATIBILITY, null);
+        }
+
+        final GradleProject targetProject = controller.getModel(GradleProject.class);
+        GradleApplicationModelSidecarValidator.validate(sidecar,
+                GradleApplicationModelSidecar.CURRENT_SCHEMA_VERSION,
+                GradleApplicationModelSidecar.Mode.valueOf(mode),
+                targetProject.getBuildTreePath(),
+                applicationModel);
+        return new QuarkusToolingModelResult(applicationModel, ProviderKind.STANDALONE_APPLICATION, sidecar);
+    }
+}

--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusToolingModelResult.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusToolingModelResult.java
@@ -1,0 +1,50 @@
+package io.quarkus.bootstrap.resolver;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.model.gradle.GradleApplicationModelSidecar;
+
+/**
+ * Internal result used to keep the application model and its provider
+ * ownership together while routing Quarkus-owned consumers.
+ */
+public final class QuarkusToolingModelResult implements Serializable {
+
+    private static final long serialVersionUID = 7032723855628300508L;
+
+    private final ApplicationModel applicationModel;
+    private final ProviderKind providerKind;
+    private final GradleApplicationModelSidecar sidecar;
+
+    public QuarkusToolingModelResult(ApplicationModel applicationModel, ProviderKind providerKind,
+            GradleApplicationModelSidecar sidecar) {
+        this.applicationModel = Objects.requireNonNull(applicationModel, "applicationModel");
+        this.providerKind = Objects.requireNonNull(providerKind, "providerKind");
+        this.sidecar = sidecar;
+        if (providerKind == ProviderKind.STANDALONE_APPLICATION && sidecar == null) {
+            throw new IllegalArgumentException("The standalone application provider requires a Gradle sidecar");
+        }
+        if (providerKind == ProviderKind.UNMARKED_COMPATIBILITY && sidecar != null) {
+            throw new IllegalArgumentException("An unmarked compatibility provider cannot carry a Gradle sidecar");
+        }
+    }
+
+    public ApplicationModel getApplicationModel() {
+        return applicationModel;
+    }
+
+    public ProviderKind getProviderKind() {
+        return providerKind;
+    }
+
+    public GradleApplicationModelSidecar getSidecar() {
+        return sidecar;
+    }
+
+    public enum ProviderKind {
+        UNMARKED_COMPATIBILITY,
+        STANDALONE_APPLICATION
+    }
+}

--- a/independent-projects/bootstrap/gradle-resolver/src/test/java/io/quarkus/bootstrap/resolver/QuarkusToolingModelBuildActionTest.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/test/java/io/quarkus/bootstrap/resolver/QuarkusToolingModelBuildActionTest.java
@@ -1,0 +1,161 @@
+package io.quarkus.bootstrap.resolver;
+
+import static io.quarkus.bootstrap.model.gradle.GradleApplicationModelSidecar.Mode.DEVELOPMENT;
+import static io.quarkus.bootstrap.model.gradle.GradleApplicationModelSidecarMismatchException.Dimension.TARGET;
+import static io.quarkus.bootstrap.resolver.QuarkusToolingModelResult.ProviderKind.STANDALONE_APPLICATION;
+import static io.quarkus.bootstrap.resolver.QuarkusToolingModelResult.ProviderKind.UNMARKED_COMPATIBILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.gradle.api.Action;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.GradleProject;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.model.ApplicationModelBuilder;
+import io.quarkus.bootstrap.model.gradle.GradleApplicationModelSidecar;
+import io.quarkus.bootstrap.model.gradle.GradleApplicationModelSidecarMismatchException;
+import io.quarkus.bootstrap.model.gradle.GradleModelCorrelationSupport;
+import io.quarkus.bootstrap.model.gradle.ModelParameter;
+import io.quarkus.bootstrap.model.gradle.impl.DefaultGradleApplicationModelSidecar;
+import io.quarkus.bootstrap.model.gradle.impl.DefaultGradleModelCorrelation;
+import io.quarkus.bootstrap.model.gradle.impl.DefaultGradleProjectIdentity;
+import io.quarkus.bootstrap.model.gradle.impl.ModelParameterImpl;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
+
+class QuarkusToolingModelBuildActionTest {
+
+    @Test
+    void preservesUnmarkedCompatibilityWhenTheSidecarIsAbsent() {
+        final var requestedModes = new ArrayList<String>();
+        final var result = new QuarkusToolingModelBuildAction("DEVELOPMENT")
+                .execute(controller(applicationModel(), null, null, requestedModes));
+
+        assertThat(result.getProviderKind()).isEqualTo(UNMARKED_COMPATIBILITY);
+        assertThat(result.getSidecar()).isNull();
+        assertThat(requestedModes).containsExactly("DEVELOPMENT", "DEVELOPMENT");
+    }
+
+    @Test
+    void returnsAndSerializesAValidatedStandalonePair() throws Exception {
+        final ApplicationModel model = applicationModel();
+        final GradleApplicationModelSidecar sidecar = sidecar(model, ":");
+
+        final QuarkusToolingModelResult result = new QuarkusToolingModelBuildAction("DEVELOPMENT")
+                .execute(controller(model, sidecar, ":", new ArrayList<>()));
+        final QuarkusToolingModelResult copy = roundTrip(result);
+
+        assertThat(copy.getProviderKind()).isEqualTo(STANDALONE_APPLICATION);
+        assertThat(copy.getSidecar()).isNotNull();
+        assertThat(copy.getApplicationModel().getAppArtifact().toGACTVString())
+                .isEqualTo("org.acme:application::jar:1.0.0");
+    }
+
+    @Test
+    void validatesTheSidecarAgainstTheToolingRequestTarget() {
+        final ApplicationModel model = applicationModel();
+        final GradleApplicationModelSidecar sidecar = sidecar(model, ":other");
+
+        assertThatExceptionOfType(GradleApplicationModelSidecarMismatchException.class)
+                .isThrownBy(() -> new QuarkusToolingModelBuildAction("DEVELOPMENT")
+                        .execute(controller(model, sidecar, ":", new ArrayList<>())))
+                .satisfies(failure -> assertThat(failure.getDimension()).isEqualTo(TARGET));
+    }
+
+    @Test
+    void enforcesProviderAndSidecarInvariants() {
+        final ApplicationModel model = applicationModel();
+        final GradleApplicationModelSidecar sidecar = sidecar(model, ":");
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new QuarkusToolingModelResult(model, STANDALONE_APPLICATION, null))
+                .withMessageContaining("requires a Gradle sidecar");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new QuarkusToolingModelResult(model, UNMARKED_COMPATIBILITY, sidecar))
+                .withMessageContaining("cannot carry a Gradle sidecar");
+    }
+
+    private static ApplicationModel applicationModel() {
+        return new ApplicationModelBuilder()
+                .setAppArtifact(ResolvedDependencyBuilder.newInstance()
+                        .setCoords(ArtifactCoords.jar("org.acme", "application", "1.0.0")))
+                .build();
+    }
+
+    private static GradleApplicationModelSidecar sidecar(ApplicationModel model, String targetBuildTreePath) {
+        final var target = new DefaultGradleProjectIdentity(":", ":", targetBuildTreePath);
+        final var correlation = new DefaultGradleModelCorrelation(
+                GradleApplicationModelSidecar.CURRENT_SCHEMA_VERSION, DEVELOPMENT, targetBuildTreePath,
+                GradleModelCorrelationSupport.canonicalGraphFacts(model));
+        return new DefaultGradleApplicationModelSidecar(correlation, target, List.of());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static BuildController controller(ApplicationModel model, GradleApplicationModelSidecar sidecar,
+            String targetBuildTreePath, List<String> requestedModes) {
+        return (BuildController) Proxy.newProxyInstance(
+                QuarkusToolingModelBuildActionTest.class.getClassLoader(),
+                new Class<?>[] { BuildController.class },
+                (proxy, method, arguments) -> {
+                    if ("getModel".equals(method.getName()) && arguments.length == 3) {
+                        requestedModes.add(configuredMode(arguments));
+                        return model;
+                    }
+                    if ("findModel".equals(method.getName()) && arguments.length == 3) {
+                        requestedModes.add(configuredMode(arguments));
+                        return sidecar;
+                    }
+                    if ("getModel".equals(method.getName()) && arguments.length == 1
+                            && arguments[0] == GradleProject.class) {
+                        if (targetBuildTreePath == null) {
+                            throw new AssertionError("The unmarked compatibility path queried target-project metadata");
+                        }
+                        return gradleProject(targetBuildTreePath);
+                    }
+                    throw new UnsupportedOperationException(method.toString());
+                });
+    }
+
+    @SuppressWarnings("unchecked")
+    private static String configuredMode(Object[] arguments) {
+        final ModelParameter parameter = new ModelParameterImpl();
+        ((Action<ModelParameter>) arguments[2]).execute(parameter);
+        return parameter.getMode();
+    }
+
+    private static GradleProject gradleProject(String buildTreePath) {
+        return (GradleProject) Proxy.newProxyInstance(
+                QuarkusToolingModelBuildActionTest.class.getClassLoader(),
+                new Class<?>[] { GradleProject.class },
+                (proxy, method, arguments) -> {
+                    if ("getBuildTreePath".equals(method.getName())) {
+                        return buildTreePath;
+                    }
+                    throw new UnsupportedOperationException(method.toString());
+                });
+    }
+
+    private static QuarkusToolingModelResult roundTrip(QuarkusToolingModelResult result)
+            throws IOException, ClassNotFoundException {
+        final byte[] serialized;
+        try (var bytes = new ByteArrayOutputStream(); var output = new ObjectOutputStream(bytes)) {
+            output.writeObject(result);
+            serialized = bytes.toByteArray();
+        }
+        try (var input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            return (QuarkusToolingModelResult) input.readObject();
+        }
+    }
+}


### PR DESCRIPTION
Add the Gradle application-model sidecar and correlation model used to connect Gradle outputs to Quarkus bootstrap.

Validate sidecar consistency, expose the tooling-model build action, and adapt workspace module resolution.
