### PR TITLE
Add strict Javadoc verification for Gradle modules

### DIFF
--- a/devtools/gradle/build-logic/src/main/kotlin/io.quarkus.devtools.java-library.gradle.kts
+++ b/devtools/gradle/build-logic/src/main/kotlin/io.quarkus.devtools.java-library.gradle.kts
@@ -1,3 +1,5 @@
+import io.quarkus.devtools.javadoc.registerStrictJavadoc
+
 plugins {
     id("java-library")
     id("java-test-fixtures")
@@ -33,6 +35,8 @@ tasks.named<Javadoc>(JavaPlugin.JAVADOC_TASK_NAME) {
     options.encoding = "UTF-8"
     (options as? CoreJavadocOptions)?.addStringOption("Xdoclint:-reference", "-quiet")
 }
+
+registerStrictJavadoc()
 
 tasks.named<Test>(JavaPlugin.TEST_TASK_NAME) {
     useJUnitPlatform()

--- a/devtools/gradle/build-logic/src/main/kotlin/io/quarkus/devtools/javadoc/StrictJavadocOptions.kt
+++ b/devtools/gradle/build-logic/src/main/kotlin/io/quarkus/devtools/javadoc/StrictJavadocOptions.kt
@@ -1,0 +1,13 @@
+package io.quarkus.devtools.javadoc
+
+import org.gradle.external.javadoc.CoreJavadocOptions
+
+internal object StrictJavadocOptions {
+
+    fun applyTo(options: CoreJavadocOptions) {
+        options.encoding = "UTF-8"
+        options.setOutputLevel(null)
+        options.addBooleanOption("Werror", true)
+        options.addBooleanOption("Xdoclint:all,-missing", true)
+    }
+}

--- a/devtools/gradle/build-logic/src/main/kotlin/io/quarkus/devtools/javadoc/StrictJavadocTaskRegistration.kt
+++ b/devtools/gradle/build-logic/src/main/kotlin/io/quarkus/devtools/javadoc/StrictJavadocTaskRegistration.kt
@@ -1,0 +1,25 @@
+package io.quarkus.devtools.javadoc
+
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.javadoc.Javadoc
+import org.gradle.external.javadoc.CoreJavadocOptions
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.register
+
+internal fun Project.registerStrictJavadoc() {
+    val mainSourceSet = extensions.getByType<SourceSetContainer>().named(SourceSet.MAIN_SOURCE_SET_NAME)
+
+    tasks.register<Javadoc>("strictJavadoc") {
+        group = JavaBasePlugin.DOCUMENTATION_GROUP
+        description = "Generates warning-clean API documentation with all relevant doclint checks enabled."
+        source(mainSourceSet.map { it.allJava })
+        classpath = mainSourceSet.get().output.plus(mainSourceSet.get().compileClasspath)
+        destinationDir = layout.buildDirectory.dir("docs/strictJavadoc").get().asFile
+        setFailOnError(true)
+        StrictJavadocOptions.applyTo(options as CoreJavadocOptions)
+    }
+}

--- a/devtools/gradle/build-logic/src/test/kotlin/io/quarkus/devtools/javadoc/StrictJavadocOptionsTest.kt
+++ b/devtools/gradle/build-logic/src/test/kotlin/io/quarkus/devtools/javadoc/StrictJavadocOptionsTest.kt
@@ -1,0 +1,68 @@
+package io.quarkus.devtools.javadoc
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.javadoc.Javadoc
+import org.gradle.external.javadoc.CoreJavadocOptions
+import org.gradle.external.javadoc.StandardJavadocDocletOptions
+import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.named
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class StrictJavadocOptionsTest {
+
+    @TempDir
+    lateinit var temporaryDirectory: Path
+
+    @Test
+    fun enablesAllRelevantDoclintChecksAndTreatsWarningsAsErrors() {
+        val options = StandardJavadocDocletOptions()
+
+        StrictJavadocOptions.applyTo(options)
+        val optionFile = temporaryDirectory.resolve("javadoc.options").toFile()
+        options.write(optionFile)
+
+        assertStrictOptions(optionFile.toPath())
+    }
+
+    @Test
+    fun registersStrictTaskWithTheMainSourceSetAndIsolatedOutput() {
+        val project = ProjectBuilder.builder()
+            .withProjectDir(temporaryDirectory.toFile())
+            .build()
+        project.pluginManager.apply("java-library")
+        project.registerStrictJavadoc()
+        val main = project.extensions.getByType<SourceSetContainer>().named("main").get()
+        val sourceFile = temporaryDirectory.resolve("src/main/java/example/Documented.java")
+        Files.createDirectories(sourceFile.parent)
+        Files.writeString(sourceFile, "package example; public final class Documented {}")
+
+        val task = project.tasks.named<Javadoc>("strictJavadoc").get()
+        val optionFile = temporaryDirectory.resolve("registered-javadoc.options")
+        (task.options as CoreJavadocOptions).write(optionFile.toFile())
+
+        assertThat(task.source.files)
+            .containsExactlyInAnyOrderElementsOf(main.allJava.files)
+            .contains(sourceFile.toFile())
+        assertThat(task.classpath.files)
+            .containsAll(main.output.files)
+            .containsAll(main.compileClasspath.files)
+        assertThat(task.destinationDir)
+            .isEqualTo(project.layout.buildDirectory.dir("docs/strictJavadoc").get().asFile)
+        assertThat(task.isFailOnError).isTrue()
+        assertStrictOptions(optionFile)
+    }
+
+    private fun assertStrictOptions(optionFile: Path) {
+        val lines = optionFile.toFile().readLines().map(String::trim).filter(String::isNotEmpty)
+        assertThat(lines).contains("-Werror")
+        assertThat(lines.filter { it.startsWith("-Xdoclint:") })
+            .containsExactly("-Xdoclint:all,-missing")
+        assertThat(lines).doesNotContain("-quiet")
+    }
+}


### PR DESCRIPTION
Register a warning-clean Javadoc task beside the existing documentation task. Validate all relevant doclint checks, generated source-set output wiring, isolated output, and the absence of quiet or reference-check weakening.
