### PR TITLE
Register test class as bean for @QuarkusTest meta-annotation in a jar

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1795,7 +1795,7 @@ For instance, you can bundle it with the `@Tag` annotation to automatically mark
 
 [source,java]
 ----
-org.acme.test
+package org.acme.test;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -1817,6 +1817,13 @@ public @interface QuarkusSecurityTest {   <1>
 }
 ----
 <1> The `@QuarkusSecurityTest` annotation can be used instead of the `@QuarkusTest` annotation.
+
+[NOTE]
+====
+If the meta-annotation is shipped in a separate dependency, that dependency must be part of the
+application index (a Jandex index, a `META-INF/beans.xml`, or `quarkus.index-dependency`) — otherwise
+the test class is not registered as a CDI bean.
+====
 
 == Testing Components
 

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/TestBeanDefiningAnnotationsBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/TestBeanDefiningAnnotationsBuildItem.java
@@ -1,0 +1,23 @@
+package io.quarkus.arc.deployment;
+
+import java.util.Set;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Holds the names of all annotations that mark a class as a Quarkus test and therefore turn it into a
+ * CDI bean. This includes the seed test annotations (e.g. {@code @QuarkusTest}) as well as any
+ * annotation (transitively) composed with them, discovered against the application index.
+ */
+final class TestBeanDefiningAnnotationsBuildItem extends SimpleBuildItem {
+
+    private final Set<String> annotationNames;
+
+    TestBeanDefiningAnnotationsBuildItem(Set<String> annotationNames) {
+        this.annotationNames = annotationNames;
+    }
+
+    Set<String> getAnnotationNames() {
+        return annotationNames;
+    }
+}

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/TestsAsBeansProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/TestsAsBeansProcessor.java
@@ -5,16 +5,19 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationTarget.Kind;
 import org.jboss.jandex.AnnotationTransformation;
+import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.ClassInfo.NestingType;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.processor.Annotations;
@@ -39,15 +42,74 @@ public class TestsAsBeansProcessor {
             .createSimple("io.quarkus.test.junit.QuarkusIntegrationTest");
     private static final DotName QUARKUS_MAIN_TEST = DotName.createSimple("io.quarkus.test.junit.main.QuarkusMainTest");
     private static final DotName NESTED = DotName.createSimple("org.junit.jupiter.api.Nested");
+    private static final DotName EXTEND_WITH = DotName.createSimple("org.junit.jupiter.api.extension.ExtendWith");
+    private static final DotName QUARKUS_TEST_EXTENSION = DotName.createSimple("io.quarkus.test.junit.QuarkusTestExtension");
 
-    @BuildStep
-    public void testAnnotations(List<TestAnnotationBuildItem> items, BuildProducer<BeanDefiningAnnotationBuildItem> producer) {
+    @BuildStep(onlyIf = IsTest.class)
+    public void testAnnotations(List<TestAnnotationBuildItem> items, CombinedIndexBuildItem combinedIndex,
+            BuildProducer<BeanDefiningAnnotationBuildItem> beanDefiningAnnotations,
+            BuildProducer<TestBeanDefiningAnnotationsBuildItem> testAnnotations) {
+        if (items.isEmpty()) {
+            return;
+        }
+        // A meta-annotation is discovered only if its jar is part of the application index.
+        IndexView index = combinedIndex.getIndex();
+
+        Set<String> annotationNames = new HashSet<>();
         for (TestAnnotationBuildItem item : items) {
-            producer.produce(new BeanDefiningAnnotationBuildItem(DotName.createSimple(item.getAnnotationClassName())));
+            String name = item.getAnnotationClassName();
+            annotationNames.add(name);
+            // annotations (transitively) composed with a test annotation, e.g. a custom @QuarkusTest
+            collectMetaAnnotations(DotName.createSimple(name), index, ai -> true, annotationNames);
+        }
+        // annotations (transitively) composed with @ExtendWith(QuarkusTestExtension.class)
+        collectMetaAnnotations(EXTEND_WITH, index, TestsAsBeansProcessor::extendsWithQuarkusTestExtension,
+                annotationNames);
+
+        for (String annotationName : annotationNames) {
+            beanDefiningAnnotations.produce(new BeanDefiningAnnotationBuildItem(DotName.createSimple(annotationName)));
+        }
+        testAnnotations.produce(new TestBeanDefiningAnnotationsBuildItem(annotationNames));
+    }
+
+    /**
+     * Collects the names of all annotations that are (transitively) meta-annotated with
+     * {@code annotationName}, adding them to {@code result}. The initial set of usages can be narrowed
+     * with {@code filter}, which is used to match {@code @ExtendWith(QuarkusTestExtension.class)}
+     * specifically; the filter is not applied while recursing.
+     */
+    private static void collectMetaAnnotations(DotName annotationName, IndexView index,
+            Predicate<AnnotationInstance> filter, Set<String> result) {
+        for (AnnotationInstance instance : index.getAnnotations(annotationName)) {
+            if (!filter.test(instance)) {
+                continue;
+            }
+            AnnotationTarget target = instance.target();
+            if (target == null || target.kind() != Kind.CLASS) {
+                continue;
+            }
+            ClassInfo clazz = target.asClass();
+            // we are only interested in annotations that are meta-annotated with the given annotation
+            if (clazz.isAnnotation() && result.add(clazz.name().toString())) {
+                collectMetaAnnotations(clazz.name(), index, ai -> true, result);
+            }
         }
     }
 
-    @BuildStep
+    private static boolean extendsWithQuarkusTestExtension(AnnotationInstance extendWith) {
+        AnnotationValue value = extendWith.value();
+        if (value == null) {
+            return false;
+        }
+        for (Type type : value.asClassArray()) {
+            if (QUARKUS_TEST_EXTENSION.equals(type.name())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @BuildStep(onlyIf = IsTest.class)
     public void testClassBeans(List<TestClassBeanBuildItem> items, BuildProducer<AdditionalBeanBuildItem> producer) {
         if (items.isEmpty()) {
             return;
@@ -62,9 +124,11 @@ public class TestsAsBeansProcessor {
 
     @BuildStep(onlyIf = IsTest.class)
     AnnotationsTransformerBuildItem vetoTestClassesNotMatchingTestProfile(Optional<TestProfileBuildItem> testProfile,
-            CombinedIndexBuildItem index, List<TestAnnotationBuildItem> testAnnotationBuildItems) {
-        Set<String> additionalTestAnnotationNames = testAnnotationBuildItems.stream()
-                .map(TestAnnotationBuildItem::getAnnotationClassName)
+            CombinedIndexBuildItem index, Optional<TestBeanDefiningAnnotationsBuildItem> testAnnotations) {
+        Set<String> additionalTestAnnotationNames = testAnnotations
+                .map(TestBeanDefiningAnnotationsBuildItem::getAnnotationNames)
+                .orElse(Set.of())
+                .stream()
                 .filter(a -> !a.equals(QUARKUS_TEST.toString()))
                 .collect(Collectors.toSet());
         // Since we only need to register all test classes that belong to the "current" test profile

--- a/integration-tests/test-extension/meta-annotation/disable-unbind-executions
+++ b/integration-tests/test-extension/meta-annotation/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/test-extension/meta-annotation/pom.xml
+++ b/integration-tests/test-extension/meta-annotation/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-test-test-extension</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-test-extension-meta-annotation</artifactId>
+    <name>Quarkus - Integration Tests - Test Extension - Meta Annotation</name>
+    <description>Defines a @QuarkusTest meta-annotation in a separate, Jandex-indexed jar. Used to verify
+        that a composed @QuarkusTest annotation shipped in a dependency jar registers the test class as a
+        CDI bean. See https://github.com/quarkusio/quarkus/issues/56133</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- The meta-annotation lives in this jar; it must be part of the application index
+                 so the deployment can discover it. -->
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/test-extension/meta-annotation/src/main/java/io/quarkus/it/metaannotation/QuarkusTestExtensionFromJar.java
+++ b/integration-tests/test-extension/meta-annotation/src/main/java/io/quarkus/it/metaannotation/QuarkusTestExtensionFromJar.java
@@ -1,0 +1,27 @@
+package io.quarkus.it.metaannotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.quarkus.test.junit.QuarkusTestExtension;
+
+/**
+ * A composed meta-annotation defined in a separate, Jandex-indexed jar that marks a Quarkus test via
+ * {@code @ExtendWith(QuarkusTestExtension.class)} rather than {@code @QuarkusTest}. A test class
+ * annotated solely with this must still be registered as a CDI bean.
+ *
+ * @see <a href="https://github.com/quarkusio/quarkus/issues/56133">quarkus#56133</a>
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ExtendWith(QuarkusTestExtension.class)
+public @interface QuarkusTestExtensionFromJar {
+}

--- a/integration-tests/test-extension/meta-annotation/src/main/java/io/quarkus/it/metaannotation/QuarkusTestFromJar.java
+++ b/integration-tests/test-extension/meta-annotation/src/main/java/io/quarkus/it/metaannotation/QuarkusTestFromJar.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.metaannotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * A composed {@code @QuarkusTest} meta-annotation defined in a separate, Jandex-indexed jar.
+ * A test class annotated solely with this annotation must be registered as a CDI bean, just like a
+ * class annotated directly with {@code @QuarkusTest}.
+ *
+ * @see <a href="https://github.com/quarkusio/quarkus/issues/56133">quarkus#56133</a>
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@QuarkusTest
+public @interface QuarkusTestFromJar {
+}

--- a/integration-tests/test-extension/pom.xml
+++ b/integration-tests/test-extension/pom.xml
@@ -16,6 +16,7 @@
     <modules>
         <module>extension</module>
         <module>extension-that-defines-junit-test-extensions</module>
+        <module>meta-annotation</module>
         <module>tests</module>
     </modules>
 </project>

--- a/integration-tests/test-extension/tests/pom.xml
+++ b/integration-tests/test-extension/tests/pom.xml
@@ -29,6 +29,13 @@
       <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Ships a @QuarkusTest meta-annotation in a separate, Jandex-indexed jar -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-integration-test-test-extension-meta-annotation</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit-internal</artifactId>

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/ExtendWithFromJarTest.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/ExtendWithFromJarTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.it.extension;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.metaannotation.QuarkusTestExtensionFromJar;
+
+/**
+ * Companion to {@link MetaAnnotationFromJarTest} that exercises the
+ * {@code @ExtendWith(QuarkusTestExtension.class)} discovery branch with a meta-annotation defined in a
+ * separate (Jandex-indexed) jar (quarkus#56133).
+ */
+@QuarkusTestExtensionFromJar
+public class ExtendWithFromJarTest {
+
+    @Inject
+    MyExtendWithJarBean bean;
+
+    @Test
+    void testInjectedBean() {
+        Assertions.assertEquals("foo", bean.foo());
+    }
+
+    @ApplicationScoped
+    public static class MyExtendWithJarBean {
+
+        public String foo() {
+            return "foo";
+        }
+
+    }
+
+}

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/MetaAnnotationFromJarTest.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/MetaAnnotationFromJarTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.it.extension;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.metaannotation.QuarkusTestFromJar;
+
+/**
+ * Reproducer for quarkus#56133: a composed {@code @QuarkusTest} meta-annotation defined in a
+ * separate (Jandex-indexed) jar must register the test class as a CDI bean so its {@code @Inject}
+ * fields resolve.
+ */
+@QuarkusTestFromJar
+public class MetaAnnotationFromJarTest {
+
+    @Inject
+    MyJarTestBean bean;
+
+    @Test
+    void testInjectedBean() {
+        Assertions.assertEquals("foo", bean.foo());
+    }
+
+    @ApplicationScoped
+    public static class MyJarTestBean {
+
+        public String foo() {
+            return "foo";
+        }
+
+    }
+
+}

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/TestBuildChainFunction.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/TestBuildChainFunction.java
@@ -2,12 +2,8 @@ package io.quarkus.test.junit;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -19,7 +15,6 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.Type;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.builder.BuildChainBuilder;
@@ -37,7 +32,6 @@ import io.quarkus.test.junit.buildchain.TestBuildChainCustomizerProducer;
 public class TestBuildChainFunction implements Function<Map<String, Object>, List<Consumer<BuildChainBuilder>>> {
 
     private static final String QUARKUS_TEST_NAME = QuarkusTest.class.getName();
-    private static final String QUARKUS_TEST_EXTENSION_NAME = QuarkusTestExtension.class.getName();
 
     @Override
     public List<Consumer<BuildChainBuilder>> apply(Map<String, Object> stringObjectMap) {
@@ -45,7 +39,6 @@ public class TestBuildChainFunction implements Function<Map<String, Object>, Lis
         // the index was written by the extension
         Index testClassesIndex = TestClassIndexer.readIndex(testLocation,
                 (Class<?>) stringObjectMap.get(AbstractJvmQuarkusTestExtension.TEST_CLASS));
-        Collection<TestAnnotationBuildItem> testAnnotationBuildItems = collectTestAnnotationItems(testClassesIndex);
 
         List<Consumer<BuildChainBuilder>> allCustomizers = new ArrayList<>(1);
         Consumer<BuildChainBuilder> defaultCustomizer = new Consumer<BuildChainBuilder>() {
@@ -85,7 +78,10 @@ public class TestBuildChainFunction implements Function<Map<String, Object>, Lis
                 buildChainBuilder.addBuildStep(new BuildStep() {
                     @Override
                     public void execute(BuildContext context) {
-                        testAnnotationBuildItems.forEach(context::produce);
+                        // Only the "seed" annotation is produced here; meta-annotations composed with
+                        // @QuarkusTest (possibly shipped in another jar) are discovered later against the
+                        // full application index by io.quarkus.arc.deployment.TestsAsBeansProcessor.
+                        context.produce(new TestAnnotationBuildItem(QUARKUS_TEST_NAME));
                     }
                 })
                         .produces(TestAnnotationBuildItem.class)
@@ -168,41 +164,5 @@ public class TestBuildChainFunction implements Function<Map<String, Object>, Lis
         }
 
         return allCustomizers;
-    }
-
-    private static Collection<TestAnnotationBuildItem> collectTestAnnotationItems(Index testClassesIndex) {
-        var result = new HashSet<String>();
-        result.add(QUARKUS_TEST_NAME);
-
-        // collect meta-annotations with @QuarkusTest
-        result.addAll(collectMetaAnnotations(QUARKUS_TEST_NAME, testClassesIndex));
-        // collect meta-annotations with @ExtendWith(QuarkusTestExtension.class)
-        Predicate<AnnotationInstance> isValueQuarkusTestExtension = ai -> ai.value() != null
-                && Arrays.stream(ai.value().asClassArray())
-                        .anyMatch(type -> type.name() != null && QUARKUS_TEST_EXTENSION_NAME.equals(type.name().toString()));
-        result.addAll(collectMetaAnnotations(ExtendWith.class.getName(), testClassesIndex, isValueQuarkusTestExtension));
-
-        return result.stream().map(TestAnnotationBuildItem::new).toList();
-    }
-
-    private static List<String> collectMetaAnnotations(String annotationName, Index testClassesIndex) {
-        return collectMetaAnnotations(annotationName, testClassesIndex, ai -> true);
-    }
-
-    private static List<String> collectMetaAnnotations(String annotationName, Index testClassesIndex,
-            Predicate<AnnotationInstance> initialFilter) {
-        return testClassesIndex.getAnnotations(annotationName)
-                .stream()
-                .filter(initialFilter)
-                .map(AnnotationInstance::target)
-                .filter(Objects::nonNull)
-                .filter(at -> at.kind() == AnnotationTarget.Kind.CLASS)
-                .map(AnnotationTarget::asClass)
-                .filter(ClassInfo::isAnnotation)
-                .<String> mapMulti((ci, consumer) -> {
-                    consumer.accept(ci.name().toString());
-                    collectMetaAnnotations(ci.name().toString(), testClassesIndex).forEach(consumer);
-                })
-                .toList();
     }
 }


### PR DESCRIPTION
Fixes #56133 

The issue lies in that we discovered the annotations only within test class index which is insufficient the moment you place your own annotation in a separate JAR. The integration test I added depicts that scenario and I believe that's what reporter meant.

A way around it is to do the meta annotation discovery in the application index from within `TestsAsBeansProcessor`.