### PR TITLE
Run writer interceptors for responses mapped from exceptions thrown before the interceptor handler

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/SecurityFailureWriterInterceptorTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/SecurityFailureWriterInterceptorTest.java
@@ -1,0 +1,100 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.ext.WriterInterceptor;
+import jakarta.ws.rs.ext.WriterInterceptorContext;
+
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.UnauthorizedException;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * A response mapped from an exception thrown by the security check, which runs before the
+ * interceptors are set up for the request, must still go through the writer interceptors.
+ */
+public class SecurityFailureWriterInterceptorTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(HelloResource.class, CustomExceptionMappers.class, HeaderWriterInterceptor.class));
+
+    @Test
+    public void writerInterceptorRunsForSecurityFailure() {
+        when().get("hello/secured")
+                .then()
+                .statusCode(401)
+                .header("X-Writer-Interceptor", is("true"))
+                .body(is("unauthorized"));
+    }
+
+    @Test
+    public void writerInterceptorRunsForExceptionFromMethod() {
+        when().get("hello/throwing")
+                .then()
+                .statusCode(401)
+                .header("X-Writer-Interceptor", is("true"))
+                .body(is("unauthorized"));
+    }
+
+    @Test
+    public void writerInterceptorRunsForNormalResponse() {
+        when().get("hello")
+                .then()
+                .statusCode(200)
+                .header("X-Writer-Interceptor", is("true"))
+                .body(is("hello world"));
+    }
+
+    @Path("hello")
+    public static final class HelloResource {
+
+        @GET
+        public String hello() {
+            return "hello world";
+        }
+
+        @GET
+        @Path("secured")
+        @RolesAllowed("test")
+        public String secured() {
+            return "secured";
+        }
+
+        @GET
+        @Path("throwing")
+        public String throwing() {
+            throw new UnauthorizedException();
+        }
+    }
+
+    public static final class CustomExceptionMappers {
+
+        @ServerExceptionMapper(UnauthorizedException.class)
+        public Response unauthorized() {
+            return Response.status(401).entity("unauthorized").build();
+        }
+    }
+
+    @Provider
+    public static final class HeaderWriterInterceptor implements WriterInterceptor {
+
+        @Override
+        public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
+            context.getHeaders().putSingle("X-Writer-Interceptor", "true");
+            context.proceed();
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -185,9 +185,13 @@ public class RuntimeResourceDeployment {
 
         //setup reader and writer interceptors first
         ServerRestHandler interceptorHandler = interceptorDeployment.setupInterceptorHandler();
-        //we want interceptors in the abort handler chain
+        //we want interceptors in the abort handler chain, as the exception may have been thrown
+        //by a handler that runs before the interceptor handler (e.g. a security check)
         List<ServerRestHandler> abortHandlingChain = new ArrayList<>(
                 3 + (interceptorHandler != null ? 1 : 0) + (info.getPreExceptionMapperHandler() != null ? 1 : 0));
+        if (interceptorHandler != null) {
+            abortHandlingChain.add(interceptorHandler);
+        }
 
         List<ServerRestHandler> handlers = new ArrayList<>(HANDLERS_CAPACITY);
         // we add null as the first item to make sure that subsequent items are added in the proper positions


### PR DESCRIPTION
A response mapped from an exception thrown by a handler registered for the `AFTER_MATCH` phase — in practice the security checks behind `@RolesAllowed`, `@DenyAll` and friends — was written without invoking the `WriterInterceptor`s, while the same response produced by an exception from the resource method or from a request filter went through them.

The per-method abort handler chain built in `RuntimeResourceDeployment` only contains the exception handler, the response handler, the response filters and the writer; it relies on the `InterceptorHandler` of the regular chain having already set the interceptors on the request context. `AFTER_MATCH` handlers run before that `InterceptorHandler`, so when one of them fails the context has no interceptors yet and `ServerSerialisers.invokeWriter` takes the interceptor-less fast path.

The abort chain was originally seeded with the interceptor handler in 51c40524066 (`new ArrayList<>(interceptorHandlers)`); 26cc6102eaa turned that into a capacity hint (`new ArrayList<>(3 + (interceptorHandler != null ? 1 : 0))`) and the element was never added back, so the comment "we want interceptors in the abort handler chain" described an intent that the code no longer implemented. This adds the interceptor handler as the first element of the abort chain, matching the global abort chain built in `RuntimeDeploymentManager`.

The regression test fails without the fix on the `@RolesAllowed` case only; the two control cases (exception from the method body, regular response) pass both before and after, which is consistent with the analysis in the issue.

- Fixes: #56030
