### PR TITLE
Keep the 206 status of Range responses when the JAX-RS response has been materialized

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/providers/FileRangeWithResponseTestCase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/providers/FileRangeWithResponseTestCase.java
@@ -1,0 +1,113 @@
+package io.quarkus.resteasy.reactive.server.test.providers;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.resteasy.reactive.server.ServerResponseFilter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * A {@code Range} request for a {@link File} must be answered with {@code 206 Partial Content} even when the
+ * JAX-RS {@link Response} has been materialized before the entity is written, either because a response filter
+ * accessed it or because the resource method returned a {@link Response} itself.
+ * See <a href="https://github.com/quarkusio/quarkus/issues/45791">GitHub issue #45791</a>.
+ */
+public class FileRangeWithResponseTestCase {
+
+    private static final String FILE = "src/test/resources/lorem.txt";
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(RangeResource.class, EntityReadingResponseFilter.class));
+
+    @Test
+    public void fileWithResponseFilterAccessingTheEntity() throws Exception {
+        assertPartialContent("/range/file");
+    }
+
+    @Test
+    public void fileWrappedInResponse() throws Exception {
+        assertPartialContent("/range/response");
+    }
+
+    @Test
+    public void pathWithResponseFilterAccessingTheEntity() throws Exception {
+        assertPartialContent("/range/path");
+    }
+
+    @Test
+    public void unsatisfiableRangeIsNotPartialContent() throws Exception {
+        String content = Files.readString(Paths.get(FILE));
+        given().header("Range", "bytes=" + (content.length() + 1) + "-")
+                .get("/range/file")
+                .then()
+                .statusCode(200)
+                .header("Content-Range", (String) null)
+                .body(equalTo(content));
+    }
+
+    private static void assertPartialContent(String path) throws Exception {
+        String content = Files.readString(Paths.get(FILE));
+        given().header("Range", "bytes=0-9")
+                .get(path)
+                .then()
+                .statusCode(206)
+                .header("Content-Range", "bytes 0-9/" + content.length())
+                .header("Content-Length", "10")
+                .body(equalTo(content.substring(0, 10)));
+        given().get(path)
+                .then()
+                .statusCode(200)
+                .header("Content-Range", (String) null)
+                .body(equalTo(content));
+    }
+
+    @Path("range")
+    public static class RangeResource {
+
+        @GET
+        @Path("file")
+        @Produces(MediaType.TEXT_PLAIN)
+        public File file() {
+            return new File(FILE);
+        }
+
+        @GET
+        @Path("path")
+        @Produces(MediaType.TEXT_PLAIN)
+        public java.nio.file.Path path() {
+            return Paths.get(FILE);
+        }
+
+        @GET
+        @Path("response")
+        @Produces(MediaType.TEXT_PLAIN)
+        public Response response() {
+            return Response.ok(new File(FILE)).build();
+        }
+    }
+
+    public static class EntityReadingResponseFilter {
+
+        @ServerResponseFilter
+        public void filter(ContainerResponseContext responseContext) {
+            // merely reading the entity materializes the JAX-RS response
+            responseContext.getEntity();
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerFileBodyHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerFileBodyHandler.java
@@ -13,7 +13,9 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.common.jaxrs.ResponseImpl;
 import org.jboss.resteasy.reactive.common.providers.serialisers.FileBodyHandler;
+import org.jboss.resteasy.reactive.server.core.LazyResponse;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
@@ -53,14 +55,26 @@ public class ServerFileBodyHandler extends FileBodyHandler implements ServerMess
             if ((fileRange.getStart() >= 0) && (fileRange.getStart() <= fileRange.getEnd())) {
                 String contentRange = "bytes " + fileRange.getStart() + "-" + fileRange.getEnd() + "/" + fileLength;
                 long length = fileRange.getEnd() - fileRange.getStart() + 1;
+                setPartialContentStatus(ctx);
                 context.serverResponse()
-                        .setStatusCode(Response.Status.PARTIAL_CONTENT.getStatusCode())
                         .setResponseHeader("Content-Range", contentRange)
                         .sendFile(file.getAbsolutePath(), fileRange.getStart(), length);
                 return;
             }
         }
         context.serverResponse().sendFile(file.getAbsolutePath(), 0, fileLength);
+    }
+
+    private static void setPartialContentStatus(ResteasyReactiveRequestContext ctx) {
+        int partialContent = Response.Status.PARTIAL_CONTENT.getStatusCode();
+        ctx.serverResponse().setStatusCode(partialContent);
+        // when the JAX-RS response has been materialized (the resource method returned a Response, or a response
+        // filter accessed it), its status is applied to the underlying response right before it is committed,
+        // which would override the status set above
+        LazyResponse lazyResponse = ctx.getResponse();
+        if (lazyResponse.isCreated() && lazyResponse.get() instanceof ResponseImpl response) {
+            response.setStatus(partialContent);
+        }
     }
 
     /**


### PR DESCRIPTION
The `File` and `Path` writers answer a `Range` request by setting `206` and `Content-Range` directly on the underlying response and then sending the file. `ServerSerialisers.invokeWriter` also installs a pre-commit listener that, right before the response is committed, applies the status and headers of the JAX-RS `Response` to the underlying response — but only when that `Response` has been materialized; otherwise it takes a fast path that leaves the status alone.

So the `206` survives as long as nothing created the JAX-RS `Response`, and is reset to `200` as soon as something did: a response filter that reads `getEntity()` (the reporter's case — "any access to the response object resets the status"), or simply a resource method returning `Response.ok(file).build()`, which fails the same way without any filter. The `Content-Range` header is kept because headers are added rather than replaced, which is exactly the inconsistent `200` + `Content-Range` output in the report.

The writers now also set the status on the materialized JAX-RS `Response`, so that the pre-commit step sees `206` too. The unsatisfiable-range and no-`Range` paths are unchanged.

Verified with the reporter's Maven reproducer (fails on `main` with `Expected status code <206> but was <200>`, passes with this change). The regression test covers `File` and `Path` with an entity-reading `@ServerResponseFilter`, `File` wrapped in a `Response`, and an unsatisfiable range as control; the first three fail without the fix.

- Fixes: #45791
