### PR TITLE
Stream InputStream multipart parts from the REST Client instead of reading them on the event loop

### DIFF
--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/multipart/MultipartInputStreamForwardingTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/multipart/MultipartInputStreamForwardingTest.java
@@ -1,0 +1,99 @@
+package io.quarkus.rest.client.reactive.multipart;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriInfo;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.jboss.resteasy.reactive.PartType;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.RestHeader;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class MultipartInputStreamForwardingTest {
+
+    private static final int BODY_SIZE = 4 * 1024 * 1024;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(ForwardingResource.class, ReceivingResource.class, Client.class,
+                    ClientForm.class));
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void forwardsIncomingBodyAsStreamedPart() {
+        byte[] body = new byte[BODY_SIZE];
+        for (int i = 0; i < body.length; i++) {
+            body[i] = (byte) i;
+        }
+        given().body(body).contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .post("/forward")
+                .then()
+                .statusCode(200)
+                .body(equalTo("chunked:" + BODY_SIZE + ":" + checksum(body)));
+    }
+
+    private static long checksum(byte[] bytes) {
+        long sum = 0;
+        for (byte b : bytes) {
+            sum = sum * 31 + b;
+        }
+        return sum;
+    }
+
+    @Path("/forward")
+    public static class ForwardingResource {
+
+        @POST
+        @Consumes(MediaType.APPLICATION_OCTET_STREAM)
+        public String forward(InputStream body, @Context UriInfo uriInfo) {
+            Client client = RestClientBuilder.newBuilder().baseUri(uriInfo.getBaseUri()).build(Client.class);
+            ClientForm form = new ClientForm();
+            form.file = body;
+            return client.upload(form);
+        }
+    }
+
+    @Path("/receive")
+    public static class ReceivingResource {
+
+        @POST
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        public String receive(@RestForm("file") FileUpload file, @RestHeader("Transfer-Encoding") String transferEncoding)
+                throws IOException {
+            byte[] bytes = java.nio.file.Files.readAllBytes(file.uploadedFile());
+            return ("chunked".equals(transferEncoding) ? "chunked" : "not-chunked") + ":" + bytes.length + ":"
+                    + checksum(bytes);
+        }
+    }
+
+    @Path("/receive")
+    public interface Client {
+
+        @POST
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        String upload(ClientForm form);
+    }
+
+    public static class ClientForm {
+
+        @RestForm("file")
+        @PartType(MediaType.APPLICATION_OCTET_STREAM)
+        public InputStream file;
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/multipart/MultipartLargeInputStreamTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/multipart/MultipartLargeInputStreamTest.java
@@ -1,0 +1,113 @@
+package io.quarkus.rest.client.reactive.multipart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.jboss.resteasy.reactive.PartType;
+import org.jboss.resteasy.reactive.RestForm;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class MultipartLargeInputStreamTest {
+
+    private static final long PART_SIZE = Runtime.getRuntime().maxMemory() + 256L * 1024 * 1024;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(Resource.class, Client.class, ClientForm.class))
+            .overrideConfigKey("quarkus.http.limits.max-body-size", "10G");
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.MINUTES)
+    void streamsPartLargerThanTheHeap() {
+        Client client = RestClientBuilder.newBuilder().baseUri(baseUri).build(Client.class);
+        ClientForm form = new ClientForm();
+        form.file = new GeneratedInputStream(PART_SIZE);
+
+        long received = client.upload(form);
+
+        // the raw body also contains the multipart boundaries and part headers
+        assertThat(received).isBetween(PART_SIZE, PART_SIZE + 1024);
+    }
+
+    /**
+     * Produces {@code size} bytes without ever holding more than one buffer of them.
+     */
+    static class GeneratedInputStream extends InputStream {
+
+        private final long size;
+        private long position;
+
+        GeneratedInputStream(long size) {
+            this.size = size;
+        }
+
+        @Override
+        public int read() {
+            if (position >= size) {
+                return -1;
+            }
+            return (int) (position++ & 0x7F);
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) {
+            if (position >= size) {
+                return -1;
+            }
+            int count = (int) Math.min(len, size - position);
+            for (int i = 0; i < count; i++) {
+                b[off + i] = (byte) (position++ & 0x7F);
+            }
+            return count;
+        }
+    }
+
+    @Path("/receive")
+    public static class Resource {
+
+        @POST
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        public long receive(InputStream body) throws IOException {
+            byte[] buffer = new byte[64 * 1024];
+            long count = 0;
+            int read;
+            while ((read = body.read(buffer)) != -1) {
+                count += read;
+            }
+            return count;
+        }
+    }
+
+    @Path("/receive")
+    public interface Client {
+
+        @POST
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        long upload(ClientForm form);
+    }
+
+    public static class ClientForm {
+
+        @RestForm("file")
+        @PartType(MediaType.APPLICATION_OCTET_STREAM)
+        public InputStream file;
+    }
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/InputStreamHttpData.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/InputStreamHttpData.java
@@ -1,0 +1,324 @@
+package org.jboss.resteasy.reactive.client.impl.multipart;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.function.Consumer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.multipart.AbstractHttpData;
+import io.netty.handler.codec.http.multipart.FileUpload;
+import io.netty.handler.codec.http.multipart.InterfaceHttpData;
+import io.netty.util.internal.ObjectUtil;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.buffer.VertxByteBufAllocator;
+
+/**
+ * A FileUpload implementation that is responsible for sending an {@link InputStream} as a file in a multipart
+ * message, reading it in chunks on a worker thread so that the stream is never read on the event loop.
+ * It is meant to be used by the {@link PausableHttpPostRequestEncoder}, in the same way as {@link MultiByteHttpData}.
+ *
+ * When created, InputStreamHttpData starts filling its buffer from the stream. Before reading the next chunk of
+ * data with {@link #getChunk(int)}, the post encoder checks if data {@link #isReady(int)} and if not, triggers
+ * {@link #suspend(int)}. That's because a chunk smaller than requested is treated as the end of input.
+ * Then, when the requested amount of bytes is ready, or the stream is exhausted, `resumption` is executed.
+ */
+public class InputStreamHttpData extends AbstractHttpData implements FileUpload, PausableHttpData {
+
+    private final InputStream inputStream;
+    private final Consumer<Throwable> errorHandler;
+    private final Context context;
+    private final Runnable resumption;
+    private final ByteBuf buffer;
+
+    private String filename;
+    private String contentType;
+    private String contentTransferEncoding;
+
+    // all the fields below are only accessed on the Vert.x context
+    private boolean done = false;
+    private boolean reading = false;
+    private boolean paused = false;
+    private int awaitedBytes;
+
+    public InputStreamHttpData(String name, String filename, String contentType,
+            String contentTransferEncoding, Charset charset, InputStream inputStream,
+            Consumer<Throwable> errorHandler, Context context, Runnable resumption, int bufferSize) {
+        super(name, charset, 0);
+        this.inputStream = inputStream;
+        this.errorHandler = errorHandler;
+        this.context = context;
+        this.resumption = resumption;
+        this.buffer = VertxByteBufAllocator.DEFAULT.heapBuffer(bufferSize, bufferSize);
+        setFilename(filename);
+        setContentType(contentType);
+        setContentTransferEncoding(contentTransferEncoding);
+        context.runOnContext(v -> fill());
+    }
+
+    /**
+     * Reads the next chunk from the stream on a worker thread, and keeps doing so until the buffer is full or the
+     * stream is exhausted.
+     */
+    private void fill() {
+        if (done || reading) {
+            return;
+        }
+        int toRead = buffer.writableBytes();
+        if (toRead == 0) {
+            return;
+        }
+        reading = true;
+        context.executeBlocking(() -> {
+            byte[] bytes = new byte[toRead];
+            int amount = inputStream.read(bytes);
+            if (amount == -1) {
+                inputStream.close();
+                return null;
+            }
+            return Unpooled.wrappedBuffer(bytes, 0, amount);
+        }, true).onComplete(ar -> {
+            reading = false;
+            if (ar.succeeded()) {
+                ByteBuf chunk = ar.result();
+                if (chunk == null) {
+                    done = true;
+                } else {
+                    buffer.writeBytes(chunk);
+                }
+            } else {
+                done = true;
+                closeQuietly();
+                errorHandler.accept(ar.cause());
+            }
+            if (paused && (done || buffer.readableBytes() >= awaitedBytes)) {
+                paused = false;
+                awaitedBytes = 0;
+                resumption.run();
+            }
+            fill();
+        });
+    }
+
+    private void closeQuietly() {
+        try {
+            inputStream.close();
+        } catch (IOException ignored) {
+        }
+    }
+
+    @Override
+    public void suspend(int awaitedBytes) {
+        this.awaitedBytes = awaitedBytes;
+        this.paused = true;
+    }
+
+    @Override
+    public boolean isReady(int chunkSize) {
+        return done || buffer.readableBytes() >= chunkSize;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <br/>
+     * NOTE: should only be invoked when {@link #isReady(int)} returns true
+     *
+     * @param toRead amount of bytes to read
+     * @return ByteBuf with the requested bytes
+     */
+    @Override
+    public ByteBuf getChunk(int toRead) {
+        if (Vertx.currentContext() != context) {
+            throw new IllegalStateException("InputStreamHttpData invoked on an invalid context : " + Vertx.currentContext()
+                    + ", thread: " + Thread.currentThread());
+        }
+        if (buffer.readableBytes() == 0 && done) {
+            return Unpooled.EMPTY_BUFFER;
+        }
+        int readBytes = Math.min(buffer.readableBytes(), toRead);
+        ByteBuf result = VertxByteBufAllocator.DEFAULT.heapBuffer(readBytes, readBytes);
+        result.writeBytes(buffer, readBytes);
+        buffer.discardReadBytes();
+        fill();
+        return result;
+    }
+
+    @Override
+    public void setContent(ByteBuf buffer) throws IOException {
+        throw new IllegalStateException("setting content of InputStreamHttpData is not supported");
+    }
+
+    @Override
+    public void addContent(ByteBuf buffer, boolean last) throws IOException {
+        throw new IllegalStateException("adding content to InputStreamHttpData is not supported");
+    }
+
+    @Override
+    public void setContent(File file) throws IOException {
+        throw new IllegalStateException("setting content of InputStreamHttpData is not supported");
+    }
+
+    @Override
+    public void setContent(InputStream inputStream) throws IOException {
+        throw new IllegalStateException("setting content of InputStreamHttpData is not supported");
+    }
+
+    @Override
+    public void delete() {
+        // do nothing
+    }
+
+    @Override
+    public byte[] get() throws IOException {
+        throw new IllegalStateException("getting all the contents of an InputStreamHttpData is not supported");
+    }
+
+    @Override
+    public ByteBuf getByteBuf() {
+        throw new IllegalStateException("getting all the contents of an InputStreamHttpData is not supported");
+    }
+
+    @Override
+    public String getString() {
+        throw new IllegalStateException("Reading InputStreamHttpData as String is not supported");
+    }
+
+    @Override
+    public String getString(Charset encoding) {
+        throw new IllegalStateException("Reading InputStreamHttpData as String is not supported");
+    }
+
+    @Override
+    public boolean renameTo(File dest) {
+        throw new IllegalStateException("Renaming destination file for InputStreamHttpData is not supported");
+    }
+
+    @Override
+    public boolean isInMemory() {
+        return true;
+    }
+
+    @Override
+    public File getFile() {
+        return null;
+    }
+
+    @Override
+    public FileUpload copy() {
+        throw new IllegalStateException("Copying InputStreamHttpData is not supported");
+    }
+
+    @Override
+    public FileUpload duplicate() {
+        throw new IllegalStateException("Duplicating InputStreamHttpData is not supported");
+    }
+
+    @Override
+    public FileUpload retainedDuplicate() {
+        throw new IllegalStateException("Duplicating InputStreamHttpData is not supported");
+    }
+
+    @Override
+    public FileUpload replace(ByteBuf content) {
+        throw new IllegalStateException("Replacing InputStreamHttpData is not supported");
+    }
+
+    @Override
+    public FileUpload retain(int increment) {
+        super.retain(increment);
+        return this;
+    }
+
+    @Override
+    public FileUpload retain() {
+        super.retain();
+        return this;
+    }
+
+    @Override
+    public FileUpload touch() {
+        touch(null);
+        return this;
+    }
+
+    @Override
+    public FileUpload touch(Object hint) {
+        buffer.touch(hint);
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return System.identityHashCode(this) == System.identityHashCode(o);
+    }
+
+    @Override
+    public int compareTo(InterfaceHttpData o) {
+        if (!(o instanceof InputStreamHttpData)) {
+            throw new ClassCastException("Cannot compare " + getHttpDataType() +
+                    " with " + o.getHttpDataType());
+        }
+        return Integer.compare(System.identityHashCode(this), System.identityHashCode(o));
+    }
+
+    @Override
+    public HttpDataType getHttpDataType() {
+        return HttpDataType.FileUpload;
+    }
+
+    @Override
+    public String getFilename() {
+        return filename;
+    }
+
+    @Override
+    public void setFilename(String filename) {
+        this.filename = ObjectUtil.checkNotNull(filename, "filename");
+    }
+
+    @Override
+    public void setContentType(String contentType) {
+        this.contentType = ObjectUtil.checkNotNull(contentType, "contentType");
+    }
+
+    @Override
+    public String getContentType() {
+        return contentType;
+    }
+
+    @Override
+    public String getContentTransferEncoding() {
+        return contentTransferEncoding;
+    }
+
+    @Override
+    public void setContentTransferEncoding(String contentTransferEncoding) {
+        this.contentTransferEncoding = contentTransferEncoding;
+    }
+
+    @Override
+    public long length() {
+        return buffer.readableBytes() + super.length();
+    }
+
+    @Override
+    public String toString() {
+        return HttpHeaderNames.CONTENT_DISPOSITION + ": " +
+                HttpHeaderValues.FORM_DATA + "; " + HttpHeaderValues.NAME + "=\"" + getName() +
+                "\"; " + HttpHeaderValues.FILENAME + "=\"" + filename + "\"\r\n" +
+                HttpHeaderNames.CONTENT_TYPE + ": " + contentType +
+                (getCharset() != null ? "; " + HttpHeaderValues.CHARSET + '=' + getCharset().name() + "\r\n" : "\r\n") +
+                HttpHeaderNames.CONTENT_LENGTH + ": " + length() + "\r\n" +
+                "Completed: " + isCompleted();
+    }
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/MultiByteHttpData.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/MultiByteHttpData.java
@@ -50,7 +50,7 @@ import io.vertx.core.impl.buffer.VertxByteBufAllocator;
  * Then, when the requested amount of bytes is ready, or the underlying Multi is completed, `resumption` is executed.
  *
  */
-public class MultiByteHttpData extends AbstractHttpData implements FileUpload {
+public class MultiByteHttpData extends AbstractHttpData implements FileUpload, PausableHttpData {
     private static final Logger log = Logger.getLogger(MultiByteHttpData.class);
 
     public static final int DEFAULT_BUFFER_SIZE = 16384;
@@ -132,7 +132,8 @@ public class MultiByteHttpData extends AbstractHttpData implements FileUpload {
                 });
     }
 
-    void suspend(int awaitedBytes) {
+    @Override
+    public void suspend(int awaitedBytes) {
         this.awaitedBytes = awaitedBytes;
         this.paused = true;
     }

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/PausableHttpData.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/PausableHttpData.java
@@ -1,0 +1,21 @@
+package org.jboss.resteasy.reactive.client.impl.multipart;
+
+/**
+ * An {@link io.netty.handler.codec.http.multipart.HttpData} whose content is produced asynchronously, and
+ * that can therefore ask the {@link PausableHttpPostRequestEncoder} to wait until enough content is available.
+ */
+interface PausableHttpData {
+
+    /**
+     * @param chunkSize amount of bytes
+     * @return true if the requested amount of bytes is ready to be read or the content is completed, i.e. there
+     *         will be no more bytes to read
+     */
+    boolean isReady(int chunkSize);
+
+    /**
+     * Asks the data to run the resumption action once {@code awaitedBytes} are available or the content is
+     * completed.
+     */
+    void suspend(int awaitedBytes);
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/PausableHttpPostRequestEncoder.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/PausableHttpPostRequestEncoder.java
@@ -967,10 +967,10 @@ public class PausableHttpPostRequestEncoder implements ChunkedInput<HttpContent>
             buffer = ((QuarkusInternalAttribute) currentData).toByteBuf();
             currentData = null;
         } else {
-            if (currentData instanceof MultiByteHttpData) {
-                MultiByteHttpData multiByteHttpData = (MultiByteHttpData) this.currentData;
-                if (!multiByteHttpData.isReady(sizeleft)) {
-                    multiByteHttpData.suspend(sizeleft);
+            if (currentData instanceof PausableHttpData) {
+                PausableHttpData pausableHttpData = (PausableHttpData) this.currentData;
+                if (!pausableHttpData.isReady(sizeleft)) {
+                    pausableHttpData.suspend(sizeleft);
                     return WAIT_MARKER; // we'll invoke this method once more when the data is ready
                 }
             }

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/QuarkusMultipartForm.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/QuarkusMultipartForm.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.reactive.client.impl.multipart;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.util.Iterator;
 import java.util.List;
@@ -35,6 +36,13 @@ public class QuarkusMultipartForm extends ClientMultipartForm implements Iterabl
             MultivaluedMap<String, String> headers = new MultivaluedTreeMap<>();
 
             Object entityObject = pojo.entity;
+            if (entityObject instanceof InputStream && context.getConfiguration().getWriterInterceptors().isEmpty()) {
+                // stream the part instead of reading the whole stream into memory, which would also block the
+                // event loop (and deadlock if the stream is fed by a connection handled by the same event loop)
+                parts.set(pojo.position, new QuarkusMultipartFormDataPart(pojo.name, pojo.filename, (InputStream) entityObject,
+                        pojo.mediaType, false));
+                continue;
+            }
             Entity<?> entity = Entity.entity(entityObject, pojo.mediaType);
             Class<?> entityClass;
             Type entityType;

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/QuarkusMultipartFormDataPart.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/QuarkusMultipartFormDataPart.java
@@ -1,5 +1,7 @@
 package org.jboss.resteasy.reactive.client.impl.multipart;
 
+import java.io.InputStream;
+
 import io.smallrye.mutiny.Multi;
 import io.vertx.core.buffer.Buffer;
 
@@ -18,6 +20,7 @@ public class QuarkusMultipartFormDataPart {
     private final Class<?> type;
     private final Buffer content;
     private final Multi<Byte> multiByteContent;
+    private final InputStream inputStreamContent;
 
     public QuarkusMultipartFormDataPart(String name, Buffer content, String mediaType, Class<?> type) {
         this(name, null, content, mediaType, type);
@@ -30,6 +33,7 @@ public class QuarkusMultipartFormDataPart {
         this.mediaType = mediaType;
         this.type = type;
         this.multiByteContent = null;
+        this.inputStreamContent = null;
 
         if (name == null) {
             throw new NullPointerException("Multipart field name cannot be null");
@@ -56,6 +60,7 @@ public class QuarkusMultipartFormDataPart {
 
         this.name = name;
         this.multiByteContent = content;
+        this.inputStreamContent = null;
         this.mediaType = mediaType;
         this.filename = filename;
         this.text = text;
@@ -65,6 +70,30 @@ public class QuarkusMultipartFormDataPart {
         this.pathname = null;
         this.type = null;
         this.content = null;
+    }
+
+    public QuarkusMultipartFormDataPart(String name, String filename, InputStream content, String mediaType, boolean text) {
+        if (name == null) {
+            throw new NullPointerException("Multipart field name cannot be null");
+        }
+        if (content == null) {
+            throw new NullPointerException("Multipart field name content cannot be null when sending files");
+        }
+        if (mediaType == null) {
+            throw new NullPointerException("Multipart field media type cannot be null");
+        }
+
+        this.name = name;
+        this.inputStreamContent = content;
+        this.multiByteContent = null;
+        this.mediaType = mediaType;
+        this.filename = filename;
+        this.text = text;
+        this.value = null;
+        this.content = null;
+        this.pathname = null;
+        this.isObject = false;
+        this.type = null;
     }
 
     public QuarkusMultipartFormDataPart(String name, String value, String filename) {
@@ -80,6 +109,7 @@ public class QuarkusMultipartFormDataPart {
         this.pathname = null;
         this.content = null;
         this.multiByteContent = null;
+        this.inputStreamContent = null;
         this.mediaType = null;
         this.text = false;
         this.isObject = false;
@@ -105,6 +135,7 @@ public class QuarkusMultipartFormDataPart {
         this.pathname = pathname;
         this.content = null;
         this.multiByteContent = null;
+        this.inputStreamContent = null;
         this.mediaType = mediaType;
         this.text = text;
         this.isObject = false;
@@ -130,6 +161,7 @@ public class QuarkusMultipartFormDataPart {
         this.pathname = null;
         this.content = content;
         this.multiByteContent = null;
+        this.inputStreamContent = null;
         this.mediaType = mediaType;
         this.text = text;
         this.isObject = false;
@@ -166,6 +198,10 @@ public class QuarkusMultipartFormDataPart {
 
     public Multi<Byte> multiByteContent() {
         return multiByteContent;
+    }
+
+    public InputStream inputStreamContent() {
+        return inputStreamContent;
     }
 
     public String mediaType() {

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/QuarkusMultipartFormUpload.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/QuarkusMultipartFormUpload.java
@@ -104,6 +104,31 @@ public class QuarkusMultipartFormUpload implements ReadStream<Buffer>, Runnable 
                         this::handleError,
                         context,
                         this));
+            } else if (formDataPart.inputStreamContent() != null) {
+                String contentTransferEncoding = null;
+                String contentType = formDataPart.mediaType();
+                if (contentType == null) {
+                    if (formDataPart.isText()) {
+                        contentType = "text/plain";
+                    } else {
+                        contentType = "application/octet-stream";
+                    }
+                }
+                if (!formDataPart.isText()) {
+                    contentTransferEncoding = "binary";
+                }
+
+                encoder.addBodyHttpData(new InputStreamHttpData(
+                        formDataPart.name(),
+                        formDataPart.filename() != null ? formDataPart.filename() : "",
+                        contentType,
+                        contentTransferEncoding,
+                        Charset.defaultCharset(),
+                        formDataPart.inputStreamContent(),
+                        this::handleError,
+                        context,
+                        this,
+                        Math.max(maxChunkSize, MultiByteHttpData.DEFAULT_BUFFER_SIZE)));
             } else {
                 String pathname = formDataPart.pathname();
                 if (pathname != null) {


### PR DESCRIPTION
An `InputStream` field in a multipart form sent by the REST Client was serialized like any other POJO part: `QuarkusMultipartForm.preparePojos` ran the `InputStream` `MessageBodyWriter`, which reads the whole stream into a buffer — and it did so from `ClientSendRequestHandler`'s connection-established callback, i.e. **on the event loop**. Two consequences:

- the part is sent with a `Content-Length` rather than streamed, which is what the reporter noticed with their Flask probe;
- a stream whose bytes are not all available yet blocks the event loop while it is being read. When the stream is fed by a connection handled by the same event loop — the typical case of forwarding the body of the request being served, since the client picks up the request's context — the client waits for bytes that only that blocked event loop can deliver, and the invocation hangs forever. That is exactly the thread dump from the reporter's project (Undertow servlet input → `commons-fileupload` → `InputStreamMessageBodyHandler.writeTo` → `preparePojos`, on `vert.x-eventloop-thread-28`, in `Object.wait()`). With Quarkus REST's own input stream the blocking read is refused instead, so the invocation fails with `BlockingNotAllowedException: Attempting a blocking read on io thread`.

A top-level `InputStream` entity already avoids all of this: it is streamed in chunks read on a worker thread through `InputStreamReadStream`. This does the same for multipart parts. `InputStreamHttpData` plugs into the pausable multipart encoder the way `MultiByteHttpData` does: it reads ahead from the stream with `executeBlocking`, and when the encoder asks for more than is buffered it suspends the encoder and resumes it once the data (or the end of the stream) arrives. The encoder now checks a small `PausableHttpData` interface instead of `MultiByteHttpData` specifically. Parts are only streamed when no writer interceptors are registered, since those need the serialized content — the same condition as for a top-level `InputStream` entity.

Verified with the reporter's projects (Quarkus REST + Undertow + commons-fileupload forwarding to a Quarkus REST downstream): on current `main` the 58-byte upload succeeds and the 98 KB one hangs until the client times out; with this change both complete. The regression test forwards a 4 MB request body as a multipart part to another endpoint of the same application and checks that it arrives chunked and intact; without the change it fails with the `BlockingNotAllowedException` above.

- Fixes: #47884
