### PR TITLE
Ignore a @RestClient qualifier placed on the REST Client interface

### DIFF
--- a/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
@@ -140,6 +140,7 @@ class RestClientReactiveProcessor {
 
     private static final Set<DotName> SKIP_COPYING_ANNOTATIONS_TO_GENERATED_CLASS = Set.of(
             REGISTER_REST_CLIENT,
+            REST_CLIENT,
             REGISTER_PROVIDER,
             REGISTER_PROVIDERS,
             CLIENT_HEADER_PARAM,

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/RestClientQualifierOnInterfaceTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/RestClientQualifierOnInterfaceTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.rest.client.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * {@link RestClient} is the qualifier of the injection point and has no meaning on the interface itself, but putting
+ * it there used to be tolerated and must keep working rather than fail the build with a duplicate annotation on the
+ * generated bean.
+ */
+public class RestClientQualifierOnInterfaceTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClasses(Client.class, Resource.class))
+            .overrideConfigKey("quarkus.rest-client.annotated.url", "http://localhost:${quarkus.http.test-port:8081}");
+
+    @Inject
+    @RestClient
+    Client client;
+
+    @Test
+    void clientWithQualifierOnInterfaceIsGeneratedAndInjected() {
+        assertThat(client.hello()).isEqualTo("hello");
+    }
+
+    @RestClient
+    @RegisterRestClient(configKey = "annotated")
+    @Path("/hello")
+    public interface Client {
+
+        @GET
+        String hello();
+    }
+
+    @Path("/hello")
+    public static class Resource {
+
+        @GET
+        public String hello() {
+            return "hello";
+        }
+    }
+}


### PR DESCRIPTION
`addRestClientBeans` annotates the generated CDI bean of a REST Client interface with `@RestClient` and then copies the interface's own annotations onto it, skipping a fixed set of client-specific ones. `@RestClient` is not in that set, so an interface that (needlessly) carries the qualifier produces a generated class with the annotation twice. Gizmo 1 wrote the duplicate out without complaint; since 2b17afb3b3e moved the wrapper generation to Gizmo 2 (first released in 3.32.0) it is rejected and the build fails with `IllegalArgumentException: Duplicate annotation …/RestClient;`.

Putting `@RestClient` on the interface has no effect and is a user mistake, but it was accepted up to 3.31.3 and breaks on upgrade with an error that names code generation internals, so this restores the previous behaviour by adding the qualifier to the annotations that are not copied. Verified with a minimal project against 3.20.5 / 3.24.5 / 3.30.2 / 3.31.3 (build) and 3.32.1 / 3.33.3.1 / 3.35.4 / 3.36.0 / 3.37.0 / 3.38.0 / 3.38.1 / `main` (fail); the test fails without the change with the same exception.

- Fixes: #56158
