### PR TITLE
Allow keeping small multipart file parts in memory

### DIFF
--- a/docs/src/main/asciidoc/rest.adoc
+++ b/docs/src/main/asciidoc/rest.adoc
@@ -612,6 +612,10 @@ Moreover, if `quarkus.http.body.delete-uploaded-files-on-end` is set to true, Qu
 the file will reside on the file system of the server (in the directory defined by the `quarkus.http.body.uploads-directory` configuration option), but as the uploaded files are saved
 with a UUID file name and no additional metadata is saved, these files are essentially a random dump of files.
 
+By default, every file part is written to the uploads directory. Setting `quarkus.http.body.multipart.file-size-threshold` (for example to `16K`) keeps file parts up to that size in memory instead:
+such parts are reported by `FileItem#isInMemory()` and are only written to the uploads directory if their file is requested, e.g. through `FileUpload#uploadedFile()`.
+Parameters of type `byte[]`, `String` or `InputStream` read them directly from memory.
+
 
 [TIP]
 ====

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartFileSizeThresholdDeleteOnEndTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartFileSizeThresholdDeleteOnEndTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.resteasy.reactive.server.test.multipart;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import jakarta.ws.rs.core.MediaType;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.response.Response;
+
+/**
+ * A part kept in memory that is written to the uploads directory on demand is deleted at the end of the request
+ * like any other uploaded file.
+ */
+public class MultipartFileSizeThresholdDeleteOnEndTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(MultipartFileSizeThresholdTest.Resource.class,
+                    MultipartFileSizeThresholdTest.Form.class))
+            .overrideRuntimeConfigKey("quarkus.http.body.multipart.file-size-threshold", "10K")
+            .overrideRuntimeConfigKey("quarkus.http.body.uploads-directory", "target/multipart-threshold-uploads-deleted");
+
+    @Test
+    void lazilyWrittenFileIsDeletedAtTheEndOfTheRequest() {
+        Response response = given()
+                .multiPart("small", "small.bin", new byte[1024], MediaType.APPLICATION_OCTET_STREAM)
+                .post("/multipart/uploads");
+        response.then().statusCode(200);
+        Path path = Paths.get(response.asString());
+        assertThat(path.toAbsolutePath().getParent())
+                .isEqualTo(Paths.get("target/multipart-threshold-uploads-deleted").toAbsolutePath());
+        await().untilAsserted(() -> assertThat(path).doesNotExist());
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartFileSizeThresholdTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartFileSizeThresholdTest.java
@@ -1,0 +1,145 @@
+package io.quarkus.resteasy.reactive.server.test.multipart;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+import org.jboss.resteasy.reactive.server.multipart.FileItem;
+import org.jboss.resteasy.reactive.server.multipart.FormValue;
+import org.jboss.resteasy.reactive.server.multipart.MultipartFormDataInput;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.response.Response;
+
+/**
+ * With {@code quarkus.http.body.multipart.file-size-threshold} set, file parts up to that size are kept in memory
+ * while larger ones are written to the uploads directory.
+ * See <a href="https://github.com/quarkusio/quarkus/issues/43127">GitHub issue #43127</a>.
+ */
+public class MultipartFileSizeThresholdTest {
+
+    private static final int THRESHOLD = 10 * 1024;
+    private static final byte[] SMALL = bytes(THRESHOLD);
+    private static final byte[] LARGE = bytes(THRESHOLD + 1);
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(Resource.class, Form.class))
+            .overrideRuntimeConfigKey("quarkus.http.body.multipart.file-size-threshold", "10K")
+            .overrideRuntimeConfigKey("quarkus.http.body.uploads-directory", "target/multipart-threshold-uploads")
+            .overrideRuntimeConfigKey("quarkus.http.body.delete-uploaded-files-on-end", "false");
+
+    @Test
+    void smallPartsStayInMemoryAndLargePartsGoToDisk() {
+        Response response = given()
+                .multiPart("small", "small.bin", SMALL, MediaType.APPLICATION_OCTET_STREAM)
+                .multiPart("large", "large.bin", LARGE, MediaType.APPLICATION_OCTET_STREAM)
+                .multiPart("text", "hello")
+                .post("/multipart/input");
+        response.then().statusCode(200);
+        assertThat(response.asString().lines())
+                .containsExactlyInAnyOrder(
+                        "small:inMemory=true,size=" + SMALL.length,
+                        "large:inMemory=false,size=" + LARGE.length,
+                        "text:hello");
+    }
+
+    @Test
+    void inMemoryPartIsWrittenToTheUploadsDirectoryWhenAFileIsRequested() throws IOException {
+        Response response = given()
+                .multiPart("small", "small.bin", SMALL, MediaType.APPLICATION_OCTET_STREAM)
+                .post("/multipart/uploads");
+        response.then().statusCode(200);
+        java.nio.file.Path path = Paths.get(response.asString());
+        assertThat(path).exists();
+        assertThat(path.toAbsolutePath().getParent())
+                .isEqualTo(Paths.get("target/multipart-threshold-uploads").toAbsolutePath());
+        assertThat(Files.readAllBytes(path)).isEqualTo(SMALL);
+    }
+
+    @Test
+    void inMemoryPartsAreAvailableThroughTheTypedParameters() {
+        given()
+                .multiPart("small", "small.bin", SMALL, MediaType.APPLICATION_OCTET_STREAM)
+                .multiPart("text", "text.txt", "hello".getBytes(), MediaType.TEXT_PLAIN)
+                .post("/multipart/typed")
+                .then()
+                .statusCode(200)
+                .body(org.hamcrest.Matchers.equalTo("bytes=" + SMALL.length + ",stream=" + SMALL.length + ",text=hello"));
+    }
+
+    private static byte[] bytes(int size) {
+        byte[] bytes = new byte[size];
+        for (int i = 0; i < size; i++) {
+            bytes[i] = (byte) i;
+        }
+        return bytes;
+    }
+
+    @Path("/multipart")
+    public static class Resource {
+
+        @POST
+        @Path("input")
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        public String input(MultipartFormDataInput input) throws IOException {
+            StringBuilder sb = new StringBuilder();
+            for (Map.Entry<String, java.util.Collection<FormValue>> entry : input.getValues().entrySet()) {
+                for (FormValue value : entry.getValue()) {
+                    sb.append(entry.getKey()).append(':');
+                    if (value.isFileItem()) {
+                        FileItem item = value.getFileItem();
+                        sb.append("inMemory=").append(item.isInMemory()).append(",size=").append(item.getFileSize());
+                    } else {
+                        sb.append(value.getValue());
+                    }
+                    sb.append('\n');
+                }
+            }
+            return sb.toString();
+        }
+
+        @POST
+        @Path("uploads")
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        public String uploads(@RestForm(FileUpload.ALL) List<FileUpload> uploads) {
+            return uploads.get(0).uploadedFile().toString();
+        }
+
+        @POST
+        @Path("typed")
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        public String typed(Form form) throws IOException {
+            try (InputStream is = form.smallStream) {
+                return "bytes=" + form.small.length + ",stream=" + is.readAllBytes().length + ",text=" + form.text;
+            }
+        }
+    }
+
+    public static class Form {
+
+        @RestForm("small")
+        public byte[] small;
+
+        @RestForm("small")
+        public InputStream smallStream;
+
+        @RestForm("text")
+        public String text;
+    }
+}

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRuntimeRecorder.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRuntimeRecorder.java
@@ -41,6 +41,7 @@ public class ResteasyReactiveRuntimeRecorder {
         RuntimeConfiguration runtimeConfiguration = new DefaultRuntimeConfiguration(httpRuntimeConfig.readTimeout(),
                 httpRuntimeConfig.body().deleteUploadedFilesOnEnd(), httpRuntimeConfig.body().uploadsDirectory(),
                 httpRuntimeConfig.body().multipart().fileContentTypes().orElse(null),
+                httpRuntimeConfig.body().multipart().fileSizeThreshold().asLongValue(),
                 runtimeConfig.multipart().inputPart().defaultCharset(), maxBodySize,
                 httpRuntimeConfig.limits().maxFormAttributeSize().asLongValue(),
                 httpRuntimeConfig.limits().maxParameters(),

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/MultiPartConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/MultiPartConfig.java
@@ -3,8 +3,10 @@ package io.quarkus.vertx.http.runtime;
 import java.util.List;
 import java.util.Optional;
 
+import io.quarkus.runtime.configuration.MemorySize;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
 import io.smallrye.config.WithConverter;
+import io.smallrye.config.WithDefault;
 
 /**
  * A config for the settings related to HTTP multipart request handling.
@@ -19,4 +21,16 @@ public interface MultiPartConfig {
      * For now, this setting only works when using RESTEasy Reactive.
      */
     Optional<List<@WithConverter(TrimmedStringConverter.class) String>> fileContentTypes();
+
+    /**
+     * The size up to which a file part is kept in memory instead of being written to the uploads directory.
+     * <p>
+     * With the default of {@code 0}, every file part is written to the uploads directory. Parts kept in memory
+     * are reported as such by {@code FileItem#isInMemory()} and are only written to a file if their path is
+     * requested.
+     * <p>
+     * For now, this setting only works when using Quarkus REST.
+     */
+    @WithDefault("0")
+    MemorySize fileSizeThreshold();
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/FormData.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/FormData.java
@@ -4,15 +4,21 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
@@ -35,8 +41,38 @@ public final class FormData implements Iterable<String> {
     private final int maxValues;
     private int valueCount = 0;
 
+    private final Path tempFileLocation;
+    private final List<Path> createdFiles = Collections.synchronizedList(new ArrayList<>());
+
     public FormData(final int maxValues) {
+        this(maxValues, Paths.get(System.getProperty("java.io.tmpdir")));
+    }
+
+    /**
+     * @param tempFileLocation the directory in which the file parts are stored
+     */
+    public FormData(final int maxValues, Path tempFileLocation) {
         this.maxValues = maxValues;
+        this.tempFileLocation = Objects.requireNonNull(tempFileLocation);
+    }
+
+    /**
+     * Creates a new file in the uploads directory and records it so that {@link #getCreatedFiles()} can delete it
+     * once the request is done.
+     */
+    public Path createTempFile() throws IOException {
+        Files.createDirectories(tempFileLocation);
+        Path file = Files.createTempFile(tempFileLocation, "resteasy-reactive", "upload");
+        createdFiles.add(file);
+        return file;
+    }
+
+    /**
+     * @return all the files created through {@link #createTempFile()}, including the ones written lazily for parts
+     *         kept in memory
+     */
+    public List<Path> getCreatedFiles() {
+        return createdFiles;
     }
 
     public MultipartFormDataInput toMultipartFormDataInput() {
@@ -73,7 +109,7 @@ public final class FormData implements Iterable<String> {
         if (values == null) {
             this.values.put(name, values = new ArrayDeque<>(1));
         }
-        values.add(new FormValueImpl(value, fileName, headers));
+        values.add(new FormValueImpl(value, fileName, headers, this));
         if (++valueCount > maxValues) {
             throw paramLimitException(maxValues);
         }
@@ -184,27 +220,46 @@ public final class FormData implements Iterable<String> {
     }
 
     public static class FileItemImpl implements FileItem {
-        private final Path file;
+        private volatile Path file;
         private final byte[] content;
+        private final FormData owner;
 
         public FileItemImpl(Path file) {
             this.file = file;
             this.content = null;
+            this.owner = null;
         }
 
-        public FileItemImpl(byte[] content) {
+        /**
+         * @param owner the form the file is written through when {@link #getFile()} is called
+         */
+        public FileItemImpl(byte[] content, FormData owner) {
             this.file = null;
             this.content = content;
+            this.owner = owner;
+        }
+
+        @Override
+        public Path getFile() {
+            if (file == null) {
+                synchronized (this) {
+                    if (file == null) {
+                        try {
+                            Path tempFile = owner.createTempFile();
+                            Files.write(tempFile, content);
+                            file = tempFile;
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    }
+                }
+            }
+            return file;
         }
 
         @Override
         public boolean isInMemory() {
             return file == null;
-        }
-
-        @Override
-        public Path getFile() {
-            return file;
         }
 
         @Override
@@ -284,8 +339,8 @@ public final class FormData implements Iterable<String> {
             this.charset = null;
         }
 
-        FormValueImpl(byte[] data, String fileName, CaseInsensitiveMap<String> headers) {
-            this.fileItemImpl = new FileItemImpl(data);
+        FormValueImpl(byte[] data, String fileName, CaseInsensitiveMap<String> headers, FormData owner) {
+            this.fileItemImpl = new FileItemImpl(data, owner);
             this.fileName = fileName;
             this.headers = headers;
             this.value = null;

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultiPartParserDefinition.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultiPartParserDefinition.java
@@ -201,7 +201,6 @@ public class MultiPartParserDefinition implements FormParserFactory.ParserDefini
 
         private final ResteasyReactiveRequestContext exchange;
         private final FormData data;
-        private final List<Path> createdFiles = new ArrayList<>();
         private final long maxIndividualFileSize;
         private final long fileSizeThreshold;
         private final long maxAttributeSize;
@@ -213,6 +212,7 @@ public class MultiPartParserDefinition implements FormParserFactory.ParserDefini
         private final ByteArrayOutputStream contentBytes = new ByteArrayOutputStream();
         private String currentName;
         private String fileName;
+        private boolean filePart;
         private Path file;
         private FileChannel fileChannel;
         private CaseInsensitiveMap<String> headers;
@@ -232,7 +232,7 @@ public class MultiPartParserDefinition implements FormParserFactory.ParserDefini
             this.maxEntitySize = maxEntitySize;
             this.maxParameters = maxParameters;
             this.fileFormNames = fileFormNames;
-            this.data = new FormData(maxParameters);
+            this.data = new FormData(maxParameters, tempFileLocation);
             String charset = defaultEncoding;
             if (contentType != null) {
                 String value = HeaderUtil.extractQuotedValueFromHeader(contentType, "charset");
@@ -285,6 +285,8 @@ public class MultiPartParserDefinition implements FormParserFactory.ParserDefini
         public void beginPart(final CaseInsensitiveMap<String> headers) {
             this.currentFileSize = 0;
             this.headers = headers;
+            this.fileName = null;
+            this.filePart = false;
             final String disposition = headers.getFirst(HttpHeaders.CONTENT_DISPOSITION);
             if (disposition != null) {
                 if (disposition.startsWith("form-data")) {
@@ -292,16 +294,10 @@ public class MultiPartParserDefinition implements FormParserFactory.ParserDefini
                     fileName = HeaderUtil.sanitizeFileName(
                             HeaderUtil.extractQuotedValueFromHeaderWithEncoding(disposition, "filename"));
                     String contentType = headers.getFirst(HttpHeaders.CONTENT_TYPE);
-                    if (((fileName != null) || isFileContentType(contentType) || fileFormNames.contains(currentName))
-                            && fileSizeThreshold == 0) {
+                    filePart = (fileName != null) || isFileContentType(contentType) || fileFormNames.contains(currentName);
+                    if (filePart && fileSizeThreshold == 0) {
                         try {
-                            if (tempFileLocation != null) {
-                                Files.createDirectories(tempFileLocation);
-                                file = Files.createTempFile(tempFileLocation, "resteasy-reactive", "upload");
-                            } else {
-                                file = Files.createTempFile("resteasy-reactive", "upload");
-                            }
-                            createdFiles.add(file);
+                            file = data.createTempFile();
                             fileChannel = FileChannel.open(file, StandardOpenOption.READ, StandardOpenOption.WRITE);
                         } catch (IOException e) {
                             throw new RuntimeException(e);
@@ -331,15 +327,9 @@ public class MultiPartParserDefinition implements FormParserFactory.ParserDefini
                 data.deleteFiles();
                 throw new WebApplicationException(Response.Status.REQUEST_ENTITY_TOO_LARGE);
             }
-            if (file == null && fileName != null && fileSizeThreshold < this.currentFileSize) {
+            if (file == null && filePart && fileSizeThreshold < this.currentFileSize) {
                 try {
-                    if (tempFileLocation != null) {
-                        Files.createDirectories(tempFileLocation);
-                        file = Files.createTempFile(tempFileLocation, "resteasy-reactive", "upload");
-                    } else {
-                        file = Files.createTempFile("resteasy-reactive", "upload");
-                    }
-                    createdFiles.add(file);
+                    file = data.createTempFile();
 
                     FileOutputStream fileOutputStream = new FileOutputStream(file.toFile());
                     contentBytes.writeTo(fileOutputStream);
@@ -354,7 +344,8 @@ public class MultiPartParserDefinition implements FormParserFactory.ParserDefini
                 while (buffer.hasRemaining()) {
                     contentBytes.write(buffer.get());
                 }
-                if (maxAttributeSize > 0 && contentBytes.size() > maxAttributeSize) {
+                // file parts kept in memory are bounded by the file size threshold and the file size limits instead
+                if (!filePart && maxAttributeSize > 0 && contentBytes.size() > maxAttributeSize) {
                     data.deleteFiles();
                     throw new WebApplicationException(Response.Status.REQUEST_ENTITY_TOO_LARGE);
                 }
@@ -375,7 +366,7 @@ public class MultiPartParserDefinition implements FormParserFactory.ParserDefini
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
-            } else if (fileName != null) {
+            } else if (filePart) {
                 data.add(currentName, Arrays.copyOf(contentBytes.toByteArray(), contentBytes.size()), fileName, headers);
                 contentBytes.reset();
             } else {
@@ -410,7 +401,7 @@ public class MultiPartParserDefinition implements FormParserFactory.ParserDefini
         }
 
         public List<Path> getCreatedFiles() {
-            return createdFiles;
+            return data.getCreatedFiles();
         }
 
         @Override

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartSupport.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartSupport.java
@@ -231,7 +231,7 @@ public final class MultipartSupport {
         for (FormValue value : values) {
             if (value.isFileItem()) {
                 try {
-                    ret.add(Files.readString(value.getFileItem().getFile(), Charset.defaultCharset()));
+                    ret.add(new String(readAllBytes(value.getFileItem()), Charset.defaultCharset()));
                 } catch (IOException e) {
                     throw new MultipartPartReadingException(e);
                 }
@@ -246,6 +246,13 @@ public final class MultipartSupport {
         return ret;
     }
 
+    private static byte[] readAllBytes(FileItem fileItem) throws IOException {
+        if (fileItem.isInMemory()) {
+            return fileItem.getInputStream().readAllBytes();
+        }
+        return Files.readAllBytes(fileItem.getFile());
+    }
+
     public static byte[] getByteArray(String formName, ResteasyReactiveRequestContext context) {
         FormValue value = getFirstValue(formName, context);
         if (value == null) {
@@ -253,11 +260,7 @@ public final class MultipartSupport {
         }
         if (value.isFileItem()) {
             try {
-                FileItem fileItem = value.getFileItem();
-                if (fileItem.isInMemory()) {
-                    return fileItem.getInputStream().readAllBytes();
-                }
-                return Files.readAllBytes(fileItem.getFile());
+                return readAllBytes(value.getFileItem());
             } catch (IOException e) {
                 throw new MultipartPartReadingException(e);
             }
@@ -275,7 +278,7 @@ public final class MultipartSupport {
         for (FormValue value : values) {
             if (value.isFileItem()) {
                 try {
-                    ret.add(Files.readAllBytes(value.getFileItem().getFile()));
+                    ret.add(readAllBytes(value.getFileItem()));
                 } catch (IOException e) {
                     throw new MultipartPartReadingException(e);
                 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/FormBodyHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/FormBodyHandler.java
@@ -44,7 +44,7 @@ public class FormBodyHandler implements GenericRuntimeConfigurableServerRestHand
     public void configure(RuntimeConfiguration configuration) {
         formParserFactory = FormParserFactory.builder(false, executorSupplier)
                 .addParser(new MultiPartParserDefinition(executorSupplier)
-                        .setFileSizeThreshold(0)
+                        .setFileSizeThreshold(configuration.body().multiPart().fileSizeThreshold())
                         .setMaxAttributeSize(configuration.limits().maxFormAttributeSize())
                         .setMaxEntitySize(configuration.limits().maxBodySize().orElse(-1L))
                         .setMaxParameters(configuration.limits().maxParameters())

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/multipart/FileItem.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/multipart/FileItem.java
@@ -15,7 +15,9 @@ public interface FileItem {
     boolean isInMemory();
 
     /**
-     * Gives access to the file stored on the file system. This should only be used when {@code isInMemory} is {@code false}
+     * Gives access to the file stored on the file system. When {@code isInMemory} is {@code true}, the content is
+     * written to a temporary file on the first call and {@code isInMemory} returns {@code false} from then on, so this
+     * should only be used when a file is actually needed
      */
     Path getFile();
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/DefaultRuntimeConfiguration.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/DefaultRuntimeConfiguration.java
@@ -11,14 +11,19 @@ public class DefaultRuntimeConfiguration implements RuntimeConfiguration {
     private final Limits limits;
 
     public DefaultRuntimeConfiguration(Duration readTimeout, boolean deleteUploadedFilesOnEnd, String uploadsDirectory,
-            List<String> fileContentTypes, Charset defaultCharset, OptionalLong maxBodySize, long maxFormAttributeSize,
-            int maxParameters, int maxMultipartPartHeaderSize, int maxMultipartHeaderCount) {
+            List<String> fileContentTypes, long fileSizeThreshold, Charset defaultCharset, OptionalLong maxBodySize,
+            long maxFormAttributeSize, int maxParameters, int maxMultipartPartHeaderSize, int maxMultipartHeaderCount) {
         this.readTimeout = readTimeout;
         body = new Body() {
             final Body.MultiPart multiPart = new Body.MultiPart() {
                 @Override
                 public List<String> fileContentTypes() {
                     return fileContentTypes;
+                }
+
+                @Override
+                public long fileSizeThreshold() {
+                    return fileSizeThreshold;
                 }
             };
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/RuntimeConfiguration.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/RuntimeConfiguration.java
@@ -25,6 +25,12 @@ public interface RuntimeConfiguration {
 
         interface MultiPart {
             List<String> fileContentTypes();
+
+            /**
+             * File parts up to this size are kept in memory rather than written to a file; {@code 0} writes every
+             * file part to a file
+             */
+            long fileSizeThreshold();
         }
     }
 

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/framework/ResteasyReactiveUnitTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/framework/ResteasyReactiveUnitTest.java
@@ -393,7 +393,7 @@ public class ResteasyReactiveUnitTest implements BeforeAllCallback, AfterAllCall
         DefaultRuntimeConfiguration runtimeConfiguration = new DefaultRuntimeConfiguration(Duration.ofMinutes(1),
                 deleteUploadedFilesOnEnd,
                 uploadPath != null ? uploadPath.toAbsolutePath().toString() : System.getProperty("java.io.tmpdir"),
-                fileContentTypes, defaultCharset, OptionalLong.empty(), maxFormAttributeSize, maxParameters,
+                fileContentTypes, 0, defaultCharset, OptionalLong.empty(), maxFormAttributeSize, maxParameters,
                 maxMultipartPartHeaderSize, maxMultipartHeaderCount);
         ResteasyReactiveDeploymentManager.RunnableApplication application = prepared.createApplication(runtimeConfiguration,
                 new VertxRequestContextFactory(), executor);


### PR DESCRIPTION
The multipart parser can keep a file part in memory below a size threshold — `FileItem#isInMemory()` and the in-memory branches in `MultipartSupport` exist for it — but `FormBodyHandler` hard-codes the threshold to `0`, so every part carrying a `filename` is written to the uploads directory, even when the application only wants its bytes. That is the behaviour reported in the issue, and geoand's suggestion there (`MultipartFormDataInput`) runs into it too.

This adds `quarkus.http.body.multipart.file-size-threshold` (a `MemorySize`, default `0` to keep today's behaviour) and threads it through `RuntimeConfiguration` to the parser. Two things had to change for a non-zero threshold to be usable:

- an in-memory file part was subject to `max-form-attribute-size` (2K by default), a limit meant for text attributes, so any file over 2K failed with a 413 — file parts are bounded by the threshold (above which they are written to disk) and the existing file size limits instead;
- "is this a file part" was decided differently at the start of a part (filename, content type or declared file form name) and at the threshold (filename only), so a part detected through its content type was never spilled to disk.

For the existing parameter types: `byte[]`, `String` and `InputStream` parts are now read from memory when available; `FileUpload#uploadedFile()` / `FileItem#getFile()` write the content to the uploads directory on first call, so nothing that used to return a path returns `null`, and the file is cleaned up with the others when `delete-uploaded-files-on-end` is set.

The test covers in-memory vs on-disk selection around the threshold, the lazy file in the configured uploads directory, and the typed parameters; the first fails with the threshold at `0`. Verified the reporter's `MultipartFormDataInput` loop on a packaged app: with the option set, a 3K part reports `inMemory=true` and a 300K part is written to the uploads directory.

- Fixes: #43127
