### PR TITLE
Fix MongoDB Panache committing sessions after a JTA transaction timeout

### DIFF
--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/MongoOperations.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/MongoOperations.java
@@ -10,8 +10,6 @@ import java.util.stream.Stream;
 
 import jakarta.transaction.Status;
 import jakarta.transaction.Synchronization;
-import jakarta.transaction.SystemException;
-import jakarta.transaction.TransactionManager;
 import jakarta.transaction.TransactionSynchronizationRegistry;
 
 import org.bson.BsonDocument;
@@ -36,7 +34,6 @@ import io.quarkus.arc.InstanceHandle;
 import io.quarkus.mongodb.panache.common.MongoEntity;
 import io.quarkus.mongodb.panache.common.binder.NativeQueryBinder;
 import io.quarkus.mongodb.panache.common.binder.PanacheQlQueryBinder;
-import io.quarkus.mongodb.panache.common.transaction.MongoTransactionException;
 import io.quarkus.mongodb.runtime.MongoClientBeanUtil;
 import io.quarkus.panache.common.Parameters;
 import io.quarkus.panache.common.Sort;
@@ -353,7 +350,6 @@ public abstract class MongoOperations<QueryType, UpdateType> {
 
     private ClientSession registerClientSession(MongoEntity mongoEntity,
             TransactionSynchronizationRegistry registry) {
-        TransactionManager transactionManager = Arc.container().instance(TransactionManager.class).get();
         MongoClient client = MongoClientBeanUtil.mongoClient(BeanUtils.beanName(mongoEntity));
         ClientSession clientSession = client.startSession();
         clientSession.startTransaction();//TODO add txoptions from annotation
@@ -364,23 +360,19 @@ public abstract class MongoOperations<QueryType, UpdateType> {
             }
 
             @Override
-            public void afterCompletion(int i) {
-                try {
-                    if (transactionManager.getStatus() == Status.STATUS_ROLLEDBACK) {
-                        try {
-                            clientSession.abortTransaction();
-                        } finally {
-                            clientSession.close();
-                        }
-                    } else {
-                        try {
-                            clientSession.commitTransaction();
-                        } finally {
-                            clientSession.close();
-                        }
+            public void afterCompletion(int status) {
+                if (status == Status.STATUS_COMMITTED) {
+                    try {
+                        clientSession.commitTransaction();
+                    } finally {
+                        clientSession.close();
                     }
-                } catch (SystemException e) {
-                    throw new MongoTransactionException(e);
+                } else {
+                    try {
+                        clientSession.abortTransaction();
+                    } finally {
+                        clientSession.close();
+                    }
                 }
             }
         });

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/transaction/TransactionPersonResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/transaction/TransactionPersonResource.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.core.Response;
 import com.mongodb.client.MongoClient;
 
 import io.quarkus.mongodb.panache.Panache;
+import io.quarkus.narayana.jta.runtime.TransactionConfiguration;
 import io.quarkus.runtime.StartupEvent;
 
 @Path("/transaction")
@@ -55,6 +56,23 @@ public class TransactionPersonResource {
     public void addPersonTwice(TransactionPerson person) {
         person.persist();
         throw new RuntimeException("You shall not pass");
+    }
+
+    @POST
+    @Path("/timeout")
+    @Transactional
+    @TransactionConfiguration(timeout = 1)
+    public Response addPersonWithTimeout(TransactionPerson person) {
+        person.persist();
+        assertNotNull(Panache.getSession(TransactionPerson.class));
+        try {
+            // the reaper (checkPeriod=500ms) will time out and roll back the transaction
+            // from its own thread while we're still sleeping here
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        return Response.created(URI.create("/transaction/" + person.id.toString())).build();
     }
 
     @PUT

--- a/integration-tests/mongodb-panache/src/main/resources/application.properties
+++ b/integration-tests/mongodb-panache/src/main/resources/application.properties
@@ -8,3 +8,6 @@ quarkus.mongodb.cl2.write-concern.journal=false
 
 #quarkus.log.category."io.quarkus.mongodb.panache.runtime".level=DEBUG
 quarkus.mongodb.metrics.enabled=true
+
+# make the transaction reaper check frequently so timeout tests don't need to wait 120s
+quarkus.transaction-manager.reaper.check-period=500ms

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/transaction/MongodbPanacheTransactionTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/transaction/MongodbPanacheTransactionTest.java
@@ -137,4 +137,37 @@ class MongodbPanacheTransactionTest {
         Assertions.assertEquals(0, count);
     }
 
+    @Test
+    public void testTransactionTimeout() {
+        String endpoint = "/transaction";
+        // clean state
+        RestAssured.given().delete(endpoint).andReturn();
+
+        PersonDTO person = new PersonDTO();
+        person.id = 99L;
+        person.firstname = "Timeout";
+        person.lastname = "Person";
+
+        // the JTA transaction is configured with a 1s timeout; the reaper rolls it back
+        // asynchronously while the request handler is still sleeping past the timeout
+        Response response = RestAssured
+                .given()
+                .header("Content-Type", "application/json")
+                .body(person)
+                .post(endpoint + "/timeout")
+                .andReturn();
+        Assertions.assertEquals(500, response.statusCode());
+
+        // the reaper thread that performs the timeout rollback was never associated with the
+        // transaction via TransactionManager.begin(), so relying on transactionManager.getStatus()
+        // in MongoOperations.registerClientSession#afterCompletion would be wrong there (it would
+        // report STATUS_NO_TRANSACTION instead of STATUS_ROLLEDBACK). afterCompletion instead uses
+        // the given status parameter, so the Mongo ClientSession is correctly aborted here too.
+        Long count = get(endpoint + "/count").as(Long.class);
+        Assertions.assertEquals(0, count);
+
+        // cleanup
+        RestAssured.given().delete(endpoint).andReturn();
+    }
+
 }


### PR DESCRIPTION
Fixes #56080.

When a transaction times out, the transaction reaper thread rolls it back and invokes `afterCompletion` without ever having associated itself with the transaction via `TransactionManager.begin()`. As a result, `transactionManager.getStatus()` reports `STATUS_NO_TRANSACTION` instead of `STATUS_ROLLEDBACK`, and `MongoOperations.registerClientSession#afterCompletion` took the "else" branch, committing the Mongo `ClientSession` anyway — leaving data persisted in MongoDB despite the JTA transaction having rolled back due to timeout.

This uses the status handed to `afterCompletion` directly (always accurate, per the issue) and only commits when it's `STATUS_COMMITTED`, aborting otherwise. Includes a reproducer test that uses a short `@TransactionConfiguration` timeout together with a shortened `quarkus.transaction-manager.reaper.check-period` to deterministically trigger the reaper's async rollback path.