### PR TITLE
Make the quarkusRun task compatible with the configuration cache

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusRun.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusRun.java
@@ -42,7 +42,9 @@ import io.smallrye.common.process.ProcessBuilder;
 @DisableCachingByDefault(because = "Not cacheable")
 public abstract class QuarkusRun extends QuarkusBuildTask {
     private final Property<File> workingDirectory;
-    private final SourceSet mainSourceSet;
+    // Resolved from the main source set at configuration time: a SourceSet cannot be serialized into the
+    // configuration cache, while the FileCollection it produces can.
+    private final FileCollection compilationOutput;
     private final ListProperty<String> jvmArgs;
 
     @Inject
@@ -51,10 +53,11 @@ public abstract class QuarkusRun extends QuarkusBuildTask {
     }
 
     public QuarkusRun(String description) {
-        super(description, false);
+        super(description, true);
         final ObjectFactory objectFactory = getProject().getObjects();
-        mainSourceSet = getProject().getExtensions().getByType(SourceSetContainer.class)
-                .getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+        compilationOutput = getProject().getExtensions().getByType(SourceSetContainer.class)
+                .getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+                .getOutput().getClassesDirs();
 
         workingDirectory = objectFactory.property(File.class);
         workingDirectory.convention(projectDir);
@@ -69,7 +72,7 @@ public abstract class QuarkusRun extends QuarkusBuildTask {
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
     public FileCollection getCompilationOutput() {
-        return mainSourceSet.getOutput().getClassesDirs();
+        return compilationOutput;
     }
 
     @Input

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/TasksConfigurationCacheCompatibilityTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/TasksConfigurationCacheCompatibilityTest.java
@@ -7,6 +7,7 @@ import static io.quarkus.gradle.QuarkusPlugin.QUARKUS_BUILD_TASK_NAME;
 import static io.quarkus.gradle.QuarkusPlugin.QUARKUS_GENERATE_CODE_DEV_TASK_NAME;
 import static io.quarkus.gradle.QuarkusPlugin.QUARKUS_GENERATE_CODE_TASK_NAME;
 import static io.quarkus.gradle.QuarkusPlugin.QUARKUS_GENERATE_CODE_TESTS_TASK_NAME;
+import static io.quarkus.gradle.QuarkusPlugin.QUARKUS_RUN_TASK_NAME;
 import static io.quarkus.gradle.QuarkusPlugin.QUARKUS_SHOW_EFFECTIVE_CONFIG_TASK_NAME;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -45,6 +46,15 @@ public class TasksConfigurationCacheCompatibilityTest {
                 "build");
     }
 
+    /**
+     * Tasks that start the application and therefore never return on their own. They cannot be executed from a test,
+     * but a dry run still calculates and stores the task graph, which is what configuration cache compatibility
+     * means for them.
+     */
+    private static Stream<String> compatibleApplicationStartingTasks() {
+        return Stream.of(QUARKUS_RUN_TASK_NAME);
+    }
+
     private static Stream<String> nonCompatibleQuarkusBuildTasks() {
         return Stream.of(DEPLOY_TASK_NAME);
     }
@@ -79,6 +89,23 @@ public class TasksConfigurationCacheCompatibilityTest {
         assertTrue(firstBuild.getOutput().contains("Configuration cache entry stored"));
 
         BuildResult secondBuild = buildResult(taskName, "-Dorg.gradle.unsafe.isolated-projects=true");
+        assertTrue(secondBuild.getOutput().contains("Reusing configuration cache."));
+    }
+
+    @ParameterizedTest
+    @MethodSource("compatibleApplicationStartingTasks")
+    public void configurationCacheIsReusedForApplicationStartingTasksTest(String taskName)
+            throws IOException, URISyntaxException {
+        URL url = getClass().getClassLoader().getResource("io/quarkus/gradle/tasks/configurationcache/main");
+        FileUtils.copyDirectory(new File(url.toURI()), testProjectDir.toFile());
+        FileUtils.copyFile(new File("../gradle.properties"), testProjectDir.resolve("gradle.properties").toFile());
+
+        buildResult(":help", "--configuration-cache");
+
+        BuildResult firstBuild = buildResult(taskName, Arrays.asList("--configuration-cache", "--dry-run"));
+        assertTrue(firstBuild.getOutput().contains("Configuration cache entry stored"));
+
+        BuildResult secondBuild = buildResult(taskName, Arrays.asList("--configuration-cache", "--dry-run"));
         assertTrue(secondBuild.getOutput().contains("Reusing configuration cache."));
     }
 


### PR DESCRIPTION
`quarkusRun` opts out of the configuration cache through `QuarkusTask(description, false)`, so any build whose task graph includes it discards the configuration cache entry rather than storing one. The concrete reason it is incompatible is a non-serializable `SourceSet` field kept to derive `getCompilationOutput()`.

Everything else the task needs already arrives through configuration-cache-friendly plumbing — it extends `QuarkusBuildTask`, so the application model is an `@InputFile` and the configuration comes from `QuarkusPluginExtensionView`, exactly as for `quarkusBuild`. This resolves the classes directories from the main source set at configuration time and keeps the resulting `FileCollection`, which can be serialized, then declares the task compatible. Build caching stays disabled (`@DisableCachingByDefault`) — `quarkusRun` has no reusable output; the build cache and the configuration cache are orthogonal.

`quarkusRun` starts the application and does not return, so it cannot be executed from a TestKit test the way the other compatible tasks are. The added test runs the task graph with `--dry-run`, which still calculates and stores the entry, and asserts that the second run reuses it.

### Steps to reproduce

On a released Quarkus (verified on 3.38.3):

```
quarkus create app org.acme:cc-repro --gradle
cd cc-repro
./gradlew quarkusRun --configuration-cache --dry-run
```

`--dry-run` is used because `quarkusRun` starts the application and never returns; the task graph is still calculated and the configuration cache entry is still stored. Current output:

```
1 problem was found storing the configuration cache.
- Task `:quarkusRun` of type `io.quarkus.gradle.tasks.QuarkusRun`: cannot serialize object of type 'org.gradle.api.internal.tasks.DefaultSourceSet', a subtype of 'org.gradle.api.tasks.SourceSet', as these are not supported with the configuration cache.
...
Configuration cache entry discarded with 1 problem.
```

With this change the task is configuration-cache compatible: running the same command twice stores the entry on the first run ("Configuration cache entry stored.") and reuses it on the second ("Reusing configuration cache.").

### Verification

- The added test passes with this change.
- Confirmed it fails without the production change: reverting only `QuarkusRun.java` to `main` while keeping the test makes the test fail (the first build reports the entry discarded instead of stored), so the test is gated on the fix.

Related to #35932.
