### PR TITLE
Qute: introduce injectable locale aware message bundles

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -3162,6 +3162,34 @@ public class MyBean {
 ----
 <1> The annotation value is a locale tag string (IETF).
 
+===== Locale Aware Message Bundles
+
+An injected message bundle interface is by default bound to the default locale.
+If you need the localized variant to be selected dynamically based on the current locale, e.g. the locale negotiated from the `Accept-Language` header of the current HTTP request, then use the `@LocaleAware` qualifier instead.
+
+.Injected Current-Locale-Aware Message Bundle Example
+[source,java]
+----
+import io.quarkus.qute.i18n.LocaleAware;
+
+@Singleton
+public class MyBean {
+
+    @LocaleAware <1>
+    AppMessages msg;
+
+    String render() {
+       return msg.hello_name("Jachym"); <2>
+    }
+}
+----
+<1> Each message method invocation selects the appropriate localized variant based on the current locale.
+<2> If the current locale is not available, or no matching localized variant exists, then the default locale is used as a fallback.
+
+The current locale is obtained from a `io.quarkus.qute.i18n.CurrentLocaleProvider` bean.
+If the `quarkus-vertx-http` extension is present (e.g. when using `quarkus-rest-qute`) then a default provider that resolves the locale from the `Accept-Language` header of the current HTTP request is used.
+You can supply a custom provider by declaring a CDI bean that implements `CurrentLocaleProvider`; it takes precedence over the default one.
+
 ===== Enums
 
 There is a convenient way to localize enums.

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/CurrentLocaleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/CurrentLocaleProcessor.java
@@ -1,0 +1,30 @@
+package io.quarkus.qute.deployment;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+
+public class CurrentLocaleProcessor {
+
+    private static final DotName CURRENT_LOCALE_PROVIDER = DotName.createSimple("io.quarkus.qute.i18n.CurrentLocaleProvider");
+
+    @BuildStep
+    void init(Capabilities capabilities, BuildProducer<AdditionalBeanBuildItem> beans,
+            BuildProducer<UnremovableBeanBuildItem> unremovableBeans) {
+        // Make sure all CurrentLocaleProvider implementations are unremovable
+        unremovableBeans.produce(UnremovableBeanBuildItem.beanTypes(CURRENT_LOCALE_PROVIDER));
+
+        if (capabilities.isPresent(Capability.VERTX)) {
+            // The default CurrentLocaleProvider resolves the current locale from the Accept-Language header of the
+            // current HTTP request; it needs the current io.vertx.core.http.HttpServerRequest and so it's only
+            // registered if the Vert.x capability is present
+            beans.produce(new AdditionalBeanBuildItem("io.quarkus.qute.runtime.i18n.HttpServerRequestLocaleProvider"));
+        }
+    }
+
+}

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/Descriptors.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/Descriptors.java
@@ -15,5 +15,7 @@ final class Descriptors {
             String.class);
     static final MethodDesc BUNDLES_GET_TEMPLATE = MethodDesc.of(MessageBundles.class, "getTemplate",
             Template.class, String.class);
+    static final MethodDesc BUNDLES_GET_FOR_CURRENT_LOCALE = MethodDesc.of(MessageBundles.class, "getForCurrentLocale",
+            Object.class, Class.class);
 
 }

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -99,6 +99,7 @@ import io.quarkus.qute.deployment.TemplatesAnalysisBuildItem.TemplateAnalysis;
 import io.quarkus.qute.deployment.Types.AssignabilityCheck;
 import io.quarkus.qute.generator.Descriptors;
 import io.quarkus.qute.generator.ValueResolverGenerator;
+import io.quarkus.qute.i18n.LocaleAware;
 import io.quarkus.qute.i18n.Localized;
 import io.quarkus.qute.i18n.Message;
 import io.quarkus.qute.i18n.MessageBundle;
@@ -115,6 +116,7 @@ public class MessageBundleProcessor {
     private static final Logger LOG = Logger.getLogger(MessageBundleProcessor.class);
 
     private static final String SUFFIX = "_Bundle";
+    private static final String LOCALE_AWARE_SUFFIX = "_LocaleAware";
     private static final String BUNDLE_DEFAULT_KEY = "defaultKey";
     private static final String BUNDLE_LOCALE = "locale";
     private static final String MESSAGES = "messages";
@@ -123,7 +125,7 @@ public class MessageBundleProcessor {
     @BuildStep
     AdditionalBeanBuildItem beans() {
         return new AdditionalBeanBuildItem(MessageBundles.class, MessageBundle.class, Message.class, Localized.class,
-                MessageTemplateLocator.class);
+                LocaleAware.class, MessageTemplateLocator.class);
     }
 
     @BuildStep
@@ -159,12 +161,12 @@ public class MessageBundleProcessor {
                             // The name starts with the DEFAULT_NAME followed by an underscore, followed by simple names of all
                             // declaring classes in the hierarchy separated by underscores
                             List<String> names = new ArrayList<>();
-                            names.add(DotNames.simpleName(bundleClass));
+                            names.add(bundleClass.simpleName());
                             DotName enclosingName = bundleClass.enclosingClass();
                             while (enclosingName != null) {
                                 ClassInfo enclosingClass = index.getClassByName(enclosingName);
                                 if (enclosingClass != null) {
-                                    names.add(DotNames.simpleName(enclosingClass));
+                                    names.add(enclosingClass.simpleName());
                                     enclosingName = enclosingClass.nestingType() == NestingType.TOP_LEVEL ? null
                                             : enclosingClass.enclosingClass();
                                 }
@@ -288,6 +290,20 @@ public class MessageBundleProcessor {
                         // Just create a new instance of the generated class
                         bc.return_(bc.new_(ConstructorDesc.of(
                                 generatedImplementations.get(bundleInterface.name().toString()))));
+                    }).done();
+
+            // The message bundle resolved for the current locale - qualified with @LocaleAware
+            beanRegistration.getContext().configure(bundleInterface.name())
+                    .addType(bundle.getDefaultBundleInterface().name())
+                    .addQualifier(Names.LOCALE_AWARE)
+                    .unremovable()
+                    .scope(Singleton.class)
+                    .creator(cg -> {
+                        BlockCreator bc = cg.createMethod();
+                        // Just create a new instance of the generated forwarding class
+                        bc.return_(bc.new_(ConstructorDesc.of(
+                                generatedImplementations
+                                        .get(bundleInterface.name().toString() + SUFFIX + LOCALE_AWARE_SUFFIX))));
                     }).done();
 
             // Localized interfaces
@@ -723,6 +739,10 @@ public class MessageBundleProcessor {
                     defaultClassOutput, messageTemplateMethods, defaultKeyToMap, null, index);
             generatedTypes.put(bundleInterface.name().toString(), ClassDesc.of(bundleImpl));
 
+            // Generate a forwarding implementation that resolves the bundle for the current locale
+            String forwardingImpl = generateForwardingImplementation(bundle, defaultClassOutput);
+            generatedTypes.put(forwardingImpl, ClassDesc.of(forwardingImpl));
+
             // Generate imeplementation for each localized interface
             for (Entry<String, ClassInfo> entry : bundle.getLocalizedInterfaces().entrySet()) {
                 ClassInfo localizedInterface = entry.getValue();
@@ -765,6 +785,48 @@ public class MessageBundleProcessor {
             }
         }
         return generatedTypes;
+    }
+
+    /**
+     * Generates an implementation of the default bundle interface that forwards each message method to the message
+     * bundle resolved for the current locale. The generated class backs the bean qualified with
+     * {@link io.quarkus.qute.i18n.LocaleAware}.
+     */
+    private String generateForwardingImplementation(MessageBundleBuildItem bundle, ClassOutput classOutput) {
+        ClassInfo bundleInterface = bundle.getDefaultBundleInterface();
+        String generatedClassName = bundleInterface.name().toString() + SUFFIX + LOCALE_AWARE_SUFFIX;
+        LOG.debugf("Generate forwarding bundle implementation for %s", bundleInterface);
+
+        Gizmo gizmo = Gizmo.create(classOutput)
+                .withDebugInfo(false)
+                .withParameters(false);
+        gizmo.class_(generatedClassName, cc -> {
+            cc.implements_(classDescOf(bundleInterface));
+            cc.defaultConstructor();
+
+            for (MethodInfo method : bundleInterface.methods()) {
+                if (Modifier.isStatic(method.flags()) || !Modifier.isAbstract(method.flags())) {
+                    // Skip static and default methods
+                    continue;
+                }
+                cc.method(methodDescOf(method), mc -> {
+                    List<ParamVar> params = new ArrayList<>(method.parametersCount());
+                    for (int i = 0; i < method.parametersCount(); i++) {
+                        String paramName = method.parameterName(i);
+                        params.add(mc.parameter(paramName != null ? paramName : "arg" + i, i));
+                    }
+                    mc.body(bc -> {
+                        // Obtain the bundle for the current locale, e.g. negotiated from the Accept-Language header
+                        Expr delegate = bc.invokeStatic(io.quarkus.qute.deployment.Descriptors.BUNDLES_GET_FOR_CURRENT_LOCALE,
+                                Const.of(classDescOf(bundleInterface)));
+                        // Forward the invocation to the resolved bundle
+                        bc.return_(bc.invokeInterface(methodDescOf(method),
+                                bc.cast(delegate, classDescOf(bundleInterface)), params));
+                    });
+                });
+            }
+        });
+        return generatedClassName;
     }
 
     private Map<String, String> getLocalizedFileKeyToTemplate(MessageBundleBuildItem bundle,
@@ -934,10 +996,10 @@ public class MessageBundleProcessor {
 
         String baseName;
         if (bundleInterface.enclosingClass() != null) {
-            baseName = DotNames.simpleName(bundleInterface.enclosingClass()) + ValueResolverGenerator.NESTED_SEPARATOR
-                    + DotNames.simpleName(bundleInterface);
+            baseName = bundleInterface.enclosingClass().withoutPackagePrefix() + ValueResolverGenerator.NESTED_SEPARATOR
+                    + bundleInterface.simpleName();
         } else {
-            baseName = DotNames.simpleName(bundleInterface);
+            baseName = bundleInterface.simpleName();
         }
         if (locale != null) {
             baseName = baseName + "_" + locale;

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/Names.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/Names.java
@@ -22,6 +22,7 @@ import io.quarkus.qute.TemplateEnum;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.qute.TemplateLocator;
 import io.quarkus.qute.ValueResolver;
+import io.quarkus.qute.i18n.LocaleAware;
 import io.quarkus.qute.i18n.Localized;
 import io.quarkus.qute.i18n.Message;
 import io.quarkus.qute.i18n.MessageBundle;
@@ -34,6 +35,7 @@ final class Names {
     static final DotName MESSAGE = DotName.createSimple(Message.class.getName());
     static final DotName MESSAGE_PARAM = DotName.createSimple(MessageParam.class.getName());
     static final DotName LOCALIZED = DotName.createSimple(Localized.class.getName());
+    static final DotName LOCALE_AWARE = DotName.createSimple(LocaleAware.class.getName());
     static final DotName TEMPLATE = DotName.createSimple(Template.class.getName());
     static final DotName ITERABLE = DotName.createSimple(Iterable.class.getName());
     static final DotName ITERATOR = DotName.createSimple(Iterator.class.getName());

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/CustomCurrentLocaleProviderTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/CustomCurrentLocaleProviderTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.qute.deployment.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Locale;
+
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.i18n.CurrentLocaleProvider;
+import io.quarkus.qute.i18n.LocaleAware;
+import io.quarkus.qute.i18n.Localized;
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * A custom {@link CurrentLocaleProvider} overrides the default one and drives the resolution of a bean injected with
+ * {@link LocaleAware}.
+ */
+public class CustomCurrentLocaleProviderTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(Messages.class, CzechMessages.class, CustomCurrentLocaleProvider.class))
+            .overrideConfigKey("quarkus.default-locale", "en");
+
+    @LocaleAware
+    Messages messages;
+
+    @Test
+    public void testCustomProviderIsUsed() {
+        assertEquals("Ahoj!", messages.hello());
+        assertEquals("Ahoj Bobe!", messages.hello_name("Bobe"));
+    }
+
+    @Singleton
+    public static class CustomCurrentLocaleProvider implements CurrentLocaleProvider {
+
+        @Override
+        public Locale currentLocale() {
+            return Locale.of("cs");
+        }
+
+    }
+
+    @MessageBundle
+    public interface Messages {
+
+        @Message("Hello!")
+        String hello();
+
+        @Message("Hello {name}!")
+        String hello_name(String name);
+
+    }
+
+    @Localized("cs")
+    public interface CzechMessages extends Messages {
+
+        @Override
+        @Message("Ahoj!")
+        String hello();
+
+        @Override
+        @Message("Ahoj {name}!")
+        String hello_name(String name);
+
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LocaleAwareFallbackTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LocaleAwareFallbackTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.qute.deployment.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.i18n.LocaleAware;
+import io.quarkus.qute.i18n.Localized;
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * When there is no {@code CurrentLocaleProvider} available (e.g. a non-web application) a bean injected with
+ * {@link LocaleAware} falls back to the default locale.
+ */
+public class LocaleAwareFallbackTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Messages.class, CzechMessages.class))
+            .overrideConfigKey("quarkus.default-locale", "en");
+
+    @LocaleAware
+    Messages messages;
+
+    @Test
+    public void testFallbackToDefaultLocale() {
+        assertEquals("Hello!", messages.hello());
+        assertEquals("Hello Honza!", messages.hello_name("Honza"));
+    }
+
+    @MessageBundle
+    public interface Messages {
+
+        @Message("Hello!")
+        String hello();
+
+        @Message("Hello {name}!")
+        String hello_name(String name);
+
+    }
+
+    @Localized("cs")
+    public interface CzechMessages extends Messages {
+
+        @Override
+        @Message("Ahoj!")
+        String hello();
+
+        @Override
+        @Message("Ahoj {name}!")
+        String hello_name(String name);
+
+    }
+
+}

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/CurrentLocaleProvider.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/CurrentLocaleProvider.java
@@ -1,0 +1,22 @@
+package io.quarkus.qute.i18n;
+
+import java.util.Locale;
+
+/**
+ * Provides the current locale used to resolve a message bundle injected with the {@link LocaleAware} qualifier.
+ * <p>
+ * Implementations must be CDI beans. Typically, an implementation resolves the locale from the {@code Accept-Language}
+ * header of the current HTTP request. Integrations that expose a notion of "current request" (such as the REST
+ * extensions) provide a built-in implementation.
+ *
+ * @see LocaleAware
+ */
+public interface CurrentLocaleProvider {
+
+    /**
+     *
+     * @return the current locale, or {@code null} if it cannot be determined
+     */
+    Locale currentLocale();
+
+}

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/LocaleAware.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/LocaleAware.java
@@ -1,0 +1,46 @@
+package io.quarkus.qute.i18n;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+/**
+ * Qualifies an injected message bundle interface that should be resolved using the current locale, e.g. the locale negotiated
+ * from the {@code Accept-Language} header of the current HTTP request.
+ * <p>
+ * Unlike the default message bundle bean, which is bound to the default locale at build time, a bean qualified with this
+ * annotation selects the appropriate localized variant per method invocation. The current locale is obtained from a
+ * {@link CurrentLocaleProvider} bean. If no provider is available, or the current locale cannot be determined, or no
+ * matching localized variant exists, then the default locale is used as a fallback.
+ *
+ * <pre>
+ * &#64;LocaleAware
+ * AppMessages messages;
+ * </pre>
+ *
+ * @see MessageBundle
+ * @see Localized
+ * @see CurrentLocaleProvider
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({ TYPE, METHOD, FIELD, PARAMETER })
+public @interface LocaleAware {
+
+    public static final class Literal extends AnnotationLiteral<LocaleAware> implements LocaleAware {
+
+        public static final Literal INSTANCE = new Literal();
+
+        private static final long serialVersionUID = 1L;
+
+    }
+
+}

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/MessageBundles.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/MessageBundles.java
@@ -58,6 +58,44 @@ public final class MessageBundles {
                 .render());
     }
 
+    /**
+     * Obtains a message bundle for the specified interface and the current locale.
+     * <p>
+     * The current locale is obtained from a {@link CurrentLocaleProvider} bean. The appropriate localized variant is
+     * selected by an exact language tag match first, then by a language-only match. If no provider is available, or the
+     * current locale cannot be determined, or no matching localized variant exists, then the bundle for the default
+     * locale is returned.
+     * <p>
+     * This method backs the beans injected with the {@link LocaleAware} qualifier.
+     *
+     * @param <T>
+     * @param bundleInterface
+     * @return the message bundle for the current locale, never {@code null}
+     * @see LocaleAware
+     * @see CurrentLocaleProvider
+     */
+    public static <T> T getForCurrentLocale(Class<T> bundleInterface) {
+        ArcContainer container = Arc.container();
+        Locale locale = null;
+        InstanceHandle<CurrentLocaleProvider> provider = container.instance(CurrentLocaleProvider.class);
+        if (provider.isAvailable()) {
+            locale = provider.get().currentLocale();
+        }
+        if (locale != null) {
+            // First try the exact language tag match
+            InstanceHandle<T> handle = container.instance(bundleInterface, Localized.Literal.of(locale.toLanguageTag()));
+            if (!handle.isAvailable()) {
+                // Next try the language-only match
+                handle = container.instance(bundleInterface, Localized.Literal.of(locale.getLanguage()));
+            }
+            if (handle.isAvailable()) {
+                return handle.get();
+            }
+        }
+        // Fall back to the default locale
+        return get(bundleInterface);
+    }
+
     static void setupNamespaceResolvers(@Observes EngineBuilder builder, Instance<BundleContext> context) {
         if (!context.isResolvable()) {
             return;

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/i18n/HttpServerRequestLocaleProvider.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/i18n/HttpServerRequestLocaleProvider.java
@@ -1,0 +1,60 @@
+package io.quarkus.qute.runtime.i18n;
+
+import java.util.List;
+import java.util.Locale;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.DefaultBean;
+import io.quarkus.qute.i18n.CurrentLocaleProvider;
+import io.vertx.core.http.HttpServerRequest;
+
+/**
+ * The default {@link CurrentLocaleProvider} that resolves the current locale from the {@code Accept-Language} header of
+ * the current HTTP request.
+ * <p>
+ * The current {@link HttpServerRequest} is injected optionally - it's only available if the {@code quarkus-vertx-http}
+ * extension is present and a request context is active. Otherwise, {@code null} is returned and the default locale is
+ * used.
+ * <p>
+ * This bean is a {@link DefaultBean} so that it can be replaced by a custom {@link CurrentLocaleProvider}.
+ */
+@DefaultBean
+@Singleton
+public class HttpServerRequestLocaleProvider implements CurrentLocaleProvider {
+
+    private static final String ACCEPT_LANGUAGE = "Accept-Language";
+
+    @Inject
+    Instance<HttpServerRequest> request;
+
+    @Override
+    public Locale currentLocale() {
+        if (!Arc.container().requestContext().isActive() || !request.isResolvable()) {
+            return null;
+        }
+        String acceptLanguage = request.get().getHeader(ACCEPT_LANGUAGE);
+        if (acceptLanguage == null || acceptLanguage.isBlank()) {
+            return null;
+        }
+        List<Locale.LanguageRange> ranges;
+        try {
+            // Parses the header value and sorts the language ranges by the weight (q-value)
+            ranges = Locale.LanguageRange.parse(acceptLanguage);
+        } catch (IllegalArgumentException e) {
+            // Malformed header
+            return null;
+        }
+        for (Locale.LanguageRange range : ranges) {
+            String languageRange = range.getRange();
+            if (!"*".equals(languageRange)) {
+                return Locale.forLanguageTag(languageRange);
+            }
+        }
+        return null;
+    }
+
+}

--- a/extensions/resteasy-reactive/rest-qute/deployment/src/test/java/io/quarkus/resteasy/reactive/qute/deployment/CzechGreetingMessages.java
+++ b/extensions/resteasy-reactive/rest-qute/deployment/src/test/java/io/quarkus/resteasy/reactive/qute/deployment/CzechGreetingMessages.java
@@ -1,0 +1,17 @@
+package io.quarkus.resteasy.reactive.qute.deployment;
+
+import io.quarkus.qute.i18n.Localized;
+import io.quarkus.qute.i18n.Message;
+
+@Localized("cs")
+public interface CzechGreetingMessages extends GreetingMessages {
+
+    @Override
+    @Message("Ahoj!")
+    String hello();
+
+    @Override
+    @Message("Ahoj {name}!")
+    String hello_name(String name);
+
+}

--- a/extensions/resteasy-reactive/rest-qute/deployment/src/test/java/io/quarkus/resteasy/reactive/qute/deployment/GreetingMessages.java
+++ b/extensions/resteasy-reactive/rest-qute/deployment/src/test/java/io/quarkus/resteasy/reactive/qute/deployment/GreetingMessages.java
@@ -1,0 +1,15 @@
+package io.quarkus.resteasy.reactive.qute.deployment;
+
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+
+@MessageBundle
+public interface GreetingMessages {
+
+    @Message("Hello!")
+    String hello();
+
+    @Message("Hello {name}!")
+    String hello_name(String name);
+
+}

--- a/extensions/resteasy-reactive/rest-qute/deployment/src/test/java/io/quarkus/resteasy/reactive/qute/deployment/GreetingResource.java
+++ b/extensions/resteasy-reactive/rest-qute/deployment/src/test/java/io/quarkus/resteasy/reactive/qute/deployment/GreetingResource.java
@@ -1,0 +1,30 @@
+package io.quarkus.resteasy.reactive.qute.deployment;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.quarkus.qute.i18n.LocaleAware;
+
+@Path("greeting")
+public class GreetingResource {
+
+    @LocaleAware
+    GreetingMessages messages;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return messages.hello();
+    }
+
+    @GET
+    @Path("{name}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String helloName(@PathParam("name") String name) {
+        return messages.hello_name(name);
+    }
+
+}

--- a/extensions/resteasy-reactive/rest-qute/deployment/src/test/java/io/quarkus/resteasy/reactive/qute/deployment/LocaleAwareTest.java
+++ b/extensions/resteasy-reactive/rest-qute/deployment/src/test/java/io/quarkus/resteasy/reactive/qute/deployment/LocaleAwareTest.java
@@ -1,0 +1,84 @@
+package io.quarkus.resteasy.reactive.qute.deployment;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.i18n.LocaleAware;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * A message bundle injected with {@link LocaleAware} is resolved using
+ * the locale negotiated from the {@code Accept-Language} header of the current
+ * HTTP request.
+ */
+public class LocaleAwareTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(GreetingMessages.class, CzechGreetingMessages.class, GreetingResource.class));
+
+    @Test
+    public void testDefaultLocaleWhenNoHeader() {
+        when()
+                .get("/greeting")
+                .then()
+                .statusCode(200)
+                .body(is("Hello!"));
+    }
+
+    @Test
+    public void testExactLocaleMatch() {
+        given()
+                .header("Accept-Language", "cs")
+                .when()
+                .get("/greeting").then()
+                .statusCode(200)
+                .body(is("Ahoj!"));
+    }
+
+    @Test
+    public void testLanguageMatchAndQValueOrdering() {
+        // cs-CZ has no exact bundle - falls back to the language-only "cs" match; also
+        // the highest q-value wins
+        given()
+                .header("Accept-Language", "cs-CZ;q=0.9,en;q=0.5")
+                .when()
+                .get("/greeting")
+                .then()
+                .statusCode(200)
+                .body(is("Ahoj!"));
+    }
+
+    @Test
+    public void testFallbackToDefaultForUnknownLocale() {
+        given()
+                .header("Accept-Language", "fr")
+                .when()
+                .get("/greeting")
+                .then()
+                .statusCode(200)
+                .body(is("Hello!"));
+    }
+
+    @Test
+    public void testMessageWithParameter() {
+        given()
+                .header("Accept-Language", "cs")
+                .when()
+                .get("/greeting/Honza")
+                .then()
+                .statusCode(200)
+                .body(is("Ahoj Honza!"));
+        when()
+                .get("/greeting/Honza")
+                .then()
+                .statusCode(200)
+                .body(is("Hello Honza!"));
+    }
+
+}


### PR DESCRIPTION
- add the `@LocaleAware` qualifier that selects the localized message bundle variant per invocation based on the current locale, obtained from a CurrentLocaleProvider bean
- resolves #56154