### PR TITLE
Allow issuer-resolved OIDC tenants unavailable at startup to recover without a restart

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -931,6 +931,10 @@ quarkus.oidc.tenant-b.credentials.secret=${tenant-b-client-secret}
 <2> Tenant `tenant-a` discovers the `issuer` from the OIDC provider's well-known configuration endpoint.
 <3> Tenant `tenant-b` configures the `issuer` because its OIDC provider does not support the discovery.
 
+If a tenant's OIDC provider is unavailable when the application starts, the tenant's metadata cannot be discovered and the tenant is excluded from issuer-based resolution until it is initialized on a later request.
+By default, only one such initialization attempt is made, on the first request that could match the tenant; if that attempt also fails, the tenant remains excluded until the application is restarted.
+Set `quarkus.oidc.<tenant-id>.initialization-retry-interval` to a positive duration to keep retrying the initialization, at most once per interval, so the tenant recovers on its own once its OIDC provider becomes available again.
+
 [[header-based-tenant-resolver]]
 ==== Resolve tenants with a token header name
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -33,6 +33,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
         super(mapping);
         tenantId = mapping.tenantId();
         tenantEnabled = mapping.tenantEnabled();
+        initializationRetryInterval = mapping.initializationRetryInterval();
         applicationType = mapping.applicationType().map(Enum::toString).map(ApplicationType::valueOf);
         authorizationPath = mapping.authorizationPath();
         userInfoPath = mapping.userInfoPath();
@@ -78,6 +79,8 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      */
     @Deprecated(since = "3.18", forRemoval = true)
     public boolean tenantEnabled = true;
+
+    private Duration initializationRetryInterval = Duration.ZERO;
 
     /**
      * The application type, which can be one of the following {@link ApplicationType} values.
@@ -3058,6 +3061,11 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     @Override
     public boolean tenantEnabled() {
         return tenantEnabled;
+    }
+
+    @Override
+    public Duration initializationRetryInterval() {
+        return initializationRetryInterval;
     }
 
     @Override

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfigBuilder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfigBuilder.java
@@ -51,6 +51,7 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
     private static final class OidcTenantConfigImpl extends OidcClientCommonConfigImpl implements OidcTenantConfig {
         private final Optional<String> tenantId;
         private final boolean tenantEnabled;
+        private final Duration initializationRetryInterval;
         private final Optional<ApplicationType> applicationType;
         private final Optional<String> authorizationPath;
         private final Optional<String> userInfoPath;
@@ -78,6 +79,7 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
             super(builder);
             this.tenantId = builder.tenantId;
             this.tenantEnabled = builder.tenantEnabled;
+            this.initializationRetryInterval = builder.initializationRetryInterval;
             this.applicationType = builder.applicationType;
             this.authorizationPath = builder.authorizationPath;
             this.userInfoPath = builder.userInfoPath;
@@ -110,6 +112,11 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
         @Override
         public boolean tenantEnabled() {
             return tenantEnabled;
+        }
+
+        @Override
+        public Duration initializationRetryInterval() {
+            return initializationRetryInterval;
         }
 
         @Override
@@ -225,6 +232,7 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
 
     private Optional<String> tenantId;
     private boolean tenantEnabled;
+    private Duration initializationRetryInterval;
     private Optional<ApplicationType> applicationType;
     private Optional<String> authorizationPath;
     private Optional<String> userInfoPath;
@@ -257,6 +265,7 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
         super(Objects.requireNonNull(mapping));
         this.tenantId = mapping.tenantId();
         this.tenantEnabled = mapping.tenantEnabled();
+        this.initializationRetryInterval = mapping.initializationRetryInterval();
         this.applicationType = mapping.applicationType();
         this.authorizationPath = mapping.authorizationPath();
         this.userInfoPath = mapping.userInfoPath();
@@ -321,6 +330,15 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
      */
     public OidcTenantConfigBuilder tenantEnabled(boolean tenantEnabled) {
         this.tenantEnabled = tenantEnabled;
+        return this;
+    }
+
+    /**
+     * @param initializationRetryInterval {@link OidcTenantConfig#initializationRetryInterval()}
+     * @return this builder
+     */
+    public OidcTenantConfigBuilder initializationRetryInterval(Duration initializationRetryInterval) {
+        this.initializationRetryInterval = initializationRetryInterval;
         return this;
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -43,6 +43,20 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
     boolean tenantEnabled();
 
     /**
+     * How often a static tenant whose OIDC metadata could not be discovered when the application started
+     * (for example, because the OIDC provider was temporarily unavailable) may be re-initialized.
+     * <p>
+     * By default (`0S`), no periodic re-initialization happens. Set a positive value to have Quarkus retry
+     * the initialization on this interval, in the background, until it succeeds, so the tenant recovers on
+     * its own once the OIDC provider becomes available again, without an application restart. Once the
+     * tenant becomes ready, no further attempts are made.
+     * <p>
+     * This property only affects tenants resolved with `quarkus.oidc.resolve-tenants-with-issuer=true`.
+     */
+    @WithDefault("0S")
+    Duration initializationRetryInterval();
+
+    /**
      * The application type, which can be one of the following {@link ApplicationType} values.
      */
     @ConfigDocDefault("service")

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/StaticTenantResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/StaticTenantResolver.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
 
 import jakarta.enterprise.inject.Instance;
@@ -116,6 +116,20 @@ final class StaticTenantResolver {
         return Uni.createFrom().nullItem();
     }
 
+    /**
+     * Decides whether a not-yet-initialized issuer-resolved tenant may be (re-)initialized now.
+     *
+     * @param previousAttemptMillis epoch millis of the last attempt, or 0 if none yet
+     * @param nowMillis current epoch millis
+     * @param retryIntervalMillis minimum interval between attempts; <= 0 disables retries after the first one
+     */
+    static boolean shouldRetryInitialization(long previousAttemptMillis, long nowMillis, long retryIntervalMillis) {
+        if (previousAttemptMillis == 0) {
+            return true; // first attempt, on the first request
+        }
+        return retryIntervalMillis > 0 && (nowMillis - previousAttemptMillis) >= retryIntervalMillis;
+    }
+
     private static final class DefaultStaticTenantResolver implements TenantResolver {
         private static final String PATH_SEPARATOR = "/";
         private final TenantConfigBean tenantConfigBean;
@@ -184,13 +198,13 @@ final class StaticTenantResolver {
 
         private final TenantConfigContext[] tenantConfigContexts;
         private final boolean detectedTenantWithoutMetadata;
-        private final Map<String, AtomicBoolean> tenantToRetry;
+        private final Map<String, AtomicLong> lastInitAttempt;
 
         private IssuerBasedTenantResolver(TenantConfigContext[] tenantConfigContexts, boolean detectedTenantWithoutMetadata,
-                Map<String, AtomicBoolean> tenantToRetry) {
+                Map<String, AtomicLong> lastInitAttempt) {
             this.tenantConfigContexts = tenantConfigContexts;
             this.detectedTenantWithoutMetadata = detectedTenantWithoutMetadata;
-            this.tenantToRetry = tenantToRetry;
+            this.lastInitAttempt = lastInitAttempt;
         }
 
         private Uni<String> resolveTenant(RoutingContext context) {
@@ -250,12 +264,25 @@ final class StaticTenantResolver {
         }
 
         /**
-         * When static tenant couldn't be initialized on Quarkus application startup,
-         * this strategy permits one more attempt on the first request when the issuer-based tenant resolver is applied.
+         * A static tenant whose OIDC metadata was not available at application startup is (re-)initialized
+         * lazily while resolving a tenant from the bearer token issuer.
+         * <p>
+         * The first attempt happens on the first request. Further attempts are only made when
+         * this tenant's 'initialization-retry-interval' is positive, and then at most once per that
+         * interval per tenant, allowing the tenant to recover after the OIDC provider becomes available
+         * again without an application restart.
          */
         private boolean tryToInitialize(TenantConfigContext context) {
             var tenantId = context.oidcConfig().tenantId().get();
-            return this.tenantToRetry.get(tenantId).compareAndExchange(true, false);
+            AtomicLong lastAttempt = lastInitAttempt.get(tenantId);
+            long previous = lastAttempt.get();
+            long now = System.currentTimeMillis();
+            long retryIntervalMillis = context.oidcConfig().initializationRetryInterval().toMillis();
+            if (shouldRetryInitialization(previous, now, retryIntervalMillis)) {
+                // only one concurrent request wins the right to (re-)initialize this tenant
+                return lastAttempt.compareAndSet(previous, now);
+            }
+            return false;
         }
 
         private static String getTenantId(RoutingContext context, TenantConfigContext tenantContext) {
@@ -337,14 +364,14 @@ final class StaticTenantResolver {
         private static IssuerBasedTenantResolver of(Map<String, TenantConfigContext> tenantConfigContexts) {
             var contextsWithIssuer = new ArrayList<TenantConfigContext>();
             boolean detectedTenantWithoutMetadata = false;
-            Map<String, AtomicBoolean> tenantToRetry = new HashMap<>();
+            Map<String, AtomicLong> lastInitAttempt = new HashMap<>();
             for (TenantConfigContext context : tenantConfigContexts.values()) {
                 if (context.oidcConfig().tenantEnabled() && !OidcUtils.isWebApp(context.oidcConfig())) {
                     if (context.getOidcMetadata() == null) {
                         // if the tenant metadata are not available, we can't decide now
                         detectedTenantWithoutMetadata = true;
                         contextsWithIssuer.add(context);
-                        tenantToRetry.put(context.oidcConfig().tenantId().get(), new AtomicBoolean(true));
+                        lastInitAttempt.put(context.oidcConfig().tenantId().get(), new AtomicLong(0));
                     } else if (isTenantWithIssuer(context)) {
                         contextsWithIssuer.add(context);
                     }
@@ -353,9 +380,9 @@ final class StaticTenantResolver {
             if (contextsWithIssuer.isEmpty()) {
                 return null;
             } else {
-                var tenantInitStrategy = detectedTenantWithoutMetadata ? Map.copyOf(tenantToRetry) : null;
+                var attempts = detectedTenantWithoutMetadata ? Map.copyOf(lastInitAttempt) : Map.<String, AtomicLong> of();
                 return new IssuerBasedTenantResolver(contextsWithIssuer.toArray(new TenantConfigContext[0]),
-                        detectedTenantWithoutMetadata, tenantInitStrategy);
+                        detectedTenantWithoutMetadata, attempts);
             }
         }
 

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
@@ -109,6 +109,7 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
         AUTHORIZATION_PATH,
         APPLICATION_TYPE,
         TENANT_ENABLED,
+        INITIALIZATION_RETRY_INTERVAL,
         TOKEN_STATE_MANAGER_ENCRYPTION_ALGORITHM,
         TOKEN_STATE_MANAGER_ENCRYPTION_SECRET,
         TOKEN_STATE_MANAGER_ENCRYPTION_REQUIRED,
@@ -235,6 +236,12 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
     public boolean tenantEnabled() {
         invocationsRecorder.put(ConfigMappingMethods.TENANT_ENABLED, true);
         return false;
+    }
+
+    @Override
+    public Duration initializationRetryInterval() {
+        invocationsRecorder.put(ConfigMappingMethods.INITIALIZATION_RETRY_INTERVAL, true);
+        return Duration.ZERO;
     }
 
     @Override

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/StaticTenantResolverTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/StaticTenantResolverTest.java
@@ -1,0 +1,32 @@
+package io.quarkus.oidc.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class StaticTenantResolverTest {
+
+    @Test
+    public void firstAttemptAlwaysAllowed() {
+        assertTrue(StaticTenantResolver.shouldRetryInitialization(0, 1_000, 0));
+        assertTrue(StaticTenantResolver.shouldRetryInitialization(0, 1_000, 30_000));
+    }
+
+    @Test
+    public void zeroIntervalKeepsSingleAttemptBehavior() {
+        assertTrue(StaticTenantResolver.shouldRetryInitialization(0, 5_000, 0));
+        assertFalse(StaticTenantResolver.shouldRetryInitialization(1_000, 5_000, 0));
+        assertFalse(StaticTenantResolver.shouldRetryInitialization(1_000, Long.MAX_VALUE, 0));
+    }
+
+    @Test
+    public void positiveIntervalThrottlesRetries() {
+        long interval = 30_000;
+        long last = 100_000;
+        assertFalse(StaticTenantResolver.shouldRetryInitialization(last, last + 1, interval));
+        assertFalse(StaticTenantResolver.shouldRetryInitialization(last, last + interval - 1, interval));
+        assertTrue(StaticTenantResolver.shouldRetryInitialization(last, last + interval, interval));
+        assertTrue(StaticTenantResolver.shouldRetryInitialization(last, last + interval + 5_000, interval));
+    }
+}

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/StaticTenantIssuerResolverOnceTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/StaticTenantIssuerResolverOnceTest.java
@@ -1,0 +1,64 @@
+package io.quarkus.it.keycloak;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+import io.smallrye.jwt.build.Jwt;
+
+@TestProfile(StaticTenantIssuerResolverOnceTest.IssuerResolverOnceProfile.class)
+@QuarkusTest
+public class StaticTenantIssuerResolverOnceTest {
+
+    private static final long RETRY_INTERVAL_MILLIS = 3000;
+
+    @Test
+    public void testTenantStaysUnresolvedAfterFailedFirstAttempt() throws InterruptedException {
+        // provider is down; this request consumes the single always-allowed initialization attempt
+        requestAdminRoles().statusCode(500);
+
+        WiremockTestResource server = new WiremockTestResource("https://correct-issuer.edu", 8185);
+        server.start();
+        try {
+            // default retry interval is 0S, so the failed attempt is never retried, even though the provider is now healthy
+            requestAdminRoles().statusCode(500);
+
+            Thread.sleep(RETRY_INTERVAL_MILLIS);
+
+            requestAdminRoles().statusCode(500);
+        } finally {
+            server.stop();
+        }
+    }
+
+    private static ValidatableResponse requestAdminRoles() {
+        var token = Jwt.preferredUserName("alice")
+                .groups(Set.of("admin"))
+                .issuer("https://correct-issuer.edu")
+                .audience("https://correct-issuer.edu")
+                .jws()
+                .keyId("1")
+                .sign("privateKey.jwk");
+        return RestAssured.given().auth().oauth2(token)
+                .when().get("/api/admin/bearer-issuer-resolver/issuer").then();
+    }
+
+    public static class IssuerResolverOnceProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.oidc.resolve-tenants-with-issuer", "true",
+                    "quarkus.oidc.bearer-issuer-resolver-a.auth-server-url", "http://localhost:8185/auth/realms/quarkus2",
+                    "quarkus.oidc.bearer-issuer-resolver-a.discovery-path", ".well-known/oauth-authorization-server",
+                    "quarkus.oidc.bearer-issuer-resolver-a.client-id", "quarkus-app",
+                    "quarkus.oidc.bearer-issuer-resolver-a.credentials.secret", "secret",
+                    "quarkus.oidc.bearer-issuer-resolver-a.token.audience", "https://correct-issuer.edu");
+        }
+    }
+}

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/StaticTenantIssuerResolverRetryTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/StaticTenantIssuerResolverRetryTest.java
@@ -1,0 +1,68 @@
+package io.quarkus.it.keycloak;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+import io.smallrye.jwt.build.Jwt;
+
+@TestProfile(StaticTenantIssuerResolverRetryTest.IssuerResolverRetryProfile.class)
+@QuarkusTest
+public class StaticTenantIssuerResolverRetryTest {
+
+    private static final long RETRY_INTERVAL_MILLIS = 3000;
+
+    @Test
+    public void testTenantRecoversAfterRetryIntervalWithoutRestart() throws InterruptedException {
+        // provider is down; this request consumes the single always-allowed initialization attempt
+        requestAdminRoles().statusCode(500);
+
+        WiremockTestResource server = new WiremockTestResource("https://correct-issuer.edu", 8185);
+        server.start();
+        try {
+            // still inside the retry interval, so the now-healthy provider is not retried yet
+            requestAdminRoles().statusCode(500);
+
+            Thread.sleep(RETRY_INTERVAL_MILLIS + 500);
+
+            // interval elapsed, tenant recovers on its own without an application restart
+            requestAdminRoles().statusCode(200)
+                    .body(Matchers.is("static.tenant.id=bearer-issuer-resolver-a"));
+        } finally {
+            server.stop();
+        }
+    }
+
+    private static ValidatableResponse requestAdminRoles() {
+        var token = Jwt.preferredUserName("alice")
+                .groups(Set.of("admin"))
+                .issuer("https://correct-issuer.edu")
+                .audience("https://correct-issuer.edu")
+                .jws()
+                .keyId("1")
+                .sign("privateKey.jwk");
+        return RestAssured.given().auth().oauth2(token)
+                .when().get("/api/admin/bearer-issuer-resolver/issuer").then();
+    }
+
+    public static class IssuerResolverRetryProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.oidc.resolve-tenants-with-issuer", "true",
+                    "quarkus.oidc.bearer-issuer-resolver-a.initialization-retry-interval", "3S",
+                    "quarkus.oidc.bearer-issuer-resolver-a.auth-server-url", "http://localhost:8185/auth/realms/quarkus2",
+                    "quarkus.oidc.bearer-issuer-resolver-a.discovery-path", ".well-known/oauth-authorization-server",
+                    "quarkus.oidc.bearer-issuer-resolver-a.client-id", "quarkus-app",
+                    "quarkus.oidc.bearer-issuer-resolver-a.credentials.secret", "secret",
+                    "quarkus.oidc.bearer-issuer-resolver-a.token.audience", "https://correct-issuer.edu");
+        }
+    }
+}


### PR DESCRIPTION
When quarkus.oidc.resolve-tenants-with-issuer=true, a static tenant whose OIDC metadata cannot be discovered at startup (e.g. the provider is briefly unavailable) was only ever re-initialized once, on the first request. If that attempt also failed, the tenant was permanently excluded from issuer resolution until the application was restarted, even after the provider became healthy again.

Add a new runtime property, quarkus.oidc.tenant-initialization-retry-interval (Duration, default 0S), that lets such a tenant be re-initialized periodically instead of only once. The default of 0S preserves the previous one-shot behavior; a positive value re-attempts initialization at most once per interval per tenant, so the tenant recovers on its own once its OIDC provider becomes reachable again.

Fixes: #56170

