### PR TITLE
Add deprecation-cleanup skill

### DIFF
--- a/.agents/skills/deprecation-cleanup/SKILL.md
+++ b/.agents/skills/deprecation-cleanup/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: deprecation-cleanup
+description: >
+  Maintain @Deprecated code in the Quarkus codebase: remove code that has been
+  deprecated for more than 12 months, and add the @Deprecated annotations that
+  were missed when a related element was deprecated (e.g. a field is deprecated
+  but its getters/setters/constructors are not). Use this skill whenever the
+  user asks to clean up deprecations, remove old/long-deprecated code, purge
+  deprecated APIs, "remove code deprecated for over a year", audit @Deprecated
+  usage, or fix inconsistent/incomplete deprecation annotations — even if they
+  don't name a specific class or module.
+---
+
+# Deprecation Cleanup
+
+Quarkus accumulates `@Deprecated` code over time. This skill covers two
+workflows, sharing one discovery tool and the same commit conventions:
+
+- **Removal** — code deprecated for **at least 12 months** (the project's
+  convention) is safe to delete; keeping it forever defeats the point of
+  deprecating it.
+- **Completion** — when one element is deprecated, everything that only exists
+  to serve it should be deprecated too. A common miss: a field is marked
+  `@Deprecated` but its getter, setter, constructor parameter, or builder method
+  is not, so callers using the accessors get no warning.
+
+## The discovery tool
+
+`scripts/find-deprecated.sh` scans Java files for `@Deprecated` and prints each
+entry **sorted by the date it was originally introduced**. It uses
+`git blame -w -M -C -C -C` so a line's date reflects when it was first written,
+not when a later refactor moved it — so the 12-month clock runs from the *real*
+introduction date. Run it from the skill's `scripts/` directory (or use the full
+path):
+
+```bash
+scripts/find-deprecated.sh core/deployment --removable --csv          # Workflow A: only entries ≥12 months old
+scripts/find-deprecated.sh core/deployment --csv                      # Workflow B: ALL deprecations (default)
+scripts/find-deprecated.sh core/deployment --min-age-months=18 --csv  # custom threshold
+```
+
+`--csv` emits CSV (easier to sort/filter) instead of the formatted table;
+redirect to `$TMPDIR` to avoid re-scanning. Columns: `File Location`
+(path:line), `Deprecated Entry` (the declaration), `Date` (YYYY-MM-DD
+introduced), `Commit` (short hash).
+
+Scan the narrowest path that covers the request — the whole repo is slow (one
+`git blame` per hit).
+
+## Workflow A — Remove long-deprecated code
+
+The rule is age-based, but age alone is not sufficient to delete safely. Removal
+of a public API can break callers, so verify before you cut.
+
+### 1. Discover the removal candidates
+
+Run `--removable` (see above); the list it prints is already the candidate set.
+Entries dated `unknown` (blame couldn't resolve) are excluded because their age
+can't be confirmed — run without `--removable` to review those individually.
+
+### 2. Confirm each candidate is genuinely safe to remove
+
+For every candidate, before deleting:
+
+- **Search the whole repo for remaining usages** of the symbol (method name,
+  constructor signature, field). Include tests, integration-tests, and docs.
+  Deprecated does not mean unused.
+- If usages remain, they were supposed to migrate to the replacement named in
+  the `@deprecated` javadoc. **Migrate them first** (in the same change), or, if
+  migration is non-trivial or out of scope, **leave that entry in place** and
+  move on — don't delete something the codebase still depends on.
+- Watch for **overrides and API contracts**: a deprecated method may implement
+  an interface or be overridden elsewhere; removing it can break the hierarchy.
+
+If in doubt about whether an external/public API can be dropped, surface it to
+the user rather than guessing — some deprecated items are kept intentionally for
+downstream compatibility.
+
+### 3. Remove, one class per change
+
+Delete the declaration and its javadoc/annotation block together. Preserve
+surrounding comments that are not about the removed element (see the repo's
+editing rules). Group all removals **within a single class into one commit**;
+keep different classes in separate commits so history stays reviewable.
+
+### 4. Build the affected module
+
+Removing code can break compilation elsewhere in the module (or its dependents).
+Build the module you touched — and rebuild its deployment module if you changed a
+runtime module (see the `building-and-testing` skill):
+
+```bash
+./mvnw install -f <module-path> -DskipTests
+```
+
+Fix any fallout (usually leftover callers you can migrate to the replacement).
+Only consider the removal done once it compiles.
+
+### 5. Commit
+
+One commit per class. See **Commit conventions** below.
+
+## Workflow B — Complete missed deprecations
+
+When you deprecate something, its satellites should be deprecated too. The
+classic gap is a deprecated **field** whose **accessors** (getter/setter),
+**constructors**, or **builder methods** were left un-annotated — so a caller
+using the getter gets no warning.
+
+### 1. Find the gaps
+
+Run the tool **without an age filter** (the default) so every deprecation shows
+up regardless of when it was introduced — the gaps you're hunting for are often
+recent:
+
+```bash
+scripts/find-deprecated.sh <path> --csv
+```
+
+While reviewing a class (or when the user reports one), look for a deprecated
+element whose companions are not deprecated:
+
+- A `@Deprecated` field → is its getter/setter deprecated? Its constructor
+  parameter? The builder method that sets it?
+- A `@Deprecated` constructor/method → do overloads that only forward to it, or
+  builder entry points that only exist for it, still lack the annotation?
+
+`git blame` the un-annotated companion to understand when it was introduced and
+whether it was meant to be deprecated alongside the element it serves. The commit
+that deprecated the primary element is your reference.
+
+### 2. Add the annotation + javadoc
+
+Add both an `@Deprecated` annotation and a javadoc `@deprecated` tag that tells
+the user what to use instead. The javadoc is what makes the deprecation
+actionable — without a replacement pointer it's just noise.
+
+```java
+/**
+ * @deprecated Use {@link GeneratedResourceBuildItem#GeneratedResourceBuildItem(String, byte[])} instead.
+ *             If you want to serve static resources use
+ *             {@link io.quarkus.vertx.http.deployment.spi.GeneratedStaticResourceBuildItem} instead.
+ */
+@Deprecated(since = "4.0")
+public GeneratedResourceBuildItem(String name, byte[] data, boolean excludeFromDevCL) {
+    ...
+}
+```
+
+### 3. Build and commit
+
+Build the module (Workflow A, step 4) and commit — message form
+*"Code deprecation in `X`"* (see below).
+
+## `@Deprecated` annotation conventions
+
+- Prefer the form **`@Deprecated(since = "<version>")`** over a bare
+  `@Deprecated`. `since` records when the deprecation started (which
+  drives the 12-month removal clock and helps future cleanup)
+- Always pair the annotation with a javadoc **`@deprecated`** tag naming the
+  replacement.
+- **Choosing `since`:**
+  - For a companion that *should have been* deprecated alongside an existing
+    element, match the intent of that element — but note the actual value is a
+    judgement call, ask the user if in doubt.
+  - For a brand-new deprecation, use the **current in-development release**
+    version. The main branch carries `999-SNAPSHOT`, so the real version isn't in
+    `pom.xml` — determine it from recent release branches/tags (recent work used
+    `4.0`). If you can't determine it confidently, ask the user rather than
+    inventing a number.
+
+## Commit conventions
+
+One class per commit. The body cites the commit(s) that introduced the
+deprecation, so a reviewer can verify the 12-month age without re-running blame.
+Follow the repository's policies.
+
+**Removal — single introducing commit:**
+
+```
+Remove deprecated code from `TransformedClassesBuildItem`
+
+The removed code has been deprecated for at least 12 months in 469fd3ae
+```
+
+**Removal — multiple introducing commits:**
+
+```
+Remove deprecated code from `ReflectiveHierarchyBuildItem`
+
+The removed code has been deprecated for at least 12 months in the
+following commits:
+
+* 498d936a
+* aeeaa55d
+```
+
+**Completing a missed deprecation:**
+
+```
+Code deprecation in `GeneratedResourceBuildItem`
+
+The removed code has been deprecated for at least 12 months in c76362ab.
+
+The newly deprecated methods should have been deprecated as part of
+41cd5830
+```
+
+Use backticks around the class name in the subject. Reference commits by their
+short hash (from the discovery tool's `Commit` column).
+
+## Common pitfalls
+
+- **Don't trust `@Deprecated` as proof of disuse.** Always grep for callers
+  first; deprecated APIs are frequently still used internally.
+- **Don't remove based on a move-date.** The tool already uses `-M -C` to trace
+  the true origin — but if you compute a date another way, a refactor can make
+  old code look recent and vice-versa.
+- **Don't skip the build.** Compilation is the cheapest check that a removal
+  didn't strand a caller.
+- **Don't reorder or hand-sort imports** after deletions — the formatter and
+  `impsort-maven-plugin` handle that during compilation. Don't pass `-Dno-format`.
+- **Keep unrelated comments.** Only delete the javadoc/annotation attached to the
+  element you're removing.

--- a/.agents/skills/deprecation-cleanup/scripts/find-deprecated.sh
+++ b/.agents/skills/deprecation-cleanup/scripts/find-deprecated.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# find-deprecated.sh
+#
+# Scans Java files for @Deprecated annotations and lists them sorted by the
+# date they were *originally* introduced, using git blame with move/copy
+# detection to avoid attributing a line to a later refactor/move commit.
+#
+# Usage:
+#   ./find-deprecated.sh [search_root] [--csv] [--removable | --min-age-months=N]
+#
+#   search_root         Directory to scan (default: current working directory)
+#   --csv               Emit CSV instead of a formatted table
+#   --removable         Only report entries introduced at least 12 months ago
+#                       (i.e. candidates for removal). Shorthand for
+#                       --min-age-months=12.
+#   --min-age-months=N  Only report entries introduced at least N months ago.
+#                       Default (0) reports ALL deprecations, which is what you
+#                       want when completing missed deprecation annotations.
+#
+# Entries whose introduction date cannot be resolved (blame "unknown") are
+# omitted when an age filter is active, because their age can't be confirmed.
+#
+# Output columns:
+#   File Location   –  path:line of the @Deprecated annotation
+#   Deprecated Entry –  first non-annotation declaration line below it
+#   Date            –  YYYY-MM-DD when the line was first introduced
+#   Commit          –  short commit hash from git blame
+#
+# Flags passed to git blame to minimise "false-late" dates caused by code moves:
+#   -w          ignore whitespace-only changes
+#   -M          detect lines moved/copied within the same file
+#   -C -C -C    detect lines moved/copied from other files across all of history
+
+set -euo pipefail
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+SEARCH_ROOT="."
+OUTPUT_CSV=0
+MIN_AGE_MONTHS=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --csv)                OUTPUT_CSV=1 ;;
+        --removable)          MIN_AGE_MONTHS=12 ;;
+        --min-age-months=*)   MIN_AGE_MONTHS="${arg#*=}" ;;
+        *)                    SEARCH_ROOT="$arg" ;;
+    esac
+done
+
+SEARCH_ROOT="$(cd "$SEARCH_ROOT" && pwd)"
+REPO_ROOT="$(git -C "$SEARCH_ROOT" rev-parse --show-toplevel 2>/dev/null || echo "$SEARCH_ROOT")"
+
+# ── Age cutoff ─────────────────────────────────────────────────────────────────
+# When an age filter is requested, compute the cutoff timestamp. Entries whose
+# introduction timestamp is > cutoff (newer than N months) are filtered out.
+# Try GNU date first, then BSD/macOS date.
+CUTOFF_TS=0
+if [[ "$MIN_AGE_MONTHS" -gt 0 ]]; then
+    CUTOFF_TS=$(date -d "-${MIN_AGE_MONTHS} months" +%s 2>/dev/null \
+                || date -v-"${MIN_AGE_MONTHS}"m +%s 2>/dev/null \
+                || echo 0)
+    if [[ "$CUTOFF_TS" -eq 0 ]]; then
+        echo "WARNING: could not compute a date cutoff; reporting all entries." >&2
+    fi
+fi
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+# get_context FILE LINE_NUM
+# Reads the file and returns the first non-annotation, non-comment, non-blank
+# line starting at LINE_NUM (i.e. the declaration that is being deprecated).
+get_context() {
+    local file="$1"
+    local start="$2"
+    local full_path="$REPO_ROOT/$file"
+
+    [[ -f "$full_path" ]] || { echo ""; return; }
+
+    awk -v start="$start" '
+        NR >= start {
+            # skip blank, annotation, javadoc/comment lines
+            gsub(/^[[:space:]]+/, "")
+            if ($0 == "")            { next }
+            if ($0 ~ /^@/)           { next }
+            if ($0 ~ /^\/\//)        { next }
+            if ($0 ~ /^\*/)          { next }
+            if ($0 ~ /^\/\*/)        { next }
+            # strip trailing brace, collapse whitespace, truncate
+            sub(/[[:space:]]*\{[[:space:]]*$/, "")
+            # collapse internal whitespace
+            gsub(/[[:space:]]+/, " ")
+            printf "%s", substr($0, 1, 120)
+            exit
+        }
+    ' "$full_path"
+}
+
+# blame_line FILE LINE_NUM  →  prints "COMMIT UNIX_TIMESTAMP"
+#
+# Uses -C -C -C so git traces the line back through file copies/renames across
+# the full history, giving us the *original* introduction date rather than the
+# date a refactor moved the line.
+blame_line() {
+    local file="$1"
+    local line="$2"
+
+    local porcelain
+    porcelain=$(git -C "$REPO_ROOT" blame -w -M -C -C -C \
+                    --porcelain -L "${line},${line}" -- "$file" 2>/dev/null) || true
+
+    local commit="" ts=""
+    while IFS= read -r bl; do
+        if [[ -z "$commit" ]]; then
+            commit="${bl%% *}"          # first token of first line = hash
+        fi
+        if [[ "$bl" == author-time\ * ]]; then
+            ts="${bl#author-time }"
+            break
+        fi
+    done <<< "$porcelain"
+
+    echo "${commit:0:8} ${ts:-0}"
+}
+
+# unix_to_date UNIX_TIMESTAMP  →  YYYY-MM-DD
+unix_to_date() {
+    local ts="$1"
+    if [[ "$ts" == "0" || -z "$ts" ]]; then
+        echo "unknown"
+    else
+        date -d "@$ts" +"%Y-%m-%d" 2>/dev/null \
+            || date -r "$ts" +"%Y-%m-%d" 2>/dev/null \
+            || echo "unknown"
+    fi
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+echo "Scanning $SEARCH_ROOT …" >&2
+
+# Collect all @Deprecated locations: "file:line"
+mapfile -t locations < <(
+    rg --line-number --no-heading --color=never -g '*.java' '@Deprecated' \
+       "$SEARCH_ROOT" \
+    | sed "s|^$REPO_ROOT/||"   # make paths relative to repo root
+)
+
+total=${#locations[@]}
+echo "Found $total @Deprecated annotations, resolving blame …" >&2
+
+# Temp file stores: UNIX_TS TAB file:line TAB context TAB commit
+tmpfile=$(mktemp)
+trap 'rm -f "$tmpfile"' EXIT
+
+idx=0
+for loc in "${locations[@]}"; do
+    idx=$(( idx + 1 ))
+    (( idx % 50 == 0 || idx == total )) && echo "  $idx/$total" >&2
+
+    # Split "path/to/File.java:42:  @Deprecated" → file and line number
+    file="${loc%%:*}"
+    rest="${loc#*:}"
+    line="${rest%%:*}"
+
+    read -r commit ts < <(blame_line "$file" "$line")
+    context=$(get_context "$file" "$(( line + 1 ))")
+
+    printf '%s\t%s\t%s\t%s\n' \
+        "${ts:-0}" "${file}:${line}" "$context" "${commit:-unknown}" \
+        >> "$tmpfile"
+done
+
+# Sort by unix timestamp (column 1), ascending
+sorted=$(sort -t$'\t' -k1,1n "$tmpfile")
+
+# Apply the age filter, if requested: keep only entries with a known timestamp
+# (column 1 != 0) that is at or before the cutoff (i.e. at least N months old).
+if [[ "$MIN_AGE_MONTHS" -gt 0 && "$CUTOFF_TS" -gt 0 ]]; then
+    sorted=$(awk -F'\t' -v cutoff="$CUTOFF_TS" '$1 != 0 && $1 <= cutoff' <<< "$sorted")
+fi
+
+# Count what will actually be shown (may differ from $total once filtered).
+shown=$(grep -c . <<< "$sorted" 2>/dev/null || echo 0)
+[[ -z "$sorted" ]] && shown=0
+
+# ── Render output ─────────────────────────────────────────────────────────────
+
+if [[ "$OUTPUT_CSV" -eq 1 ]]; then
+    echo "File Location,Deprecated Entry,Date,Commit"
+    while IFS=$'\t' read -r ts fileloc context commit; do
+        date_str=$(unix_to_date "$ts")
+        # CSV-escape fields (wrap in quotes, double any internal quotes)
+        printf '"%s","%s","%s","%s"\n' \
+            "${fileloc//\"/\"\"}" \
+            "${context//\"/\"\"}" \
+            "$date_str" \
+            "$commit"
+    done <<< "$sorted"
+else
+    FILE_W=70
+    ENTRY_W=90
+    DATE_W=12
+    CMT_W=9
+
+    sep_len=$(( FILE_W + ENTRY_W + DATE_W + CMT_W + 6 ))
+
+    printf "%-${FILE_W}s  %-${ENTRY_W}s  %-${DATE_W}s  %-${CMT_W}s\n" \
+        "File Location" "Deprecated Entry" "Date" "Commit"
+    printf '%*s\n' "$sep_len" '' | tr ' ' '-'
+
+    while IFS=$'\t' read -r ts fileloc context commit; do
+        date_str=$(unix_to_date "$ts")
+        printf "%-${FILE_W}s  %-${ENTRY_W}s  %-${DATE_W}s  %-${CMT_W}s\n" \
+            "${fileloc:0:$FILE_W}" \
+            "${context:0:$ENTRY_W}" \
+            "$date_str" \
+            "$commit"
+    done <<< "$sorted"
+fi
+
+echo "" >&2
+if [[ "$MIN_AGE_MONTHS" -gt 0 ]]; then
+    echo "Total: $shown of $total entries (at least ${MIN_AGE_MONTHS} months old)" >&2
+else
+    echo "Total: $total entries" >&2
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,3 +120,4 @@ Consult the relevant skill when you are about to do that type of work:
 | `pull-requests` | PR title/description conventions, commit hygiene, labels, and contribution rules      |
 | `writing-extension-devui` | Writing a Dev UI for a Quarkus extension                                              |
 | `building-docs` | Building, previewing, or testing documentation changes locally                        |
+| `deprecation-cleanup` | Removing code deprecated for over 12 months, or adding missed `@Deprecated` annotations |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,3 +25,6 @@ guidance before starting work:
   when preparing a pull request, writing commit messages, or choosing labels.
 - **Building docs** — Read `.agents/skills/building-docs/SKILL.md`
   when building, previewing, or testing documentation changes locally.
+- **Deprecation cleanup** — Read `.agents/skills/deprecation-cleanup/SKILL.md`
+  when removing code that has been deprecated for over 12 months, or adding
+  `@Deprecated` annotations that were missed on companions of a deprecated element.


### PR DESCRIPTION
Adds a skill for maintaining @Deprecated code in the Quarkus codebase:
removing code deprecated for over 12 months and completing missed
@Deprecated annotations on companion elements. Includes a
find-deprecated.sh discovery tool that sorts deprecations by their true
introduction date via git blame with move/copy detection, and registers
the skill in AGENTS.md and CLAUDE.md.

The skill was generated using [skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator) based on my existing manual workflow.

The skill has been tested in the creation of https://github.com/quarkusio/quarkus/pull/56172

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>
