### PR TITLE
Redis: make sure the configured hosts are ordered

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/client/RedisHostsProvider.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/client/RedisHostsProvider.java
@@ -1,7 +1,7 @@
 package io.quarkus.redis.client;
 
 import java.net.URI;
-import java.util.Set;
+import java.util.Collection;
 
 /**
  * Programmatically provides redis hosts
@@ -14,5 +14,5 @@ public interface RedisHostsProvider {
      *
      * @return the hosts
      */
-    Set<URI> getHosts();
+    Collection<URI> getHosts();
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/VertxRedisClientFactory.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/VertxRedisClientFactory.java
@@ -10,9 +10,9 @@ import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxTrustOpt
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Consumer;
 
 import org.jboss.logging.Logger;
@@ -58,9 +58,9 @@ public class VertxRedisClientFactory {
             ProxyConfigurationRegistry proxyRegistry) {
         RedisOptions options = new RedisOptions();
 
-        Consumer<Set<URI>> configureOptions = new Consumer<Set<URI>>() {
+        Consumer<Collection<URI>> configureOptions = new Consumer<Collection<URI>>() {
             @Override
-            public void accept(Set<URI> uris) {
+            public void accept(Collection<URI> uris) {
                 for (URI uri : uris) {
                     if (config.configureClientName()) {
                         String client = config.clientName().orElse(name);
@@ -79,7 +79,7 @@ public class VertxRedisClientFactory {
             configureOptions.accept(config.hosts().get());
         } else if (config.hostsProviderName().isPresent()) {
             RedisHostsProvider hostsProvider = findProvider(config.hostsProviderName().get());
-            Set<URI> computedHosts = hostsProvider.getHosts();
+            Collection<URI> computedHosts = hostsProvider.getHosts();
             hosts.addAll(computedHosts);
             configureOptions.accept(computedHosts);
         } else {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisClientConfig.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisClientConfig.java
@@ -2,8 +2,8 @@ package io.quarkus.redis.runtime.client.config;
 
 import java.net.URI;
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import io.quarkus.redis.client.RedisClientName;
 import io.quarkus.runtime.annotations.ConfigDocDefault;
@@ -35,7 +35,7 @@ public interface RedisClientConfig {
      *
      * @see <a href="https://www.iana.org/assignments/uri-schemes/prov/redis">Redis scheme on www.iana.org</a>
      */
-    Optional<Set<URI>> hosts();
+    Optional<List<URI>> hosts();
 
     /**
      * The hosts provider bean name.

--- a/integration-tests/redis-client/src/main/java/io/quarkus/redis/it/RedisLocalHostProvider.java
+++ b/integration-tests/redis-client/src/main/java/io/quarkus/redis/it/RedisLocalHostProvider.java
@@ -1,8 +1,8 @@
 package io.quarkus.redis.it;
 
 import java.net.URI;
-import java.util.Collections;
-import java.util.Set;
+import java.util.Collection;
+import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -15,7 +15,7 @@ public class RedisLocalHostProvider implements RedisHostsProvider {
 
     // Select the database "3"
     @Override
-    public Set<URI> getHosts() {
-        return Collections.singleton(URI.create("redis://localhost:6379/3"));
+    public Collection<URI> getHosts() {
+        return List.of(URI.create("redis://localhost:6379/3"));
     }
 }


### PR DESCRIPTION
The `quarkus.redis.hosts` config property used to be a `Set<String>`, which means it doesn't have a well-defined iteration order. This typically doesn't matter, unless one configures static topology with replication, in which case the first host is a master and the others are replicas.

This commit turns the config property into `List<String>`, which means duplicates may suddenly occur. I don't see a huge problem in this; arguably, if the user does configure the same host multiple times, they have a reason.

Further, the `RedisHostsProvider` interface used to prescribe a method also returning `Set<String>`. This method now returns `Collection<String>`, which breaks binary compatibility, but retains source compatibility. This seems fair in a major version like Quarkus 4.0.

* Fixes #56132