### PR TITLE
Add missing include::_attributes.adoc[] to init-tasks and build-analytics guides

### DIFF
--- a/docs/src/main/asciidoc/build-analytics.adoc
+++ b/docs/src/main/asciidoc/build-analytics.adoc
@@ -4,6 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Build analytics
+include::_attributes.adoc[]
 :summary: This guide presents what build analytics is and how to configure it.
 
 The Quarkus team has limited knowledge, from Maven download numbers, of the remarkable growth of Quarkus and the number of users reporting issues/concerns. Still, we need more insight into the platforms, operating system, Java combinations, and build tools our users employ.

--- a/docs/src/main/asciidoc/init-tasks.adoc
+++ b/docs/src/main/asciidoc/init-tasks.adoc
@@ -4,6 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Initialization tasks
+include::_attributes.adoc[]
 :summary: This reference guide explains how to configure initialization tasks
 :topics: init,kubernetes,openshift,liquibase,flyway
 :extensions: io.quarkus:quarkus-kubernetes,io.quarkus:quarkus-openshift,io.quarkus:quarkus-flyway,io.quarkus:quarkus-liquibase


### PR DESCRIPTION
A few guides are missing the include of the attributes doc. This affects remarkably little, but it *does* mean the workaround in https://github.com/quarkusio/quarkusio.github.io/pull/2919 doesn't work for those pages. That means those pages will have some dead links in dev mode (only in dev mode). 
