### PR TITLE
Register the Lambda test base URI with the HTTP root path

### DIFF
--- a/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AbstractLambdaPollLoop.java
+++ b/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AbstractLambdaPollLoop.java
@@ -8,8 +8,11 @@ import java.net.SocketException;
 import java.net.URI;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 import org.jboss.logging.MDC;
 
@@ -55,6 +58,31 @@ public abstract class AbstractLambdaPollLoop {
 
     private static final RuntimeKey<URI> LOCAL_BASE_URI = RuntimeKey.key("quarkus.http.local-base-uri");
 
+    /**
+     * The path part of the local base URI, built like the one the Vert.x HTTP server registers so that tests
+     * see the same base path ({@code quarkus.http.root-path} and {@code quarkus.servlet.context-path})
+     * whether requests go through the HTTP server or the mock event server.
+     */
+    private static String localBasePath() {
+        Config config = ConfigProvider.getConfig();
+        String rootPath = config.getOptionalValue("quarkus.http.root-path", String.class).orElse("/");
+        Optional<String> contextPath = config.getOptionalValue("quarkus.servlet.context-path", String.class);
+        StringBuilder path = new StringBuilder(rootPath);
+        if (!rootPath.endsWith("/")) {
+            path.append("/");
+        }
+        if (!rootPath.startsWith("/")) {
+            path.insert(0, "/");
+        }
+        if (contextPath.isPresent()) {
+            path.append(contextPath.get().startsWith("/") ? contextPath.get().substring(1) : contextPath.get());
+        }
+        if (path.charAt(path.length() - 1) == '/') {
+            path.deleteCharAt(path.length() - 1);
+        }
+        return path.toString();
+    }
+
     public void startPollLoop(ValueRegistry valueRegistry, ShutdownContext context) {
         final AtomicBoolean running = new AtomicBoolean(true);
         // flag to check whether to interrupt.
@@ -62,7 +90,8 @@ public abstract class AbstractLambdaPollLoop {
         String baseUrl = AmazonLambdaApi.baseUrl();
         URI lambdaBase = URI.create(AmazonLambdaApi.baseUrl());
         valueRegistry.register(LOCAL_BASE_URI,
-                URI.create(lambdaBase.getScheme() + "://" + lambdaBase.getHost() + ":" + lambdaBase.getPort()));
+                URI.create(lambdaBase.getScheme() + "://" + lambdaBase.getHost() + ":" + lambdaBase.getPort()
+                        + localBasePath()));
         final Thread pollingThread = new Thread(new Runnable() {
             @Override
             public void run() {

--- a/integration-tests/amazon-lambda-rest-resteasy-reactive/src/test/java/io/quarkus/it/amazon/lambda/rest/resteasy/reactive/AmazonLambdaRootPathTestCase.java
+++ b/integration-tests/amazon-lambda-rest-resteasy-reactive/src/test/java/io/quarkus/it/amazon/lambda/rest/resteasy/reactive/AmazonLambdaRootPathTestCase.java
@@ -1,0 +1,49 @@
+package io.quarkus.it.amazon.lambda.rest.resteasy.reactive;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+
+/**
+ * With a root path, REST Assured must target the mock event server with the same base path it would use
+ * for the HTTP server, so tests written against the resource paths keep working.
+ */
+@QuarkusTest
+@TestProfile(RootPathProfile.class)
+public class AmazonLambdaRootPathTestCase {
+
+    @Test
+    public void testResourcePathsAreRelativeToTheRootPath() {
+        assertEquals("svc", RestAssured.basePath);
+        given()
+                .when()
+                .get("/hello/context")
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
+    public void testAbsolutePath() {
+        String basePath = RestAssured.basePath;
+        try {
+            RestAssured.basePath = "/";
+            given()
+                    .when()
+                    .get("/svc/hello/context")
+                    .then()
+                    .statusCode(204);
+            given()
+                    .when()
+                    .get("/hello/context")
+                    .then()
+                    .statusCode(404);
+        } finally {
+            RestAssured.basePath = basePath;
+        }
+    }
+}

--- a/integration-tests/amazon-lambda-rest-resteasy-reactive/src/test/java/io/quarkus/it/amazon/lambda/rest/resteasy/reactive/RootPathProfile.java
+++ b/integration-tests/amazon-lambda-rest-resteasy-reactive/src/test/java/io/quarkus/it/amazon/lambda/rest/resteasy/reactive/RootPathProfile.java
@@ -1,0 +1,13 @@
+package io.quarkus.it.amazon.lambda.rest.resteasy.reactive;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class RootPathProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("quarkus.http.root-path", "/svc");
+    }
+}


### PR DESCRIPTION
Fixes the Lambda half of #51364, where a `quarkus-amazon-lambda-rest` application with `quarkus.http.root-path` set gets 404s from every `@QuarkusTest`.

Since the local base URI moved to the value registry, `AbstractLambdaPollLoop` registers it without any path, so `RestAssured.basePath` is empty for tests going through the mock event server, while the Vert.x HTTP server registers a URI including `quarkus.http.root-path` and `quarkus.servlet.context-path`. The Lambda URI is now built the same way, so `given().get("/health/status")` works again with a root path, as it did in 3.21.

Test: `AmazonLambdaRootPathTestCase` in the Lambda REST integration tests, which fails with an empty base path before the fix (`expected: <svc> but was: <>`). I also reproduced the reporter's setup with 3.21.1 and current main before/after: with the fix, main behaves like 3.21.1 again. Note that the request in the issue, `.get("/svc/health/status")`, still doubles the prefix because REST Assured already carries the root path in `basePath`, on 3.21.1 as well; `.get("/health/status")` is the working form, as @MdTanwer pointed out.

The other half of the issue, `TestHTTPConfigSourceInterceptor` turning a root path expression such as `${API_ROOT_PATH:/svc}` into `//svc`, is not addressed here: #56128 removes that interceptor, and `TestHTTPResourceManager#rootPath` already normalizes the expanded value, so the expression case is fixed by that removal. The test profile here deliberately uses a plain `/svc` so this PR does not depend on #56128.

- Fixes: #51364
