### PR TITLE
Confine Dev UI workspace JSON-RPC operations to the project root

### DIFF
--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/WorkspaceProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/WorkspaceProcessor.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.file.AccessDeniedException;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -224,7 +225,13 @@ public class WorkspaceProcessor {
                     .function((Map<String, String> t) -> {
                         String actionId = t.get("actionId");
                         if (actionId != null) {
-                            Path path = Path.of(URI.create(t.get("path")));
+                            Path path;
+                            try {
+                                path = resolveWorkspacePath(workspaceBuildItem.get().getRootPath(), t.get("path"));
+                            } catch (SecurityException e) {
+                                LOG.warn(e.getMessage());
+                                return null;
+                            }
                             Action actionToExecute = actionMap.get(actionId);
                             Path convertedPath = (Path) actionToExecute.getPathConverter().apply(path);
 
@@ -256,8 +263,14 @@ public class WorkspaceProcessor {
                     .parameter("path", "The path, as a URI in String format, to the workspace item that content is requested")
                     .function((Map<String, String> params) -> {
                         if (params.containsKey("path")) {
-                            Path path = Paths.get(URI.create(params.get("path")));
-                            return readContents(path);
+                            try {
+                                Path path = resolveWorkspacePath(workspaceBuildItem.get().getRootPath(),
+                                        params.get("path"));
+                                return readContents(path);
+                            } catch (SecurityException e) {
+                                LOG.warn(e.getMessage());
+                                return new WorkspaceContent("text", "Error: " + e.getMessage(), false);
+                            }
                         }
                         return null;
                     })
@@ -273,10 +286,16 @@ public class WorkspaceProcessor {
                     .function((Map<String, String> params) -> {
                         if (params.containsKey("content")) {
                             String content = params.get("content");
-                            Path path = Paths.get(URI.create(params.get("path")));
-                            writeContent(path, content);
-                            return new SavedResult(workspaceBuildItem.get().getRootPath().relativize(path).toString(), true,
-                                    null);
+                            try {
+                                Path path = resolveWorkspacePath(workspaceBuildItem.get().getRootPath(),
+                                        params.get("path"));
+                                writeContent(path, content);
+                                return new SavedResult(workspaceBuildItem.get().getRootPath().relativize(path).toString(),
+                                        true, null);
+                            } catch (SecurityException e) {
+                                LOG.warn(e.getMessage());
+                                return new SavedResult(null, false, e.getMessage());
+                            }
                         }
                         return new SavedResult(null, false, "Invalid input");
                     })
@@ -322,6 +341,53 @@ public class WorkspaceProcessor {
 
     private boolean isFileInRoot(String name) {
         return !name.contains("/");
+    }
+
+    /**
+     * Resolve a client supplied path URI and make sure it stays confined to the project root.
+     * The workspace operations are only meant to act on files inside the user's project, so any
+     * path (including ones using {@code ..} or symlinks) that resolves outside the root is rejected.
+     */
+    private static Path resolveWorkspacePath(Path rootPath, String uriString) {
+        if (uriString == null) {
+            throw new SecurityException("No workspace path provided");
+        }
+
+        Path root;
+        Path resolved;
+        try {
+            root = toCanonicalPath(rootPath);
+            resolved = toCanonicalPath(Paths.get(URI.create(uriString)));
+        } catch (IllegalArgumentException | FileSystemNotFoundException | IOException e) {
+            // Malformed URI, a non-file scheme or a path we cannot safely canonicalize: reject it.
+            throw new SecurityException("Invalid workspace path: " + uriString);
+        }
+
+        if (!resolved.startsWith(root)) {
+            throw new SecurityException("Path is outside the project root: " + resolved);
+        }
+        return resolved;
+    }
+
+    /**
+     * Normalize a path to an absolute form with symlinks resolved. The file itself may not exist
+     * yet (e.g. when creating a new workspace item), so symlinks are only resolved on the nearest
+     * existing ancestor to prevent a symlinked directory from escaping the root. If the real path
+     * cannot be determined the {@link IOException} is propagated so the caller can fail closed
+     * rather than fall back to an unresolved (potentially escaping) path.
+     */
+    private static Path toCanonicalPath(Path path) throws IOException {
+        Path absolute = path.toAbsolutePath().normalize();
+        Path existing = absolute;
+        while (existing != null && !Files.exists(existing)) {
+            existing = existing.getParent();
+        }
+        if (existing == null) {
+            return absolute;
+        }
+        Path realExisting = existing.toRealPath();
+        Path remainder = existing.relativize(absolute);
+        return realExisting.resolve(remainder).normalize();
     }
 
     private String writeContent(Path path, String contents) {

--- a/extensions/devui/deployment/src/test/java/io/quarkus/devui/WorkspacePathConfinementTest.java
+++ b/extensions/devui/deployment/src/test/java/io/quarkus/devui/WorkspacePathConfinementTest.java
@@ -1,0 +1,147 @@
+package io.quarkus.devui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.devui.testrunner.HelloResource;
+import io.quarkus.devui.tests.DevUIJsonRPCTest;
+import io.quarkus.test.QuarkusDevModeTest;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * Verifies that the workspace JSON-RPC operations only act on files inside the project root and
+ * reject client supplied {@code file://} paths that resolve outside of it (path traversal /
+ * arbitrary file read and write).
+ */
+public class WorkspacePathConfinementTest extends DevUIJsonRPCTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(HelloResource.class)
+                    .add(new StringAsset("quarkus.application.name=workspace-confinement-test\n"),
+                            "application.properties"));
+
+    private static final String SECRET = "top-secret-content";
+
+    public WorkspacePathConfinementTest() {
+        super("devui-workspace");
+    }
+
+    @Test
+    public void testCanReadItemInsideProjectRoot() throws Exception {
+        JsonNode firstItem = firstWorkspaceItem();
+        String pathUri = firstItem.get("path").asText();
+
+        JsonNode content = super.executeJsonRPCMethod("getWorkspaceItemContent", Map.of("path", pathUri));
+
+        assertThat(content).isNotNull();
+        assertThat(content.has("content")).isTrue();
+    }
+
+    @Test
+    public void testCannotReadFileOutsideProjectRoot() throws Exception {
+        Path projectRoot = projectRoot();
+        Path secret = projectRoot.getParent().resolve("devui-confinement-secret.txt");
+        Files.writeString(secret, SECRET);
+        try {
+            // Absolute path pointing outside the project root
+            JsonNode byAbsolute = super.executeJsonRPCMethod("getWorkspaceItemContent",
+                    Map.of("path", secret.toUri().toString()));
+            assertThat(byAbsolute.get("content").asText())
+                    .as("Reading a file outside the project root must not leak its content").doesNotContain(SECRET);
+
+            // The same file reached via a '..' traversal from inside the root
+            String traversalUri = projectRoot.toUri().toString() + "../devui-confinement-secret.txt";
+            JsonNode byTraversal = super.executeJsonRPCMethod("getWorkspaceItemContent",
+                    Map.of("path", traversalUri));
+            assertThat(byTraversal.get("content").asText())
+                    .as("Reading via a '..' traversal must not leak its content").doesNotContain(SECRET);
+        } finally {
+            Files.deleteIfExists(secret);
+        }
+    }
+
+    @Test
+    public void testCannotWriteFileOutsideProjectRoot() throws Exception {
+        Path projectRoot = projectRoot();
+        Path escaped = projectRoot.getParent().resolve("devui-confinement-written.txt");
+        Files.deleteIfExists(escaped);
+        try {
+            JsonNode result = super.executeJsonRPCMethod("saveWorkspaceItemContent",
+                    Map.of("path", escaped.toUri().toString(), "content", "should-not-be-written"));
+
+            assertThat(result).isNotNull();
+            assertThat(result.get("success").asBoolean())
+                    .as("Writing a file outside the project root must be rejected").isFalse();
+            assertThat(Files.exists(escaped)).as("No file must be created outside the project root").isFalse();
+        } finally {
+            Files.deleteIfExists(escaped);
+        }
+    }
+
+    @Test
+    public void testCannotReadFileViaSymlinkOutsideProjectRoot() throws Exception {
+        Path projectRoot = projectRoot();
+        Path secret = projectRoot.getParent().resolve("devui-confinement-symlink-secret.txt");
+        Files.writeString(secret, SECRET);
+
+        Path link = projectRoot.resolve("devui-confinement-escape-link");
+        Files.deleteIfExists(link);
+        try {
+            Files.createSymbolicLink(link, secret.getParent());
+        } catch (UnsupportedOperationException | IOException e) {
+            // Filesystem does not support symlinks (e.g. Windows without privileges): nothing to test
+            Assumptions.assumeTrue(false, "Symlinks are not supported on this filesystem");
+        }
+        try {
+            // A symlink inside the root that points outside of it must not be usable to escape
+            String symlinkUri = link.toUri().toString() + "devui-confinement-symlink-secret.txt";
+            JsonNode content = super.executeJsonRPCMethod("getWorkspaceItemContent",
+                    Map.of("path", symlinkUri));
+            assertThat(content.get("content").asText())
+                    .as("Reading through a symlink that escapes the project root must not leak content")
+                    .doesNotContain(SECRET);
+        } finally {
+            Files.deleteIfExists(link);
+            Files.deleteIfExists(secret);
+        }
+    }
+
+    private JsonNode firstWorkspaceItem() throws Exception {
+        JsonNode workspace = super.executeJsonRPCMethod("getWorkspaceItems");
+        assertThat(workspace).isNotNull();
+        JsonNode items = workspace.get("items");
+        assertThat(items).isNotNull();
+        assertThat(items.isArray()).isTrue();
+        assertThat(items.size()).isGreaterThan(0);
+        return items.get(0);
+    }
+
+    /**
+     * Derive the project root from a workspace item: its absolute path minus the relative name.
+     */
+    private Path projectRoot() throws Exception {
+        JsonNode item = firstWorkspaceItem();
+        Path abs = Paths.get(URI.create(item.get("path").asText()));
+        Path relative = Paths.get(item.get("name").asText());
+        Path root = abs;
+        for (int i = 0; i < relative.getNameCount(); i++) {
+            root = root.getParent();
+        }
+        return root;
+    }
+}


### PR DESCRIPTION
The Dev UI workspace screen exposes JSON-RPC (and MCP) actions to read, write and act on workspace files. These actions took a `file://` URI straight from the client and resolved it directly, reading or writing the file without checking that it stayed inside the project. A crafted path - an absolute location or one using `..` - could therefore read or write arbitrary files that the developer's user account has access to (for example SSH keys or shell profiles), reachable by anything that can talk to the dev-mode HTTP port, including a malicious page in the developer's browser.

Although this only runs in local dev mode, the read/write reach makes it worth closing. Each workspace path is now canonicalized and confined to the workspace root (resolving `..` and symlinks), and requests that fall outside the root are rejected with a clear response instead of performing the operation.

Release note: The Dev UI workspace no longer allows JSON-RPC/MCP file operations to read or write files outside the current project root.