### PR TITLE
Do not rebuild the application for every launch of a QuarkusMainTest

### DIFF
--- a/integration-tests/devservices/tests/src/main/java/io/quarkus/devservices/test/PrintContainerIdMain.java
+++ b/integration-tests/devservices/tests/src/main/java/io/quarkus/devservices/test/PrintContainerIdMain.java
@@ -1,0 +1,23 @@
+package io.quarkus.devservices.test;
+
+import static io.quarkus.tests.simpleextension.Constants.SIMPLE_EXTENSION_CONTAINER_ID;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.quarkus.runtime.QuarkusApplication;
+import io.quarkus.runtime.annotations.QuarkusMain;
+
+/*
+ * Not the default main class, so that it is only run by the tests that explicitly select it.
+ */
+@QuarkusMain(name = "print-container-id")
+public class PrintContainerIdMain implements QuarkusApplication {
+
+    public static final String PREFIX = "container-id=";
+
+    @Override
+    public int run(String... args) {
+        System.out.println(PREFIX + ConfigProvider.getConfig().getValue(SIMPLE_EXTENSION_CONTAINER_ID, String.class));
+        return 0;
+    }
+}

--- a/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesMainTestWithRestrictedTestResourceTest.java
+++ b/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesMainTestWithRestrictedTestResourceTest.java
@@ -1,0 +1,76 @@
+package io.quarkus.devservices.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+import io.quarkus.test.junit.main.QuarkusMainTest;
+
+/**
+ * A test resource restricted to the test class must not make every {@link Launch} of a {@link QuarkusMainTest}
+ * rebuild the application, otherwise the dev services are restarted between launches of the same test class.
+ */
+@QuarkusMainTest
+@TestProfile(DevServicesMainTestWithRestrictedTestResourceTest.PrintContainerIdProfile.class)
+@QuarkusTestResource(value = DevServicesMainTestWithRestrictedTestResourceTest.NoopResource.class, restrictToAnnotatedClass = true)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class DevServicesMainTestWithRestrictedTestResourceTest {
+
+    private static String firstContainerId;
+
+    @Test
+    @Order(1)
+    @Launch({})
+    public void firstLaunch(LaunchResult result) {
+        firstContainerId = containerId(result);
+        assertThat(firstContainerId).isNotBlank();
+    }
+
+    @Test
+    @Order(2)
+    @Launch({})
+    public void secondLaunchReusesTheDevService(LaunchResult result) {
+        assertThat(containerId(result))
+                .as("the dev service must be reused between launches of the same test class")
+                .isEqualTo(firstContainerId);
+    }
+
+    private static String containerId(LaunchResult result) {
+        return result.getOutputStream().stream()
+                .filter(line -> line.startsWith(PrintContainerIdMain.PREFIX))
+                .map(line -> line.substring(PrintContainerIdMain.PREFIX.length()).trim())
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("container id not printed: " + result.getOutput()));
+    }
+
+    public static class PrintContainerIdProfile implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quarkus.package.main-class", "print-container-id");
+        }
+    }
+
+    public static class NoopResource implements QuarkusTestResourceLifecycleManager {
+
+        @Override
+        public Map<String, String> start() {
+            return Map.of();
+        }
+
+        @Override
+        public void stop() {
+        }
+    }
+}

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
@@ -77,6 +77,9 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
         QuarkusTestExtensionState state = getState(extensionContext);
         // we reload the test resources if we changed test class and if we had or will have per-test test resources
         boolean isNewTestClass = !Objects.equals(extensionContext.getRequiredTestClass(), currentJUnitTestClass);
+        if (isNewTestClass) {
+            currentJUnitTestClass = extensionContext.getRequiredTestClass();
+        }
         if (isWrongProfile(extensionContext) || (isNewTestClass && TestResourceUtil.testResourcesRequireReload(state,
                 extensionContext.getRequiredTestClass(), getQuarkusTestProfile(extensionContext)))) {
             if (state != null) {


### PR DESCRIPTION
`QuarkusMainTestExtension#ensurePrepared` decides whether the test resources, and with them the application, have to be reloaded by comparing the current test class with the one of the previous launch (`currentJUnitTestClass`), but unlike `QuarkusTestExtension` it never records that class. Every `@Launch` therefore looks like a new test class, and as soon as a `@QuarkusTestResource(restrictToAnnotatedClass = true)` is declared, `testResourcesRequireReload` is true and each launch closes the state and prepares a new curated application.

Since 3.22 that matters for Dev Services: the new application gets a new `ApplicationInstanceIdBuildItem`, the dev services registry no longer recognises the running services as its own, closes them and starts new ones. With the reporter's reproducer, the second launch of the same test class gets a brand new PostgreSQL container and the rows inserted by the first launch are gone. I confirmed with a temporary diagnostic in `RunningDevServicesRegistry` that the instance id is the only part of the identifying config that differs between the two launches; global and datasource config are identical.

The fix records the current test class the way `QuarkusTestExtension` does, so the application is only rebuilt when the test class changes. With it, the reproducer from the issue passes on main, the container is reused within the class, and it is still rebuilt when moving to the next test class (the restricted-to-class semantics).

The new `DevServicesMainTestWithRestrictedTestResourceTest` in `integration-tests/devservices` runs two launches of a `@QuarkusMainTest` with a restricted test resource and asserts both see the same dev service container id; it fails without the fix (two different ids) and passes with it. `QuarkusMainTest` users (`integration-tests/test-extension/tests`, `command-mode`, `picocli`) and the `test-framework/junit` unit tests still pass.

- Fixes: #48943