### PR TITLE
Run the JPA MySQL integration tests with Podman again

### DIFF
--- a/integration-tests/jpa-mysql/pom.xml
+++ b/integration-tests/jpa-mysql/pom.xml
@@ -156,22 +156,6 @@
                 </plugins>
             </build>
         </profile>
-
-        <!-- Disabled pending fix of #33105 -->
-        <profile>
-            <id>podman</id>
-            <activation>
-                <property>
-                    <name>env.IS_PODMAN</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <properties>
-                <skipTests>true</skipTests>
-                <skipITs>true</skipITs>
-                <enforcer.skip>true</enforcer.skip>
-            </properties>
-        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
`integration-tests/jpa-mysql` is skipped when `IS_PODMAN=true` because, in 2023, the MySQL container started by the docker-maven-plugin timed out on its `mysqladmin ping` healthcheck in the Podman CI (#33105). The module has since moved to Dev Services, so the container startup path that failed no longer exists, and the last request on the issue was for someone to check manually on Linux.

I ran the module on Linux (kernel 6.19) with rootless Podman 5.8.3 and no Docker, `DOCKER_HOST` pointing at the Podman socket, against current main:

- JVM: `./mvnw verify -f integration-tests/jpa-mysql -Dtest-containers -Dstart-containers -DskipITs` → two MySQL 9.7 Dev Service containers (default and `samebutxa`), 4/4 tests pass.
- Native (Mandrel 25 builder image through Podman): `./mvnw verify -f integration-tests/jpa-mysql -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=podman -Dtest-containers -Dstart-containers -Dnative.surefire.skip=true` → 3/3 `*InGraalITCase` pass.

So this removes the `podman` profile from the module's `pom.xml`, as the issue asks. The other `IS_PODMAN` guards in the repository reference different issues (#33090, #33092, #33093, #33094, #33454) and are left alone.

Fixes #33105