### PR TITLE
Run the JDBC PostgreSQL and Micrometer deployment tests with Podman again

### DIFF
--- a/extensions/jdbc/jdbc-postgresql/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-postgresql/deployment/pom.xml
@@ -129,25 +129,5 @@
                 </plugins>
             </build>
         </profile>
-        <!-- Disabled pending fix of #33092 -->
-        <profile>
-            <id>podman</id>
-            <activation>
-                <property>
-                    <name>env.IS_PODMAN</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/extensions/micrometer/deployment/pom.xml
+++ b/extensions/micrometer/deployment/pom.xml
@@ -200,27 +200,6 @@
     </build>
 
     <profiles>
-        <!-- Disabled pending fix of #33093 -->
-        <profile>
-            <id>podman</id>
-            <activation>
-                <property>
-                    <name>env.IS_PODMAN</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <profile>
             <id>Java 21+</id>
             <activation>


### PR DESCRIPTION
Two more of the `IS_PODMAN` guards from the 2023 Podman CI experiment, same approach as #56193:

- `extensions/jdbc/jdbc-postgresql/deployment` — guarded for #33092, which was closed in October 2024 for lack of feedback; the guard stayed behind.
- `extensions/micrometer/deployment` — guarded for #33093, which never got a reproduction (@brunobat asked in October 2025 whether it was still relevant).

I ran both suites on Linux (kernel 6.19) with rootless Podman 5.8.3 and no Docker, `DOCKER_HOST` on the Podman socket, against current main with `-Dtest-containers -Dstart-containers`:

- `jdbc-postgresql/deployment`: 9/9, all the `DevServicesPostgresql*` cases start their PostgreSQL 17 Dev Service through Podman (the dev-mode case included).
- `micrometer/deployment`: 100/100.

So this removes the two `podman` profiles. The remaining guards (#33090 logging-gelf, #33094 Oracle, #33454 hibernate-reactive-panache) still involve the docker-maven-plugin or a heavier image and are left for separate checks.

- Fixes: #33093