### PR TITLE
Upgrade aesh, aesh-readline, fix ffm downcall and customizers

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -204,8 +204,8 @@
         <!-- Check the compatibility matrix (https://github.com/opensearch-project/opensearch-testcontainers) before upgrading: -->
         <opensearch-testcontainers.version>2.1.3</opensearch-testcontainers.version>
         <com.dajudge.kindcontainer>2.0.0</com.dajudge.kindcontainer>
-        <aesh.version>3.16.8</aesh.version>
-        <aesh-readline.version>3.16.4</aesh-readline.version>
+        <aesh.version>3.17.2</aesh.version>
+        <aesh-readline.version>3.17.1</aesh-readline.version>
         <jline.version>4.2.1</jline.version> <!-- Keep in sync with dekorate -->
         <!-- these two artifacts needs to be compatible together -->
         <strimzi-oauth.version>0.16.1</strimzi-oauth.version>

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/FfmDowncallBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/FfmDowncallBuildItem.java
@@ -1,10 +1,193 @@
 package io.quarkus.deployment.builditem.nativeimage;
 
+import java.util.Objects;
+
 /**
  * Used to register a downcall signature for FFI/FFM runtime access.
+ * <p>
+ * Downcalls can optionally specify linker options that affect how GraalVM
+ * generates the native call stub:
+ * <ul>
+ * <li>{@code captureCallState} — captures native error state (e.g. {@code errno})
+ * after the call</li>
+ * <li>{@code firstVariadicArg} — index of the first variadic argument for
+ * variadic C functions (e.g. {@code printf}, {@code ioctl})</li>
+ * <li>{@code critical} — marks the call as critical (no safepoint, no GC),
+ * optionally allowing heap access</li>
+ * </ul>
+ * <p>
+ * Use the builder to create downcall registrations:
+ *
+ * <pre>
+ * // Simple downcall without options
+ * FfmDowncallBuildItem.builder(FfmType.INT, FfmType.INT).build()
+ *
+ * // Downcall with options
+ * FfmDowncallBuildItem.builder(FfmType.INT, FfmType.INT, FfmType.ADDRESS)
+ *         .captureCallState()
+ *         .firstVariadicArg(2)
+ *         .build()
+ * </pre>
+ *
+ * @see <a href=
+ *      "https://www.graalvm.org/jdk25.2/reference-manual/native-image/native-code-interoperability/ffm-api/#linker-options">GraalVM
+ *      FFM Linker Options</a>
  */
 public final class FfmDowncallBuildItem extends FfmCallBuildItem {
+
+    private final boolean captureCallState;
+    private final int firstVariadicArg;
+    private final CriticalOption critical;
+
+    /**
+     * Creates a downcall registration without any linker options.
+     *
+     * @param returnType the return type
+     * @param parameterTypes the parameter types
+     * @deprecated Use {@link #builder(FfmType, FfmType...)} instead
+     */
+    @Deprecated(since = "4.0", forRemoval = true)
     public FfmDowncallBuildItem(FfmType returnType, FfmType... parameterTypes) {
+        this(false, -1, null, returnType, parameterTypes);
+    }
+
+    private FfmDowncallBuildItem(boolean captureCallState, int firstVariadicArg,
+            CriticalOption critical, FfmType returnType, FfmType... parameterTypes) {
         super(returnType, parameterTypes);
+        this.captureCallState = captureCallState;
+        this.firstVariadicArg = firstVariadicArg;
+        this.critical = critical;
+    }
+
+    /**
+     * Creates a builder for a downcall registration.
+     *
+     * @param returnType the return type
+     * @param parameterTypes the parameter types
+     * @return a new builder
+     */
+    public static Builder builder(FfmType returnType, FfmType... parameterTypes) {
+        return new Builder(returnType, parameterTypes);
+    }
+
+    /**
+     * Whether this downcall captures native error state (e.g. {@code errno}).
+     */
+    public boolean isCaptureCallState() {
+        return captureCallState;
+    }
+
+    /**
+     * The index of the first variadic argument, or {@code -1} if not set.
+     */
+    public int getFirstVariadicArg() {
+        return firstVariadicArg;
+    }
+
+    /**
+     * The critical option for this downcall, or {@code null} if not set.
+     */
+    public CriticalOption getCritical() {
+        return critical;
+    }
+
+    /**
+     * Whether any linker options are set on this downcall.
+     */
+    public boolean hasOptions() {
+        return captureCallState || firstVariadicArg >= 0 || critical != null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!super.equals(o)) {
+            return false;
+        }
+        FfmDowncallBuildItem that = (FfmDowncallBuildItem) o;
+        return captureCallState == that.captureCallState
+                && firstVariadicArg == that.firstVariadicArg
+                && critical == that.critical;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), captureCallState, firstVariadicArg, critical);
+    }
+
+    /**
+     * Specifies whether a critical downcall allows the native function to
+     * access Java heap objects during execution.
+     * <p>
+     * Critical calls skip safepoints and GC, which improves performance
+     * but restricts what the native function can do.
+     *
+     * @see <a href=
+     *      "https://www.graalvm.org/jdk25.2/reference-manual/native-image/native-code-interoperability/ffm-api/#linker-options">GraalVM
+     *      FFM Linker Options</a>
+     */
+    public enum CriticalOption {
+        /** Critical call where the native function must NOT access Java heap objects. */
+        NO_HEAP_ACCESS(false),
+        /** Critical call where the native function may access Java heap objects. */
+        ALLOW_HEAP_ACCESS(true);
+
+        private final boolean allowHeapAccess;
+
+        CriticalOption(boolean allowHeapAccess) {
+            this.allowHeapAccess = allowHeapAccess;
+        }
+
+        public boolean allowHeapAccess() {
+            return allowHeapAccess;
+        }
+    }
+
+    public static class Builder {
+        private final FfmType returnType;
+        private final FfmType[] parameterTypes;
+        private boolean captureCallState;
+        private int firstVariadicArg = -1;
+        private CriticalOption critical;
+
+        private Builder(FfmType returnType, FfmType... parameterTypes) {
+            this.returnType = returnType;
+            this.parameterTypes = parameterTypes;
+        }
+
+        /**
+         * Captures native error state (e.g. {@code errno}) after the downcall.
+         * Corresponds to {@code Linker.Option.captureCallState("errno")}.
+         */
+        public Builder captureCallState() {
+            this.captureCallState = true;
+            return this;
+        }
+
+        /**
+         * Sets the index of the first variadic argument for variadic C functions.
+         * Corresponds to {@code Linker.Option.firstVariadicArg(index)}.
+         *
+         * @param index the zero-based index of the first variadic parameter
+         */
+        public Builder firstVariadicArg(int index) {
+            this.firstVariadicArg = index;
+            return this;
+        }
+
+        /**
+         * Marks this downcall as critical (no safepoint, no GC during the call).
+         * Corresponds to {@code Linker.Option.critical(allowHeapAccess)}.
+         *
+         * @param option whether the native function may access Java heap objects
+         */
+        public Builder critical(CriticalOption option) {
+            this.critical = option;
+            return this;
+        }
+
+        public FfmDowncallBuildItem build() {
+            return new FfmDowncallBuildItem(captureCallState, firstVariadicArg,
+                    critical, returnType, parameterTypes);
+        }
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFFMConfigStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFFMConfigStep.java
@@ -40,6 +40,21 @@ public class NativeImageFFMConfigStep {
                 final JsonArrayBuilder paramsArray = Json.array();
                 paramsArray.addAll(downcall.getParameterTypes());
                 dcb.put("parameterTypes", paramsArray);
+                if (downcall.hasOptions()) {
+                    final JsonObjectBuilder options = Json.object();
+                    if (downcall.isCaptureCallState()) {
+                        options.put("captureCallState", true);
+                    }
+                    if (downcall.getFirstVariadicArg() >= 0) {
+                        options.put("firstVariadicArg", downcall.getFirstVariadicArg());
+                    }
+                    if (downcall.getCritical() != null) {
+                        final JsonObjectBuilder criticalObj = Json.object();
+                        criticalObj.put("allowHeapAccess", downcall.getCritical().allowHeapAccess());
+                        options.put("critical", criticalObj);
+                    }
+                    dcb.put("options", options);
+                }
                 downcallsArray.add(dcb);
             });
             foreignJson.put("downcalls", downcallsArray);

--- a/core/deployment/src/test/java/io/quarkus/deployment/steps/NativeImageFFMConfigStepTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/steps/NativeImageFFMConfigStepTest.java
@@ -1,0 +1,168 @@
+package io.quarkus.deployment.steps;
+
+import static io.quarkus.deployment.builditem.nativeimage.FfmType.ADDRESS;
+import static io.quarkus.deployment.builditem.nativeimage.FfmType.INT;
+import static io.quarkus.deployment.builditem.nativeimage.FfmType.LONG;
+import static io.quarkus.deployment.builditem.nativeimage.FfmType.VOID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.FfmDowncallBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.FfmDowncallBuildItem.CriticalOption;
+import io.quarkus.deployment.builditem.nativeimage.FfmUpcallBuildItem;
+
+class NativeImageFFMConfigStepTest {
+
+    @Test
+    void simpleDowncallWithoutOptions() {
+        String json = generateJson(List.of(FfmDowncallBuildItem.builder(INT, INT).build()), List.of());
+
+        assertThat(json).contains("\"returnType\":\"jint\"");
+        assertThat(json).contains("\"parameterTypes\":[\"jint\"]");
+        assertThat(json).doesNotContain("options");
+    }
+
+    @Test
+    void downcallWithCaptureCallState() {
+        String json = generateJson(
+                List.of(FfmDowncallBuildItem.builder(INT, ADDRESS, INT)
+                        .captureCallState()
+                        .build()),
+                List.of());
+
+        assertThat(json).contains("\"returnType\":\"jint\"");
+        assertThat(json).contains("\"parameterTypes\":[\"void*\",\"jint\"]");
+        assertThat(json).contains("\"captureCallState\":true");
+    }
+
+    @Test
+    void downcallWithFirstVariadicArg() {
+        String json = generateJson(
+                List.of(FfmDowncallBuildItem.builder(INT, INT, LONG, ADDRESS)
+                        .firstVariadicArg(2)
+                        .build()),
+                List.of());
+
+        assertThat(json).contains("\"firstVariadicArg\":2");
+        assertThat(json).doesNotContain("captureCallState");
+    }
+
+    @Test
+    void downcallWithCaptureCallStateAndFirstVariadicArg() {
+        String json = generateJson(
+                List.of(FfmDowncallBuildItem.builder(INT, INT, LONG, ADDRESS)
+                        .captureCallState()
+                        .firstVariadicArg(2)
+                        .build()),
+                List.of());
+
+        assertThat(json).contains("\"captureCallState\":true");
+        assertThat(json).contains("\"firstVariadicArg\":2");
+    }
+
+    @Test
+    void downcallWithCriticalNoHeapAccess() {
+        String json = generateJson(
+                List.of(FfmDowncallBuildItem.builder(VOID, ADDRESS)
+                        .critical(CriticalOption.NO_HEAP_ACCESS)
+                        .build()),
+                List.of());
+
+        assertThat(json).contains("\"critical\":{\"allowHeapAccess\":false}");
+    }
+
+    @Test
+    void downcallWithCriticalAllowHeapAccess() {
+        String json = generateJson(
+                List.of(FfmDowncallBuildItem.builder(VOID, ADDRESS)
+                        .critical(CriticalOption.ALLOW_HEAP_ACCESS)
+                        .build()),
+                List.of());
+
+        assertThat(json).contains("\"critical\":{\"allowHeapAccess\":true}");
+    }
+
+    @Test
+    void mixOfDowncallsWithAndWithoutOptions() {
+        String json = generateJson(
+                List.of(
+                        FfmDowncallBuildItem.builder(INT, INT).build(),
+                        FfmDowncallBuildItem.builder(INT, INT)
+                                .captureCallState()
+                                .build()),
+                List.of());
+
+        // Should have two downcall entries
+        assertThat(json).contains("\"downcalls\":[");
+        // One without options, one with
+        assertThat(json).contains("\"captureCallState\":true");
+    }
+
+    @Test
+    void duplicateDowncallsAreDeduplicatedBySignatureAndOptions() {
+        String json = generateJson(
+                List.of(
+                        FfmDowncallBuildItem.builder(INT, INT).build(),
+                        FfmDowncallBuildItem.builder(INT, INT).build()),
+                List.of());
+
+        // Count occurrences of returnType — should appear once (deduplicated)
+        long count = json.chars().filter(c -> c == '{').count();
+        // root + foreign + one downcall = 3
+        assertThat(count).isEqualTo(3);
+    }
+
+    @Test
+    void sameSignatureDifferentOptionsAreNotDeduplicated() {
+        String json = generateJson(
+                List.of(
+                        FfmDowncallBuildItem.builder(INT, INT).build(),
+                        FfmDowncallBuildItem.builder(INT, INT)
+                                .captureCallState()
+                                .build()),
+                List.of());
+
+        // Both should be present — different options means different registrations
+        // root + foreign + two downcalls + options = 5 objects
+        long count = json.chars().filter(c -> c == '{').count();
+        assertThat(count).isEqualTo(5);
+    }
+
+    @Test
+    void simpleUpcall() {
+        String json = generateJson(List.of(), List.of(new FfmUpcallBuildItem(INT, ADDRESS, ADDRESS)));
+
+        assertThat(json).contains("\"upcalls\":[");
+        assertThat(json).contains("\"returnType\":\"jint\"");
+        assertThat(json).contains("\"parameterTypes\":[\"void*\",\"void*\"]");
+        assertThat(json).doesNotContain("downcalls");
+    }
+
+    @Test
+    void emptyListsProduceNoOutput() {
+        NativeImageFFMConfigStep step = new NativeImageFFMConfigStep();
+        List<GeneratedResourceBuildItem> produced = new ArrayList<>();
+
+        step.generateFfmConfig(produced::add, List.of(), List.of());
+
+        assertThat(produced).isEmpty();
+    }
+
+    private static String generateJson(List<FfmDowncallBuildItem> downcalls, List<FfmUpcallBuildItem> upcalls) {
+        NativeImageFFMConfigStep step = new NativeImageFFMConfigStep();
+        List<GeneratedResourceBuildItem> produced = new ArrayList<>();
+
+        step.generateFfmConfig(produced::add, downcalls, upcalls);
+
+        assertThat(produced).hasSize(1);
+        assertThat(produced.get(0).getName())
+                .isEqualTo("META-INF/native-image/foreign/reachability-metadata.json");
+        return new String(produced.get(0).getData(), StandardCharsets.UTF_8);
+    }
+}

--- a/docs/src/main/asciidoc/aesh.adoc
+++ b/docs/src/main/asciidoc/aesh.adoc
@@ -640,6 +640,56 @@ public class MyCliSettings implements CliSettings {
 
 Multiple `CliSettings` beans can be registered. They are applied in arbitrary order, so avoid conflicting settings across implementations.
 
+=== Custom CommandInvocation
+
+You can use `CliSettings` to register a custom `CommandInvocationProvider` that wraps the default `CommandInvocation` with application-specific context.
+This is useful when commands need shared state or services that are not available through CDI injection:
+
+[source,java]
+----
+package com.acme.aesh;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.invocation.CommandInvocationProvider;
+import org.aesh.command.settings.SettingsBuilder;
+
+import io.quarkus.aesh.runtime.CliSettings;
+
+@ApplicationScoped
+public class MyCliSettings implements CliSettings {
+
+    @Inject
+    MyAppContext appContext;
+
+    @Override
+    public void customize(SettingsBuilder<?> builder) {
+        builder.commandInvocationProvider(new MyInvocationProvider(appContext));
+    }
+}
+----
+
+Commands can then declare the custom invocation type and access the additional context:
+
+[source,java]
+----
+@CommandDefinition(name = "status", description = "Show status")
+public class StatusCommand implements Command<MyCommandInvocation> {
+
+    @Override
+    public CommandResult execute(MyCommandInvocation invocation) {
+        invocation.println("Context: " + invocation.getAppContext().getName());
+        return CommandResult.SUCCESS;
+    }
+}
+----
+
+The custom `CommandInvocationProvider` is applied in all execution modes: console REPL, console single-command execution (with arguments), and runtime mode.
+
+Similarly, you can register custom `ConverterInvocationProvider` and `ValidatorInvocationProvider` implementations to pass additional context to converters and validators.
+
 == Command execution listener
 
 Implement `CommandExecutionListener` as a CDI bean to receive a callback after each command completes.

--- a/extensions/aesh/README.md
+++ b/extensions/aesh/README.md
@@ -239,6 +239,8 @@ public class MyCliSettings implements CliSettings {
 }
 ```
 
+`CliSettings` also supports registering custom `commandInvocationProvider`, `converterInvocationProvider`, and `validatorInvocationProvider` implementations to wrap the default invocations with application-specific context. These providers are applied in all execution modes (console REPL, console single-command, and runtime mode).
+
 ## Remote Terminal Access
 
 The extension supports remote terminal access via WebSocket and SSH, allowing users to interact with a running console-mode application from a browser or SSH client.

--- a/extensions/aesh/deployment/src/main/java/io/quarkus/aesh/deployment/AeshNativeImageProcessor.java
+++ b/extensions/aesh/deployment/src/main/java/io/quarkus/aesh/deployment/AeshNativeImageProcessor.java
@@ -1,5 +1,9 @@
 package io.quarkus.aesh.deployment;
 
+import static io.quarkus.deployment.builditem.nativeimage.FfmType.ADDRESS;
+import static io.quarkus.deployment.builditem.nativeimage.FfmType.INT;
+import static io.quarkus.deployment.builditem.nativeimage.FfmType.LONG;
+
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Collection;
@@ -22,7 +26,6 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.FfmDowncallBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.FfmType;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -64,27 +67,38 @@ class AeshNativeImageProcessor {
      * GraalVM native image requires explicit registration of all FFM downcall
      * signatures. Without this, the FFM terminal provider fails at runtime with
      * {@code MissingForeignRegistrationError} and falls back to ExecPty.
+     * <p>
+     * Most LibC functions use {@code captureCallState} to capture {@code errno},
+     * and {@code ioctl} additionally uses {@code firstVariadicArg}.
      */
     @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
     void registerFfmDowncalls(BuildProducer<FfmDowncallBuildItem> downcalls) {
         // int isatty(int fd) — no captureCallState
-        downcalls.produce(new FfmDowncallBuildItem(FfmType.INT, FfmType.INT));
-        // int open(const char *pathname, int flags) — with captureCallState
-        downcalls.produce(new FfmDowncallBuildItem(FfmType.INT, FfmType.ADDRESS, FfmType.INT));
-        // int close(int fd) — with captureCallState
-        downcalls.produce(new FfmDowncallBuildItem(FfmType.INT, FfmType.INT));
-        // ssize_t read(int fd, void *buf, size_t count) — with captureCallState
-        downcalls.produce(new FfmDowncallBuildItem(FfmType.LONG, FfmType.INT, FfmType.ADDRESS, FfmType.LONG));
+        downcalls.produce(FfmDowncallBuildItem.builder(INT, INT).build());
+        // int open(const char *pathname, int flags)
+        downcalls.produce(FfmDowncallBuildItem.builder(INT, ADDRESS, INT)
+                .captureCallState().build());
+        // int close(int fd)
+        downcalls.produce(FfmDowncallBuildItem.builder(INT, INT)
+                .captureCallState().build());
+        // ssize_t read(int fd, void *buf, size_t count)
+        downcalls.produce(FfmDowncallBuildItem.builder(LONG, INT, ADDRESS, LONG)
+                .captureCallState().build());
         // int poll(struct pollfd *fds, nfds_t nfds, int timeout) — Linux: nfds_t=long
-        downcalls.produce(new FfmDowncallBuildItem(FfmType.INT, FfmType.ADDRESS, FfmType.LONG, FfmType.INT));
+        downcalls.produce(FfmDowncallBuildItem.builder(INT, ADDRESS, LONG, INT)
+                .captureCallState().build());
         // int poll(struct pollfd *fds, nfds_t nfds, int timeout) — macOS: nfds_t=int
-        downcalls.produce(new FfmDowncallBuildItem(FfmType.INT, FfmType.ADDRESS, FfmType.INT, FfmType.INT));
-        // int tcgetattr(int fd, struct termios *termios_p) — with captureCallState
-        downcalls.produce(new FfmDowncallBuildItem(FfmType.INT, FfmType.INT, FfmType.ADDRESS));
+        downcalls.produce(FfmDowncallBuildItem.builder(INT, ADDRESS, INT, INT)
+                .captureCallState().build());
+        // int tcgetattr(int fd, struct termios *termios_p)
+        downcalls.produce(FfmDowncallBuildItem.builder(INT, INT, ADDRESS)
+                .captureCallState().build());
         // int tcsetattr(int fd, int actions, const struct termios *termios_p)
-        downcalls.produce(new FfmDowncallBuildItem(FfmType.INT, FfmType.INT, FfmType.INT, FfmType.ADDRESS));
+        downcalls.produce(FfmDowncallBuildItem.builder(INT, INT, INT, ADDRESS)
+                .captureCallState().build());
         // int ioctl(int fd, unsigned long request, void *arg) — variadic
-        downcalls.produce(new FfmDowncallBuildItem(FfmType.INT, FfmType.INT, FfmType.LONG, FfmType.ADDRESS));
+        downcalls.produce(FfmDowncallBuildItem.builder(INT, INT, LONG, ADDRESS)
+                .captureCallState().firstVariadicArg(2).build());
     }
 
     @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/CustomConverterProviderRuntimeModeTest.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/CustomConverterProviderRuntimeModeTest.java
@@ -1,0 +1,126 @@
+package io.quarkus.aesh.deployment;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.converter.Converter;
+import org.aesh.command.converter.ConverterInvocation;
+import org.aesh.command.converter.ConverterInvocationProvider;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.option.Option;
+import org.aesh.command.settings.SettingsBuilder;
+import org.aesh.command.validator.OptionValidatorException;
+import org.aesh.console.AeshContext;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.aesh.runtime.CliSettings;
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Tests that a custom {@link ConverterInvocationProvider} set via {@link CliSettings}
+ * is applied in runtime mode ({@code DefaultAeshRuntimeRunnerFactory} path).
+ * <p>
+ * The custom provider wraps the converter invocation with a prefix so the
+ * converter can prepend it to the converted value, proving the provider is active.
+ */
+public class CustomConverterProviderRuntimeModeTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot(jar -> jar.addClasses(
+                    PrefixedCmd.class,
+                    PrefixedConverterInvocation.class,
+                    PrefixedConverterInvocationProvider.class,
+                    PrefixingConverter.class,
+                    PrefixedCliSettings.class))
+            .setApplicationName("custom-converter-provider-app")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setExpectExit(true)
+            .setRun(true)
+            .setCommandLineParameters("--label=World");
+
+    @Test
+    void converterInvocationProviderApplied() {
+        // The PrefixingConverter prepends the prefix from the custom invocation
+        Assertions.assertThat(config.getStartupConsoleOutput())
+                .containsOnlyOnce("Label: prefixed:World");
+        Assertions.assertThat(config.getExitCode()).isZero();
+    }
+
+    /**
+     * Custom {@link ConverterInvocation} that carries a prefix string.
+     */
+    public static class PrefixedConverterInvocation implements ConverterInvocation {
+
+        private final ConverterInvocation delegate;
+        private final String prefix;
+
+        PrefixedConverterInvocation(ConverterInvocation delegate, String prefix) {
+            this.delegate = delegate;
+            this.prefix = prefix;
+        }
+
+        public String getPrefix() {
+            return prefix;
+        }
+
+        @Override
+        public String getInput() {
+            return delegate.getInput();
+        }
+
+        @Override
+        public AeshContext getAeshContext() {
+            return delegate.getAeshContext();
+        }
+    }
+
+    public static class PrefixedConverterInvocationProvider implements ConverterInvocationProvider {
+
+        @Override
+        public ConverterInvocation enhanceConverterInvocation(ConverterInvocation converterInvocation) {
+            return new PrefixedConverterInvocation(converterInvocation, "prefixed");
+        }
+    }
+
+    /**
+     * Converter that uses the custom invocation to prepend a prefix.
+     */
+    public static class PrefixingConverter implements Converter<String, PrefixedConverterInvocation> {
+
+        @Override
+        public String convert(PrefixedConverterInvocation invocation) throws OptionValidatorException {
+            return invocation.getPrefix() + ":" + invocation.getInput();
+        }
+    }
+
+    @ApplicationScoped
+    public static class PrefixedCliSettings implements CliSettings {
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void customize(SettingsBuilder<?> builder) {
+            ((SettingsBuilder) builder).converterInvocationProvider(new PrefixedConverterInvocationProvider());
+        }
+    }
+
+    /**
+     * Single command with a converter that expects the custom invocation.
+     */
+    @CommandDefinition(name = "prefixed", description = "Test converter provider")
+    public static class PrefixedCmd implements Command<CommandInvocation> {
+
+        @Option(name = "label", converter = PrefixingConverter.class)
+        String label;
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("Label: " + label);
+            return CommandResult.SUCCESS;
+        }
+    }
+}

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/CustomInvocationRuntimeModeTest.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/CustomInvocationRuntimeModeTest.java
@@ -1,0 +1,194 @@
+package io.quarkus.aesh.deployment;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandNotFoundException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.Executor;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.invocation.CommandInvocationConfiguration;
+import org.aesh.command.invocation.CommandInvocationProvider;
+import org.aesh.command.option.Option;
+import org.aesh.command.parser.CommandLineParserException;
+import org.aesh.command.settings.SettingsBuilder;
+import org.aesh.command.shell.Shell;
+import org.aesh.command.validator.CommandValidatorException;
+import org.aesh.command.validator.OptionValidatorException;
+import org.aesh.readline.prompt.Prompt;
+import org.aesh.terminal.KeyAction;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.aesh.runtime.CliSettings;
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Tests that a custom {@link CommandInvocationProvider} set via {@link CliSettings}
+ * is applied in runtime mode (single top command, {@code AeshRunner} path via
+ * {@code DefaultAeshRuntimeRunnerFactory}).
+ * <p>
+ * This verifies that the fix for aesh#583 (adding {@code commandInvocationProvider()}
+ * to {@code AeshRuntimeRunner}) is properly wired through the Quarkus extension.
+ */
+public class CustomInvocationRuntimeModeTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot(jar -> jar.addClasses(
+                    TaggedRuntimeCmd.class,
+                    RuntimeTaggedInvocation.class,
+                    RuntimeTaggedInvocationProvider.class,
+                    RuntimeTaggedCliSettings.class))
+            .setApplicationName("custom-invocation-runtime-mode-app")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setExpectExit(true)
+            .setRun(true)
+            .setCommandLineParameters("--name=Runtime");
+
+    @Test
+    void customInvocationProviderAppliedInRuntimeMode() {
+        Assertions.assertThat(config.getStartupConsoleOutput())
+                .containsOnlyOnce("[runtime-tagged] Hello Runtime!");
+        Assertions.assertThat(config.getExitCode()).isZero();
+    }
+
+    /**
+     * A custom {@link CommandInvocation} subtype that adds a tag prefix.
+     */
+    public static class RuntimeTaggedInvocation implements CommandInvocation {
+
+        private final CommandInvocation delegate;
+        private final String tag;
+
+        RuntimeTaggedInvocation(CommandInvocation delegate, String tag) {
+            this.delegate = delegate;
+            this.tag = tag;
+        }
+
+        public String getTag() {
+            return tag;
+        }
+
+        @Override
+        public Shell getShell() {
+            return delegate.getShell();
+        }
+
+        @Override
+        public void setPrompt(Prompt prompt) {
+            delegate.setPrompt(prompt);
+        }
+
+        @Override
+        public Prompt getPrompt() {
+            return delegate.getPrompt();
+        }
+
+        @Override
+        public String getHelpInfo(String commandName) {
+            return delegate.getHelpInfo(commandName);
+        }
+
+        @Override
+        public String getHelpInfo() {
+            return delegate.getHelpInfo();
+        }
+
+        @Override
+        public void stop() {
+            delegate.stop();
+        }
+
+        @Override
+        public CommandInvocationConfiguration getConfiguration() {
+            return delegate.getConfiguration();
+        }
+
+        @Override
+        public KeyAction input() throws InterruptedException {
+            return delegate.input();
+        }
+
+        @Override
+        public KeyAction input(long timeout, TimeUnit unit) throws InterruptedException {
+            return delegate.input(timeout, unit);
+        }
+
+        @Override
+        public String inputLine() throws InterruptedException {
+            return delegate.inputLine();
+        }
+
+        @Override
+        public String inputLine(Prompt prompt) throws InterruptedException {
+            return delegate.inputLine(prompt);
+        }
+
+        @Override
+        public void print(String msg, boolean paging) {
+            delegate.print(msg, paging);
+        }
+
+        @Override
+        public void println(String msg, boolean paging) {
+            delegate.println(msg, paging);
+        }
+
+        @Override
+        public Executor<? extends CommandInvocation> buildExecutor(String line)
+                throws CommandNotFoundException, CommandLineParserException,
+                OptionValidatorException, CommandValidatorException, IOException {
+            return delegate.buildExecutor(line);
+        }
+
+        @Override
+        public void executeCommand(String input) throws CommandNotFoundException,
+                CommandLineParserException, OptionValidatorException,
+                CommandValidatorException, CommandException, InterruptedException, IOException {
+            delegate.executeCommand(input);
+        }
+    }
+
+    public static class RuntimeTaggedInvocationProvider
+            implements CommandInvocationProvider<RuntimeTaggedInvocation> {
+
+        @Override
+        public RuntimeTaggedInvocation enhanceCommandInvocation(CommandInvocation commandInvocation) {
+            return new RuntimeTaggedInvocation(commandInvocation, "runtime-tagged");
+        }
+    }
+
+    @ApplicationScoped
+    public static class RuntimeTaggedCliSettings implements CliSettings {
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void customize(SettingsBuilder<?> builder) {
+            ((SettingsBuilder) builder).commandInvocationProvider(new RuntimeTaggedInvocationProvider());
+        }
+    }
+
+    /**
+     * Single command — triggers runtime mode auto-detection.
+     * Expects {@link RuntimeTaggedInvocation} and uses the tag in output.
+     */
+    @CommandDefinition(name = "tagged-runtime", description = "Runtime mode with custom invocation")
+    public static class TaggedRuntimeCmd implements Command<RuntimeTaggedInvocation> {
+
+        @Option(shortName = 'n', name = "name", defaultValue = "World")
+        String name;
+
+        @Override
+        public CommandResult execute(RuntimeTaggedInvocation invocation) {
+            invocation.println("[" + invocation.getTag() + "] Hello " + name + "!");
+            return CommandResult.SUCCESS;
+        }
+    }
+}

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/CustomValidatorProviderRuntimeModeTest.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/CustomValidatorProviderRuntimeModeTest.java
@@ -1,0 +1,136 @@
+package io.quarkus.aesh.deployment;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.option.Option;
+import org.aesh.command.settings.SettingsBuilder;
+import org.aesh.command.validator.OptionValidator;
+import org.aesh.command.validator.OptionValidatorException;
+import org.aesh.command.validator.ValidatorInvocation;
+import org.aesh.command.validator.ValidatorInvocationProvider;
+import org.aesh.console.AeshContext;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.aesh.runtime.CliSettings;
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Tests that a custom {@link ValidatorInvocationProvider} set via {@link CliSettings}
+ * is applied in runtime mode ({@code DefaultAeshRuntimeRunnerFactory} path).
+ * <p>
+ * The custom provider wraps the validator invocation with a minimum length
+ * threshold so the validator can enforce it, proving the provider is active.
+ */
+public class CustomValidatorProviderRuntimeModeTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot(jar -> jar.addClasses(
+                    ValidatedCmd.class,
+                    MinLengthValidatorInvocation.class,
+                    MinLengthValidatorInvocationProvider.class,
+                    MinLengthValidator.class,
+                    ValidatorCliSettings.class))
+            .setApplicationName("custom-validator-provider-app")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setExpectExit(true)
+            .setRun(true)
+            .setCommandLineParameters("--name=ValidName");
+
+    @Test
+    void validatorInvocationProviderAppliedWithValidInput() {
+        // Valid input (length >= 3) should succeed
+        Assertions.assertThat(config.getStartupConsoleOutput())
+                .containsOnlyOnce("Hello ValidName!");
+        Assertions.assertThat(config.getExitCode()).isZero();
+    }
+
+    /**
+     * Custom {@link ValidatorInvocation} that carries a minimum length.
+     */
+    public static class MinLengthValidatorInvocation implements ValidatorInvocation<String, Object> {
+
+        private final ValidatorInvocation<String, Object> delegate;
+        private final int minLength;
+
+        @SuppressWarnings("unchecked")
+        MinLengthValidatorInvocation(ValidatorInvocation<?, ?> delegate, int minLength) {
+            this.delegate = (ValidatorInvocation<String, Object>) delegate;
+            this.minLength = minLength;
+        }
+
+        public int getMinLength() {
+            return minLength;
+        }
+
+        @Override
+        public String getValue() {
+            return delegate.getValue();
+        }
+
+        @Override
+        public Object getCommand() {
+            return delegate.getCommand();
+        }
+
+        @Override
+        public AeshContext getAeshContext() {
+            return delegate.getAeshContext();
+        }
+    }
+
+    public static class MinLengthValidatorInvocationProvider implements ValidatorInvocationProvider {
+
+        @Override
+        public ValidatorInvocation enhanceValidatorInvocation(ValidatorInvocation validatorInvocation) {
+            return new MinLengthValidatorInvocation(validatorInvocation, 3);
+        }
+    }
+
+    /**
+     * Validator that uses the custom invocation to enforce a minimum length.
+     */
+    public static class MinLengthValidator implements OptionValidator<MinLengthValidatorInvocation> {
+
+        @Override
+        public void validate(MinLengthValidatorInvocation invocation) throws OptionValidatorException {
+            String value = invocation.getValue();
+            if (value != null && value.length() < invocation.getMinLength()) {
+                throw new OptionValidatorException(
+                        "Value '" + value + "' is too short (min " + invocation.getMinLength() + " chars)");
+            }
+        }
+    }
+
+    @ApplicationScoped
+    public static class ValidatorCliSettings implements CliSettings {
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void customize(SettingsBuilder<?> builder) {
+            ((SettingsBuilder) builder).validatorInvocationProvider(new MinLengthValidatorInvocationProvider());
+        }
+    }
+
+    /**
+     * Single command with a validated option that expects the custom invocation.
+     */
+    @CommandDefinition(name = "validated", description = "Test validator provider")
+    public static class ValidatedCmd implements Command<CommandInvocation> {
+
+        @Option(name = "name", defaultValue = "World", validator = MinLengthValidator.class)
+        String name;
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("Hello " + name + "!");
+            return CommandResult.SUCCESS;
+        }
+    }
+}

--- a/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/DefaultAeshRuntimeRunnerFactory.java
+++ b/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/DefaultAeshRuntimeRunnerFactory.java
@@ -18,13 +18,16 @@ import io.quarkus.arc.Arc;
 public class DefaultAeshRuntimeRunnerFactory implements AeshRuntimeRunnerFactory {
 
     private final Instance<DefaultValueProvider> defaultValueProvider;
+    private final Instance<CliSettings> customizers;
     private final CliConfig configuration;
     private final AeshContext aeshContext;
 
     public DefaultAeshRuntimeRunnerFactory(Instance<DefaultValueProvider> defaultValueProvider,
+            Instance<CliSettings> customizers,
             CliConfig configuration,
             AeshContext aeshContext) {
         this.defaultValueProvider = defaultValueProvider;
+        this.customizers = customizers;
         this.configuration = configuration;
         this.aeshContext = aeshContext;
     }
@@ -34,9 +37,23 @@ public class DefaultAeshRuntimeRunnerFactory implements AeshRuntimeRunnerFactory
     public AeshRuntimeRunner create() {
         Command<?> commandInstance = resolveTopCommand();
         if (commandInstance != null) {
+            // Build settings with customizers applied so that custom providers
+            // (e.g. CommandInvocationProvider) are available for runtime execution.
+            var settings = CliSettingsHelper.createBaseSettings(configuration, customizers).build();
+
             AeshRuntimeRunner runner = AeshRuntimeRunner.builder()
                     .containerBuilder(new AeshCdiCommandContainerBuilder<>())
                     .command(commandInstance);
+            if (settings.commandInvocationProvider() != null) {
+                runner.commandInvocationProvider(
+                        (org.aesh.command.invocation.CommandInvocationProvider<?>) settings.commandInvocationProvider());
+            }
+            if (settings.converterInvocationProvider() != null) {
+                runner.converterInvocationProvider(settings.converterInvocationProvider());
+            }
+            if (settings.validatorInvocationProvider() != null) {
+                runner.validatorInvocationProvider(settings.validatorInvocationProvider());
+            }
             if (defaultValueProvider.isResolvable()) {
                 runner.defaultValueProvider(defaultValueProvider.get());
             }

--- a/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
+++ b/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
@@ -399,16 +399,16 @@ class AwtProcessor {
         if (v.compareTo(GraalVM.Version.VERSION_25_0_0) >= 0) {
             // Downcalls
             // malloc
-            downcalls.produce(new FfmDowncallBuildItem(ADDRESS, LONG));
+            downcalls.produce(FfmDowncallBuildItem.builder(ADDRESS, LONG).build());
             // HBCreateFace
-            downcalls.produce(new FfmDowncallBuildItem(ADDRESS, ADDRESS));
+            downcalls.produce(FfmDowncallBuildItem.builder(ADDRESS, ADDRESS).build());
             // HBDisposeFace
-            downcalls.produce(new FfmDowncallBuildItem(VOID, ADDRESS));
+            downcalls.produce(FfmDowncallBuildItem.builder(VOID, ADDRESS).build());
             // jdk_hb_shape
-            downcalls.produce(new FfmDowncallBuildItem(VOID, FLOAT, ADDRESS, ADDRESS, ADDRESS, INT, INT, INT, INT, INT, FLOAT,
-                    FLOAT, INT, INT, ADDRESS, ADDRESS));
+            downcalls.produce(FfmDowncallBuildItem.builder(VOID, FLOAT, ADDRESS, ADDRESS, ADDRESS, INT, INT, INT, INT, INT,
+                    FLOAT, FLOAT, INT, INT, ADDRESS, ADDRESS).build());
             // HBCreateFontFuncs
-            downcalls.produce(new FfmDowncallBuildItem(ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS));
+            downcalls.produce(FfmDowncallBuildItem.builder(ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS).build());
 
             // Upcalls
             // getFontTableData


### PR DESCRIPTION
aesh-readline 3.17 includes:
- Flush terminal output after writes to prevent buffered prompts in native images and fallback terminal paths (https://github.com/aeshell/aesh-readline/issues/250)

aesh 3.17.1 includes:
- Add commandInvocationProvider() to AeshRuntimeRunner builder API for framework integration (https://github.com/aeshell/aesh/issues/583)

Apply CliSettings customizers in DefaultAeshRuntimeRunnerFactory so that custom CommandInvocationProvider, ConverterInvocationProvider, and ValidatorInvocationProvider beans are propagated to the AeshRuntimeRunner in runtime mode.

Fix FFM downcall metadata to include captureCallState and firstVariadicArg options required by LibC's POSIX terminal functions. The previous FfmDowncallBuildItem-based registration did not support these options, causing the FFM terminal provider to fail at runtime with MissingForeignRegistrationError.

