### PR TITLE
Support reflection-free json serialization of a Map subtype

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
@@ -279,6 +279,8 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
         boolean valid;
         if (isClassFormatShapeArray(classInfo)) {
             valid = deserializeArrayFields(deserData, deserializedHandle);
+        } else if (isAssignableTo(beanClassName, MAP_NAME)) {
+            valid = deserializeMapEntries(deserData, deserializedHandle);
         } else {
             valid = deserializeObjectFields(deserData, deserializedHandle);
         }
@@ -458,6 +460,52 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
             }
         }
         return valid;
+    }
+
+    /**
+     * Generates deserialization code for classes that extend {@code Map}. Instead of routing JSON fields
+     * through a per-property string switch, every key/value pair is put directly into the map instance.
+     * This matches standard Jackson's behavior where a {@code Map} subclass is treated as a map, not a bean.
+     *
+     * <p>
+     * For example, for a class extending {@code HashMap<String, Object>}, this generates:
+     *
+     * <pre>{@code
+     * Iterator fields = jsonNode.properties().iterator();
+     * while (fields.hasNext()) {
+     *     Map.Entry entry = (Map.Entry) fields.next();
+     *     JsonNode value = (JsonNode) entry.getValue();
+     *     String key = (String) entry.getKey();
+     *     bean.put(key, context.readTreeAsValue(value, Object.class));
+     * }
+     * }</pre>
+     */
+    private boolean deserializeMapEntries(DeserializationData deserData, ResultHandle objHandle) {
+        ResultHandle deserializationContext = deserData.methodCreator().getMethodParam(1);
+
+        ResultHandle propertiesSet = deserData.methodCreator()
+                .invokeVirtualMethod(ofMethod(JsonNode.class, "properties", Set.class), deserData.jsonNode());
+        ResultHandle fieldsIterator = deserData.methodCreator()
+                .invokeInterfaceMethod(ofMethod(Set.class, "iterator", Iterator.class), propertiesSet);
+        BytecodeCreator loopCreator = deserData.methodCreator().whileLoop(c -> iteratorHasNext(c, fieldsIterator)).block();
+        ResultHandle nextField = loopCreator
+                .invokeInterfaceMethod(ofMethod(Iterator.class, "next", Object.class), fieldsIterator);
+        ResultHandle mapEntry = loopCreator.checkCast(nextField, Map.Entry.class);
+        ResultHandle fieldValue = loopCreator.checkCast(loopCreator
+                .invokeInterfaceMethod(ofMethod(Map.Entry.class, "getValue", Object.class), mapEntry), JsonNode.class);
+        ResultHandle fieldName = loopCreator
+                .invokeInterfaceMethod(ofMethod(Map.Entry.class, "getKey", Object.class), mapEntry);
+
+        ResultHandle deserializedValue = loopCreator.invokeVirtualMethod(
+                ofMethod(DeserializationContext.class, "readTreeAsValue", Object.class, JsonNode.class, Class.class),
+                deserializationContext, fieldValue, loopCreator.loadClass(Object.class));
+
+        ResultHandle castedFieldName = loopCreator.checkCast(fieldName, String.class);
+        loopCreator.invokeInterfaceMethod(
+                ofMethod(Map.class, "put", Object.class, Object.class, Object.class),
+                objHandle, castedFieldName, deserializedValue);
+
+        return true;
     }
 
     private List<FieldSpecs> collectOrderedFieldSpecs(DeserializationData deserData) {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
@@ -243,6 +243,7 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
 
         boolean isJsonValue = jsonValueFieldSpecs.isPresent();
         boolean isArrayShape = !isJsonValue && isClassFormatShapeArray(classInfo);
+        boolean isMapSubclass = !isJsonValue && !isArrayShape && isAssignableTo(beanClassName, MAP_NAME);
 
         // Generate serializeContent() — writes field content without object boundaries
         MethodCreator contentMethod = classCreator.getMethodCreator("serializeContent", void.class,
@@ -252,6 +253,9 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
         if (isJsonValue) {
             GenerationSerializationContext ctx = new GenerationSerializationContext(contentMethod, beanClassName);
             serializeJsonValue(ctx, contentMethod, jsonValueFieldSpecs.get());
+        } else if (isMapSubclass) {
+            serializeMapEntries(contentMethod, beanClassName);
+            classCreator.getMethodCreator("<clinit>", void.class).setModifiers(ACC_STATIC).returnVoid();
         } else {
             Set<String> serializedFields = new HashSet<>();
             GenerationSerializationContext ctx = new GenerationSerializationContext(contentMethod, beanClassName);
@@ -557,6 +561,14 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
                 MethodDescriptor.ofMethod(JacksonMapperUtil.class, "serializeAnyGetterMap", void.class,
                         Map.class, JsonGenerator.class, SerializationContext.class),
                 map, ctx.jsonGenerator, ctx.serializerProvider);
+    }
+
+    private static void serializeMapEntries(MethodCreator bytecode, String beanClassName) {
+        ResultHandle valueHandle = bytecode.checkCast(bytecode.getMethodParam(0), beanClassName);
+        bytecode.invokeStaticMethod(
+                MethodDescriptor.ofMethod(JacksonMapperUtil.class, "serializeAnyGetterMap", void.class,
+                        Map.class, JsonGenerator.class, SerializationContext.class),
+                valueHandle, bytecode.getMethodParam(1), bytecode.getMethodParam(2));
     }
 
     private FieldSpecs fieldSpecsFromMethod(MethodInfo methodInfo, PropertyNamingStrategy namingStrategy) {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
@@ -1124,6 +1124,32 @@ public abstract class AbstractGeneratedAnnotationTest {
                 .body("billing_zip", Matchers.is("00100"));
     }
 
+    // --- HashMap subclass with declared bean properties ---
+
+    @Test
+    public void testMapSubclassRoundTrip() {
+        given()
+                .contentType("application/json")
+                .body("{\"declared\":\"d\",\"extra\":1}")
+                .when()
+                .post("/generated/map-subclass")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("declared", Matchers.is("d"))
+                .body("extra", Matchers.is(1));
+    }
+
+    @Test
+    public void testMapSubclassSerialization() {
+        RestAssured.get("/generated/map-subclass")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("declared", Matchers.is("d"))
+                .body("extra", Matchers.is(1));
+    }
+
     // --- @JsonRawValue ---
 
     @Test

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
@@ -695,6 +695,24 @@ public class GeneratedAnnotationResource {
         return bean;
     }
 
+    // --- MapSubclassBean: HashMap subclass with declared bean properties ---
+
+    @POST
+    @Path("/map-subclass")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public MapSubclassBean echoMapSubclass(MapSubclassBean bean) {
+        return bean;
+    }
+
+    @GET
+    @Path("/map-subclass")
+    public MapSubclassBean getMapSubclass() {
+        MapSubclassBean bean = new MapSubclassBean();
+        bean.put("declared", "d");
+        bean.put("extra", 1);
+        return bean;
+    }
+
     // --- UnwrappedWithPrefixBean: @JsonUnwrapped with prefix ---
 
     @GET

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
@@ -68,7 +68,8 @@ public class GeneratedAnnotationTest extends AbstractGeneratedAnnotationTest {
                                     UnwrappedIgnorePropertiesBean.User.class,
                                     UnwrappedWithPrefixBean.class,
                                     UnwrappedWithPrefixBean.Address.class,
-                                    JavaBeansTransientBean.class)
+                                    JavaBeansTransientBean.class,
+                                    MapSubclassBean.class)
                             .addAsResource(new StringAsset(
                                     "quarkus.jackson.fail-on-unknown-properties=true\n" +
                                             "quarkus.jackson.default-view-inclusion=true\n" +

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
@@ -71,7 +71,8 @@ public class GeneratedAnnotationWithReflectionFreeSerializersTest extends Abstra
                                     UnwrappedIgnorePropertiesBean.User.class,
                                     UnwrappedWithPrefixBean.class,
                                     UnwrappedWithPrefixBean.Address.class,
-                                    JavaBeansTransientBean.class)
+                                    JavaBeansTransientBean.class,
+                                    MapSubclassBean.class)
                             .addAsResource(new StringAsset(
                                     "quarkus.jackson.fail-on-unknown-properties=true\n" +
                                             "quarkus.jackson.default-view-inclusion=true\n" +

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/MapSubclassBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/MapSubclassBean.java
@@ -1,0 +1,20 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import java.util.HashMap;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MapSubclassBean extends HashMap<String, Object> {
+
+    private String declared;
+
+    @JsonProperty("declared")
+    public String getDeclared() {
+        return declared;
+    }
+
+    @JsonProperty("declared")
+    public void setDeclared(String declared) {
+        this.declared = declared;
+    }
+}


### PR DESCRIPTION
This pull request is intended to replace #56065 adding support for `Map` subtypes in generated reflection-free serializers. I believe that the change is minimal and reasonable since it leverages the biggest part of the work that was already done to support the `@JsonAnyGetter` and `@JsonAnySetter` annotations.

- Fixes: #56064