### PR TITLE
Use Vert.x ContextLocal instead of SmallRye ContextLocals data maps

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/grpc/override/ContextStorageOverride.java
+++ b/extensions/grpc/runtime/src/main/java/io/grpc/override/ContextStorageOverride.java
@@ -1,8 +1,7 @@
 package io.grpc.override;
 
-import java.util.concurrent.ConcurrentHashMap;
-
 import io.grpc.Context;
+import io.quarkus.grpc.runtime.GrpcContextLocalsProvider;
 import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Vertx;
 
@@ -12,15 +11,13 @@ import io.vertx.core.Vertx;
 public class ContextStorageOverride extends Context.Storage {
 
     private static final ThreadLocal<Context> fallback = new ThreadLocal<>();
-    private static final String GRPC_CONTEXT = "GRPC_CONTEXT";
 
     @Override
     public Context doAttach(Context toAttach) {
         Context current = current();
         io.vertx.core.Context dc = Vertx.currentContext();
         if (dc != null && VertxContext.isDuplicatedContext(dc)) {
-            var local = dc.getLocal(VertxContext.DATA_MAP_LOCAL, ConcurrentHashMap::new);
-            local.put(GRPC_CONTEXT, toAttach);
+            GrpcContextLocalsProvider.GRPC_CONTEXT_LOCAL.put(dc, toAttach);
         } else {
             fallback.set(toAttach);
         }
@@ -32,8 +29,7 @@ public class ContextStorageOverride extends Context.Storage {
         io.vertx.core.Context dc = Vertx.currentContext();
         if (toRestore != Context.ROOT) {
             if (dc != null && VertxContext.isDuplicatedContext(dc)) {
-                var local = dc.getLocal(VertxContext.DATA_MAP_LOCAL, ConcurrentHashMap::new);
-                local.put(GRPC_CONTEXT, toRestore);
+                GrpcContextLocalsProvider.GRPC_CONTEXT_LOCAL.put(dc, toRestore);
             } else {
                 fallback.set(toRestore);
             }
@@ -49,8 +45,7 @@ public class ContextStorageOverride extends Context.Storage {
     @Override
     public Context current() {
         if (VertxContext.isOnDuplicatedContext()) {
-            Context current = (Context) Vertx.currentContext().getLocal(VertxContext.DATA_MAP_LOCAL, ConcurrentHashMap::new)
-                    .get(GRPC_CONTEXT);
+            Context current = GrpcContextLocalsProvider.GRPC_CONTEXT_LOCAL.get(Vertx.currentContext());
             if (current == null) {
                 return Context.ROOT;
             }

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcContextLocalsProvider.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcContextLocalsProvider.java
@@ -1,0 +1,21 @@
+package io.quarkus.grpc.runtime;
+
+import io.grpc.Context;
+import io.vertx.core.internal.VertxBootstrap;
+import io.vertx.core.spi.VertxServiceProvider;
+import io.vertx.core.spi.context.storage.ContextLocal;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Provides ContextLocal storage for gRPC contexts.
+ */
+public class GrpcContextLocalsProvider implements VertxServiceProvider {
+
+    public static final ContextLocal<Context> GRPC_CONTEXT_LOCAL = ContextLocal.registerLocal(Context.class);
+    public static final ContextLocal<RoutingContext> ROUTING_CONTEXT_LOCAL = ContextLocal.registerLocal(RoutingContext.class);
+
+    @Override
+    public void init(VertxBootstrap builder) {
+        // ContextLocal registration happens via the static fields above.
+    }
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
@@ -8,7 +8,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 import jakarta.enterprise.inject.Any;
@@ -43,7 +42,6 @@ import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.http.runtime.QuarkusErrorHandler;
 import io.quarkus.vertx.http.runtime.security.HttpAuthenticator;
 import io.quarkus.virtual.threads.VirtualThreadsRecorder;
-import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -254,12 +252,11 @@ public class GrpcServerRecorder {
 
     private static void routingContextAware(GrpcIoServer server, RoutingContext context) {
         Context currentContext = Vertx.currentContext();
-        var local = currentContext.getLocal(VertxContext.DATA_MAP_LOCAL, ConcurrentHashMap::new);
-        local.put(RoutingContext.class.getName(), context);
+        GrpcContextLocalsProvider.ROUTING_CONTEXT_LOCAL.put(currentContext, context);
         try {
             server.handle(context.request());
         } finally {
-            local.remove(RoutingContext.class.getName());
+            GrpcContextLocalsProvider.ROUTING_CONTEXT_LOCAL.remove(currentContext);
         }
     }
 

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/context/RoutingContextGrpcInterceptor.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/context/RoutingContextGrpcInterceptor.java
@@ -1,7 +1,5 @@
 package io.quarkus.grpc.runtime.supports.context;
 
-import java.util.concurrent.ConcurrentHashMap;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.spi.Prioritized;
 
@@ -13,9 +11,9 @@ import io.grpc.ServerInterceptor;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.ManagedContext;
+import io.quarkus.grpc.runtime.GrpcContextLocalsProvider;
 import io.quarkus.grpc.runtime.Interceptors;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
-import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.RoutingContext;
@@ -30,8 +28,7 @@ public class RoutingContextGrpcInterceptor implements ServerInterceptor, Priorit
             ServerCallHandler<ReqT, RespT> next) {
 
         Context currentContext = Vertx.currentContext();
-        var local = currentContext.getLocal(VertxContext.DATA_MAP_LOCAL, ConcurrentHashMap::new);
-        RoutingContext routingContext = (RoutingContext) local.get(RoutingContext.class.getName());
+        RoutingContext routingContext = GrpcContextLocalsProvider.ROUTING_CONTEXT_LOCAL.get(currentContext);
 
         return new ForwardingServerCallListener.SimpleForwardingServerCallListener<>(
                 next.startCall(call, headers)) {

--- a/extensions/grpc/runtime/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
+++ b/extensions/grpc/runtime/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
@@ -1,0 +1,1 @@
+io.quarkus.grpc.runtime.GrpcContextLocalsProvider

--- a/extensions/oidc-token-propagation-reactive/runtime/src/main/java/io/quarkus/oidc/token/propagation/reactive/AccessTokenRequestReactiveFilter.java
+++ b/extensions/oidc-token-propagation-reactive/runtime/src/main/java/io/quarkus/oidc/token/propagation/reactive/AccessTokenRequestReactiveFilter.java
@@ -5,8 +5,6 @@ import static io.quarkus.oidc.token.propagation.common.runtime.TokenPropagationC
 
 import java.lang.reflect.Method;
 import java.util.Collections;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
 
 import jakarta.annotation.PostConstruct;
@@ -32,10 +30,10 @@ import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.security.credential.TokenCredential;
 import io.quarkus.security.spi.runtime.MethodDescription;
+import io.quarkus.vertx.core.runtime.ContextLocalsVertxServiceProvider;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
-import io.vertx.core.internal.ContextInternal;
 
 @Priority(Priorities.AUTHENTICATION)
 public class AccessTokenRequestReactiveFilter implements ResteasyReactiveClientRequestFilter {
@@ -178,9 +176,7 @@ public class AccessTokenRequestReactiveFilter implements ResteasyReactiveClientR
 
     private static TokenCredential getTokenCredentialFromContext() {
         VertxContextSafetyToggle.validateContextIfExists(ERROR_MSG, ERROR_MSG);
-        ConcurrentMap<Object, Object> locals = ((ContextInternal) Vertx.currentContext())
-                .getLocal(ContextInternal.LOCAL_MAP, ConcurrentHashMap::new);
-        return (TokenCredential) locals.get(TokenCredential.class.getName());
+        return ContextLocalsVertxServiceProvider.TOKEN_CREDENTIAL_LOCAL.get(Vertx.currentContext());
     }
 
     private Uni<String> exchangeToken(String token) {

--- a/extensions/oidc-token-propagation/runtime/src/main/java/io/quarkus/oidc/token/propagation/AccessTokenRequestFilter.java
+++ b/extensions/oidc-token-propagation/runtime/src/main/java/io/quarkus/oidc/token/propagation/AccessTokenRequestFilter.java
@@ -6,8 +6,6 @@ import static io.quarkus.oidc.token.propagation.common.runtime.TokenPropagationC
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Collections;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.inject.Instance;
@@ -25,9 +23,9 @@ import io.quarkus.oidc.token.propagation.runtime.AbstractTokenRequestFilter;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.security.credential.TokenCredential;
 import io.quarkus.security.spi.runtime.MethodDescription;
+import io.quarkus.vertx.core.runtime.ContextLocalsVertxServiceProvider;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
 import io.vertx.core.Vertx;
-import io.vertx.core.internal.ContextInternal;
 
 public class AccessTokenRequestFilter extends AbstractTokenRequestFilter {
     // note: We can't use constructor injection for these fields because they are registered by RESTEasy
@@ -122,9 +120,7 @@ public class AccessTokenRequestFilter extends AbstractTokenRequestFilter {
 
     private static TokenCredential getTokenCredentialFromContext() {
         VertxContextSafetyToggle.validateContextIfExists(ERROR_MSG, ERROR_MSG);
-        ConcurrentMap<Object, Object> locals = ((ContextInternal) Vertx.currentContext())
-                .getLocal(ContextInternal.LOCAL_MAP, ConcurrentHashMap::new);
-        return (TokenCredential) locals.get(TokenCredential.class.getName());
+        return ContextLocalsVertxServiceProvider.TOKEN_CREDENTIAL_LOCAL.get(Vertx.currentContext());
     }
 
     private boolean skipPropagation(ClientRequestContext requestContext) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/AbstractOidcAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/AbstractOidcAuthenticationMechanism.java
@@ -1,8 +1,5 @@
 package io.quarkus.oidc.runtime;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-
 import io.quarkus.oidc.AccessTokenCredential;
 import io.quarkus.oidc.IdTokenCredential;
 import io.quarkus.oidc.common.runtime.OidcConstants;
@@ -10,12 +7,12 @@ import io.quarkus.security.credential.TokenCredential;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.request.TokenAuthenticationRequest;
+import io.quarkus.vertx.core.runtime.ContextLocalsVertxServiceProvider;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
 import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
 import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
-import io.vertx.core.internal.ContextInternal;
 import io.vertx.ext.web.RoutingContext;
 
 abstract class AbstractOidcAuthenticationMechanism {
@@ -56,16 +53,14 @@ abstract class AbstractOidcAuthenticationMechanism {
             final var tokenCredential = (token instanceof IdTokenCredential)
                     ? new AccessTokenCredential(context.get(OidcConstants.ACCESS_TOKEN_VALUE))
                     : token;
-            ConcurrentMap<Object, Object> locals = ((ContextInternal) ctx)
-                    .getLocal(ContextInternal.LOCAL_MAP, ConcurrentHashMap::new);
-            locals.put(TokenCredential.class.getName(), tokenCredential);
+            ContextLocalsVertxServiceProvider.TOKEN_CREDENTIAL_LOCAL.put(ctx, tokenCredential);
             return identityProviderManager
                     .authenticate(HttpSecurityUtils.setRoutingContextAttribute(new TokenAuthenticationRequest(token), context))
                     .invoke(new Runnable() {
                         @Override
                         public void run() {
                             // remove as we recommend to acquire TokenCredential via CDI
-                            locals.remove(TokenCredential.class.getName());
+                            ContextLocalsVertxServiceProvider.TOKEN_CREDENTIAL_LOCAL.remove(ctx);
                         }
                     });
         }

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/reactive/MongodbPanacheContextLocalsProvider.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/reactive/MongodbPanacheContextLocalsProvider.java
@@ -1,0 +1,17 @@
+package io.quarkus.mongodb.panache.common.reactive;
+
+import com.mongodb.reactivestreams.client.ClientSession;
+
+import io.vertx.core.internal.VertxBootstrap;
+import io.vertx.core.spi.VertxServiceProvider;
+import io.vertx.core.spi.context.storage.ContextLocal;
+
+public class MongodbPanacheContextLocalsProvider implements VertxServiceProvider {
+
+    static final ContextLocal<ClientSession> SESSION_LOCAL = ContextLocal.registerLocal(ClientSession.class);
+
+    @Override
+    public void init(VertxBootstrap builder) {
+        // ContextLocal registration happens via the static field above.
+    }
+}

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/reactive/Panache.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/reactive/Panache.java
@@ -1,6 +1,5 @@
 package io.quarkus.mongodb.panache.common.reactive;
 
-import java.util.UUID;
 import java.util.function.Supplier;
 
 import org.reactivestreams.Publisher;
@@ -10,7 +9,6 @@ import com.mongodb.reactivestreams.client.ClientSession;
 import io.quarkus.mongodb.reactive.ReactiveMongoClient;
 import io.quarkus.mongodb.runtime.MongoClientBeanUtil;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
-import io.smallrye.common.vertx.ContextLocals;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
@@ -22,8 +20,6 @@ import mutiny.zero.flow.adapters.AdaptersToFlow;
 public class Panache {
     private static final String ERROR_MSG = "MongoDB reactive with Panache requires a safe (isolated) Vert.x sub-context, but the current context hasn't been flagged as such.";
 
-    private static final String SESSION_KEY = UUID.randomUUID().toString();
-
     /**
      * Performs the given work within the scope of a MongoDB transaction.
      * The transaction will be rolled back if the work completes with an uncaught exception.
@@ -34,7 +30,7 @@ public class Panache {
      */
     public static <T> Uni<T> withTransaction(Supplier<Uni<T>> work) {
         Context context = vertxContext();
-        ClientSession current = ContextLocals.get(context, SESSION_KEY, null);
+        ClientSession current = MongodbPanacheContextLocalsProvider.SESSION_LOCAL.get(context);
         if (current != null && current.hasActiveTransaction()) {
             // reactive session exists - reuse this session
             return work.get();
@@ -42,7 +38,7 @@ public class Panache {
             // reactive session does not exist - open a new one and close it when the returned Uni completes
             return Panache.startSession()
                     .invoke(s -> s.startTransaction())
-                    .invoke(s -> ContextLocals.put(context, SESSION_KEY, s))
+                    .invoke(s -> MongodbPanacheContextLocalsProvider.SESSION_LOCAL.put(context, s))
                     .chain(s -> work.get())
                     .call(() -> commitTransaction())
                     .onFailure().call(() -> abortTransaction())
@@ -63,18 +59,18 @@ public class Panache {
         if (context == null) {
             return null;
         }
-        return ContextLocals.get(context, SESSION_KEY, null);
+        return MongodbPanacheContextLocalsProvider.SESSION_LOCAL.get(context);
     }
 
     private static Uni<?> abortTransaction() {
         Context context = vertxContext();
-        ClientSession current = ContextLocals.get(context, SESSION_KEY, null);
+        ClientSession current = MongodbPanacheContextLocalsProvider.SESSION_LOCAL.get(context);
         return toUni(current.abortTransaction());
     }
 
     private static Uni<?> commitTransaction() {
         Context context = vertxContext();
-        ClientSession current = ContextLocals.get(context, SESSION_KEY, null);
+        ClientSession current = MongodbPanacheContextLocalsProvider.SESSION_LOCAL.get(context);
         return toUni(current.commitTransaction());
     }
 
@@ -94,11 +90,11 @@ public class Panache {
 
     private static void closeSession() {
         Context context = vertxContext();
-        ClientSession current = ContextLocals.get(context, SESSION_KEY, null);
+        ClientSession current = MongodbPanacheContextLocalsProvider.SESSION_LOCAL.get(context);
         try {
             current.close();
         } finally {
-            ContextLocals.remove(context, SESSION_KEY);
+            MongodbPanacheContextLocalsProvider.SESSION_LOCAL.remove(context);
         }
     }
 

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
@@ -1,0 +1,1 @@
+io.quarkus.mongodb.panache.common.reactive.MongodbPanacheContextLocalsProvider

--- a/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/JWTAuthMechanism.java
+++ b/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/JWTAuthMechanism.java
@@ -5,8 +5,6 @@ import static io.vertx.core.http.HttpHeaders.COOKIE;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -21,6 +19,7 @@ import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.request.AuthenticationRequest;
 import io.quarkus.security.identity.request.TokenAuthenticationRequest;
+import io.quarkus.vertx.core.runtime.ContextLocalsVertxServiceProvider;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
 import io.quarkus.vertx.http.runtime.security.ChallengeData;
 import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
@@ -31,7 +30,6 @@ import io.smallrye.jwt.auth.principal.JWTAuthContextInfo;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.Cookie;
-import io.vertx.core.internal.ContextInternal;
 import io.vertx.ext.web.RoutingContext;
 
 /**
@@ -78,9 +76,7 @@ public class JWTAuthMechanism implements HttpAuthenticationMechanism {
                 VertxContextSafetyToggle.validateContextIfExists(ERROR_MSG, ERROR_MSG);
                 final var ctx = Vertx.currentContext();
                 final var token = new JsonWebTokenCredential(jwtToken);
-                // Assume that consumers of this expect to find the context entry in the Vert.x 4 era context local maps
-                ConcurrentMap<Object, Object> localMap = ctx.getLocal(ContextInternal.LOCAL_MAP, ConcurrentHashMap::new);
-                localMap.put(TokenCredential.class.getName(), token);
+                ContextLocalsVertxServiceProvider.TOKEN_CREDENTIAL_LOCAL.put(ctx, token);
                 return identityProviderManager
                         .authenticate(HttpSecurityUtils.setRoutingContextAttribute(
                                 new TokenAuthenticationRequest(token), context))
@@ -88,7 +84,7 @@ public class JWTAuthMechanism implements HttpAuthenticationMechanism {
                             @Override
                             public void run() {
                                 // remove as we recommend to acquire TokenCredential via CDI
-                                localMap.remove(TokenCredential.class.getName());
+                                ContextLocalsVertxServiceProvider.TOKEN_CREDENTIAL_LOCAL.remove(ctx);
                             }
                         });
             }

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/ContextLocalsVertxServiceProvider.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/ContextLocalsVertxServiceProvider.java
@@ -1,12 +1,17 @@
 package io.quarkus.vertx.core.runtime;
 
+import io.quarkus.security.credential.TokenCredential;
 import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.internal.VertxBootstrap;
 import io.vertx.core.spi.VertxServiceProvider;
+import io.vertx.core.spi.context.storage.ContextLocal;
 
-// Temporary - we need to implement this SPI in SmallRye commons and move the local declaration in the provider
-// implementation, as done for MDC.
+// Registers Quarkus-level ContextLocal instances and triggers SmallRye VertxContext static initialization.
 public class ContextLocalsVertxServiceProvider implements VertxServiceProvider {
+
+    public static final ContextLocal<TokenCredential> TOKEN_CREDENTIAL_LOCAL = ContextLocal
+            .registerLocal(TokenCredential.class);
+
     @Override
     public void init(VertxBootstrap builder) {
         // Just touch the class.

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/context/VertxContextSafetyToggle.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/context/VertxContextSafetyToggle.java
@@ -1,10 +1,11 @@
 package io.quarkus.vertx.core.runtime.context;
 
-import java.util.concurrent.ConcurrentHashMap;
-
 import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
+import io.vertx.core.internal.VertxBootstrap;
+import io.vertx.core.spi.VertxServiceProvider;
+import io.vertx.core.spi.context.storage.ContextLocal;
 
 /**
  * This is meant for other extensions to integrate with, to help
@@ -39,9 +40,9 @@ import io.vertx.core.Vertx;
  * can't flag the context explicitly, but bear in mind that this will
  * have a global impact and possibly let other uses go unnoticed as well.
  */
-public final class VertxContextSafetyToggle {
+public final class VertxContextSafetyToggle implements VertxServiceProvider {
 
-    private static final String ACCESS_TOGGLE_KEY = "___QUARKUS_CONTEXT_ACCESS_TOGGLE____";
+    static final ContextLocal<Boolean> ACCESS_TOGGLE = ContextLocal.registerLocal(Boolean.class);
     public static final String UNRESTRICTED_BY_DEFAULT_PROPERTY = "io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle.UNRESTRICTED_BY_DEFAULT";
 
     /**
@@ -51,6 +52,11 @@ public final class VertxContextSafetyToggle {
     public static final String FULLY_DISABLE_PROPERTY = "io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle.I_HAVE_CHECKED_EVERYTHING";
     private static final boolean UNRESTRICTED_BY_DEFAULT = Boolean.getBoolean(UNRESTRICTED_BY_DEFAULT_PROPERTY);
     private static final boolean FULLY_DISABLED = Boolean.getBoolean(FULLY_DISABLE_PROPERTY);
+
+    @Override
+    public void init(VertxBootstrap builder) {
+        // ContextLocal registration happens via the static field above.
+    }
 
     /**
      * Verifies if the current Vert.x context was flagged as safe
@@ -76,7 +82,7 @@ public final class VertxContextSafetyToggle {
     }
 
     private static Boolean getToggleFlag(final Context context) {
-        return (Boolean) context.getLocal(VertxContext.DATA_MAP_LOCAL, ConcurrentHashMap::new).get(ACCESS_TOGGLE_KEY);
+        return ACCESS_TOGGLE.get(context);
     }
 
     private static void checkIsSafe(final Context context, final String errorMessageOnVeto, final String errorMessageOnDoubt) {
@@ -125,12 +131,11 @@ public final class VertxContextSafetyToggle {
                     "Can't set the context safety flag: the current context is not a duplicated context");
         } else {
             // save storm of true -> true transitions by shielding it
-            ConcurrentHashMap<String, Object> map = context.getLocal(VertxContext.DATA_MAP_LOCAL, ConcurrentHashMap::new);
-            Boolean maybe = (Boolean) map.get(ACCESS_TOGGLE_KEY);
+            Boolean maybe = ACCESS_TOGGLE.get(context);
             if (safe && maybe == Boolean.TRUE) {
                 return;
             }
-            map.put(ACCESS_TOGGLE_KEY, safe);
+            ACCESS_TOGGLE.put(context, safe);
         }
     }
 

--- a/extensions/vertx/runtime/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
+++ b/extensions/vertx/runtime/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
@@ -1,2 +1,3 @@
 io.quarkus.vertx.core.runtime.ContextLocalsVertxServiceProvider
 io.quarkus.vertx.core.runtime.VertxMDCServiceProvider
+io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/ContextSupport.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/ContextSupport.java
@@ -1,7 +1,6 @@
 package io.quarkus.websockets.next.runtime;
 
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.jboss.logging.Logger;
 
@@ -10,6 +9,9 @@ import io.quarkus.arc.ManagedContext;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
 import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Context;
+import io.vertx.core.internal.VertxBootstrap;
+import io.vertx.core.spi.VertxServiceProvider;
+import io.vertx.core.spi.context.storage.ContextLocal;
 
 /**
  * Per-endpoint CDI context support.
@@ -17,8 +19,6 @@ import io.vertx.core.Context;
 public class ContextSupport {
 
     private static final Logger LOG = Logger.getLogger(ContextSupport.class);
-
-    static final String WEB_SOCKET_CONN_KEY = WebSocketConnectionBase.class.getName();
 
     private final WebSocketConnectionBase connection;
     private final ContextState sessionContextState;
@@ -86,10 +86,20 @@ public class ContextSupport {
         VertxContextSafetyToggle.setContextSafe(duplicated, true);
         // We need to store the connection in the duplicated context
         // It's used to initialize the synthetic bean later on
-        duplicated.getLocal(VertxContext.DATA_MAP_LOCAL, ConcurrentHashMap::new)
-                .put(ContextSupport.WEB_SOCKET_CONN_KEY, connection);
+        WebSocketContextLocalsProvider.WEB_SOCKET_CONN_LOCAL.put(duplicated, connection);
         LOG.debugf("New vertx duplicated context [%s] created: %s", duplicated, connection);
         return duplicated;
+    }
+
+    public static class WebSocketContextLocalsProvider implements VertxServiceProvider {
+
+        static final ContextLocal<WebSocketConnectionBase> WEB_SOCKET_CONN_LOCAL = ContextLocal
+                .registerLocal(WebSocketConnectionBase.class);
+
+        @Override
+        public void init(VertxBootstrap builder) {
+            // ContextLocal registration happens via the static field above.
+        }
     }
 
 }

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketClientRecorder.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketClientRecorder.java
@@ -1,7 +1,6 @@
 package io.quarkus.websockets.next.runtime;
 
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import io.quarkus.runtime.annotations.RecordableConstructor;
@@ -21,9 +20,7 @@ public class WebSocketClientRecorder {
             public Object get() {
                 Context context = Vertx.currentContext();
                 if (context != null && VertxContext.isDuplicatedContext(context)) {
-                    Object connection = context
-                            .getLocal(VertxContext.DATA_MAP_LOCAL, ConcurrentHashMap::new)
-                            .get(ContextSupport.WEB_SOCKET_CONN_KEY);
+                    Object connection = ContextSupport.WebSocketContextLocalsProvider.WEB_SOCKET_CONN_LOCAL.get(context);
                     if (connection != null) {
                         return connection;
                     }

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketSecurityIdentityAssociation.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketSecurityIdentityAssociation.java
@@ -1,7 +1,5 @@
 package io.quarkus.websockets.next.runtime;
 
-import java.util.concurrent.ConcurrentHashMap;
-
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 
@@ -106,8 +104,8 @@ public class WebSocketSecurityIdentityAssociation implements CurrentIdentityAsso
     private static SecuritySupport getSecuritySupportFromCtx() {
         Context context = Vertx.currentContext();
         if (context != null && VertxContext.isDuplicatedContext(context)) {
-            var contextMap = context.getLocal(VertxContext.DATA_MAP_LOCAL, ConcurrentHashMap::new);
-            if (contextMap.get(ContextSupport.WEB_SOCKET_CONN_KEY) instanceof WebSocketConnectionImpl connection) {
+            if (ContextSupport.WebSocketContextLocalsProvider.WEB_SOCKET_CONN_LOCAL
+                    .get(context) instanceof WebSocketConnectionImpl connection) {
                 return connection.securitySupport();
             }
         }

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketServerRecorder.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketServerRecorder.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -77,8 +76,7 @@ public class WebSocketServerRecorder {
             public Object get() {
                 Context context = Vertx.currentContext();
                 if (context != null && VertxContext.isDuplicatedContext(context)) {
-                    var contextMap = context.getLocal(VertxContext.DATA_MAP_LOCAL, ConcurrentHashMap::new);
-                    Object connection = contextMap.get(ContextSupport.WEB_SOCKET_CONN_KEY);
+                    Object connection = ContextSupport.WebSocketContextLocalsProvider.WEB_SOCKET_CONN_LOCAL.get(context);
                     if (connection != null) {
                         return connection;
                     }

--- a/extensions/websockets-next/runtime/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
+++ b/extensions/websockets-next/runtime/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
@@ -1,0 +1,1 @@
+io.quarkus.websockets.next.runtime.ContextSupport$WebSocketContextLocalsProvider


### PR DESCRIPTION
Migrate several extensions from SmallRye ContextLocals (DATA_MAP_LOCAL / LOCAL_MAP shared ConcurrentHashMap) to dedicated Vert.x ContextLocal<T> instances registered via VertxServiceProvider SPI.

Each migrated key gets its own typed ContextLocal slot, removing reliance on stringly-keyed shared maps and improving type safety.

Extensions migrated:
- vertx, websockets-next: ContextSafetyToggle, WebSocket session/connection
- grpc: gRPC context storage
- mongodb-panache: reactive client/session context
- oidc, smallrye-jwt, token-propagation: TokenCredential

Cross-extension keys that require cross-thread DuplicatedContext visibility (ForwardedInfo, VertxRoute, RoutingContext) are not migrated here. Raw ContextLocal values are scoped to a single DuplicatedContext instance, so they are not visible after dispatch to a new context (e.g., event loop to worker thread). The current DATA_MAP_LOCAL approach works because its duplicator shares the backing ConcurrentHashMap reference across contexts.

This is part of #51959

This partially fixes #39710 (see the leftovers).
