### PR TITLE
Update LGTM to 0.31.0, expose Prometheus endpoint

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -161,7 +161,7 @@
         <kafka.native.image>quay.io/ogunalp/kafka-native:latest</kafka.native.image>
         <kafka.upstream.image>docker.io/apache/kafka:4.2.0</kafka.upstream.image>
         <kafka.upstream.native.image>docker.io/apache/kafka-native:4.2.0</kafka.upstream.native.image>
-        <observability.lgtm.image>docker.io/grafana/otel-lgtm:0.24.0</observability.lgtm.image>
+        <observability.lgtm.image>docker.io/grafana/otel-lgtm:0.31.0</observability.lgtm.image>
 
         <!-- Code Coverage Properties-->
         <jacoco.agent.argLine></jacoco.agent.argLine>

--- a/docs/src/main/asciidoc/observability-devservices-lgtm.adoc
+++ b/docs/src/main/asciidoc/observability-devservices-lgtm.adoc
@@ -148,7 +148,7 @@ You will see a log entry like this:
 
 [source, log]
 ----
-[io.qu.ob.de.ObservabilityDevServiceProcessor] (build-35) Dev Service Lgtm started, config: {grafana.endpoint=http://localhost:42797, quarkus.otel.exporter.otlp.endpoint=http://localhost:34711, otel-collector.url=localhost:34711, quarkus.micrometer.export.otlp.url=http://localhost:34711/v1/metrics, quarkus.otel.exporter.otlp.protocol=http/protobuf}
+[io.qu.ob.de.ObservabilityDevServiceProcessor] (build-35) Dev Service Lgtm started, config: {grafana.endpoint=http://localhost:42797, prometheus.endpoint=http://localhost:39090, tempo-mcp.endpoint=http://localhost:43200, quarkus.otel.exporter.otlp.endpoint=http://localhost:34711, otel-collector.url=localhost:34711, quarkus.micrometer.export.otlp.url=http://localhost:34711/v1/metrics, quarkus.otel.exporter.otlp.protocol=http/protobuf}
 ----
 Remember that Grafana is accessible in an ephemeral port, so you need to check the logs to see which port is being used. In this example, the grafana endpoint is `grafana.endpoint=http://localhost:42797`.
 
@@ -308,6 +308,268 @@ quarkus.observability.dev-resources=true
 `quarkus.observability.enabled` must be set to `false` when using Dev Resources mode. The two modes are mutually exclusive.
 ====
 
+=== MCP integration for AI tools
+
+The LGTM Dev Service supports the https://github.com/grafana/docker-otel-lgtm/blob/main/docs/mcp-integration.md[Model Context Protocol (MCP)], allowing AI coding tools like Claude Code and Cursor to query telemetry data directly from the running container.
+
+Two MCP pathways are available:
+
+[cols="1,1,1,1"]
+|===
+|Component |MCP Server |Transport |Capabilities
+
+|Grafana
+|`uvx mcp-grafana` (runs on host)
+|stdio
+|Dashboards, PromQL, LogQL
+
+|Tempo
+|Built-in HTTP endpoint
+|HTTP
+|Traces via TraceQL
+|===
+
+==== Tempo MCP
+
+The Tempo MCP server is automatically enabled and exposes an HTTP endpoint at port 3200 (`/api/mcp`).
+
+You can fix the Tempo MCP port if needed:
+
+[source,properties]
+----
+quarkus.observability.lgtm.tempo-mcp-port=3200
+----
+
+The mapped endpoint is available as the `tempo-mcp.endpoint` config property:
+
+[source,java]
+----
+@ConfigProperty(name = "tempo-mcp.endpoint")
+String tempoMcpEndpoint; // e.g. http://localhost:45678
+----
+
+To add the Tempo MCP server to Claude Code, use the endpoint from the Dev Service startup log:
+
+[source,bash]
+----
+claude mcp add --transport http tempo <tempo-mcp.endpoint>/api/mcp
+----
+
+==== Grafana MCP
+
+The Grafana MCP server runs as a client-side process on the host using https://github.com/grafana/mcp-grafana[`uvx mcp-grafana`] and connects to the Grafana instance inside the container. It provides access to dashboards, PromQL queries (metrics), and LogQL queries (logs).
+
+The mapped Grafana endpoint is available as the `grafana.endpoint` config property:
+
+[source,java]
+----
+@ConfigProperty(name = "grafana.endpoint")
+String grafanaEndpoint; // e.g. http://localhost:42797
+----
+
+After the container starts, a Grafana service account token is automatically created inside the container at `/tmp/grafana-sa-token`. You can retrieve it and the full MCP configuration:
+
+[source,bash]
+----
+# Find the container name
+docker ps --filter "label=quarkus-dev-service=lgtm" --format '{{.Names}}'
+
+# Retrieve the service account token
+TOKEN=$(docker exec <container-name> cat /tmp/grafana-sa-token)
+
+# Retrieve the full MCP configuration JSON
+docker exec <container-name> cat /etc/lgtm/mcp.json
+----
+
+To add the Grafana MCP server to Claude Code (requires https://docs.astral.sh/uv/[`uvx`]), use the `grafana.endpoint` URL from the Dev Service startup log:
+
+[source,bash]
+----
+claude mcp add grafana \
+  -e GRAFANA_URL=<grafana.endpoint> \
+  -e GRAFANA_SERVICE_ACCOUNT_TOKEN="$TOKEN" \
+  -- uvx mcp-grafana
+----
+
+[NOTE]
+====
+The Grafana MCP server also proxies the Tempo MCP server, so adding both is optional. Tempo's standalone endpoint is useful when you only need trace queries without the full Grafana integration.
+====
+
+=== Exposed backend endpoints
+
+In addition to the Grafana, Tempo MCP, and OTel Collector endpoints, the Dev Service also exposes the Prometheus HTTP API directly. This is useful for querying metrics programmatically without going through Grafana:
+
+[source,java]
+----
+@ConfigProperty(name = "prometheus.endpoint")
+String prometheusEndpoint; // e.g. http://localhost:39090
+----
+
+The full list of exposed endpoints:
+
+[cols="1,1"]
+|===
+|Config property |Description
+
+|`grafana.endpoint`
+|Grafana UI and API
+
+|`prometheus.endpoint`
+|Prometheus HTTP API (e.g. `/api/v1/query`)
+
+|`tempo-mcp.endpoint`
+|Tempo query-frontend (search API and MCP)
+
+|`otel-collector.url`
+|OpenTelemetry Collector (gRPC or HTTP, depending on `otlp-protocol`)
+|===
+
+=== Container component logging
+
+You can enable container log output for individual LGTM components by setting the `logging` property. This maps to the `ENABLE_LOGS_*` environment variables in the container.
+
+[source,properties]
+----
+quarkus.observability.lgtm.logging=TEMPO,OTELCOL
+----
+
+Available components: `GRAFANA`, `LOKI`, `PROMETHEUS`, `TEMPO`, `PYROSCOPE`, `OTELCOL`, `OBI`, `ALL`.
+
+=== Shutdown timeout
+
+The container forwards `SIGTERM` and `SIGINT` to every backend and waits for a graceful shutdown. By default the timeout is 5 seconds. You can override it:
+
+[source,properties]
+----
+quarkus.observability.lgtm.shutdown-timeout=15
+----
+
+=== OBI (eBPF auto-instrumentation)
+
+https://github.com/grafana/docker-otel-lgtm#enable-obi-ebpf-auto-instrumentation[OBI] (OpenTelemetry eBPF Instrumentation) automatically generates traces and RED metrics for HTTP/gRPC services without code changes. It requires Linux kernel 5.8+ with BTF support.
+
+When enabled, the container is started with `--pid=host` and `--privileged` flags.
+
+[source,properties]
+----
+quarkus.observability.lgtm.enable-obi=true
+quarkus.observability.lgtm.obi-target=java
+----
+
+Additional OBI targeting options:
+
+[cols="1,1"]
+|===
+|Property |Description
+
+|`quarkus.observability.lgtm.obi-target`
+|Language (`java`, `python`, `node`, `dotnet`, `ruby`) or any regex matching an executable name
+
+|`quarkus.observability.lgtm.obi-open-port`
+|Override which ports OBI monitors (e.g. `8080,9090`)
+
+|`quarkus.observability.lgtm.obi-auto-target-exe`
+|Executable name pattern for targeting
+|===
+
+=== Customize backend configuration
+
+==== Extra CLI arguments
+
+Each backend supports extra CLI arguments appended at startup. The value is split on whitespace into separate arguments.
+
+[source,properties]
+----
+quarkus.observability.lgtm.prometheus-extra-args=--storage.tsdb.retention.time=90d
+quarkus.observability.lgtm.loki-extra-args=-store.retention=90d
+quarkus.observability.lgtm.tempo-extra-args=--additional-flag=value
+quarkus.observability.lgtm.pyroscope-extra-args=--some-flag
+quarkus.observability.lgtm.otelcol-extra-args=--some-flag
+----
+
+[NOTE]
+====
+Tempo always includes `--query-frontend.mcp-server.enabled=true` by default. Any value set via `tempo-extra-args` is appended after this flag.
+====
+
+==== Custom configuration files
+
+For deeper customization, you can mount full configuration files from the classpath into the container. Place your custom YAML file in `src/main/resources/` and reference it:
+
+[source,properties]
+----
+quarkus.observability.lgtm.prometheus-config=my-prometheus.yaml
+quarkus.observability.lgtm.loki-config=my-loki-config.yaml
+quarkus.observability.lgtm.tempo-config=my-tempo-config.yaml
+quarkus.observability.lgtm.pyroscope-config=my-pyroscope-config.yaml
+quarkus.observability.lgtm.otelcol-config=my-otelcol-config.yaml
+----
+
+[cols="1,1"]
+|===
+|Property |Container path
+
+|`prometheus-config`
+|`/otel-lgtm/prometheus.yaml`
+
+|`loki-config`
+|`/otel-lgtm/loki-config.yaml`
+
+|`tempo-config`
+|`/otel-lgtm/tempo-config.yaml`
+
+|`pyroscope-config`
+|`/otel-lgtm/pyroscope-config.yaml`
+
+|`otelcol-config`
+|`/otel-lgtm/otelcol-config.yaml`
+|===
+
+[NOTE]
+====
+When a custom `prometheus-config` is provided, it replaces the Prometheus configuration that Quarkus generates (including scraping configuration). The other backends have no generated configuration, so the custom file simply replaces the container defaults.
+====
+
+=== Pre-install Grafana plugins
+
+You can pre-install Grafana plugins by setting a comma-separated list:
+
+[source,properties]
+----
+quarkus.observability.lgtm.grafana-plugins-preinstall=grafana-clock-panel,grafana-simple-json-datasource
+----
+
+See the https://grafana.com/docs/grafana/latest/setup-grafana/installation/docker/#install-plugins-in-the-docker-container[Grafana documentation] for details on available plugins.
+
+=== Custom Grafana home dashboard
+
+To set a custom dashboard as the Grafana home dashboard, point to a dashboard JSON file path inside the container. This is useful in combination with <<Custom dashboards>> which are copied to `/otel-lgtm/`:
+
+[source,properties]
+----
+quarkus.observability.lgtm.grafana-home-dashboard-path=/otel-lgtm/grafana-dashboard-my-home.json
+----
+
+=== Forward telemetry to external vendors
+
+The built-in OpenTelemetry Collector can forward telemetry data to external backends via OTLP/HTTP, enabling easy comparison between the local LGTM stack and a vendor backend.
+
+[source,properties]
+----
+quarkus.observability.lgtm.vendor-otlp-endpoint=https://otlp-gateway.example.com
+quarkus.observability.lgtm.vendor-otlp-headers=Authorization=Basic xxx
+----
+
+Per-signal endpoints take precedence over the global endpoint:
+
+[source,properties]
+----
+quarkus.observability.lgtm.vendor-otlp-logs-endpoint=https://logs.example.com
+quarkus.observability.lgtm.vendor-otlp-metrics-endpoint=https://metrics.example.com
+quarkus.observability.lgtm.vendor-otlp-traces-endpoint=https://traces.example.com
+----
+
 == Testing full Grafana OTel LGTM stack - example
 
 Use existing Quarkus MicroMeter OTLP registry
@@ -351,7 +613,7 @@ public class SimpleEndpoint {
 }
 ----
 
-Where you can then check Grafana's datasource API for existing metrics data.
+Where you can then check Prometheus for existing metrics data, using the exposed `prometheus.endpoint`:
 
 [source, java]
 ----
@@ -360,11 +622,14 @@ public class LgtmTestBase {
     @ConfigProperty(name = "grafana.endpoint")
     String endpoint; // NOTE -- injected Grafana endpoint!
 
+    @ConfigProperty(name = "prometheus.endpoint")
+    String prometheusEndpoint; // NOTE -- injected Prometheus endpoint!
+
     @Test
     public void testTracing() {
         String response = RestAssured.get("/api/poke?f=100").body().asString();
         System.out.println(response);
-        GrafanaClient client = new GrafanaClient(endpoint, "admin", "admin");
+        GrafanaClient client = new GrafanaClient(endpoint, prometheusEndpoint, null, "admin", "admin");
         Awaitility.await().atMost(61, TimeUnit.SECONDS).until(
                 client::user,
                 u -> "admin".equals(u.login));
@@ -374,84 +639,4 @@ public class LgtmTestBase {
     }
 
 }
-
-// simple Grafana HTTP client
-
-public class GrafanaClient {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-
-    private final String url;
-    private final String username;
-    private final String password;
-
-    public GrafanaClient(String url, String username, String password) {
-        this.url = url;
-        this.username = username;
-        this.password = password;
-    }
-
-    private <T> void handle(
-            String path,
-            Function<HttpRequest.Builder, HttpRequest.Builder> method,
-            HttpResponse.BodyHandler<T> bodyHandler,
-            BiConsumer<HttpResponse<T>, T> consumer) {
-        try {
-            String credentials = username + ":" + password;
-            String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes());
-
-            HttpClient httpClient = HttpClient.newHttpClient();
-            HttpRequest.Builder builder = HttpRequest.newBuilder()
-                    .uri(URI.create(url + path))
-                    .header("Authorization", "Basic " + encodedCredentials);
-            HttpRequest request = method.apply(builder).build();
-
-            HttpResponse<T> response = httpClient.send(request, bodyHandler);
-            int code = response.statusCode();
-            if (code < 200 || code > 299) {
-                throw new IllegalStateException("Bad response: " + code + " >> " + response.body());
-            }
-            consumer.accept(response, response.body());
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
-        }
-    }
-
-    public User user() {
-        AtomicReference<User> ref = new AtomicReference<>();
-        handle(
-                "/api/user",
-                HttpRequest.Builder::GET,
-                HttpResponse.BodyHandlers.ofString(),
-                (r, b) -> {
-                    try {
-                        User user = MAPPER.readValue(b, User.class);
-                        ref.set(user);
-                    } catch (JsonProcessingException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                });
-        return ref.get();
-    }
-
-    public QueryResult query(String query) {
-        AtomicReference<QueryResult> ref = new AtomicReference<>();
-        handle(
-                "/api/datasources/proxy/1/api/v1/query?query=" + query,
-                HttpRequest.Builder::GET,
-                HttpResponse.BodyHandlers.ofString(),
-                (r, b) -> {
-                    try {
-                        QueryResult result = MAPPER.readValue(b, QueryResult.class);
-                        ref.set(result);
-                    } catch (JsonProcessingException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                });
-        return ref.get();
-    }
-}
-
 ----

--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/ContainerConstants.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/ContainerConstants.java
@@ -4,7 +4,7 @@ public final class ContainerConstants {
 
     // Images
 
-    public static final String LGTM = "docker.io/grafana/otel-lgtm:0.24.0";
+    public static final String LGTM = "docker.io/grafana/otel-lgtm:0.31.0";
 
     // Ports
 
@@ -14,6 +14,7 @@ public final class ContainerConstants {
     public static final int OTEL_HTTP_EXPORTER_PORT = 4318;
 
     public static final int TEMPO_MCP_PORT = 3200;
+    public static final int PROMETHEUS_PORT = 9090;
 
     public static final String OTEL_GRPC_PROTOCOL = "grpc";
     public static final String OTEL_HTTP_PROTOCOL = "http/protobuf";

--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/LgtmComponent.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/LgtmComponent.java
@@ -7,5 +7,6 @@ public enum LgtmComponent {
     TEMPO,
     PYROSCOPE,
     OTELCOL,
+    OBI,
     ALL
 }

--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/LgtmConfig.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/LgtmConfig.java
@@ -77,9 +77,133 @@ public interface LgtmConfig extends GrafanaConfig {
     OptionalInt otelHttpPort();
 
     /**
+     * Prometheus port, if set it will be a fixed value.
+     */
+    OptionalInt prometheusPort();
+
+    /**
      * Tempo MCP port, if set it will be a fixed value.
      */
     OptionalInt tempoMcpPort();
+
+    /**
+     * The grace period in seconds for graceful shutdown after the container receives SIGTERM or SIGINT.
+     */
+    OptionalInt shutdownTimeout();
+
+    /**
+     * Enable OBI (OpenTelemetry eBPF Instrumentation) for automatic trace and RED metric generation.
+     * Requires Linux kernel 5.8+ with BTF support. Enables {@code --pid=host} and {@code --privileged} on the container.
+     */
+    @WithDefault("false")
+    boolean enableObi();
+
+    /**
+     * The OBI target to instrument. Can be a language ({@code java}, {@code python}, {@code node},
+     * {@code dotnet}, {@code ruby}) or any regex matching an executable name.
+     */
+    Optional<String> obiTarget();
+
+    /**
+     * Override which ports OBI monitors for auto-instrumentation.
+     */
+    Optional<String> obiOpenPort();
+
+    /**
+     * Executable name pattern for OBI auto-instrumentation targeting.
+     */
+    Optional<String> obiAutoTargetExe();
+
+    /**
+     * Extra CLI arguments for Prometheus. The value is split on whitespace into separate arguments.
+     */
+    Optional<String> prometheusExtraArgs();
+
+    /**
+     * Extra CLI arguments for Loki. The value is split on whitespace into separate arguments.
+     */
+    Optional<String> lokiExtraArgs();
+
+    /**
+     * Extra CLI arguments for Tempo, appended after the default MCP enablement flag.
+     * The value is split on whitespace into separate arguments.
+     */
+    Optional<String> tempoExtraArgs();
+
+    /**
+     * Extra CLI arguments for Pyroscope. The value is split on whitespace into separate arguments.
+     */
+    Optional<String> pyroscopeExtraArgs();
+
+    /**
+     * Extra CLI arguments for the OpenTelemetry Collector. The value is split on whitespace into separate arguments.
+     */
+    Optional<String> otelcolExtraArgs();
+
+    /**
+     * Classpath resource path to a custom Prometheus configuration file.
+     * Mounted to {@code /otel-lgtm/prometheus.yaml} inside the container.
+     */
+    Optional<String> prometheusConfig();
+
+    /**
+     * Classpath resource path to a custom Loki configuration file.
+     * Mounted to {@code /otel-lgtm/loki-config.yaml} inside the container.
+     */
+    Optional<String> lokiConfig();
+
+    /**
+     * Classpath resource path to a custom Tempo configuration file.
+     * Mounted to {@code /otel-lgtm/tempo-config.yaml} inside the container.
+     */
+    Optional<String> tempoConfig();
+
+    /**
+     * Classpath resource path to a custom Pyroscope configuration file.
+     * Mounted to {@code /otel-lgtm/pyroscope-config.yaml} inside the container.
+     */
+    Optional<String> pyroscopeConfig();
+
+    /**
+     * Classpath resource path to a custom OpenTelemetry Collector configuration file.
+     * Mounted to {@code /otel-lgtm/otelcol-config.yaml} inside the container.
+     */
+    Optional<String> otelcolConfig();
+
+    /**
+     * Comma-separated list of Grafana plugins to pre-install.
+     */
+    Optional<String> grafanaPluginsPreinstall();
+
+    /**
+     * Path inside the container to a dashboard JSON file to use as the Grafana home dashboard.
+     */
+    Optional<String> grafanaHomeDashboardPath();
+
+    /**
+     * Global OTLP endpoint for forwarding logs, metrics, and traces to an external vendor via OTLP/HTTP.
+     */
+    Optional<String> vendorOtlpEndpoint();
+
+    /**
+     * Per-signal OTLP endpoint for forwarding logs to an external vendor. Takes precedence over the global endpoint.
+     */
+    Optional<String> vendorOtlpLogsEndpoint();
+
+    /**
+     * Per-signal OTLP endpoint for forwarding metrics to an external vendor. Takes precedence over the global endpoint.
+     */
+    Optional<String> vendorOtlpMetricsEndpoint();
+
+    /**
+     * Per-signal OTLP endpoint for forwarding traces to an external vendor. Takes precedence over the global endpoint.
+     */
+    Optional<String> vendorOtlpTracesEndpoint();
+
+    /**
+     * Authentication headers for the vendor OTLP endpoint (e.g. API keys or tokens).
+     */
+    Optional<String> vendorOtlpHeaders();
 
     /**
      * A way to override `quarkus.otel.metric.export.interval` property's default value.

--- a/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/ObservabilityDevServiceProcessor.java
+++ b/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/ObservabilityDevServiceProcessor.java
@@ -138,20 +138,8 @@ class ObservabilityDevServiceProcessor {
             if (discovered != null) {
                 services.produce(discovered);
             } else {
-                Map<String, Function<ObservabilityStartable, String>> configProvider = new LinkedHashMap<>();
-                configProvider.put("grafana.endpoint", s -> s.getDevServiceConfig().get("grafana.endpoint"));
-                configProvider.put("tempo-mcp.endpoint", s -> s.getDevServiceConfig().get("tempo-mcp.endpoint"));
-                configProvider.put("otel-collector.url", s -> s.getDevServiceConfig().get("otel-collector.url"));
-                if (catalog.hasMicrometerOtlp()) {
-                    configProvider.put("quarkus.micrometer.export.otlp.url",
-                            s -> s.getDevServiceConfig().get("quarkus.micrometer.export.otlp.url"));
-                }
-                if (catalog.hasOpenTelemetry()) {
-                    configProvider.put("quarkus.otel.exporter.otlp.endpoint",
-                            s -> s.getDevServiceConfig().get("quarkus.otel.exporter.otlp.endpoint"));
-                    configProvider.put("quarkus.otel.exporter.otlp.protocol",
-                            s -> s.getDevServiceConfig().get("quarkus.otel.exporter.otlp.protocol"));
-                }
+                Map<String, Function<ObservabilityStartable, String>> configProvider = dev
+                        .configProvider(ObservabilityStartable::getDevServiceConfig);
 
                 services.produce(
                         DevServicesResultBuildItem.owned()
@@ -161,8 +149,10 @@ class ObservabilityDevServiceProcessor {
                                 .startable(() -> new ObservabilityStartable(dev, currentDevServicesConfiguration,
                                         configuration, devServicesConfig.timeout()))
                                 .configProvider(configProvider)
-                                .postStartHook(s -> log.infof("Dev Service %s started, config: %s",
-                                        devId, s.getDevServiceConfig()))
+                                .postStartHook(s -> {
+                                    log.infof("Dev Service %s started, config: %s", devId, s.getDevServiceConfig());
+                                    dev.logInfo();
+                                })
                                 .build());
             }
         }

--- a/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/LgtmContainer.java
+++ b/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/LgtmContainer.java
@@ -1,6 +1,7 @@
 package io.quarkus.observability.testcontainers;
 
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
@@ -93,6 +94,11 @@ public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
             """;
 
     private final boolean scrapingRequired;
+    private final Set<String> customDashboards = new LinkedHashSet<>();
+
+    public Set<String> getCustomDashboards() {
+        return customDashboards;
+    }
 
     public LgtmContainer(boolean scrapingRequired) {
         this(new LgtmConfigImpl(), scrapingRequired);
@@ -106,10 +112,45 @@ public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
         addExposedPorts(
                 ContainerConstants.OTEL_GRPC_EXPORTER_PORT,
                 ContainerConstants.OTEL_HTTP_EXPORTER_PORT,
+                ContainerConstants.PROMETHEUS_PORT,
                 ContainerConstants.TEMPO_MCP_PORT);
         config.otelGrpcPort().ifPresent(port -> addFixedExposedPort(port, ContainerConstants.OTEL_GRPC_EXPORTER_PORT));
         config.otelHttpPort().ifPresent(port -> addFixedExposedPort(port, ContainerConstants.OTEL_HTTP_EXPORTER_PORT));
+        config.prometheusPort().ifPresent(port -> addFixedExposedPort(port, ContainerConstants.PROMETHEUS_PORT));
         config.tempoMcpPort().ifPresent(port -> addFixedExposedPort(port, ContainerConstants.TEMPO_MCP_PORT));
+
+        String tempoArgs = "--query-frontend.mcp-server.enabled=true";
+        Optional<String> extraTempoArgs = config.tempoExtraArgs();
+        if (extraTempoArgs.isPresent()) {
+            tempoArgs += " " + extraTempoArgs.get();
+        }
+        withEnv("TEMPO_EXTRA_ARGS", tempoArgs);
+        config.prometheusExtraArgs().ifPresent(a -> withEnv("PROMETHEUS_EXTRA_ARGS", a));
+        config.lokiExtraArgs().ifPresent(a -> withEnv("LOKI_EXTRA_ARGS", a));
+        config.pyroscopeExtraArgs().ifPresent(a -> withEnv("PYROSCOPE_EXTRA_ARGS", a));
+        config.otelcolExtraArgs().ifPresent(a -> withEnv("OTELCOL_EXTRA_ARGS", a));
+        // allow for timeout shutdown, default is 5sec
+        config.shutdownTimeout()
+                .ifPresent(timeout -> withEnv("LGTM_SHUTDOWN_TIMEOUT_SECONDS", Integer.toString(timeout)));
+
+        if (config.enableObi()) {
+            withEnv("ENABLE_OBI", "true");
+            withPrivilegedMode(true);
+            withCreateContainerCmdModifier(cmd -> cmd.getHostConfig().withPidMode("host"));
+            config.obiTarget().ifPresent(target -> withEnv("OBI_TARGET", target));
+            config.obiOpenPort().ifPresent(port -> withEnv("OTEL_EBPF_OPEN_PORT", port));
+            config.obiAutoTargetExe().ifPresent(exe -> withEnv("OTEL_EBPF_AUTO_TARGET_EXE", exe));
+        }
+
+        config.grafanaPluginsPreinstall().ifPresent(p -> withEnv("GF_PLUGINS_PREINSTALL", p));
+        config.grafanaHomeDashboardPath()
+                .ifPresent(p -> withEnv("GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH", p));
+
+        config.vendorOtlpEndpoint().ifPresent(e -> withEnv("OTEL_EXPORTER_OTLP_ENDPOINT", e));
+        config.vendorOtlpLogsEndpoint().ifPresent(e -> withEnv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", e));
+        config.vendorOtlpMetricsEndpoint().ifPresent(e -> withEnv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", e));
+        config.vendorOtlpTracesEndpoint().ifPresent(e -> withEnv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", e));
+        config.vendorOtlpHeaders().ifPresent(h -> withEnv("OTEL_EXPORTER_OTLP_HEADERS", h));
 
         Optional<Set<LgtmComponent>> logging = config.logging();
         logging.ifPresent(set -> set.forEach(l -> withEnv("ENABLE_LOGS_" + l.name(), "true")));
@@ -120,7 +161,7 @@ public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
                     withCopyFileToContainer(
                             MountableFile.forClasspathResource(GrafanaUtils.META_INF_GRAFANA + "/" + s),
                             "/otel-lgtm/" + s);
-                    log.infof("Adding custom Grafana dashboard config: %s", s);
+                    customDashboards.add(s);
                 });
 
         // Replacing bundled dashboards with our own
@@ -140,7 +181,21 @@ public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
                 MountableFile.forClasspathResource("/grafana-dashboard-opentelemetry-logging.json"),
                 "/otel-lgtm/grafana-dashboard-opentelemetry-logging.json");
 
-        addFileToContainer(getPrometheusConfig().getBytes(), "/otel-lgtm/prometheus.yaml");
+        if (config.prometheusConfig().isPresent()) {
+            withCopyFileToContainer(
+                    MountableFile.forClasspathResource(config.prometheusConfig().get()),
+                    "/otel-lgtm/prometheus.yaml");
+        } else {
+            addFileToContainer(getPrometheusConfig().getBytes(), "/otel-lgtm/prometheus.yaml");
+        }
+        config.lokiConfig().ifPresent(r -> withCopyFileToContainer(
+                MountableFile.forClasspathResource(r), "/otel-lgtm/loki-config.yaml"));
+        config.tempoConfig().ifPresent(r -> withCopyFileToContainer(
+                MountableFile.forClasspathResource(r), "/otel-lgtm/tempo-config.yaml"));
+        config.pyroscopeConfig().ifPresent(r -> withCopyFileToContainer(
+                MountableFile.forClasspathResource(r), "/otel-lgtm/pyroscope-config.yaml"));
+        config.otelcolConfig().ifPresent(r -> withCopyFileToContainer(
+                MountableFile.forClasspathResource(r), "/otel-lgtm/otelcol-config.yaml"));
     }
 
     @Override
@@ -256,8 +311,123 @@ public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
         }
 
         @Override
+        public OptionalInt prometheusPort() {
+            return OptionalInt.empty();
+        }
+
+        @Override
         public OptionalInt tempoMcpPort() {
             return OptionalInt.empty();
+        }
+
+        @Override
+        public OptionalInt shutdownTimeout() {
+            return OptionalInt.empty();
+        }
+
+        @Override
+        public boolean enableObi() {
+            return false;
+        }
+
+        @Override
+        public Optional<String> obiTarget() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> obiOpenPort() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> obiAutoTargetExe() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> prometheusExtraArgs() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> lokiExtraArgs() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> tempoExtraArgs() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> pyroscopeExtraArgs() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> otelcolExtraArgs() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> prometheusConfig() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> lokiConfig() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> tempoConfig() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> pyroscopeConfig() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> otelcolConfig() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> grafanaPluginsPreinstall() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> grafanaHomeDashboardPath() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> vendorOtlpEndpoint() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> vendorOtlpLogsEndpoint() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> vendorOtlpMetricsEndpoint() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> vendorOtlpTracesEndpoint() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> vendorOtlpHeaders() {
+            return Optional.empty();
         }
 
         @Override

--- a/extensions/observability-devservices/testlibs/devresource-common/src/main/java/io/quarkus/observability/devresource/DevResourceLifecycleManager.java
+++ b/extensions/observability-devservices/testlibs/devresource-common/src/main/java/io/quarkus/observability/devresource/DevResourceLifecycleManager.java
@@ -1,6 +1,7 @@
 package io.quarkus.observability.devresource;
 
 import java.util.Map;
+import java.util.function.Function;
 
 import io.quarkus.observability.common.config.ContainerConfig;
 import io.quarkus.observability.common.config.ModulesConfiguration;
@@ -84,6 +85,24 @@ public interface DevResourceLifecycleManager<T extends ContainerConfig> extends 
      * @return A map of system properties that should be set for the running dev-mode app
      */
     Map<String, String> config(int privatePort, String host, int publicPort);
+
+    /**
+     * Create a map of lazily created configs from dev resource.
+     * e.g. endpoint urls, etc
+     *
+     * @param fn mapping function to lazily get properties map
+     * @return map of configs provided by dev resource
+     */
+    default <S> Map<String, Function<S, String>> configProvider(Function<S, Map<String, String>> fn) {
+        return Map.of();
+    }
+
+    /**
+     * Additional info we want to log right after dev resource was started.
+     * e.g. mounted files into testcontainer, etc
+     */
+    default void logInfo() {
+    }
 
     /**
      * Called even before {@link #start()} so that the implementation can prepare itself

--- a/extensions/observability-devservices/testlibs/devresource-lgtm/src/main/java/io/quarkus/observability/devresource/lgtm/LgtmResource.java
+++ b/extensions/observability-devservices/testlibs/devresource-lgtm/src/main/java/io/quarkus/observability/devresource/lgtm/LgtmResource.java
@@ -159,6 +159,9 @@ public class LgtmResource extends ContainerResource<LgtmContainer, LgtmConfig> {
             case ContainerConstants.GRAFANA_PORT:
                 containerConfigs.put("grafana.endpoint", String.format("http://%s:%s", host, publicPort));
                 break;
+            case ContainerConstants.PROMETHEUS_PORT:
+                containerConfigs.put("prometheus.endpoint", String.format("http://%s:%s", host, publicPort));
+                break;
             case ContainerConstants.TEMPO_MCP_PORT:
                 containerConfigs.put("tempo-mcp.endpoint", String.format("http://%s:%s", host, publicPort));
                 break;
@@ -191,6 +194,19 @@ public class LgtmResource extends ContainerResource<LgtmContainer, LgtmConfig> {
     }
 
     @Override
+    public <S> Map<String, Function<S, String>> configProvider(Function<S, Map<String, String>> fn) {
+        return createConfigProvider(
+                fn,
+                Prop.of("grafana.endpoint"),
+                Prop.of("prometheus.endpoint"),
+                Prop.of("tempo-mcp.endpoint"),
+                Prop.of("otel-collector.url"),
+                new Prop("quarkus.micrometer.export.otlp.url", () -> catalog != null && catalog.hasMicrometerOtlp()),
+                new Prop("quarkus.otel.exporter.otlp.endpoint", () -> catalog != null && catalog.hasOpenTelemetry()),
+                new Prop("quarkus.otel.exporter.otlp.protocol", () -> catalog != null && catalog.hasOpenTelemetry()));
+    }
+
+    @Override
     protected LgtmContainer defaultContainer() {
         return new LgtmContainer(isScrapingRequired(TCCL_FN)); // best we can do?
     }
@@ -201,13 +217,23 @@ public class LgtmResource extends ContainerResource<LgtmContainer, LgtmConfig> {
         Map<String, String> containerConfigs = new HashMap<>();
 
         containerConfigs.putAll(config(ContainerConstants.GRAFANA_PORT, host));
+        containerConfigs.putAll(config(ContainerConstants.PROMETHEUS_PORT, host));
         containerConfigs.putAll(config(ContainerConstants.TEMPO_MCP_PORT, host));
         containerConfigs.putAll(config(ContainerConstants.OTEL_HTTP_EXPORTER_PORT, host));
         // Iff GRPC is the OTLP protocol, overwrite the otel-collector.url we just wrote with the correct grpc one, and set up the otlp endpoints
         if (ContainerConstants.OTEL_GRPC_PROTOCOL.equals(container.getOtlpProtocol())) {
             containerConfigs.putAll(config(ContainerConstants.OTEL_GRPC_EXPORTER_PORT, host));
         }
+
         return containerConfigs;
+    }
+
+    @Override
+    public void logInfo() {
+        // move here, so we see it logged
+        for (String dashboard : container.getCustomDashboards()) {
+            log.infof("Adding custom Grafana dashboard config: %s", dashboard);
+        }
     }
 
     @Override

--- a/extensions/observability-devservices/testlibs/devresource-testcontainers/src/main/java/io/quarkus/observability/devresource/testcontainers/ContainerResource.java
+++ b/extensions/observability-devservices/testlibs/devresource-testcontainers/src/main/java/io/quarkus/observability/devresource/testcontainers/ContainerResource.java
@@ -1,6 +1,9 @@
 package io.quarkus.observability.devresource.testcontainers;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.testcontainers.containers.GenericContainer;
 
@@ -32,6 +35,19 @@ public abstract class ContainerResource<T extends GenericContainer<T>, C extends
         return doStart();
     }
 
+    protected <S> Map<String, Function<S, String>> createConfigProvider(
+            Function<S, Map<String, String>> fn,
+            Prop... props) {
+        Map<String, Function<S, String>> map = new LinkedHashMap<>();
+        for (Prop prop : props) {
+            if (prop.predicate.get()) {
+                String name = prop.name();
+                map.put(name, o -> fn.apply(o).get(name));
+            }
+        }
+        return map;
+    }
+
     @Override
     public void stop() {
         if (container != null) {
@@ -42,4 +58,12 @@ public abstract class ContainerResource<T extends GenericContainer<T>, C extends
     protected abstract T defaultContainer();
 
     protected abstract Map<String, String> doStart();
+
+    public record Prop(
+            String name,
+            Supplier<Boolean> predicate) {
+        public static Prop of(String name) {
+            return new Prop(name, () -> true);
+        }
+    }
 }

--- a/integration-tests/observability-lgtm-fixedports/src/test/java/io/quarkus/observability/test/LgtmFixedPortsTest.java
+++ b/integration-tests/observability-lgtm-fixedports/src/test/java/io/quarkus/observability/test/LgtmFixedPortsTest.java
@@ -23,12 +23,18 @@ public class LgtmFixedPortsTest {
     @ConfigProperty(name = "grafana.endpoint")
     String endpoint;
 
+    @ConfigProperty(name = "prometheus.endpoint")
+    String prometheusEndpoint;
+
+    @ConfigProperty(name = "tempo-mcp.endpoint")
+    String tempoEndpoint;
+
     @Test
     protected void testPoke() {
         log.info("Testing Grafana ...");
         String response = RestAssured.get("/api/poke?f=100").body().asString();
         log.info("Response: " + response);
-        GrafanaClient client = new GrafanaClient(endpoint, "admin", "admin");
+        GrafanaClient client = new GrafanaClient(endpoint, prometheusEndpoint, tempoEndpoint, "admin", "admin");
 
         Awaitility.setDefaultPollInterval(5, TimeUnit.SECONDS); // reduce load on the server. Default is .1s
 

--- a/integration-tests/observability-lgtm-prometheus/src/test/java/io/quarkus/observability/test/LgtmTest.java
+++ b/integration-tests/observability-lgtm-prometheus/src/test/java/io/quarkus/observability/test/LgtmTest.java
@@ -28,12 +28,18 @@ public class LgtmTest {
     @ConfigProperty(name = "grafana.endpoint")
     String endpoint;
 
+    @ConfigProperty(name = "prometheus.endpoint")
+    String prometheusEndpoint;
+
+    @ConfigProperty(name = "tempo-mcp.endpoint")
+    String tempoEndpoint;
+
     @Test
     public void testPoke() {
         log.info("Testing Grafana ...");
         String response = RestAssured.get("/api/poke?f=100").body().asString();
         log.info("Response: " + response);
-        GrafanaClient client = new GrafanaClient(endpoint, "admin", "admin");
+        GrafanaClient client = new GrafanaClient(endpoint, prometheusEndpoint, tempoEndpoint, "admin", "admin");
 
         Awaitility.setDefaultPollInterval(1, TimeUnit.SECONDS); // reduce load on the server. Default is .1s
 

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmConfigTestBase.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmConfigTestBase.java
@@ -7,8 +7,24 @@ public abstract class LgtmConfigTestBase extends LgtmTestBase {
     @ConfigProperty(name = "grafana.endpoint")
     String endpoint;
 
+    @ConfigProperty(name = "prometheus.endpoint")
+    String prometheusEp;
+
+    @ConfigProperty(name = "tempo-mcp.endpoint")
+    String tempoEp;
+
     @Override
     protected String grafanaEndpoint() {
         return endpoint;
+    }
+
+    @Override
+    protected String prometheusEndpoint() {
+        return prometheusEp;
+    }
+
+    @Override
+    protected String tempoEndpoint() {
+        return tempoEp;
     }
 }

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmReloadTest.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmReloadTest.java
@@ -32,6 +32,16 @@ public class LgtmReloadTest extends LgtmTestHelper {
         return GrafanaClient.endpoint();
     }
 
+    @Override
+    protected String prometheusEndpoint() {
+        return null;
+    }
+
+    @Override
+    protected String tempoEndpoint() {
+        return null;
+    }
+
     @Test
     public void testReload() {
         poke("/reload");

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmTestHelper.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmTestHelper.java
@@ -14,11 +14,16 @@ public abstract class LgtmTestHelper {
 
     protected abstract String grafanaEndpoint();
 
+    protected abstract String prometheusEndpoint();
+
+    protected abstract String tempoEndpoint();
+
     protected void poke(String path) {
         log.info("Testing Grafana ...");
         String response = RestAssured.get(path + "/poke?f=100").body().asString();
         log.info("Response: " + response);
-        GrafanaClient client = new GrafanaClient(grafanaEndpoint(), "admin", "admin");
+        GrafanaClient client = new GrafanaClient(grafanaEndpoint(), prometheusEndpoint(), tempoEndpoint(), "admin",
+                "admin");
 
         Awaitility.setDefaultPollInterval(5, TimeUnit.SECONDS); // reduce load on the server. Default is .1s
 

--- a/test-framework/observability/src/main/java/io/quarkus/observability/test/utils/GrafanaClient.java
+++ b/test-framework/observability/src/main/java/io/quarkus/observability/test/utils/GrafanaClient.java
@@ -21,28 +21,38 @@ public class GrafanaClient {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final String url;
+    private final String prometheusUrl;
+    private final String tempoUrl;
     private final String username;
     private final String password;
 
     public GrafanaClient(String url, String username, String password) {
+        this(url, null, null, username, password);
+    }
+
+    public GrafanaClient(String url, String prometheusUrl, String tempoUrl, String username, String password) {
         this.url = url;
+        this.prometheusUrl = prometheusUrl;
+        this.tempoUrl = tempoUrl;
         this.username = username;
         this.password = password;
     }
 
     private <T> void handle(
+            String baseUrl,
             String path,
             Function<HttpRequest.Builder, HttpRequest.Builder> method,
             HttpResponse.BodyHandler<T> bodyHandler,
             BiConsumer<HttpResponse<T>, T> consumer) {
         try {
-            String credentials = username + ":" + password;
-            String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes());
-
             HttpClient httpClient = HttpClient.newHttpClient();
             HttpRequest.Builder builder = HttpRequest.newBuilder()
-                    .uri(URI.create(url + path))
-                    .header("Authorization", "Basic " + encodedCredentials);
+                    .uri(URI.create(baseUrl + path));
+            if (username != null && password != null) {
+                String credentials = username + ":" + password;
+                String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes());
+                builder.header("Authorization", "Basic " + encodedCredentials);
+            }
             HttpRequest request = method.apply(builder).build();
 
             HttpResponse<T> response = httpClient.send(request, bodyHandler);
@@ -67,6 +77,7 @@ public class GrafanaClient {
     private String grafana() {
         AtomicReference<String> ref = new AtomicReference<>();
         handle(
+                url,
                 "/config/grafana",
                 HttpRequest.Builder::GET,
                 HttpResponse.BodyHandlers.ofString(),
@@ -79,6 +90,7 @@ public class GrafanaClient {
     public User user() {
         AtomicReference<User> ref = new AtomicReference<>();
         handle(
+                url,
                 "/api/user",
                 HttpRequest.Builder::GET,
                 HttpResponse.BodyHandlers.ofString(),
@@ -94,7 +106,8 @@ public class GrafanaClient {
     public QueryResult query(String query) {
         AtomicReference<QueryResult> ref = new AtomicReference<>();
         handle(
-                "/api/datasources/proxy/1/api/v1/query?query=" + query,
+                prometheusUrl != null ? prometheusUrl : url,
+                "/api/v1/query?query=" + query,
                 HttpRequest.Builder::GET,
                 HttpResponse.BodyHandlers.ofString(),
                 (r, b) -> {
@@ -108,9 +121,10 @@ public class GrafanaClient {
 
     public TempoResult traces(String service, int limit, int spss) {
         AtomicReference<TempoResult> ref = new AtomicReference<>();
-        String path = "/api/datasources/proxy/uid/tempo/api/search?q=%7Bresource.service.name%3D%22"
+        String path = "/api/search?q=%7Bresource.service.name%3D%22"
                 + service + "%22%7D&limit=" + limit + "&spss=" + spss;
         handle(
+                tempoUrl != null ? tempoUrl : url,
                 path,
                 HttpRequest.Builder::GET,
                 HttpResponse.BodyHandlers.ofString(),
@@ -126,6 +140,7 @@ public class GrafanaClient {
     public String dashboard(String uid) {
         AtomicReference<String> ref = new AtomicReference<>();
         handle(
+                url,
                 "/api/dashboards/uid/" + uid,
                 HttpRequest.Builder::GET,
                 HttpResponse.BodyHandlers.ofString(),


### PR DESCRIPTION
New LGTM 0.31.0 Docker image has a bunch of new env var config / features, which might be useful for the advanced users.
The defaults stay the same, and are imho good enough as they are.

This change also exposes Prometheus endpoint, which might be more "powerful" for metrics queries then Grafana proxy API.

It also moves LGTM specific config out of processor - those configs are dev resource specific, as it is done now.

Log DevResource info in post-start, so it doesn't get lost.
e.g. new Grafana dashboards, etc