### PR TITLE
Fix dead link

### DIFF
--- a/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2RuntimeConfig.java
+++ b/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2RuntimeConfig.java
@@ -35,7 +35,7 @@ public interface OAuth2RuntimeConfig {
     /**
      * The OAuth2 server certificate file. <em>Warning</em>: this is not supported in native mode where the certificate
      * must be included in the truststore used during the native image generation, see
-     * <a href="native-and-ssl.html">Using SSL With Native Executables</a>.
+     * <a href="/guides/native-and-ssl">Using SSL With Native Executables</a>.
      */
     Optional<String> caCertFile();
 


### PR DESCRIPTION
One of the links in our javadoc used to work with Jekyll, but no longer works with Roq. I debated whether to add the server or not (which would be needed on an external site like javadoc.io), but in the end did not. 