### PR TITLE
Fix annoying `null` at end of toString when there are no paths

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedArtifactDependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedArtifactDependency.java
@@ -79,7 +79,10 @@ public class ResolvedArtifactDependency extends ArtifactDependency implements Re
     @Override
     public String toString() {
         final StringBuilder buf = new StringBuilder();
-        buf.append(toGACTVString()).append(paths);
+        buf.append(toGACTVString());
+        if (paths != null) {
+            buf.append(paths);
+        }
         if (module != null) {
             buf.append(" " + module);
         }


### PR DESCRIPTION
Just a trivial formatting fix. This should be arbitrarily backportable to any version if desired.