### PR TITLE
Explain native-image build failures by exit code

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -658,21 +658,26 @@ public class NativeImageBuildStep {
         }
     }
 
+    /**
+     * Guidance for an out-of-memory <em>kill</em> (exit code 137). Unlike an in-process Java-heap OOM (exit code 3),
+     * the builder here was killed from the outside because system or container memory was exhausted, so the fix is to
+     * make more memory available rather than to raise the builder heap - raising it actually makes a kill more likely.
+     * The advice is the same for every build; only a container build needs an extra hint about where the memory limit
+     * lives, and that hint differs between a Linux host (the container/cgroup limit) and a non-Linux host (the
+     * container runtime's Linux VM).
+     */
     private static String oomGuidance(boolean isContainerBuild) {
-        StringBuilder sb = new StringBuilder();
-        if (isContainerBuild && !OS.LINUX.isCurrent()) {
-            sb.append("The most likely cause is the container runtime not being given enough memory "
-                    + "(Docker Desktop: Settings > Resources; Podman: 'podman machine set --memory 8192'), "
-                    + "or a low vm.max_map_count inside its Linux VM. ");
+        String containerHint = "";
+        if (isContainerBuild) {
+            containerHint = OS.LINUX.isCurrent()
+                    ? "Raise the container/cgroup memory limit, and check vm.max_map_count and memory overcommit "
+                            + "settings (the kernel records the real reason in dmesg / 'journalctl -k'). "
+                    : "Give the container runtime more memory (Docker Desktop: Settings > Resources; "
+                            + "Podman: 'podman machine set --memory 8192') or raise vm.max_map_count inside its Linux VM. ";
         }
-        sb.append("Consider increasing the Xmx value for native image generation by setting the \"")
-                .append(QUARKUS_XMX_PROPERTY).append("\" property");
-        if (isContainerBuild && OS.LINUX.isCurrent()) {
-            sb.append(", and if the machine has free memory the cause may instead be a container/cgroup memory limit, "
-                    + "a low vm.max_map_count, memory overcommit settings, or a ulimit "
-                    + "(the kernel records the real reason in dmesg / journalctl -k)");
-        }
-        return sb.append(".").toString();
+        return containerHint + "Free up memory on the machine, or give it more RAM or swap. "
+                + "Raising the \"" + QUARKUS_XMX_PROPERTY + "\" property makes the process more likely to be killed, "
+                + "so if it is set high relative to the available memory, lowering it may help instead.";
     }
 
     private void checkGraalVMVersion(GraalVM.Version version) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -84,7 +84,6 @@ public class NativeImageBuildStep {
      */
     private static final String JAVA_HOME_ENV = "JAVA_HOME";
 
-    private static final int OOM_ERROR_VALUE = 137;
     private static final String QUARKUS_XMX_PROPERTY = "quarkus.native.native-image-xmx";
     public static final String CONTAINER_BUILD_VOLUME_PATH = "/project";
     private static final String TRUST_STORE_SYSTEM_PROPERTY_MARKER = "-Djavax.net.ssl.trustStore=";
@@ -602,19 +601,78 @@ public class NativeImageBuildStep {
     }
 
     private RuntimeException imageGenerationFailed(Throwable cause, boolean isContainerBuild) {
-        if (cause instanceof AbnormalExitException aee && aee.exitCode() == OOM_ERROR_VALUE) {
-            if (isContainerBuild && !OS.LINUX.isCurrent()) {
-                return new ImageGenerationFailureException("Image generation failed. Exit code was " + aee.exitCode()
-                        + " which indicates an out of memory error. The most likely cause is Docker not being given enough memory. Also consider increasing the Xmx value for native image generation by setting the \""
-                        + QUARKUS_XMX_PROPERTY + "\" property", cause);
-            } else {
-                return new ImageGenerationFailureException("Image generation failed. Exit code was " + aee.exitCode()
-                        + " which indicates an out of memory error. Consider increasing the Xmx value for native image generation by setting the \""
-                        + QUARKUS_XMX_PROPERTY + "\" property", cause);
-            }
-        } else {
-            return new ImageGenerationFailureException("Image generation failed", cause);
+        if (cause instanceof AbnormalExitException aee) {
+            return new ImageGenerationFailureException(describeFailure(aee.exitCode(), isContainerBuild), cause);
         }
+        return new ImageGenerationFailureException("Image generation failed", cause);
+    }
+
+    /**
+     * Turns a native-image process exit code into a human-readable explanation.
+     * <p>
+     * The codes are the ones the native-image driver uses ({@code com.oracle.svm.core.util.ExitStatus}), plus the
+     * Unix {@code 128 + signal} codes for a builder that was killed by a signal. The exit code is always included,
+     * and for failures where the builder already printed the real cause the message points at the native-image
+     * output above.
+     */
+    static String describeFailure(int exitCode, boolean isContainerBuild) {
+        String prefix = "Image generation failed with exit code " + exitCode;
+        switch (exitCode) {
+            case 1: // ExitStatus.BUILDER_ERROR
+                return prefix + ": the native-image builder reported an error. "
+                        + "See the native-image output above for the cause.";
+            case 2: // fallback image created; Quarkus passes --no-fallback and fallback images are gone since GraalVM 25.1,
+                    // so this case can be dropped once GraalVM 25.0 is no longer supported
+                return prefix + ": native-image produced a fallback image instead of a native executable. "
+                        + "See the native-image output above for the reason.";
+            case 3: // ExitStatus.OUT_OF_MEMORY (builder Java heap, via -XX:+ExitOnOutOfMemoryError)
+                return prefix + ": the native-image builder ran out of Java heap. Increase the maximum heap size for "
+                        + "the build by setting the \"" + QUARKUS_XMX_PROPERTY + "\" property.";
+            case 20: // ExitStatus.DRIVER_ERROR
+                return prefix + " (native-image driver error). See the native-image output above for the cause.";
+            case 21: // ExitStatus.DRIVER_TO_BUILDER_ERROR
+                return prefix + ": the native-image driver could not communicate with the builder. "
+                        + "See the native-image output above.";
+            case 30: // ExitStatus.WATCHDOG_EXIT
+                return prefix + ": the native-image build watchdog fired because the build appears to be stuck. "
+                        + "See the native-image output above.";
+            case 125: // ExitStatus.CONTAINER_REUSE, only expected from a bundle build with a container
+                return prefix + ": the native-image driver could not reuse its build container. "
+                        + "See the native-image output above.";
+            case 134: // 128 + 6, SIGABRT
+                return prefix + ": the native-image builder aborted (SIGABRT). See the native-image output above.";
+            case 137: // ExitStatus.OUT_OF_MEMORY_KILLED (128 + 9, SIGKILL)
+                return prefix + ": the native-image build process was killed, which indicates it ran out of memory. "
+                        + oomGuidance(isContainerBuild);
+            case 139: // 128 + 11, SIGSEGV
+                return prefix + ": the native-image builder crashed with a segmentation fault (SIGSEGV). "
+                        + "See the native-image output above.";
+            case 143: // 128 + 15, SIGTERM
+                return prefix + ": the native-image build was terminated (SIGTERM), "
+                        + "usually because of a timeout or an external stop.";
+            case 172: // ExitStatus.MISSING_METADATA
+                return prefix + ": required reachability metadata is missing. "
+                        + "See the native-image output above for the missing entries.";
+            default:
+                return prefix + ". See the native-image output above for details.";
+        }
+    }
+
+    private static String oomGuidance(boolean isContainerBuild) {
+        StringBuilder sb = new StringBuilder();
+        if (isContainerBuild && !OS.LINUX.isCurrent()) {
+            sb.append("The most likely cause is the container runtime not being given enough memory "
+                    + "(Docker Desktop: Settings > Resources; Podman: 'podman machine set --memory 8192'), "
+                    + "or a low vm.max_map_count inside its Linux VM. ");
+        }
+        sb.append("Consider increasing the Xmx value for native image generation by setting the \"")
+                .append(QUARKUS_XMX_PROPERTY).append("\" property");
+        if (isContainerBuild && OS.LINUX.isCurrent()) {
+            sb.append(", and if the machine has free memory the cause may instead be a container/cgroup memory limit, "
+                    + "a low vm.max_map_count, memory overcommit settings, or a ulimit "
+                    + "(the kernel records the real reason in dmesg / journalctl -k)");
+        }
+        return sb.append(".").toString();
     }
 
     private void checkGraalVMVersion(GraalVM.Version version) {

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStepFailureMessageTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStepFailureMessageTest.java
@@ -1,0 +1,50 @@
+package io.quarkus.deployment.pkg.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class NativeImageBuildStepFailureMessageTest {
+
+    @Test
+    void includesTheExitCode() {
+        assertThat(NativeImageBuildStep.describeFailure(20, false)).contains("exit code 20");
+    }
+
+    @Test
+    void mapsKnownGraalVmExitStatusCodes() {
+        assertThat(NativeImageBuildStep.describeFailure(20, false)).contains("driver error");
+        assertThat(NativeImageBuildStep.describeFailure(30, false)).contains("watchdog");
+        assertThat(NativeImageBuildStep.describeFailure(172, false)).contains("reachability metadata");
+        assertThat(NativeImageBuildStep.describeFailure(1, false)).contains("builder reported an error");
+        assertThat(NativeImageBuildStep.describeFailure(2, false)).contains("fallback image");
+        assertThat(NativeImageBuildStep.describeFailure(125, false)).contains("build container");
+    }
+
+    @Test
+    void decodesSignalDerivedCodes() {
+        assertThat(NativeImageBuildStep.describeFailure(139, false)).contains("SIGSEGV");
+        assertThat(NativeImageBuildStep.describeFailure(134, false)).contains("SIGABRT");
+        assertThat(NativeImageBuildStep.describeFailure(143, false)).contains("SIGTERM");
+    }
+
+    @Test
+    void outOfMemoryCodesSuggestXmx() {
+        assertThat(NativeImageBuildStep.describeFailure(137, false)).contains("out of memory")
+                .contains("quarkus.native.native-image-xmx");
+        assertThat(NativeImageBuildStep.describeFailure(3, false)).contains("Java heap")
+                .contains("quarkus.native.native-image-xmx");
+    }
+
+    @Test
+    void containerHintsOnlyForContainerBuilds() {
+        assertThat(NativeImageBuildStep.describeFailure(137, false)).doesNotContain("cgroup")
+                .doesNotContain("container runtime");
+    }
+
+    @Test
+    void unknownCodeStillPointsAtTheOutput() {
+        String msg = NativeImageBuildStep.describeFailure(200, false);
+        assertThat(msg).contains("exit code 200").contains("native-image output above");
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStepFailureMessageTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStepFailureMessageTest.java
@@ -29,17 +29,36 @@ public class NativeImageBuildStepFailureMessageTest {
     }
 
     @Test
-    void outOfMemoryCodesSuggestXmx() {
-        assertThat(NativeImageBuildStep.describeFailure(137, false)).contains("out of memory")
-                .contains("quarkus.native.native-image-xmx");
+    void javaHeapOomSuggestsRaisingXmx() {
+        // Exit code 3 is an in-process Java-heap OOM: raising the builder heap is the correct fix.
         assertThat(NativeImageBuildStep.describeFailure(3, false)).contains("Java heap")
+                .contains("Increase the maximum heap size")
                 .contains("quarkus.native.native-image-xmx");
     }
 
     @Test
+    void oomKillDoesNotAdviseRaisingXmx() {
+        // Exit code 137 is an OOM *kill* (SIGKILL): memory was exhausted, so making more memory available is the
+        // fix and raising the builder heap would make a kill more likely. It must not be confused with a Java-heap OOM.
+        String msg = NativeImageBuildStep.describeFailure(137, false);
+        assertThat(msg).contains("out of memory")
+                .contains("Free up memory")
+                .contains("more likely to be killed")
+                .doesNotContain("Java heap");
+    }
+
+    @Test
+    void oomKillGuidanceIsShownForNonContainerBuilds() {
+        // Regression guard: a plain (non-container) build killed by the kernel OOM-killer must still get the
+        // "free up memory" guidance, not only container builds.
+        assertThat(NativeImageBuildStep.describeFailure(137, false)).contains("Free up memory");
+    }
+
+    @Test
     void containerHintsOnlyForContainerBuilds() {
-        assertThat(NativeImageBuildStep.describeFailure(137, false)).doesNotContain("cgroup")
-                .doesNotContain("container runtime");
+        // The shared guidance never mentions containers; only a container build gets the extra hint.
+        assertThat(NativeImageBuildStep.describeFailure(137, false)).doesNotContain("container");
+        assertThat(NativeImageBuildStep.describeFailure(137, true)).contains("container");
     }
 
     @Test


### PR DESCRIPTION
## Explain native-image build failures by exit code

Relates to #1140

### Problem

When a native image build fails, Quarkus reports a bare `Image generation failed`. The exit code is only reachable through the exception cause, so for anything other than 137 the message is unactionable — which is why the issue thread keeps asking *"what is exit code 20?"*.

### What this does

`NativeImageBuildStep.imageGenerationFailed(...)` now maps the exit code to a readable explanation.

The codes are the ones the native-image driver itself uses (`com.oracle.svm.core.util.ExitStatus`), plus the Unix `128 + signal` codes for a builder killed by a signal:

| Exit code | Meaning in the message |
|-----------|------------------------|
| 1 `BUILDER_ERROR` | build failed — points at the output above (the builder already printed the cause) |
| 3 `OUT_OF_MEMORY` | builder ran out of Java heap → raise `native-image-xmx` |
| 20 `DRIVER_ERROR` / 21 `DRIVER_TO_BUILDER_ERROR` | native-image driver error → points at the output |
| 30 `WATCHDOG_EXIT` | build watchdog fired (stuck / timed out) |
| 137 `OUT_OF_MEMORY_KILLED` | out of memory (broadened guidance — see below) |
| 172 `MISSING_METADATA` | missing reachability metadata |
| 134 / 139 / 143 | builder killed by SIGABRT / SIGSEGV / SIGTERM |
| anything else | includes the code and points at the output |

The exit code is always included in the message.

For **137**, the message also lists the real candidate causes rather than only "add memory": the container/engine memory limit, `native-image-xmx`, and — on Linux — a cgroup limit, a low `vm.max_map_count`, overcommit, or a ulimit (with a pointer to `dmesg` / `journalctl -k`).

`ExitStatus` is an internal GraalVM class, not a public contract, so unknown codes fall through to a generic "see the native-image output above" message.

### Testing

`NativeImageBuildStepFailureMessageTest` covers the mapping: the known `ExitStatus` codes, the signal-derived codes, the out-of-memory guidance, and the unknown-code fallback.

### Release note

Release note: Native image build failures now report a readable explanation for the exit code — driver error, watchdog timeout, missing reachability metadata, out of memory, or a builder killed by a signal — instead of a bare "Image generation failed".
