### PR TITLE
Hint at a missing C compiler in native-image build failures

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/ErrorReplacingProcessReader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/ErrorReplacingProcessReader.java
@@ -17,6 +17,17 @@ import java.util.regex.Pattern;
 public final class ErrorReplacingProcessReader {
 
     private static final String LINE_START = "Call path from entry point to ";
+
+    /**
+     * Printed by native-image when the C compiler it needs to link the executable is not installed, for example
+     * {@code Error: Default native-compiler executable 'gcc' not found via environment variable PATH}. The exit code
+     * does not tell this apart from other failures, but the output does.
+     */
+    private static final String MISSING_C_COMPILER = "native-compiler executable";
+    private static final String MISSING_C_COMPILER_HINT = "the native-image build could not find a C compiler. Install the "
+            + "platform C toolchain: the Microsoft Visual C++ Build Tools on Windows, gcc with the glibc and zlib headers "
+            + "on Linux, or the Xcode Command Line Tools on macOS.";
+
     private final BufferedReader reader;
     private final File reportdir;
 
@@ -29,8 +40,12 @@ public final class ErrorReplacingProcessReader {
 
     public void run() throws IOException {
         Deque<String> fullBuffer = new ArrayDeque<>();
+        boolean missingCCompiler = false;
         boolean buffering = false;
         for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+            if (line.contains(MISSING_C_COMPILER)) {
+                missingCCompiler = true;
+            }
             if (line.startsWith(LINE_START)) {
                 buffering = true;
             }
@@ -65,6 +80,9 @@ public final class ErrorReplacingProcessReader {
                     System.err.println(line);
                 }
             }
+        }
+        if (missingCCompiler) {
+            System.err.println("Hint: " + MISSING_C_COMPILER_HINT);
         }
     }
 

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/ErrorReplacingProcessReaderTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/ErrorReplacingProcessReaderTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.deployment.pkg.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+public class ErrorReplacingProcessReaderTest {
+
+    @Test
+    void hintsOnMissingCCompiler() throws IOException {
+        String output = run("[1/8] Initializing... (2.3s @ 0.50GB)\n"
+                + "Error: Default native-compiler executable 'cl.exe' not found via environment variable PATH\n");
+        assertThat(output).contains("native-compiler executable 'cl.exe'").contains("Hint: ").contains("C toolchain");
+    }
+
+    @Test
+    void noHintForOrdinaryOutput() throws IOException {
+        String output = run("[1/8] Initializing... (2.3s @ 0.50GB)\nError: Cannot allocate memory\n");
+        assertThat(output).contains("Cannot allocate memory").doesNotContain("Hint: ");
+    }
+
+    private static String run(String nativeImageOutput) throws IOException {
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+        try {
+            new ErrorReplacingProcessReader(new BufferedReader(new StringReader(nativeImageOutput)),
+                    new File("does-not-exist")).run();
+        } finally {
+            System.setErr(originalErr);
+        }
+        return captured.toString(StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
Relates to #1140. Companion of #56212, which decodes the **exit code**; this one decodes the **output text** for the one case the exit code cannot tell apart.

When native-image cannot find the C compiler it links the executable with, it prints

```
Error: Default native-compiler executable 'gcc' not found via environment variable PATH
```

and exits with a generic code. `ErrorReplacingProcessReader` already post-processes the native-image error stream; it now also watches for that signature and prints, after the build output:

> Hint: the native-image build could not find a C compiler. Install the platform C toolchain: the Microsoft Visual C++ Build Tools on Windows, gcc with the glibc and zlib headers on Linux, or the Xcode Command Line Tools on macOS.

The call-tree rewriting is untouched. The out-of-memory and `Cannot allocate memory` hints of the first version were dropped, as #56212 covers them through the exit code (3 and 137).

`ErrorReplacingProcessReaderTest` checks the signature and that ordinary output produces no hint.

Release note: The native image build prints a hint naming the C toolchain to install when native-image reports that it could not find a C compiler.
