### PR TITLE
Make Gradle build cache relocatable across checkout directories

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ApplicationModelCacheKey.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ApplicationModelCacheKey.java
@@ -1,0 +1,145 @@
+package io.quarkus.gradle.tasks;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Provider;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.model.ExtensionCapabilities;
+import io.quarkus.bootstrap.workspace.WorkspaceModule;
+import io.quarkus.gradle.tooling.ToolingUtils;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.ResolvedDependency;
+
+/**
+ * Derives build-cache inputs from a serialized {@link ApplicationModel} that do not depend on where
+ * the project happens to be checked out.
+ * <p>
+ * The serialized model ({@code quarkus-app-model*.dat}) embeds absolute filesystem paths: the module
+ * directories of the project itself and the resolved locations of every dependency inside the Gradle
+ * dependency cache. Fingerprinting that file directly as an {@code @InputFile} therefore makes the
+ * cache key a function of the checkout directory and of {@code GRADLE_USER_HOME}, so entries produced
+ * in one working directory can never be reused from another. {@code @PathSensitive(RELATIVE)} does not
+ * help, because it normalises the location of the input file, not its contents.
+ * <p>
+ * Instead the file is carried as an {@code @Internal} property and the semantically relevant content is
+ * declared as properly normalised inputs: dependency jars as a {@code @Classpath} (content-hashed,
+ * order-sensitive, location-independent) and the remaining coordinates, flags and capability metadata
+ * as plain {@code @Input} values.
+ * <p>
+ * Both are returned as {@link Provider}s derived from the model file property: the model is only read
+ * when Gradle actually computes the inputs, and the dependency on the task that produces the file is
+ * carried along by the property itself.
+ */
+final class ApplicationModelCacheKey {
+
+    private ApplicationModelCacheKey() {
+    }
+
+    /**
+     * The resolved artifact files of every dependency in the model, to be declared as a
+     * {@code @Classpath} input. Gradle hashes these by content, so they contribute the identity of the
+     * dependencies without contributing the absolute locations they were resolved to.
+     */
+    static Provider<List<File>> resolvedDependencyFiles(RegularFileProperty modelFile) {
+        return modelFile.map(file -> {
+            var files = new ArrayList<File>();
+            for (ResolvedDependency dependency : deserialize(file.getAsFile().toPath()).getDependencies()) {
+                for (Path path : dependency.getResolvedPaths()) {
+                    files.add(path.toFile());
+                }
+            }
+            return files;
+        });
+    }
+
+    /**
+     * Everything else about the model that influences code generation and the build, expressed as
+     * location-independent strings: dependency coordinates with their flags, the application artifact,
+     * platform properties, extension capabilities and the artifact-key sets.
+     * <p>
+     * Workspace module directories are deliberately reduced to their module ids, since the directories
+     * themselves are exactly the checkout-dependent part.
+     */
+    static Provider<Map<String, String>> relocatableProperties(RegularFileProperty modelFile) {
+        return modelFile.map(file -> relocatableProperties(deserialize(file.getAsFile().toPath())));
+    }
+
+    private static Map<String, String> relocatableProperties(ApplicationModel model) {
+        var props = new TreeMap<String, String>();
+
+        props.put("app-artifact", coordinates(model.getAppArtifact()));
+
+        var dependencies = new TreeSet<String>();
+        for (ResolvedDependency dependency : model.getDependencies()) {
+            // the flags carry deployment/runtime/reloadable classification, which changes behaviour
+            dependencies.add(coordinates(dependency) + "/flags:" + dependency.getFlags());
+        }
+        props.put("dependencies", String.join(",", dependencies));
+
+        var modules = new TreeSet<String>();
+        for (WorkspaceModule module : model.getWorkspaceModules()) {
+            // spelled out rather than WorkspaceModuleId.toString(): the interface does not define it
+            var id = module.getId();
+            modules.add(id.getGroupId() + ":" + id.getArtifactId() + ":" + id.getVersion());
+        }
+        props.put("workspace-modules", String.join(",", modules));
+
+        props.put("platform-properties", new TreeMap<>(model.getPlatformProperties()).toString());
+
+        // ExtensionCapabilities does not override toString(), so the contract has to be spelled out
+        // explicitly here - relying on toString() would hash identity hash codes, which differ on
+        // every JVM run and would make the key unstable even within a single working directory.
+        var capabilities = new TreeSet<String>();
+        for (ExtensionCapabilities capability : model.getExtensionCapabilities()) {
+            capabilities.add(capability.getExtension()
+                    + "/provides:" + new TreeSet<>(capability.getProvidesCapabilities())
+                    + "/requires:" + new TreeSet<>(capability.getRequiresCapabilities()));
+        }
+        props.put("extension-capabilities", String.join(",", capabilities));
+
+        props.put("parent-first", artifactKeys(model.getParentFirst()));
+        props.put("runner-parent-first", artifactKeys(model.getRunnerParentFirst()));
+        props.put("lower-priority", artifactKeys(model.getLowerPriorityArtifacts()));
+        props.put("reloadable-workspace", artifactKeys(model.getReloadableWorkspaceDependencies()));
+
+        var removedResources = new TreeMap<String, String>();
+        model.getRemovedResources()
+                .forEach((key, resources) -> removedResources.put(key.toString(), new TreeSet<>(resources).toString()));
+        props.put("removed-resources", removedResources.toString());
+
+        return props;
+    }
+
+    private static ApplicationModel deserialize(Path path) {
+        try {
+            return ToolingUtils.deserializeAppModel(path);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to deserialize the Quarkus application model from " + path, e);
+        }
+    }
+
+    private static String artifactKeys(Set<ArtifactKey> keys) {
+        var sorted = new TreeSet<String>();
+        keys.forEach(key -> sorted.add(key.toString()));
+        return String.join(",", sorted);
+    }
+
+    private static String coordinates(ResolvedDependency dependency) {
+        return dependency.getGroupId()
+                + ":" + dependency.getArtifactId()
+                + ":" + dependency.getClassifier()
+                + ":" + dependency.getType()
+                + ":" + dependency.getVersion();
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -24,10 +25,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.PathSensitive;
-import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.StopExecutionException;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.jvm.tasks.Jar;
@@ -210,9 +208,25 @@ public abstract class QuarkusBuildTask extends QuarkusTaskWithExtensionView {
 
     }
 
-    @InputFile
-    @PathSensitive(PathSensitivity.RELATIVE)
+    /**
+     * The serialized application model. Deliberately {@code @Internal}: the file embeds absolute
+     * filesystem paths, so hashing it as an {@code @InputFile} would tie the build cache key to the
+     * checkout directory and to {@code GRADLE_USER_HOME}, making entries produced in one working
+     * directory unusable from another. Its cache-relevant content is declared by
+     * {@link #getApplicationModelDependencies()} and {@link #getApplicationModelProperties()} instead.
+     */
+    @Internal
     public abstract RegularFileProperty getApplicationModel();
+
+    @Classpath
+    public Provider<List<File>> getApplicationModelDependencies() {
+        return ApplicationModelCacheKey.resolvedDependencyFiles(getApplicationModel());
+    }
+
+    @Input
+    public Provider<Map<String, String>> getApplicationModelProperties() {
+        return ApplicationModelCacheKey.relocatableProperties(getApplicationModel());
+    }
 
     ApplicationModel resolveAppModelForBuild() {
         try {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -19,11 +19,13 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -100,9 +102,25 @@ public abstract class QuarkusGenerateCode extends QuarkusTaskWithExtensionView {
         return inputDirectories;
     }
 
-    @InputFile
-    @PathSensitive(PathSensitivity.RELATIVE)
+    /**
+     * The serialized application model. Deliberately {@code @Internal}: the file embeds absolute
+     * filesystem paths, so hashing it as an {@code @InputFile} would tie the build cache key to the
+     * checkout directory and to {@code GRADLE_USER_HOME}, making entries produced in one working
+     * directory unusable from another. Its cache-relevant content is declared by
+     * {@link #getApplicationModelDependencies()} and {@link #getApplicationModelProperties()} instead.
+     */
+    @Internal
     public abstract RegularFileProperty getApplicationModel();
+
+    @Classpath
+    public Provider<List<File>> getApplicationModelDependencies() {
+        return ApplicationModelCacheKey.resolvedDependencyFiles(getApplicationModel());
+    }
+
+    @Input
+    public Provider<Map<String, String>> getApplicationModelProperties() {
+        return ApplicationModelCacheKey.relocatableProperties(getApplicationModel());
+    }
 
     @OutputDirectory
     public abstract DirectoryProperty getGeneratedOutputDirectory();

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/CachingTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/CachingTest.java
@@ -28,6 +28,7 @@ import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -220,6 +221,55 @@ public class CachingTest extends BaseGradleTest {
 
         result = buildResult(env, arguments);
         assertBuildResult("follow-up", result, ALL_UP_TO_DATE);
+    }
+
+    /**
+     * Cache entries must be reusable from a different working directory. The serialized application
+     * model embeds absolute paths, so hashing it as an {@code @InputFile} used to make the cache key a
+     * function of the checkout directory, and nothing could be resolved from a cache populated
+     * elsewhere - which is exactly the shared/remote cache case.
+     */
+    @Test
+    void buildCacheIsReusedFromADifferentProjectDirectory(@TempDir Path otherProjectDir, @TempDir Path localCacheDir)
+            throws Exception {
+        prepareGradleBuildProject("");
+        enableLocalBuildCache(testProjectDir, localCacheDir);
+
+        Map<String, String> env = cachingTestEnvironment(false);
+        String[] arguments = List.of("build", "--info", "--stacktrace", "--build-cache", "--no-configuration-cache",
+                "-Dquarkus.package.jar.type=fast-jar")
+                .toArray(new String[0]);
+
+        assertBuildResult("populate cache", buildResult(env, rerunTasks(arguments)), ALL_SUCCESS);
+
+        // Same sources and same shared cache, but a different project directory.
+        FileUtils.copyDirectory(testProjectDir.toFile(), otherProjectDir.toFile());
+        FileUtils.deleteDirectory(otherProjectDir.resolve("build").toFile());
+        FileUtils.deleteDirectory(otherProjectDir.resolve(".gradle").toFile());
+
+        BuildResult result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(otherProjectDir.toFile())
+                .withArguments(defaultGradleArguments(List.of(arguments)))
+                .withEnvironment(env)
+                .build();
+
+        soft.assertThat(taskResults(result))
+                .describedAs("output: %s", result.getOutput())
+                .containsEntry(":quarkusGenerateCode", TaskOutcome.FROM_CACHE)
+                .containsEntry(":quarkusAppPartsBuild", TaskOutcome.FROM_CACHE);
+    }
+
+    /**
+     * Points the build at a build cache directory shared between project directories, so a build run
+     * from one directory can resolve entries produced by another.
+     */
+    private static void enableLocalBuildCache(Path projectDir, Path cacheDir) throws IOException {
+        Path settings = projectDir.resolve("settings.gradle.kts");
+        String directory = cacheDir.toAbsolutePath().toString().replace("\\", "\\\\");
+        Files.writeString(settings, Files.readString(settings) + String.format(
+                "%nbuildCache {%n    local {%n        directory = \"%s\"%n        isEnabled = true%n    }%n}%n",
+                directory));
     }
 
     private static Map<String, String> cachingTestEnvironment(boolean simulateCI) {

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/EagerResolutionTaskTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/EagerResolutionTaskTest.java
@@ -2,8 +2,9 @@ package io.quarkus.gradle.tasks;
 
 import static io.quarkus.gradle.QuarkusPlugin.QUARKUS_BUILD_TASK_NAME;
 import static io.quarkus.gradle.QuarkusPlugin.QUARKUS_GENERATE_CODE_TASK_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.gradle.testkit.runner.TaskOutcome.FROM_CACHE;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
@@ -65,6 +66,8 @@ public class EagerResolutionTaskTest extends BaseGradleTest {
         }
 
         BuildResult firstBuild = buildResult(Map.of(), taskName);
-        assertEquals(SUCCESS, firstBuild.task(":quarkusGenerateCode").getOutcome());
+        // the build cache is enabled for these builds, so an unchanged project can legitimately serve
+        // the task from the cache instead of executing it; either outcome means it did not fail
+        assertThat(firstBuild.task(":quarkusGenerateCode").getOutcome()).isIn(SUCCESS, FROM_CACHE);
     }
 }


### PR DESCRIPTION
# Issue

The serialized application model (`quarkus-app-model-build.dat`) contains absolute filesystem paths,
and `QuarkusGenerateCode` / `QuarkusBuildTask` declare it as an `@InputFile`. Gradle fingerprints
that by content, so their cache keys depend on where the project is checked out and a shared cache
gives no reuse across working directories. `@PathSensitive(RELATIVE)` does not help: it normalizes
the input file's location, not its contents.

# Solution

This makes the build cache produced by `quarkusGenerateCode` and `quarkusAppPartsBuild `reusable from a different checkout directory.

It marks the model file `@Internal` on both consumers and declare its cache-relevant content instead:

- `getApplicationModelDependencies()` as `@Classpath` — the resolved dependency jars, hashed by
  content, so they identify the dependencies without their locations.
- `getApplicationModelProperties()` as `@Input` — coordinates, dependency flags, workspace module
  ids, platform properties, extension capabilities and the artifact-key sets, as
  location-independent strings.

Two things worth flagging for review:

- Both are `Provider`s derived from the file property. Computing them eagerly fails at configuration
  time with `NoSuchFileException`, before `quarkusGenerateAppModel` has run.
- `ApplicationModelCacheKey` spells out the capability contract field by field instead of calling
  `toString()`. `ExtensionCapabilities` does not override it, so the key would otherwise hash
  identity hash codes and change on every JVM run. `WorkspaceModuleId` has the same gap at the
  interface level.

# Verification

`CachingTest.buildCacheIsReusedFromADifferentProjectDirectory` populates a shared build cache from
one project directory, builds the same sources from another, and asserts `quarkusGenerateCode` and
`quarkusAppPartsBuild` resolve `FROM-CACHE`. It fails if the model is declared as an `@InputFile`
again.

Measured on a two-checkout setup sharing one cache:

| | Before | After |
| --- | --- | --- |
| `quarkusGenerateCode` | re-executed | `FROM-CACHE` |
| `quarkusAppPartsBuild` | re-executed | `FROM-CACHE` |
| Second build | 9 executed, 7 from cache | 7 executed, 9 from cache |

Generated sources are byte-identical between the two checkouts, and a full `./gradlew build`
succeeds from the relocated one. Adding a dependency still changes the key and forces re-execution,
so no real input was dropped.

# Not covered

This does not make `QuarkusApplicationModelTask` itself cacheable — its `projectDescriptor` and
`mainClassesDirs` inputs remain checkout-dependent. That costs nothing while the task is
`@DisableCachingByDefault`, but would need addressing first if the model were ever to be cached.

Fixes #56214
