### PR TITLE
Avoid early token acquisition for DeferredOidcClient

### DIFF
--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientProxyTest.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientProxyTest.java
@@ -35,6 +35,7 @@ class OidcClientProxyTest {
     static final QuarkusExtensionTest test = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar
                     .addClass(OidcClientResource.class)
+                    .addClass(OidcClientProxyTestStartupBean.class)
                     .addAsResource(new StringAsset("""
                             quarkus.keycloak.devservices.enabled=false
                             quarkus.oidc.enabled=false

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientProxyTestStartupBean.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientProxyTestStartupBean.java
@@ -1,0 +1,17 @@
+package io.quarkus.oidc.client;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import io.quarkus.oidc.client.runtime.TokensProducer;
+import io.quarkus.runtime.StartupEvent;
+
+@ApplicationScoped
+public class OidcClientProxyTestStartupBean {
+    // Injecting TokensProducer forces its @PostConstruct init() -> initTokens() to run at startup.
+    // With early token acquisition enabled and the OIDC server unavailable on startup, this would fail
+    // the application startup unless early token acquisition is skipped for a DeferredOidcClient.
+    void startup(@Observes StartupEvent event, TokensProducer tokensProducer) {
+        tokensProducer.toString();
+    }
+}

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/AbstractTokensProducer.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/AbstractTokensProducer.java
@@ -76,6 +76,11 @@ public abstract class AbstractTokensProducer {
                     + " but the initTokens() method is called.");
         }
         if (earlyTokenAcquisition) {
+            // Skip early token acquisition for deferred clients - they will recover on first request
+            if (oidcClient instanceof DeferredOidcClient) {
+                LOG.debug("Skipping early token acquisition for deferred OIDC client");
+                return;
+            }
             tokensHelper.initTokens(oidcClient, additionalParameters());
         }
     }

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -76,8 +76,10 @@ public class OidcClientRecorder {
 
     protected static OidcClient createOidcClient(OidcClientConfig oidcConfig, String oidcClientId, Vertx vertx,
             OidcTlsSupport tlsSupport, ProxyConfigurationRegistry proxyConfigurationRegistry) {
+        // The discovery branch in createOidcClientUni enforces the connection timeout internally and
+        // recovers to a DeferredOidcClient, so this call will not block beyond the configured connection timeout.
         return createOidcClientUni(oidcConfig, oidcClientId, vertx, tlsSupport, proxyConfigurationRegistry).await()
-                .atMost(oidcConfig.connectionTimeout());
+                .indefinitely();
     }
 
     protected static Uni<OidcClient> createOidcClientUni(OidcClientConfig oidcConfig, String oidcClientId,
@@ -141,12 +143,13 @@ public class OidcClientRecorder {
                     oidcConfig, client, oidcRequestFilters, oidcResponseFilters, vertx));
 
             return deferredClient
+                    // Fail with a TimeoutException if discovery does not complete within the connection timeout
+                    // so that it is handled by the recoverWithItem below and a DeferredOidcClient is returned.
+                    .ifNoItem().after(oidcConfig.connectionTimeout()).fail()
                     .onFailure(f -> !(f instanceof ConfigurationException))
                     .recoverWithItem(originalFailure -> {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debugf(originalFailure, "OIDC metadata discovery for OIDC client '%s' failed. "
-                                    + "Will try again the first time this OIDC client is used", oidcClientId);
-                        }
+                        LOG.warnf(originalFailure, "OIDC metadata discovery for OIDC client '%s' failed. "
+                                + "Will try again the first time this OIDC client is used", oidcClientId);
                         return new DeferredOidcClient(
                                 deferredClient.onFailure().transform(t -> toOidcClientException(getEndpointUrl(oidcConfig), t)),
                                 oidcClientId, client);


### PR DESCRIPTION
The customer noted that the OidcClient RESTEasy filter does not recover like quarkus-oidc does in case of the connection exception. 

I spent most of the day not on the fix but on trying to figure out why the DeferredClientTest passes (it works fine with the rest filter since we disable early token acquisition there). CDI docs revealed we need to have a CDI token producer to be called to trigger its initialization - so that startup bean addition is there to make the test fail, unless the early token acquisition is skipped for the deferred client. 

I also did some manual refactoring to be able to handle `TimeoutException` without having to recreate oidc client, request/response filters.