### PR TITLE
Detect OOM-killed native-image build container instead of always using --rm

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
@@ -22,7 +22,7 @@ public abstract class NativeImageBuildContainerRunner extends NativeImageBuildRu
     final NativeConfig nativeConfig;
     protected final ContainerRuntimeUtil.ContainerRuntime containerRuntime;
     String[] baseContainerRuntimeArgs;
-    private final String containerName;
+    protected final String containerName;
     private final AtomicBoolean setupInvoked = new AtomicBoolean();
 
     protected NativeImageBuildContainerRunner(NativeConfig nativeConfig) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
@@ -2,6 +2,7 @@ package io.quarkus.deployment.pkg.steps;
 
 import static io.quarkus.deployment.pkg.steps.LinuxIDUtil.getLinuxID;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -14,10 +15,13 @@ import org.jboss.logging.Logger;
 import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.util.ContainerRuntimeUtil.ContainerRuntime;
 import io.quarkus.deployment.util.FileUtil;
+import io.smallrye.common.process.ProcessBuilder;
 
 public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContainerRunner {
 
     private static final Logger log = Logger.getLogger(NativeImageBuildLocalContainerRunner.class);
+
+    private volatile Thread cleanupHook;
 
     public NativeImageBuildLocalContainerRunner(NativeConfig nativeConfig) {
         super(nativeConfig);
@@ -28,6 +32,68 @@ public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContai
         containerRuntimeArgs
                 .addAll(getVolumeAccessArguments(containerRuntime, nativeConfig.builderImage().getEffectiveImage()));
         baseContainerRuntimeArgs = containerRuntimeArgs.toArray(baseContainerRuntimeArgs);
+    }
+
+    /**
+     * Runs the build container without {@code --rm} so that, on failure, its {@code State.OOMKilled} flag can be
+     * inspected before the container is removed (see {@link #postBuild}). The container is removed by Quarkus
+     * instead, both on completion and via a shutdown hook if the build is interrupted. See
+     * <a href="https://github.com/quarkusio/quarkus/issues/1140">#1140</a>.
+     */
+    @Override
+    protected String[] getBuildCommand(Path outputDir, List<String> args) {
+        return Arrays.stream(super.getBuildCommand(outputDir, args))
+                .filter(arg -> !"--rm".equals(arg))
+                .toArray(String[]::new);
+    }
+
+    @Override
+    protected void preBuild(Path outputDir, List<String> buildArgs) throws IOException, InterruptedException {
+        cleanupHook = new Thread(this::removeBuildContainer, "native-image-build-container-cleanup");
+        Runtime.getRuntime().addShutdownHook(cleanupHook);
+        super.preBuild(outputDir, buildArgs);
+    }
+
+    @Override
+    protected void postBuild(Path outputDir, String nativeImageName, String resultingExecutableName)
+            throws InterruptedException, IOException {
+        try {
+            if (wasOutOfMemoryKilled()) {
+                log.error("The native image build container was killed by the out-of-memory killer "
+                        + "(the container runtime reports State.OOMKilled=true). Give the build more memory - e.g. raise "
+                        + "\"quarkus.native.native-image-xmx\", or increase the memory available to the container runtime.");
+            }
+        } finally {
+            removeBuildContainer();
+            if (cleanupHook != null) {
+                try {
+                    Runtime.getRuntime().removeShutdownHook(cleanupHook);
+                } catch (IllegalStateException ignored) {
+                    // JVM is already shutting down; the hook will run (or has run) on its own.
+                }
+                cleanupHook = null;
+            }
+        }
+        super.postBuild(outputDir, nativeImageName, resultingExecutableName);
+    }
+
+    private boolean wasOutOfMemoryKilled() {
+        try {
+            List<String> output = ProcessBuilder.newBuilder(containerRuntime.getExecutableName())
+                    .arguments("inspect", "--format", "{{.State.OOMKilled}}", containerName)
+                    .output().toStringList(1024, 256)
+                    .error().discard()
+                    .exitCodeChecker(ec -> true)
+                    .run();
+            return output.stream().anyMatch(line -> "true".equals(line.trim()));
+        } catch (Exception e) {
+            log.debugf(e, "Could not inspect the native image build container for an out-of-memory kill");
+            return false;
+        }
+    }
+
+    private void removeBuildContainer() {
+        runCommand(new String[] { containerRuntime.getExecutableName(), "rm", "-f", containerName }, null);
     }
 
     /**

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunnerTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunnerTest.java
@@ -2,6 +2,7 @@ package io.quarkus.deployment.pkg.steps;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.file.Path;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
@@ -61,6 +62,16 @@ class NativeImageBuildContainerRunnerTest {
             }
         }
         assertThat(found).isTrue();
+    }
+
+    @DisabledIfSystemProperty(named = "avoid-containers", matches = "true")
+    @Test
+    void buildContainerRunsWithoutRmSoTheOomFlagCanBeInspected() {
+        NativeImageBuildLocalContainerRunner runner = new NativeImageBuildLocalContainerRunner(new TestNativeConfig("mandrel"));
+        // The build container is NOT run with --rm: Quarkus removes it itself, after inspecting State.OOMKilled.
+        assertThat(runner.getBuildCommand(Path.of("target"), Collections.emptyList())).doesNotContain("--rm");
+        // The short-lived version container is still auto-removed.
+        assertThat(runner.getGraalVMVersionCommand(Collections.singletonList("--version"))).contains("--rm");
     }
 
 }


### PR DESCRIPTION
### Relates to #1140

Third, **proof-of-concept** step for #1140. Opened as a **draft** to get maintainer feedback on the approach before polishing.

#### Problem

When the native image is built in a container and that container is killed by the kernel out-of-memory killer, the build fails with exit `137`. Quarkus can't distinguish this from an ordinary builder crash, because the container is launched with `--rm` and is already gone by the time the failure is handled — the one authoritative signal, the engine's `State.OOMKilled` flag, is destroyed with it.

I checked whether this could be solved while keeping `--rm`: neither Docker nor Podman print anything on `run` when the OOM killer fires, the `oom` event backend is fragile to read (rootless Podman logs it to journald, which isn't reliably queryable), and there's no flag to foreground the kill reason. Dropping `--rm` and inspecting the container is the only reliable path.

#### Change

For the **local** container build only:

- Strip `--rm` from the build `run` command (`getBuildCommand` override).
- Quarkus manages the lifecycle instead: a shutdown hook removes the container if the build is interrupted, and `postBuild` removes it on completion.
- Before removing it, `postBuild` runs `inspect --format {{.State.OOMKilled}}`; when `true`, it logs an explicit out-of-memory message pointing at `quarkus.native.native-image-xmx` / engine memory.

Short-lived helper containers (version probe, objcopy) still use `--rm`. The remote container runner (create/cp model) is untouched.

#### Verified

`podman` rootless: an OOM-killed build reports `State.OOMKilled=true`; an ordinary failure reports `false`. Unit test asserts the local build command no longer contains `--rm` while the version command still does.

#### Why the exit code alone isn't enough

`State.OOMKilled` is the only reliable OOM signal — the exit code is neither self-explanatory nor even always non-zero. Two probes on rootless Podman with a memory-limited container (`--memory=32m`):

- **Main process OOM-killed** (the `native-image` case): the process dies mid-output with exit `137` and **nothing** about memory on stdout/stderr — only `State.OOMKilled=true` records why.
- **A subprocess OOM-killed while PID 1 survives**: the OOM killer takes the child, the parent continues and exits cleanly, so the container reports **exit `0`** — yet `State.OOMKilled` is still `true`. The engine sets the flag whenever the OOM killer fires against anything in the container's cgroup, independent of PID 1's exit code. Judging OOM by exit code alone would miss this entirely.

`native-image` is the heavy/main process, so in practice its OOM surfaces as `137` (the first case); the second is included only as proof that the exit code and the OOM fact are independent — which is the whole reason this PR inspects `State.OOMKilled` rather than inferring OOM from `137`.

#### Notes for reviewers

- This is deliberately scoped to the local runner as a discussion starter; happy to extend to the remote runner if the direction is agreed.
- Pairs with the two other #1140 PRs (exit-code messages, output-signature hints), but stands alone.

Release note:
```
The native image build container is no longer run with `--rm`; Quarkus removes it itself so an out-of-memory kill (`State.OOMKilled`) can be detected and reported.
```
