### PR TITLE
Add quarkus.smallrye-openapi.store-schemas-directory

### DIFF
--- a/docs/src/main/asciidoc/openapi-swaggerui.adoc
+++ b/docs/src/main/asciidoc/openapi-swaggerui.adoc
@@ -618,6 +618,21 @@ Operations are filtered into documents based on their profiles:
 * If neither is configured: all operations are *included*.
 
 
+=== Storing the schema documents of all configured documents
+
+The generated OpenAPI schema documents are stored on build when `quarkus.smallrye-openapi.store-schema-directory` is configured, and each named OpenAPI document can configure its own `quarkus.smallrye-openapi.<document-name>.store-schema-directory`.
+Instead of configuring the directory for every document individually, the schema documents of all configured OpenAPI documents can be stored in one go:
+
+[source,properties]
+----
+quarkus.smallrye-openapi.store-schemas-directory=target/openapi
+----
+
+With the `user` and `order` documents from the example above, this stores the default schema document (`openapi.json` and `openapi.yaml`) as well as `openapi-user.json`, `openapi-user.yaml`, `openapi-order.json` and `openapi-order.yaml`.
+
+A `store-schema-directory` configured for an individual document takes precedence over `store-schemas-directory` for that document.
+
+
 === Cleanup
 
 The generated OpenAPI documents by default include every schema, even those referenced by operations which are excluded.

--- a/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
+++ b/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
@@ -1,6 +1,8 @@
 package io.quarkus.smallrye.openapi.common.deployment;
 
+import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -43,6 +45,17 @@ public interface SmallRyeOpenApiConfig {
      */
     @WithName("js-client")
     SmallRyeOpenApiJsClientConfig jsClient();
+
+    /**
+     * If set, the generated OpenAPI schema documents of every configured OpenAPI document will be stored in this
+     * directory on build, without having to configure a {@code store-schema-directory} for each document
+     * individually. Both the json and yaml variants of each document will be stored here.
+     * <p>
+     * A {@code store-schema-directory} configured for an individual document takes precedence over this directory
+     * for that document.
+     */
+    @WithName("store-schemas-directory")
+    Optional<Path> storeSchemasDirectory();
 
     /**
      * OpenAPI documents

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -1028,18 +1028,20 @@ public class SmallRyeOpenApiProcessor {
                     documentFiltersBuildItem.filterNamesFor(documentName, OpenApiFilter.RunStage.RUNTIME_STARTUP),
                     documentConfig);
 
-            // Store schema if configured
-            documentConfig.storeSchemaDirectory().ifPresent(storageDir -> {
-                try {
-                    String documentStoreFileName = documentConfig.storeSchemaFileName();
-                    storeGeneratedSchema(storageDir, documentStoreFileName, outputTargetBuildItem,
-                            storedOpenAPI.toJSON(), "json");
-                    storeGeneratedSchema(storageDir, documentStoreFileName, outputTargetBuildItem,
-                            storedOpenAPI.toYAML(), "yaml");
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-            });
+            // Store schema if configured, either for this document or for all documents at once
+            documentConfig.storeSchemaDirectory()
+                    .or(smallRyeOpenApiConfig::storeSchemasDirectory)
+                    .ifPresent(storageDir -> {
+                        try {
+                            String documentStoreFileName = documentConfig.storeSchemaFileName();
+                            storeGeneratedSchema(storageDir, documentStoreFileName, outputTargetBuildItem,
+                                    storedOpenAPI.toJSON(), "json");
+                            storeGeneratedSchema(storageDir, documentStoreFileName, outputTargetBuildItem,
+                                    storedOpenAPI.toYAML(), "yaml");
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    });
 
             openApiDocumentProducer
                     .produce(new OpenApiDocumentBuildItem(storedOpenAPI, documentName));

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/deployment/filter/SecurityConfigFilterTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/deployment/filter/SecurityConfigFilterTest.java
@@ -83,6 +83,11 @@ class SecurityConfigFilterTest {
         }
 
         @Override
+        public Optional<Path> storeSchemasDirectory() {
+            return Optional.empty();
+        }
+
+        @Override
         public Map<String, OpenApiDocumentConfig> documents() {
             return Map.of(SmallRyeOpenApiConfig.DEFAULT_DOCUMENT_NAME, dummySmallRyeOpenApiConfigConfig);
         }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiStoreAllSchemasTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiStoreAllSchemasTest.java
@@ -1,0 +1,87 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+class OpenApiStoreAllSchemasTest {
+
+    private static final String directory = "target/generated/all-schemas/";
+    private static final String adminDirectory = "target/generated/all-schemas-admin/";
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(ProfilesResource.class))
+            .overrideConfigKey("quarkus.smallrye-openapi.store-schemas-directory", directory)
+            .overrideConfigKey("quarkus.smallrye-openapi.user.scan-profiles", "user")
+            .overrideConfigKey("quarkus.smallrye-openapi.internal.scan-profiles", "internal")
+            // the "admin" document configures its own directory, which takes precedence
+            .overrideConfigKey("quarkus.smallrye-openapi.admin.scan-profiles", "admin")
+            .overrideConfigKey("quarkus.smallrye-openapi.admin.store-schema-directory", adminDirectory);
+
+    @Test
+    void testStoresSchemaForAllConfiguredDocuments() throws IOException {
+        Assertions.assertTrue(Files.exists(Paths.get(directory, "openapi.json")));
+        Assertions.assertTrue(Files.exists(Paths.get(directory, "openapi.yaml")));
+
+        Assertions.assertTrue(Files.exists(Paths.get(directory, "openapi-user.json")));
+        Assertions.assertTrue(Files.exists(Paths.get(directory, "openapi-user.yaml")));
+        Assertions.assertTrue(Files.exists(Paths.get(directory, "openapi-internal.json")));
+        Assertions.assertTrue(Files.exists(Paths.get(directory, "openapi-internal.yaml")));
+
+        String userDocument = Files.readString(Paths.get(directory, "openapi-user.json"));
+        Assertions.assertTrue(userDocument.contains("/api/user"));
+        Assertions.assertFalse(userDocument.contains("/api/internal"));
+        Assertions.assertFalse(userDocument.contains("/api/admin"));
+    }
+
+    @Test
+    void testDocumentSpecificDirectoryTakesPrecedence() {
+        Assertions.assertTrue(Files.exists(Paths.get(adminDirectory, "openapi-admin.json")));
+        Assertions.assertTrue(Files.exists(Paths.get(adminDirectory, "openapi-admin.yaml")));
+
+        Assertions.assertFalse(Files.exists(Paths.get(directory, "openapi-admin.json")));
+        Assertions.assertFalse(Files.exists(Paths.get(directory, "openapi-admin.yaml")));
+    }
+
+    @Path("/api")
+    public static class ProfilesResource {
+
+        @GET
+        @Path("/user")
+        @Extension(name = "x-smallrye-profile-user", value = "")
+        public String user() {
+            return "user";
+        }
+
+        @GET
+        @Path("/internal")
+        @Extension(name = "x-smallrye-profile-internal", value = "")
+        public String internal() {
+            return "internal";
+        }
+
+        @GET
+        @Path("/admin")
+        @Extension(name = "x-smallrye-profile-admin", value = "")
+        public String admin() {
+            return "admin";
+        }
+
+        @GET
+        @Path("/no-profile")
+        public String noProfile() {
+            return "no-profile";
+        }
+    }
+}


### PR DESCRIPTION
````markdown
When multiple OpenAPI documents are configured, storing their generated
schema documents currently requires setting
`quarkus.smallrye-openapi.<document-name>.store-schema-directory` for each
document individually, even when they should all end up in the same place.

This PR adds a new top-level (non-document) config property:

```properties
quarkus.smallrye-openapi.store-schemas-directory=target/openapi
```

When set, the generated schema documents (both JSON and YAML) of **all
configured OpenAPI documents** are stored in this directory on build — the
default document plus every named document. A `store-schema-directory`
configured for an individual document takes precedence over this directory
for that document.

No extra documents are built: the property only activates storing for the
documents that are already configured and built, respecting each document's
own configuration (`scan-profiles`, `scan-exclude-profiles`, filters,
`store-schema-file-name`, etc.).

Note: this PR does not implement the automatic per-profile document
generation originally requested in #53702 — as discussed in the review,
that approach would be costly and would bypass the document-based
configuration model. It instead provides a simple way to store the schemas
of all configured documents in one place. Related to #53702 (to be closed
separately as "won't do").

Release note: The new `quarkus.smallrye-openapi.store-schemas-directory`
config property stores the generated schema documents of all configured
OpenAPI documents in a single directory, without configuring a
`store-schema-directory` for each document individually.
````