### PR TITLE
Make protobuf-java a compile dependency for Pulsar extension

### DIFF
--- a/extensions/smallrye-reactive-messaging-pulsar/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-pulsar/runtime/pom.xml
@@ -89,7 +89,6 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
GraalVM 25 enforces stricter linking for, causing NoClassDefFoundError when protobuf-java is not on compile classpath. 

Fixes pulsar errors in https://github.com/quarkusio/quarkus-quickstarts/actions/runs/32808181738

I wasn't able to write a substitution that works around this. If we can one day, we can revert to not always pulling `protobuf-java`.