### PR TITLE
Deprecate `quarkus.native.enable-fallback-images`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -163,7 +163,11 @@ public interface NativeConfig {
     /**
      * If a JVM based 'fallback image' should be created if native image fails. This is not recommended, as this is
      * functionally the same as just running the application in a JVM
+     *
+     * @deprecated Fallback images are generally discouraged and are discontinued in GraalVM 25.1
+     *             (https://github.com/oracle/graal/pull/12755)
      */
+    @Deprecated(since = "4.0", forRemoval = true)
     @WithDefault("false")
     boolean enableFallbackImages();
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -1000,11 +1000,20 @@ public class NativeImageBuildStep {
                 }
 
                 if (nativeConfig.enableFallbackImages()) {
-                    nativeImageArgs.add("--auto-fallback");
+                    if (graalVMVersion.compareTo(io.quarkus.runtime.graal.GraalVM.Version.VERSION_25_1_0) < 0) {
+                        nativeImageArgs.add("--auto-fallback");
+                    } else {
+                        log.warn("Option deprecated in GraalVM 25.1 and is a no-op,"
+                                + " fallback images are not supported in GraalVM 25.1 and later."
+                                + " Avoid using it to prevent warnings.");
+                    }
                 } else {
-                    //Default: be strict as those fallback images aren't very useful
-                    //and tend to cover up real problems.
-                    nativeImageArgs.add("--no-fallback");
+                    // Option Deprecated in GraalVM 25.1 and is a no-op, avoid using it to prevent warnings
+                    if (graalVMVersion.compareTo(io.quarkus.runtime.graal.GraalVM.Version.VERSION_25_1_0) < 0) {
+                        //Default: be strict as those fallback images aren't very useful
+                        //and tend to cover up real problems.
+                        nativeImageArgs.add("--no-fallback");
+                    }
                 }
 
                 if (!classpathIsBroken) {


### PR DESCRIPTION
`--auto-fallback` and `--no-fallback` have been deprecated and became a
no-op in GraalVM 25.1, see https://github.com/oracle/graal/pull/12755