### PR TITLE
Make sure the callouts follow the Asciidoc syntax

### DIFF
--- a/docs/src/main/asciidoc/_includes/opentelemetry-config.adoc
+++ b/docs/src/main/asciidoc/_includes/opentelemetry-config.adoc
@@ -12,7 +12,6 @@ quarkus.log.console.format=%d{HH:mm:ss} %-5p traceId=%X{traceId}, parentId=%X{pa
 # Alternative to the console log
 quarkus.http.access-log.pattern="...traceId=%{X,traceId} spanId=%{X,spanId}" // <5>
 ----
-
 <1> All telemetry created from the application will include an OpenTelemetry `Resource` attribute indicating the telemetry was created by the `myservice` application. If not set, it will default to the artifact id.
 <2> OTLP endpoint to send the telemetry. If not set, it will default to `http://localhost:4318`.
 <3> Optional headers commonly used for authentication

--- a/docs/src/main/asciidoc/blaze-persistence.adoc
+++ b/docs/src/main/asciidoc/blaze-persistence.adoc
@@ -103,7 +103,6 @@ public class SantaClausService {
     }
 }
 ----
-
 <1> Inject the `EntityManager`
 <2> Inject the `CriteriaBuilderFactory`
 <3> Inject the `EntityViewManager`

--- a/docs/src/main/asciidoc/building-my-first-extension.adoc
+++ b/docs/src/main/asciidoc/building-my-first-extension.adoc
@@ -143,7 +143,6 @@ applying codestarts...
 [INFO] ------------------------------------------------------------------------
 
 ----
-
 <1> The extension groupId
 <2> The extension id (not namespaced).
 <3> Indicate that we don't want to generate any test
@@ -228,7 +227,6 @@ Your extension is a multi-module project. So let's start by checking out the par
   </build>
 </project>
 ----
-
 <1> Your extension declares 2 sub-modules `deployment` and `runtime`.
 <2> Quarkus requires a recent version of the Maven compiler plugin supporting the annotationProcessorPaths configuration.
 <3> The `quarkus-bom` aligns your dependencies with those used by Quarkus during the augmentation phase.
@@ -423,7 +421,6 @@ include 'runtime', 'deployment' <2>
 
 rootProject.name = 'greeting-extension'
 ----
-
 <1> Configure the quarkus extension plugin version
 <2> Include both `runtime` and `deployment` modules
 
@@ -439,7 +436,6 @@ subprojects {
     version '1.0-SNAPSHOT'
 }
 ----
-
 <1> Apply the `java-library` plugin for all sub-modules
 <2> Apply the `maven-publish` plugin used to publish our artifacts
 <3> Globally set the group id used for publication
@@ -464,7 +460,6 @@ dependencies {
     testImplementation 'io.quarkus:quarkus-junit-internal'
 }
 ----
-
 <1> By convention, the deployment module has the `-deployment` suffix (`greeting-extension-deployment`).
 <2> The deployment module *must* depend on the `runtime` module.
 
@@ -490,7 +485,6 @@ dependencies {
     implementation platform("io.quarkus:quarkus-bom:${quarkus.version}")
 }
 ----
-
 <1> Apply the `io.quarkus.extension` plugin.
 <2> By convention, the runtime module doesn't have a suffix (and thus is named `greeting-extension`) as it is the artifact exposed to the end user.
 
@@ -550,7 +544,6 @@ public class GreetingExtensionServlet extends HttpServlet { // <1>
     }
 }
 ----
-
 <1> As usual, defining a servlet requires to extend `jakarta.servlet.http.HttpServlet`.
 <2> Since we want to respond to the HTTP GET verb, we override the `doGet` method and write `Hello` in the Servlet response's output stream.
 
@@ -584,7 +577,6 @@ class GreetingExtensionProcessor {
 
 }
 ----
-
 <1> `feature()` method is annotated with `@BuildStep` which means it is identified as a deployment task Quarkus will have to execute during the deployment.
 `BuildStep` methods are run concurrently at augmentation time to augment the application.
 They use a producer/consumer model, where a step is guaranteed not to be run until all the items that it is consuming have been produced.
@@ -655,7 +647,6 @@ class GreetingExtensionProcessor {
 
 }
 ----
-
 <1> We add a `createServlet` method which returns a `ServletBuildItem` and annotate it with `@BuildStep`.
 Now, Quarkus will process this new task which will result in the bytecode generation of the Servlet registration at build time.
 
@@ -725,7 +716,6 @@ public class GreetingExtensionTest {
 
 }
 ----
-
 <1> We register a Junit Extension which will start a Quarkus application with the Greeting extension.
 <2> We verify the application has a `greeting` endpoint responding to an HTTP GET request with an OK status (200) and a plain text body containing `Hello`
 

--- a/docs/src/main/asciidoc/cdi-integration.adoc
+++ b/docs/src/main/asciidoc/cdi-integration.adoc
@@ -337,7 +337,6 @@ SyntheticBeanBuildItem syntheticBean(TestRecorder recorder) {
                 .done();
 }
 ----
-
 <1> `types()` or `addType()` must be used to specify the generic type.
 
 It is possible to mark a synthetic bean to be initialized during `RUNTIME_INIT`.

--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -1278,7 +1278,6 @@ class MyProducer {
     }
 }
 ----
-
 <1> Declares an injection point of type `InterceptionProxy<MyClass>`.
     This means that at build time, a subclass of `MyClass` is generated that does the interception and forwarding.
     Note that the type argument must be identical to the return type of the producer method.
@@ -1314,7 +1313,6 @@ class MyProducer {
     }
 }
 ----
-
 <1> A class that mirrors the `MyClass` structure and contains interceptor bindings.
 <2> The `@BindingsSource` annotation says that interceptor bindings for `MyClass` should be read from `MyClassBindings`.
 
@@ -1352,7 +1350,6 @@ class MyClassBindings {
     }
 }
 ----
-
 <1> The method body does not matter.
 
 Note that for generic classes, the type variable names must also be identical.
@@ -1409,7 +1406,6 @@ public void register(RegistrationContext context) {
             .done();
 }
 ----
-
 <1> Once again, this means that at build time, a subclass of `MyClass` is generated that does the interception and forwarding.
 
 Second, you have to obtain the `InterceptionProxy` from the `SyntheticCreationalContext` in the `BeanCreator` and use it:
@@ -1421,7 +1417,6 @@ public MyClass create(SyntheticCreationalContext<MyClass> context) {
     return proxy.create(new MyClass());
 }
 ----
-
 <1> Obtains the `InterceptionProxy` for `MyClass`, as declared above.
     It would also be possible to use the `getInjectedReference()` method, passing a `TypeLiteral`, but `getInterceptionProxy()` is easier.
 
@@ -1438,7 +1433,6 @@ public void register(RegistrationContext context) {
             .done();
 }
 ----
-
 <1> The argument is the bindings source class.
 
 === `Instance.Handle.close()` Behavior

--- a/docs/src/main/asciidoc/conditional-extension-dependencies.adoc
+++ b/docs/src/main/asciidoc/conditional-extension-dependencies.adoc
@@ -59,7 +59,6 @@ The condition which triggers activation of an extension is configured in the ext
 
   <!-- SKIPPED CONTENT -->
 ----
-
 <1> runtime Quarkus extension artifact ID;
 <2> the goal that generates the extension descriptor which every Quarkus runtime extension project should be configured with;
 <3> configuration of the dependency condition which will have to be satisfied for this extension to be added to a Quarkus application expressed as a list of artifacts that must be present among the application dependencies;
@@ -100,7 +99,6 @@ If an extension includes a dependency condition in its descriptor, other extensi
 
   <!-- SKIPPED CONTENT -->
 ----
-
 <1> the runtime extension artifact `quarkus-extension-a`
 <2> declares an optional Maven dependency on the runtime extension artifact `quarkus-extension-b`
 
@@ -129,7 +127,6 @@ IMPORTANT: In general, for every runtime extension artifact dependency on anothe
 
   <!-- SKIPPED CONTENT -->
 ----
-
 <1> the deployment extension artifact `quarkus-extension-a-deployment`
 <2> declares an optional Maven dependency on the deployment extension artifact `quarkus-extension-b-deployment`
 

--- a/docs/src/main/asciidoc/databases-dev-services.adoc
+++ b/docs/src/main/asciidoc/databases-dev-services.adoc
@@ -188,7 +188,6 @@ quarkus.datasource.devservices.volumes."/path/from"=/container/to <1>
 # Using a classpath volume:
 quarkus.datasource.devservices.volumes."classpath\:./file"=/container/to <2>
 ----
-
 <1> The file or folder "/path/from" from the local machine will be accessible at "/container/to" in the container.
 <2> When using classpath volumes, the location has to start with "classpath:". The file or folder "./file" from the project's classpath will be accessible at "/container/to" in the container.
 

--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -951,7 +951,6 @@ quarkus.kubernetes.rbac.roles.my-role.policy-rules.0.api-groups=extensions,apps
 quarkus.kubernetes.rbac.roles.my-role.policy-rules.0.resources=deployments
 quarkus.kubernetes.rbac.roles.my-role.policy-rules.0.verbs=list
 ----
-
 <1> In this example, the role "my-role" will be generated with a policy rule to get the list of deployments.
 
 By default, if one role is configured, a RoleBinding resource will be generated as well to link this role with the ServiceAccount resource.
@@ -973,7 +972,6 @@ quarkus.kubernetes.rbac.role-bindings.my-role-binding.subjects.my-service-accoun
 quarkus.kubernetes.rbac.role-bindings.my-role-binding.subjects.my-service-account.namespace=my_namespace
 quarkus.kubernetes.rbac.role-bindings.my-role-binding.role-name=my-role
 ----
-
 <1> In this example, the role "my-role" will be generated with the specified policy rules.
 <2> Also, the service account "my-service-account" will be generated.
 <3> And we can configure the generated RoleBinding resource by selecting the role to be used and the subject.
@@ -992,7 +990,6 @@ quarkus.kubernetes.rbac.cluster-role-bindings.my-cluster-role-binding.subjects.m
 quarkus.kubernetes.rbac.cluster-role-bindings.my-cluster-role-binding.subjects.manager.api-group=rbac.authorization.k8s.io
 quarkus.kubernetes.rbac.cluster-role-bindings.my-cluster-role-binding.role-name=my-cluster-role <2>
 ----
-
 <1> In this example, the cluster role "my-cluster-role" will be generated with the specified policy rules.
 <2> The name of the ClusterRole resource to use. Role resources are namespace-based and hence not allowed in ClusterRoleBinding resources.
 

--- a/docs/src/main/asciidoc/dev-ui.adoc
+++ b/docs/src/main/asciidoc/dev-ui.adoc
@@ -696,7 +696,6 @@ export class QwcJokesList extends LitElement { // <3>
 }
 customElements.define('qwc-jokes-list', QwcJokesList); // <12>
 ----
-
 <1> You can import Classes and/or functions from other libraries.
 In this case, we use the `LitElement` class and `html` & `css` functions from `Lit`
 <2> Build time data as defined in the Build step and can be imported using the key and always from `build-time-data`. All keys added in your Build step will be available.
@@ -1623,7 +1622,6 @@ connectedCallback() {
     });
 }
 ----
-
 <1> Note the method `getJoke` corresponds to the method in your Java Service. This method returns a https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise[Promise] with the JsonRPC result.
 <2> In this case, the result is an object, so we just add it to our list of jokes. This could also be an array if the server returned some collection.
 

--- a/docs/src/main/asciidoc/doc-create-tutorial.adoc
+++ b/docs/src/main/asciidoc/doc-create-tutorial.adoc
@@ -46,7 +46,6 @@ Copy `docs/src/main/diataxis/_templates/template-tutorial.adoc` from the Quarkus
 include::_attributes.adoc[] // <3>
 :extension-status: experimental // <4>
 ----
-
 <1> Use the file name as a unique id for the section.
 <2> Add the title as a top-level heading.
 <3> Include additional attributes that help define consistent formatting and provide source portability.
@@ -110,7 +109,6 @@ include::{includes}/prerequisites.adoc[] // <4>
 
 The `curl` command line utility is also used to manually test the endpoint.
 ----
-
 <1> Declare that our hypothetical tutorial will take about 30 minutes to complete.
 <2> Declare that our nonsensical acme extension also requires a container runtime.
 <3> For simplicity in this tutorial, we will avoid GraalVM and Mandrel prerequisites.
@@ -146,7 +144,6 @@ Create a new project with the following command: // <3>
 :create-app-extensions: acme // <5>
 include::{includes}/devtools/create-app.adoc[] // <6>
 ----
-
 <1> Enable section numbering
 <2> Create a second level heading for the first step
 <3> Describe the step briefly
@@ -233,7 +230,6 @@ Create a new source file, `src/main/java/org/acme/MyAcmeApplication.java`, and d
 ----
 \include::{doc-examples}/acme-serve-http-requests-MyAcmeApplication.java[tags=*;!goodbye]
 ----
-
 <1> Specify the CDI lifecycle of this bean.
 An `@ApplicationScoped` bean has a single bean instance that is used for the application.
 <2> The `@Anvil` annotation always implies a simple Http GET request with the uri derived from the method name, `/hello` in this case.
@@ -388,7 +384,6 @@ The two new code listings should be focused on the methods that were omitted bef
 
 Congratulations! You have created a project that uses the acme extension to create fanciful endpoints using the `@Anvil` and `@Toaster` annotations. // <2>
 ----
-
 <1> Turn off section numbering
 <2> Congratulate the user on a job well done!
 

--- a/docs/src/main/asciidoc/doc-reference.adoc
+++ b/docs/src/main/asciidoc/doc-reference.adoc
@@ -158,7 +158,6 @@ Minimally, each document should define an id and a title, include common attribu
 \include::_attributes.adoc[] // <3>
 :diataxis-type: {type} // <4>
 ----
-
 <1> Use the filename as the ID for the document.
 <2> Define the document title following guidance in <<titles-headings>>.
 <3> Include common document attributes.
@@ -366,7 +365,6 @@ examples:
 - source: path/to/source/file/SomeClassFile.java <1>
   target: prefix-simplified-unique-filename.java <2>
 ----
-
 <1> define the path of source to be copied
 <2> define the simplified target file name to use when copying the file into the `target/asciidoc/examples` directory.
 

--- a/docs/src/main/asciidoc/extension-codestart.adoc
+++ b/docs/src/main/asciidoc/extension-codestart.adoc
@@ -585,7 +585,6 @@ The value of `magic.source` can be customized in a platform descriptor like this
     },
 ...
 ----
-
 <1> `project` groups metadata that is relevant for project creation tools
 <2> `codestart-data` is a source of data for various codestarts
 <3> a name of the codestart to which the data nested under it should be passed

--- a/docs/src/main/asciidoc/extension-metadata.adoc
+++ b/docs/src/main/asciidoc/extension-metadata.adoc
@@ -87,7 +87,6 @@ metadata:
   config: <10>
   - "quarkus.rest."
 ----
-
 <1> Extension name displayed to users
 <2> Extension runtime artifact expression that will be replaced with the actual coordinates during the build, this field could be omitted
 <3> Short name that could be used to quickly locate an extension in the catalog of extensions provided by the dev tools to the users

--- a/docs/src/main/asciidoc/flyway.adoc
+++ b/docs/src/main/asciidoc/flyway.adoc
@@ -368,7 +368,6 @@ public class MigrationService {
     }
 }
 ----
-
 <1> Inject the Flyway object if you want to use it directly
 <2> Inject Flyway for named datasources using the Quarkus `FlywayDataSource` qualifier
 <3> Inject Flyway for named datasources

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -80,7 +80,6 @@ test {
     systemProperty "quarkus.test.profile", "foo" <1>
 }
 ----
-
 <1> The `foo` configuration profile will be used to run the tests.
 ****
 
@@ -93,7 +92,6 @@ tasks.test {
     systemProperty("quarkus.test.profile", "foo") <1>
 }
 ----
-
 <1> The `foo` configuration profile will be used to run the tests.
 ****
 
@@ -521,7 +519,6 @@ quarkusBuild {
     }
 }
 ----
-
 <1> Set `quarkus.native.container-build` property to `true`
 <2> Set `quarkus.native.builder-image` property to `quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor}`
 ****
@@ -538,7 +535,6 @@ tasks.quarkusBuild {
     }
 }
 ----
-
 <1> Set `quarkus.native.container-build` property to `true`
 <2> Set `quarkus.native.builder-image` property to `quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor}`
 ****

--- a/docs/src/main/asciidoc/grpc-generation-reference.adoc
+++ b/docs/src/main/asciidoc/grpc-generation-reference.adoc
@@ -235,7 +235,6 @@ Then, add the `eu.maveniverse.maven.nisse:plugin3` and the `protobuf-maven-plugi
     </plugins>
 </build>
 ----
-
 <1> The `protobuf-maven-plugin` generates stub classes from your gRPC service definition (`proto` files).
 <2> Class generation uses the tool `protoc`, which is OS-specific. This is why we use the Nisse Maven plugin to target the executable compatible with the operating system.
 

--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -946,7 +946,6 @@ public class DogDto {
 
 PanacheQuery<DogDto> query = Dog.findAll().project(DogDto.class);
 ----
-
 <1> This annotation can be used when you want to project `@Embedded` entity or `@ManyToOne`, `@OneToOne` relation.
 It does not support `@OneToMany` or `@ManyToMany` relation.
 
@@ -1013,7 +1012,6 @@ public class PersonName {
 // only 'name' will be loaded from the database
 PanacheQuery<PersonName> query = Person.find("status", Status.Alive).project(PersonName.class);
 ----
-
 <1> This will use your annotated constructor to create the query. (`select new PersonName(name) from ...`)
 
 [WARNING]

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -122,7 +122,6 @@ public class SantaClausService {
     }
 }
 ----
-
 <1> Inject your Hibernate ORM session and have fun
 <2> Mark your CDI bean method as `@Transactional` and the `Session` will enlist and flush at commit.
 

--- a/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
@@ -685,7 +685,6 @@ public class DogDto {
 
 PanacheQuery<DogDto> query = Dog.findAll().project(DogDto.class);
 ----
-
 <1> This annotation can be used when you want to project `@Embedded` entity or `@ManyToOne`, `@OneToOne` relation.
 It does not support `@OneToMany` or `@ManyToMany` relation.
 
@@ -751,7 +750,6 @@ public class PersonName {
 // only 'name' will be loaded from the database
 PanacheQuery<PersonName> query = Person.find("status", Status.Alive).project(PersonName.class);
 ----
-
 <1> This will use your annotated constructor to create the query. (`select new PersonName(name) from ...`)
 
 [WARNING]

--- a/docs/src/main/asciidoc/hibernate-reactive.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive.adoc
@@ -141,7 +141,6 @@ public class SantaClausService {
     }
 }
 ----
-
 <1> Inject the reactive session directly
 <2> Use `@Transactional` for write operations such as `persist()`
 
@@ -226,7 +225,6 @@ public class FruitResource {
 
 }
 ----
-
 <1> Inject the reactive session directly
 <2> Use `@Transactional` for persist operations - creates new entities in the database
 <3> Use `@Transactional` for update operations - modifies existing entities

--- a/docs/src/main/asciidoc/infinispan-dev-services.adoc
+++ b/docs/src/main/asciidoc/infinispan-dev-services.adoc
@@ -90,7 +90,6 @@ If you want run the Infinispan Server container with Cross Site Replication conf
 quarkus.infinispan-client.devservices.site=NYC <1>
 quarkus.infinispan-client.devservices.mcast-port=46666 <2>
 ----
-
 <1> Provides a site name for your Infinispan cluster
 <2> Eventually configure a mcastPort if you want to avoid creating a cluster with another container
 

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -1055,7 +1055,6 @@ Configuration for the Kafka connector outgoing channels is similar to that of in
 mp.messaging.outgoing.prices-out.connector=smallrye-kafka <2>
 mp.messaging.outgoing.prices-out.topic=prices <3>
 ----
-
 <1> Configure the broker location for the production profile. You can configure it globally or per channel using `mp.messaging.outgoing.$channel.bootstrap.servers` property.
 In dev mode and when running tests, <<kafka-dev-services>> automatically starts a Kafka broker.
 When not provided, this property defaults to `localhost:9092`.
@@ -1926,7 +1925,6 @@ public class KafkaExactlyOnceProcessor {
 
 }
 ----
-
 <1> It is recommended to use exactly-once processing along with the batch consumption mode.
 While it is possible to use it with a single Kafka message, it'll have a significant performance impact.
 <2> The consumed message is passed to the `KafkaTransactions#withTransactionAndAck` in order to handle the offset commits and message acks.
@@ -2806,7 +2804,6 @@ public class OrderProcessorTest {
     }
 }
 ----
-
 <1> `@InjectKafkaCompanion` injects the `KafkaCompanion` instance, configured to access the Kafka broker created for tests.
 <2> Use `KafkaCompanion` to create producer task which writes 10 records to 'orders' topic.
 <3> Create consumer task which subscribes to 'orders-processed' topic and consumes 10 records.
@@ -3559,7 +3556,6 @@ public class FruitProducer {
     }
 }
 ----
-
 <1> Inject the Hibernate Reactive `SessionFactory`.
 <2> Begin a Hibernate Reactive transaction.
 <3> Begin a Kafka transaction.
@@ -3599,7 +3595,6 @@ public class FruitProducer {
     }
 }
 ----
-
 <1> Start a Hibernate Reactive transaction and commit it when the method returns.
 <2> Begin a Kafka transaction.
 <3> Persist the payload and send the entity to Kafka.
@@ -3644,7 +3639,6 @@ public class FruitProducer {
     }
 }
 ----
-
 <1> Start a Hibernate ORM transaction. The transaction is committed when the method returns.
 <2> Begin a Kafka transaction.
 <3> Persist the payload.

--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -240,7 +240,6 @@ compileTestKotlin {
     kotlinOptions.jvmTarget = JavaVersion.VERSION_21
 }
 ----
-
 <1> The Kotlin plugin version needs to be specified.
 <2> The all-open configuration required, as per Maven guide above
 
@@ -308,7 +307,6 @@ kotlin {
 }
 
 ----
-
 <1> The Kotlin plugin version needs to be specified.
 <2> The all-open configuration required, as per Maven guide above
 

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -1028,7 +1028,6 @@ your default testing database.
   [...]
 </project>
 ----
-
 <1> The `foo` configuration profile will be used to run the tests.
 
 [WARNING]
@@ -1103,7 +1102,6 @@ These system properties above could be added to, e.g., a `surefire` and/or `fail
   [...]
 </project>
 ----
-
 <1> Propagate `maven.home` system property set by the Maven CLI to the tests
 <2> Set the Maven local repository directory for the tests
 <3> Set the Maven settings file the tests
@@ -1157,7 +1155,6 @@ Here is an example `info` output for a simple project:
 [INFO] Extensions from registry.quarkus.io: <4>
 [INFO]   io.quarkiverse.prettytime:quarkus-prettytime:2.0.1
 ----
-
 <1> Quarkus platform BOMs imported in the project (BOMs imported by parent POMs will also be reported)
 <2> Direct Quarkus extension dependencies managed by the `quarkus-bom`
 <3> Direct Quarkus extension dependencies managed by the `quarkus-camel-bom`
@@ -1220,7 +1217,6 @@ Assuming we have a project including Kogito, Camel and core Quarkus extensions a
 [INFO] Update: {quarkus-platform-groupid}:quarkus-bom:pom:2.7.1.Final -> {quarkus-version}
 [INFO] Update: {quarkus-platform-groupid}:quarkus-camel-bom:pom:2.7.1.Final -> {quarkus-version}
 ----
-
 <1> A list of currently recommended Quarkus platform BOM updates
 
 NOTE: Typically, a single project property will be used to manage all the Quarkus platform BOMs but the implementation isn't currently smart enough to point that out and will report updates for each BOM individually.
@@ -1239,7 +1235,6 @@ If we modify the project to remove all the Camel Quarkus extensions from the pro
 [INFO] Extensions from registry.quarkus.io:
 [INFO] Update: io.quarkiverse.prettytime:quarkus-prettytime:0.2.0 -> 0.2.1 <4>
 ----
-
 <1> A list of the currently recommended Quarkus platform BOM updates for the project
 <2> Given that the project does not include any Camel Quarkus extensions, the BOM import is recommended to be removed
 <3> An outdated version of the `quarkus-resteasy-reactive` is recommended to be removed in favor of the one managed by the `quarkus-bom`

--- a/docs/src/main/asciidoc/messaging-virtual-threads.adoc
+++ b/docs/src/main/asciidoc/messaging-virtual-threads.adoc
@@ -121,7 +121,6 @@ public class PriceConsumer {
 
 }
 ----
-
 <1> `@RunOnVirtualThread` annotation on the `@Incoming` method ensures that the method will be called on a virtual thread.
 <2> the REST client stub is injected with the `@RestClient` annotation.
 <3> `alert` method blocks the virtual thread until the REST call returns.

--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -2504,7 +2504,6 @@ docker run \
   $(cat native-builder.image) \# <3>
   -c "native-image $(cat native-image.args) -J-Xmx4g"# <4>
 ----
-
 <1> Mount the host's directory `target/native-image` to the container's `/work`. Thus, the generated binary will also be written to this directory.
 <2> Switch the working directory to `/work`, which we have mounted in <1>.
 <3> Use the docker image from the file `native-builder.image`.

--- a/docs/src/main/asciidoc/opentelemetry-logging.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-logging.adoc
@@ -123,7 +123,6 @@ quarkus.otel.logs.enabled=true // <2>
 quarkus.otel.exporter.otlp.logs.endpoint=http://localhost:4318 // <3>
 quarkus.otel.exporter.otlp.logs.headers=authorization=Bearer my_secret // <4>
 ----
-
 <1> All logs created from the application will include an OpenTelemetry `Resource` indicating the logs were created by the `myservice` application.
 If not set, it will default to the artifact id.
 <2> Enable the OpenTelemetry logging.
@@ -172,7 +171,6 @@ You can output all logs to the console by setting the exporter to `logging` in t
 ----
 quarkus.otel.logs.exporter=logging <1>
 ----
-
 <1> Set the exporter to `logging`.
 Normally you don't need to set this.
 The default is `cdi`.

--- a/docs/src/main/asciidoc/opentelemetry-metrics.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-metrics.adoc
@@ -145,7 +145,6 @@ quarkus.otel.metrics.enabled=true // <2>
 quarkus.otel.exporter.otlp.metrics.endpoint=http://localhost:4318 // <3>
 quarkus.otel.exporter.otlp.metrics.headers=authorization=Bearer my_secret // <4>
 ----
-
 <1> All metrics created from the application will include an OpenTelemetry `Resource` indicating the metrics was created by the `myservice` application.
 If not set, it will default to the artifact id.
 <2> Enable the OpenTelemetry metrics.
@@ -183,7 +182,6 @@ You can output all metrics to the console by setting the exporter to `logging` i
 quarkus.otel.metrics.exporter=logging <1>
 quarkus.otel.metric.export.interval=10000ms <2>
 ----
-
 <1> Set the exporter to `logging`.
 Normally you don't need to set this.
 The default is `cdi`.
@@ -358,7 +356,6 @@ LongCounter counter = meter.counterBuilder("hello-metrics") // <1>
 counter.add(1, // <2>
         Attributes.of(AttributeKey.stringKey("attribute.name"), "attribute value")); // optional <3>
 ----
-
 <1> Create a `LongCounter` named `hello-metrics` with a description and unit.
 <2> Increment the counter by one.
 <3> Add an attribute to the counter.

--- a/docs/src/main/asciidoc/opentelemetry-tracing.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-tracing.adoc
@@ -780,7 +780,6 @@ public static class HelloPropagation {
         }
     }
 ----
-
 <1> The `MAP_SETTER` handles how to store data in the carrier map that will transport the context.
 <2> `MAP_GETTER` handles how to retrieve data from the carrier map transporting the context.
 <3> The `createParentContext()` method explains how to create an OpenTelemetry context. In this case we generate the default https://www.w3.org/TR/trace-context/[W3C Trace Context] header: `traceparent`.

--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -447,7 +447,6 @@ quarkus.otel.metrics.exporter=logging <1>
 quarkus.otel.metric.export.interval=10000ms <2>
 quarkus.otel.traces.exporter=logging <3>
 ----
-
 <1> Set the metrics exporter to `logging`. Normally you don't need to set this. The default is `cdi`.
 <2> Set the interval to export the metrics. The default is `1m`, which is too long for debugging.
 <3> Set the traces exporter to `logging`. Normally you don't need to set this. The default is `cdi`.

--- a/docs/src/main/asciidoc/platform.adoc
+++ b/docs/src/main/asciidoc/platform.adoc
@@ -86,7 +86,6 @@ The platform descriptor will normally be generated using a Maven plugin, e.g.
   </configuration>
 </plugin>
 ----
-
 <1> the version of the `quarkus-platform-descriptor-json-plugin`
 <2> `generate-extensions-json` is the goal generating the platform descriptor
 <3> the `groupId` of the platform BOM

--- a/docs/src/main/asciidoc/reactive-routes.adoc
+++ b/docs/src/main/asciidoc/reactive-routes.adoc
@@ -697,7 +697,6 @@ public class MyFilters {
     }
 }
 ----
-
 <1> The `RouteFilter#value()` defines the priority used to sort the filters - filters with higher priority are called first.
 <2> The filter is likely required to call the `next()` method to continue the chain.
 

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -293,7 +293,6 @@ To retrieve all the data, we will use the `query` method again:
         return new Fruit(row.getLong("id"), row.getString("name"));
     }
 ----
-
 <1> Transform the `io.vertx.mutiny.sqlclient.RowSet` to a `Multi<Row>`.
 <2> Convert each `io.vertx.mutiny.sqlclient.Row` to a `Fruit`.
 

--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -496,7 +496,6 @@ public class MyRedisService {
     }
 }
 ----
-
 <1> Inject the `RedisDataSource` in the constructor
 <2> Creates the `HashCommands` object.
 This object has three type parameters: the type of the key, the type of the field, and the type of the member
@@ -693,7 +692,6 @@ public static class MyRedisCounter {
 
 }
 ----
-
 <1> Retrieve the commands.
 This time we will manipulate `Long` values
 <2> Retrieve the counter associated with the given `key`.

--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -213,7 +213,6 @@ public interface Client {
     }
 }
 ----
-
 <1> By placing `@ClientQueryParam` on the interface, we ensure that `my-param` will be added to all requests of the client.
 Because we used the `${...}` syntax, the actual value of the parameter will be obtained using the `my.property-value` configuration property.
 <2> When `getWithOtherParam` is called, in addition to the `my-param` query parameter, `some-other-param` with the value of `other` will also be added.
@@ -501,7 +500,6 @@ The name of the property needs to follow a certain convention which is best disp
 # Your configuration properties
 quarkus.rest-client."org.acme.rest.client.ExtensionsService".url=https://stage.code.quarkus.io/api // <1>
 ----
-
 <1> Having this configuration means that all requests performed using `org.acme.rest.client.ExtensionsService` will use `https://stage.code.quarkus.io/api` as the base URL.
 Using the configuration above, calling the `getById` method of `ExtensionsService` with a value of `io.quarkus:quarkus-rest-client` would result in an HTTP GET request being made to `https://stage.code.quarkus.io/api/extensions?id=io.quarkus:quarkus-rest-client`.
 
@@ -755,7 +753,6 @@ public class ExtensionsResource {
     // ...
 }
 ----
-
 <1> the client will use the registered HTTP Client options over the HTTP Client options provided via CDI if any.
 
 [[redirection]]
@@ -842,7 +839,6 @@ public class ExtensionsResource {
     // ...
 }
 ----
-
 <1> the client will use the registered redirect handler over the redirect handler provided via CDI if any.
 
 == Update the test
@@ -1241,7 +1237,6 @@ public interface ExtensionsService {
     Set<Extension> getById(@QueryParam("id") String id, @HeaderParam("jaxrs-style-header") String headerValue, @NotBody String token); // <6>
 }
 ----
-
 <1> There can be only one `ClientHeadersFactory` per class. With it, you can not only add custom headers, but you can also transform existing ones. See the `RequestUUIDHeaderFactory` class below for an example of the factory.
 <2> `@ClientHeaderParam` can be used on the client interface and on methods. It can specify a constant header value...
 <3> ... and a name of a method that should compute the value of the header. It can either be a static method or a default method in this interface. The method can take either no parameters, a single String parameter or a single `io.quarkus.rest.client.reactive.ComputedParamContext` parameter (which is very useful for code that needs to compute headers based on method parameters and naturally complements `@io.quarkus.rest.client.reactive.NotBody`).
@@ -1507,7 +1502,6 @@ public interface ExtensionsService {
     }
 }
 ----
-
 <1> The method must be annotated with `@ClientObjectMapper`.
 <2> It's must be a static method. Also, the parameter `defaultObjectMapper` will be resolved via CDI. If not found, it will throw an exception at runtime.
 <3> In this example, we're creating a copy of the default object mapper. You should *NEVER* modify the default object mapper, but create a copy instead.
@@ -1659,7 +1653,6 @@ public class MyResponseExceptionMapper implements ResponseExceptionMapper<Runtim
     }
 }
 ----
-
 <1> With the `@Blocking` annotation, the MyResponseExceptionMapper exception mapper will be executed in the worker thread pool.
 <2> Reading the entity is now allowed because we're executing the mapper on the worker thread pool.
 
@@ -1832,7 +1825,6 @@ public ClientMultipartForm buildClientMultipartForm(MultipartFormDataInput input
   return multiPartForm;
 }
 ----
-
 <1> `MultipartFormDataInput` is a Quarkus REST (Server) type representing a received multipart request.
 <2> A `ClientMultipartForm` is created.
 <3> `FileItem` attribute is created for the request attribute that represented an in memory file attribute
@@ -1869,7 +1861,6 @@ public ClientMultipartForm buildClientMultipartForm(Request request) { // <1>
   return multiPartForm;
 }
 ----
-
 <1> `Request` representing the request the server parts accepts
 <2> A `jsonPayload` attribute is added directly to `ClientMultipartForm`
 <3> A `fileUpload` is created from the request's `FileUpload`
@@ -2022,7 +2013,6 @@ quarkus.proxy.credentials-provider.bean-name=credentialBean
 quarkus.proxy.credentials-provider.username-key=userKey
 quarkus.proxy.credentials-provider.password-key=passwordKey
 ----
-
 <1> Define a named proxy configuration `baby-proxy` without username and password.
 <2> Configure the Credentials Provider to obtain the username and password for the proxy.
 
@@ -2280,7 +2270,6 @@ public class QuarkusMockTest {
     }
 }
 ----
-
 <1> here we use a manually created implementation of the client interface to replace the actual Client
 <2> note that `RestClient.LITERAL` has to be passed as the last argument of the `installMockForType` method
 
@@ -2367,7 +2356,6 @@ public class WireMockExtensions implements QuarkusTestResourceLifecycleManager {
     }
 }
 ----
-
 <1> Statically importing the methods in the Wiremock package makes it easier to read the test.
 <2> The `start` method is invoked by Quarkus before any test is run and returns a `Map` of configuration properties that apply during the test execution.
 <3> Launch Wiremock.

--- a/docs/src/main/asciidoc/resteasy-client.adoc
+++ b/docs/src/main/asciidoc/resteasy-client.adoc
@@ -187,7 +187,6 @@ The name of the property needs to follow a certain convention which is best disp
 quarkus.rest-client."org.acme.rest.client.ExtensionsService".url=https://stage.code.quarkus.io/api # // <1>
 quarkus.rest-client."org.acme.rest.client.ExtensionsService".scope=jakarta.inject.Singleton # // <2>
 ----
-
 <1> Having this configuration means that all requests performed using `ExtensionsService` will use `https://stage.code.quarkus.io` as the base URL.
 Using the configuration above, calling the `getById` method of `ExtensionsService` with a value of `io.quarkus:quarkus-resteasy-client` would result in an HTTP GET request being made to `https://stage.code.quarkus.io/api/extensions?id=io.quarkus:quarkus-rest-client`.
 <2> Having this configuration means that the default scope of `ExtensionsService` will be `@Singleton`. Supported scope values are `@Singleton`, `@Dependent`, `@ApplicationScoped` and `@RequestScoped`. The default scope is `@Dependent`.

--- a/docs/src/main/asciidoc/resteasy.adoc
+++ b/docs/src/main/asciidoc/resteasy.adoc
@@ -717,7 +717,6 @@ Quarkus comes with GZip support (even though it is not enabled by default). The 
 quarkus.resteasy.gzip.enabled=true // <1>
 quarkus.resteasy.gzip.max-input=10M // <2>
 ----
-
 <1> Enable Gzip support.
 <2> Configure the upper limit on the deflated request body.
 This is useful to mitigate potential attacks by limiting their reach. The default value is `10M`.

--- a/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
+++ b/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
@@ -285,7 +285,6 @@ quarkus.http.auth.permission.default.paths=/* <4>
 quarkus.http.auth.permission.default.policy=authenticated
 quarkus.http.insecure-requests=disabled <5>
 ----
-
 <1> The keystore where the server's private key is located.
 <2> The truststore from which the trusted certificates are loaded.
 <3> Setting `quarkus.http.ssl.client-auth` to `required` makes the server demand client certificates. You can set it to `REQUEST` if the server should accept requests without a certificate. This setting is useful when supporting multiple authentication methods besides mTLS.

--- a/docs/src/main/asciidoc/security-cors.adoc
+++ b/docs/src/main/asciidoc/security-cors.adoc
@@ -59,7 +59,6 @@ quarkus.http.cors.exposed-headers=Content-Disposition <5>
 quarkus.http.cors.access-control-max-age=24H <6>
 quarkus.http.cors.access-control-allow-credentials=true <7>
 ----
-
 <1> Enables the CORS filter.
 <2> Specifies allowed origins, including a regular expression.
 When not specified, CORS is not permitted, and only same-origin requests are allowed.

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -380,7 +380,6 @@ public class GenerateToken {
     }
 }
 ----
-
 <1> Sets the `iss` (issuer) claim in the JWT.
     This value must match the server-side `mp.jwt.verify.issuer` configuration for the token to be considered valid.
 <2> Specifies the `upn` (User Principal Name) claim, which the {mp-jwt} specification defines as the preferred claim for identifying the `Principal` in container security APIs.

--- a/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
@@ -221,7 +221,6 @@ For example, by default, a test container will be available at a randomly alloca
 %test.quarkus.keycloak.devservices.port=${kc.admin.port.test:45180} <1>
 %test.quarkus.keycloak.admin-client.server-url=http://localhost:${kc.admin.port.test:45180}/ <2>
 ----
-
 <1> Configure the Keycloak container to listen on the `45180` port by default
 <2> Configure the Keycloak Admin Client to use the same port
 

--- a/docs/src/main/asciidoc/security-oauth2.adoc
+++ b/docs/src/main/asciidoc/security-oauth2.adoc
@@ -393,7 +393,6 @@ public class MockAuthorizationServerTestResource implements QuarkusTestResourceL
     }
 }
 ----
-
 <1> The `start` method is invoked by Quarkus before any test is run and returns a `Map` of configuration properties that apply during the test execution.
 <2> Launch Wiremock.
 <3> Configure Wiremock to stub the calls to `/introspect` by returning an OAuth2 introspect response. You need to customize this line to return what's needed for your application (at least the scope property as roles are derived from the scope).
@@ -436,7 +435,6 @@ class TokenSecuredResourceTest {
     }
 }
 ----
-
 <1> Use the previously created `MockAuthorizationServerTestResource` as a Quarkus test resource.
 <2> Define whatever token you want, it will not be validated by the OAuth2 mock authorization server.
 <3> Use this token inside the `Authorization` header to trigger OAuth2 authentication.

--- a/docs/src/main/asciidoc/security-openid-connect-providers.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-providers.adoc
@@ -681,7 +681,6 @@ public interface GoogleCalendarClient {
     }
 }
 ----
-
 <1> The `@AccessToken` annotation enables an access token propagation to the target service.
 
 Finally,  you need to configure the Google Calendar address and request  the Google Calendar scope for an access token, as outlined in the following example:

--- a/docs/src/main/asciidoc/security-properties.adoc
+++ b/docs/src/main/asciidoc/security-properties.adoc
@@ -75,7 +75,6 @@ jdoe=p4ssw0rd <2>
 stuart=test
 noadmin=n0Adm1n
 ----
-
 <1> User `scott` has password defined as `jb0ss`
 <2> User `jdoe` has password defined as `p4ssw0rd`
 
@@ -93,7 +92,6 @@ jdoe=NoRolesUser <2>
 stuart=admin,user <3>
 noadmin=user
 ----
-
 <1> User `scott` has been assigned the roles `Admin`, `admin`, `Tester` and `user`
 <2> User `jdoe` has been assigned the role `NoRolesUser`
 <3> User `stuart` has been assigned the roles `admin` and `user`.
@@ -139,7 +137,6 @@ quarkus.security.users.embedded.users.stuart=test # <2>
 quarkus.security.users.embedded.users.jdoe=p4ssw0rd
 quarkus.security.users.embedded.users.noadmin=n0Adm1n
 ----
-
 <1> User `scott` has password `jb0ss`
 <2> User `stuart` has password `test`
 
@@ -157,7 +154,6 @@ quarkus.security.users.embedded.roles.stuart=admin,user # <2>
 quarkus.security.users.embedded.roles.jdoe=NoRolesUser
 quarkus.security.users.embedded.roles.noadmin=user
 ----
-
 <1> User `scott` has roles `Admin`, `admin`, `Tester`, and `user`
 <2> User `stuart` has roles `admin` and `user`
 

--- a/docs/src/main/asciidoc/security-webauthn.adoc
+++ b/docs/src/main/asciidoc/security-webauthn.adoc
@@ -870,7 +870,6 @@ webAuthn.login({ username: username }) <1>
     // login failed
   });
 ----
-
 <1> The username is optional, in the case of https://www.w3.org/TR/webauthn-3/#discoverable-credential[Discoverable Credentials] (with PassKeys)
 
 === Only invoke the registration challenge and authenticator
@@ -920,7 +919,6 @@ webAuthn.loginClientSteps({ username: username }) <1>
     // login failed
   });
 ----
-
 <1> The username is optional, in the case of https://www.w3.org/TR/webauthn-3/#discoverable-credential[Discoverable Credentials] (with PassKeys)
 
 == Handling login and registration endpoints yourself

--- a/docs/src/main/asciidoc/smallrye-graphql-client.adoc
+++ b/docs/src/main/asciidoc/smallrye-graphql-client.adoc
@@ -332,7 +332,6 @@ public List<Film> getAllFilmsUsingDynamicClient() throws Exception {
     return response.getObject(FilmConnection.class, "allFilms").getFilms();  <4>
 }
 ----
-
 <1> Qualifies the injection point so that we know which named client needs to be injected here.
 
 <2> Here we build a document representing the GraphQL query, using the provided DSL language.

--- a/docs/src/main/asciidoc/smallrye-graphql.adoc
+++ b/docs/src/main/asciidoc/smallrye-graphql.adoc
@@ -249,7 +249,6 @@ public class FilmResource {
     }
 }
 ----
-
 <1> `@GraphQLApi` annotation indicates that the CDI bean will be a GraphQL endpoint
 <2> `@Query` annotation defines that this method will be queryable with the name `allFilms`
 <3> Documentation of the queryable method
@@ -412,7 +411,6 @@ Add the following to our `FilmResource` class:
         return service.getHeroesByFilm(film);
     }
 ----
-
 <1> Enable `List<Hero>` data to be added to queries that respond with `Film`
 
 By adding this method we have effectively changed the schema of the GraphQL API.
@@ -453,7 +451,6 @@ the heroes:
         // Here fetch all hero lists
     }
 ----
-
 <1> Here receive the films as a batch, allowing you to fetch the corresponding heroes.
 
 === Non blocking
@@ -636,7 +633,6 @@ public interface Character {
     String getSurname();
 }
 ----
-
 <1> Getters defined in an interface will define the GraphQL fields that it contains
 
 Now, update our `Hero` and `Ally` entities to implement this interface.
@@ -671,7 +667,6 @@ public class Ally implements Character {
     }
 }
 ----
-
 <1> Because interfaces can't define fields, we have to implement the getters
 
 By adding an interface and updating existing entities to implement it, we have effectively changed the schema.
@@ -699,7 +694,6 @@ type Hero implements Character {
     # ...
 }
 ----
-
 <1> The `Character` interface was defined with the getters as fields
 <2> The `Ally` type was added and it implements `Character`
 <3> The `Hero` type was updated to implement `Character`
@@ -762,7 +756,6 @@ public interface SearchResult {
 
 }
 ----
-
 <1> `@Union` is required to indicate this Java interface represents a GraphQL union, not a GraphQL interface
 
 TIP: The Java interface representing the GraphQL union does not have to be empty,
@@ -930,7 +923,6 @@ Example: We want to know when new Heroes are being created:
     }
 
 ----
-
 <1> The `Multi` processor that will broadcast any new ``Hero``es
 <2> When adding a new `Hero`, also broadcast it
 <3> Make the stream available in the schema and as a WebSocket during runtime
@@ -1335,7 +1327,6 @@ When `SomeBusinessException` occurs, the error output will contain the Error cod
     }
 }
 ----
-
 <1> The error code
 
 == JavaScript Client

--- a/docs/src/main/asciidoc/software-transactional-memory.adoc
+++ b/docs/src/main/asciidoc/software-transactional-memory.adoc
@@ -179,7 +179,6 @@ concurrency control.
     FlightServiceImpl instance = new FlightServiceImpl(); <2>
     FlightService flightServiceProxy = container.create(instance); <3>
 ----
-
 <1> You need to tell each Container about the type of objects for which it will be responsible. In this example
     it will be instances that implement the FlightService interface.
 <2> Then you create an instance that implements `FlightService`. You should not use it directly at this stage because
@@ -224,7 +223,6 @@ aa.begin(); <2>
     }
 }
 ----
-
 <1> An object for manually controlling transaction boundaries (AtomicAction and many other useful
     classes are included in the extension).
     Refer https://javadoc.io/doc/org.jboss.narayana.jta/narayana-jta/latest/com/arjuna/ats/arjuna/AtomicAction.html[to the javadoc] for more detail.

--- a/docs/src/main/asciidoc/telemetry-micrometer-to-opentelemetry.adoc
+++ b/docs/src/main/asciidoc/telemetry-micrometer-to-opentelemetry.adoc
@@ -223,7 +223,6 @@ You can output all metrics to the console by setting the exporter to `logging` i
 quarkus.otel.metrics.exporter=logging <1>
 quarkus.otel.metric.export.interval=10000ms <2>
 ----
-
 <1> Set the exporter to `logging`.
 Normally you don't need to set this.
 The default is `cdi`.

--- a/docs/src/main/asciidoc/telemetry-micrometer-tutorial.adoc
+++ b/docs/src/main/asciidoc/telemetry-micrometer-tutorial.adoc
@@ -124,7 +124,6 @@ We'll add a dimensional label (also called an attribute or a tag) that will allo
 ----
 include::{generated-dir}/examples/telemetry-micrometer-tutorial-example-resource.java[tags=primeMethod;counted;!ignore;!timed]
 ----
-
 <1> Find or create a counter called `example.prime.number` that has a `type` label with the specified value.
 <2> Increment that counter.
 
@@ -172,7 +171,6 @@ Let's add a timer to measure how long it takes to determine if a number is prime
 ----
 include::{generated-dir}/examples/telemetry-micrometer-tutorial-example-resource.java[tags=primeMethod;counted;timed;!ignore;!default]
 ----
-
 <1> Find or create a counter called `example.prime.number` that has a `type` label with the specified value.
 <2> Increment that counter.
 <3> Call a method that wraps the original `testPrimeNumber` method.
@@ -217,7 +215,6 @@ Use a gauge to observe the size of a collection, or the value returned from a fu
 ----
 include::{generated-dir}/examples/telemetry-micrometer-tutorial-example-resource.java[tags=ctor;gauge]
 ----
-
 <1> Define list that will hold arbitrary numbers.
 <2> Register a gauge that will track the size of the list.
 <3> Create a REST endpoint to populate the list.

--- a/docs/src/main/asciidoc/telemetry-micrometer.adoc
+++ b/docs/src/main/asciidoc/telemetry-micrometer.adoc
@@ -177,7 +177,6 @@ public StatsdMeterRegistry createStatsdMeterRegistry(StatsdConfig statsdConfig, 
           .build();
 }
 ----
-
 <1> The method returns a `@Singleton`.
 <2> The method returns the specific type of `MeterRegistry`
 

--- a/docs/src/main/asciidoc/telemetry-opentracing-to-otel-tutorial.adoc
+++ b/docs/src/main/asciidoc/telemetry-opentracing-to-otel-tutorial.adoc
@@ -267,7 +267,6 @@ public class GreetingResource {
     }
 }
 ----
-
 <1> The legacy OpenTracing tracer, must be replaced by the new OpenTelemetry tracer.
 <2> The `@Traced` annotation is replaced by the `@WithSpan` annotation but beware that this new annotation will always create a new Span. You shouldn't use it on JAX-RS endpoints because they are already instrumented.
 <3> The `Tag` class is replaced by the `Attribute` class. `Tags` is replaced by the `SemanticAttributes` class, which should be used whenever possible, to keep attribute names consistent with the specification.
@@ -470,7 +469,6 @@ public class GreetingResource {
     }
 }
 ----
-
 <1> The `Tracer` annotation must be removed and instead, we need to inject the OpenTelemetry SDK. We will need it in <3>.
 <2> The `@Traced` annotation is replaced by the `@WithSpan` annotation but beware that this new annotation will always create a new Span. You shouldn't use it on JAX-RS endpoints and we only have it here for demonstration purposes.
 <3> We must obtain an instance of the `legacyTracer`. The Shim includes a utility class for this purpose: `Tracer legacyTracer = OpenTracingShim.createTracerShim(openTelemetry);`

--- a/docs/src/main/asciidoc/transaction.adoc
+++ b/docs/src/main/asciidoc/transaction.adoc
@@ -69,7 +69,6 @@ public class SantaClausService {
     }
 }
 ----
-
 <1> This annotation defines your transaction boundaries and will wrap this call within a transaction.
 <2> A `RuntimeException` crossing the transaction boundaries will roll back the transaction.
 
@@ -118,7 +117,6 @@ public class SantaClausService {
     }
 }
 ----
-
 <1> Inject the `TransactionManager` to be able to activate `setRollbackOnly` semantic.
 <2> Programmatically decide to set the transaction for rollback.
 

--- a/docs/src/main/asciidoc/web.adoc
+++ b/docs/src/main/asciidoc/web.adoc
@@ -74,7 +74,6 @@ Here is a simple example of a Qute template:
 </body>
 </html>
 ----
-
 <1> With the https://docs.quarkiverse.io/quarkus-web-bundler/dev/[Web Bundler extension], this expression will be replaced by the bundled scripts and styles.
 <2> You can directly use the HTTP parameters in your templates.
 <3> This expression is validated. Try to change the expression to `cdi:Product.notHere` and the build will fail.

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -544,7 +544,6 @@ metadata:
   - "data"
   status: "stable" <5>
 ----
-
 <1> the name of the extension that will be displayed to users
 <2> keywords that can be used to find the extension in the extension catalog
 <3> link to the extension's guide or documentation
@@ -2066,7 +2065,6 @@ public void keyPairDevService(LiveReloadBuildItem liveReloadBuildItem, BuildProd
 
 static record KeyPairContext(Map<String, String> properties) {}
 ----
-
 <1> You can retrieve the context from `LiveReloadBuildItem`. This call returns `null` if there is no context for the specified type; otherwise, it returns the stored instance from a previous live reload execution.
 <2> You can check if this is the first execution (not a live reload).
 <3> The `LiveReloadBuildItem#setContextObject` method allows you to set a context across live reloads.
@@ -2155,7 +2153,6 @@ public class FailingUnitTest {
     }
 }
 ----
-
 <1> The `QuarkusExtensionTest` extension must be used with a static field. If used with a non-static field, the test application is not started.
 <2> This producer is used to build the application to be tested. It uses Shrinkwrap to create a JavaArchive to test
 <3> It is possible to inject beans from our test deployment directly into the test case
@@ -2196,7 +2193,6 @@ public class PersistenceAndQuarkusConfigTest {
 
 }
 ----
-
 <1> This tells JUnit that the Quarkus deployment should fail with a specific exception
 
 
@@ -2338,7 +2334,6 @@ public class ServletChangeTestCase {
     }
 }
 ----
-
 <1> This starts the deployment, your test can modify it as part of the test suite. Quarkus will be restarted between
 each test method so every method starts with a clean deployment.
 


### PR DESCRIPTION
We used to be a bit lenient about it because it was working but given we are using more and more different Asciidoc engines, let's stick to canonical syntax: no new line between source block and callouts.