### PR TITLE
[3.39] Fix serialization of string-shaped dates without a pattern in reflection-free Jackson serializers

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
@@ -623,7 +623,8 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
             } else if ("STRING".equals(formatShape) && fieldSpecs.formatPattern() == null && isJavaTimeDateType(typeName)) {
                 writeToStringValue(fieldSpecs, bytecode, ctx, pkgName, arg);
             } else if ("STRING".equals(formatShape) && fieldSpecs.formatPattern() == null && isJavaUtilDateType(typeName)) {
-                writeToStringValue(fieldSpecs, bytecode, ctx, pkgName, arg);
+                // java.util.Date#toString() is not a valid representation: use the configured date format instead
+                writeDefaultFormatDateValue(fieldSpecs, bytecode, ctx, pkgName, arg);
             } else if (fieldSpecs.isFormatShapeNumber() && isBooleanType(typeName)) {
                 writeNumberShapedBoolean(fieldSpecs, bytecode, ctx, pkgName, typeName, arg);
             } else if (fieldSpecs.isFormatShapeNumber() && isJavaUtilDateType(typeName)) {
@@ -680,6 +681,19 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
                 bytecode.load(fieldSpecs.formatPattern()),
                 timezone != null ? bytecode.load(timezone) : bytecode.loadNull(),
                 ctx.jsonGenerator);
+    }
+
+    private static void writeDefaultFormatDateValue(FieldSpecs fieldSpecs, BytecodeCreator bytecode,
+            SerializationContext ctx,
+            String pkgName, ResultHandle arg) {
+        writeFieldName(fieldSpecs, bytecode, ctx, pkgName);
+        String timezone = fieldSpecs.formatTimezone();
+        MethodDescriptor serializeDefaultFormat = MethodDescriptor.ofMethod(JacksonMapperUtil.class.getName(),
+                "serializeDefaultFormatDate", void.class, Object.class, String.class, JsonGenerator.class,
+                SerializerProvider.class);
+        bytecode.invokeStaticMethod(serializeDefaultFormat, arg,
+                timezone != null ? bytecode.load(timezone) : bytecode.loadNull(),
+                ctx.jsonGenerator, ctx.serializerProvider);
     }
 
     private static void writeToStringValue(FieldSpecs fieldSpecs, BytecodeCreator bytecode, SerializationContext ctx,

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
@@ -721,6 +721,30 @@ public abstract class AbstractGeneratedAnnotationTest {
                 .body("[0].directDate", Matchers.is("2026-07-20T11:11:11Z"));
     }
 
+    // --- @JsonFormat(shape = STRING) without pattern on java.util.Date ---
+
+    @Test
+    public void testFormatDateStringShapeWithoutPatternSerialization() {
+        RestAssured.get("/generated/date-string-shape-no-pattern")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("date-string-shape"))
+                .body("utcDate", Matchers.is("2026-07-20T11:11:11.000+00:00"))
+                .body("pragueDate", Matchers.is("2026-07-20T13:11:11.000+02:00"));
+    }
+
+    @Test
+    public void testFormatDateStringShapeWithoutPatternListSerialization() {
+        RestAssured.get("/generated/date-string-shape-no-pattern-list")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("[0].name", Matchers.is("date-string-shape"))
+                .body("[0].utcDate", Matchers.is("2026-07-20T11:11:11.000+00:00"))
+                .body("[0].pragueDate", Matchers.is("2026-07-20T13:11:11.000+02:00"));
+    }
+
     // --- @JsonFormat ---
 
     @Test

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/DateStringShapeNoPatternBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/DateStringShapeNoPatternBean.java
@@ -1,0 +1,40 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+public class DateStringShapeNoPatternBean {
+
+    private String name;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "UTC")
+    private Date utcDate;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "Europe/Prague")
+    private Date pragueDate;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Date getUtcDate() {
+        return utcDate;
+    }
+
+    public void setUtcDate(Date utcDate) {
+        this.utcDate = utcDate;
+    }
+
+    public Date getPragueDate() {
+        return pragueDate;
+    }
+
+    public void setPragueDate(Date pragueDate) {
+        this.pragueDate = pragueDate;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
@@ -621,6 +621,24 @@ public class GeneratedAnnotationResource {
         return List.of(bean);
     }
 
+    // --- DateStringShapeNoPatternBean: @JsonFormat(shape = STRING) without pattern on java.util.Date ---
+
+    @GET
+    @Path("/date-string-shape-no-pattern")
+    public DateStringShapeNoPatternBean getDateStringShapeNoPattern() {
+        DateStringShapeNoPatternBean bean = new DateStringShapeNoPatternBean();
+        bean.setName("date-string-shape");
+        bean.setUtcDate(Date.from(Instant.parse("2026-07-20T11:11:11Z")));
+        bean.setPragueDate(Date.from(Instant.parse("2026-07-20T11:11:11Z")));
+        return bean;
+    }
+
+    @GET
+    @Path("/date-string-shape-no-pattern-list")
+    public List<DateStringShapeNoPatternBean> getDateStringShapeNoPatternList() {
+        return List.of(getDateStringShapeNoPattern());
+    }
+
     // --- FormatArrayShapeBean: @JsonFormat(shape = ARRAY) on class ---
 
     @GET

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
@@ -44,6 +44,7 @@ public class GeneratedAnnotationTest extends AbstractGeneratedAnnotationTest {
                                     ManagedReferenceChild.class,
                                     DateFormatBean.class,
                                     DateStringShapeWithPatternBean.class,
+                                    DateStringShapeNoPatternBean.class,
                                     DurationFormatBean.class,
                                     NumberShapedTemporalBean.class,
                                     ZonedDateTimeFormatBean.class,

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
@@ -47,6 +47,7 @@ public class GeneratedAnnotationWithReflectionFreeSerializersTest extends Abstra
                                     ManagedReferenceChild.class,
                                     DateFormatBean.class,
                                     DateStringShapeWithPatternBean.class,
+                                    DateStringShapeNoPatternBean.class,
                                     DurationFormatBean.class,
                                     NumberShapedTemporalBean.class,
                                     ZonedDateTimeFormatBean.class,

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
+import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
@@ -92,6 +93,21 @@ public class JacksonMapperUtil {
             sdf.setTimeZone(TimeZone.getTimeZone(timezone));
         }
         generator.writeString(sdf.format(value));
+    }
+
+    public static void serializeDefaultFormatDate(Object value, String timezone, JsonGenerator generator,
+            SerializerProvider serializerProvider) throws IOException {
+        if (value == null) {
+            generator.writeNull();
+            return;
+        }
+        // mirrors Jackson's DateSerializer: the configured date format (StdDateFormat unless overridden),
+        // re-zoned to the timezone from the @JsonFormat annotation, if any
+        DateFormat dateFormat = (DateFormat) serializerProvider.getConfig().getDateFormat().clone();
+        if (timezone != null) {
+            dateFormat.setTimeZone(TimeZone.getTimeZone(timezone));
+        }
+        generator.writeString(dateFormat.format(value));
     }
 
     public static void serializeFormattedTemporal(Object value, String pattern, String timezone,


### PR DESCRIPTION
Fixes #55907 (backport to 3.39)

The change in test assertions from "2026-07-20T11:11:11.000Z" to "2026-07-20T11:11:11.000+00:00" is caused by a deliberate Jackson 2 to Jackson 3 behavioral change and indeed both the reflection-free and Jackson-based serialization work in the same way.

The difference is in `StdDateFormat` that specifically how zero-offset (UTC) timezones are serialized:

Jackson 2.x (StdDateFormat.java line 500-506): When the offset is 0, it always writes +00:00 (or +0000 without colon). There's even a comment acknowledging this will change:

"While Z would be conveniently short, older specs mandate use of full +0000... This will change in 3.0 at latest"

Jackson 3.x (StdDateFormat.java line 155-159): A new _writeZeroOffsetAsZ boolean was added, which defaults to true in 3.0. When true, it writes Z instead of +00:00. The Javadoc says:

"Default is true in Jackson 3.0; was effectively false in 2.x."

The relevant code in Jackson 3:
if (_writeZeroOffsetAsZ) {
    buffer.append('Z');
} else {
    _appendOffset(buffer, 0);  // legacy "+00:00" behavior
}

Note that both are semantically equivalent ISO-8601, just different string representations.

