### PR TITLE
Eliminate FFM downcall warning in dev-mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeCommandLineBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeCommandLineBuilder.java
@@ -444,6 +444,7 @@ public class DevModeCommandLineBuilder {
 
             manifest.getMainAttributes().put(Attributes.Name.CLASS_PATH, classPathManifest.toString());
             manifest.getMainAttributes().put(Attributes.Name.MAIN_CLASS, DevModeMain.class.getName());
+            manifest.getMainAttributes().put(new Attributes.Name("Enable-Native-Access"), "ALL-UNNAMED");
             out.putNextEntry(new ZipEntry("META-INF/MANIFEST.MF"));
             manifest.write(out);
 


### PR DESCRIPTION
I'm not happy about this as this means dev-mode allows native access in a totally coarse manner, but there isn't any other way I'm aware of (short of not making the call) that would suppress the warning.

The current situation is not great as users see a scary warning that is not their problem which would require a super ugly command line property to be set to silence on their end

- Fixes: #55835