### PR TITLE
Force re-authentication when the OIDC session token state is no longer available

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -1301,6 +1301,10 @@ public class CustomTokenStateManager implements TokenStateManager {
 }
 ----
 
+If the tokens are kept in an external storage, this storage might no longer have them, for example, because they have expired and were evicted or removed.
+In this case, the custom `TokenStateManager#getTokens` method must either return a `null` value or fail with `io.quarkus.security.AuthenticationFailedException`.
+Both options are treated the same way: the session cookie is removed and the user is redirected to the OIDC provider to re-authenticate.
+
 For information about the default `TokenStateManager` storing tokens in an encrypted session cookie, see <<token-state-manager>>.
 
 ifndef::no-quarkus-oidc-db-token-state-manager[]

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/AbstractDbTokenStateManagerTest.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/AbstractDbTokenStateManagerTest.java
@@ -89,6 +89,46 @@ public abstract class AbstractDbTokenStateManagerTest {
         }
     }
 
+    @Test
+    public void testTokenStateIsNoLongerAvailable() throws IOException {
+
+        try (final WebClient webClient = createWebClient()) {
+
+            HtmlPage page = webClient.getPage(url.toString() + "protected");
+
+            assertEquals("Sign in to quarkus", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+
+            loginForm.getButtonByName("login").click();
+
+            assertTokenStateCount(1);
+
+            // the token state may have expired and been removed from the database,
+            // in which case the user must be redirected to re-authenticate
+            deleteTokenStates();
+
+            webClient.getOptions().setRedirectEnabled(false);
+            WebResponse webResponse = webClient
+                    .loadWebResponse(new WebRequest(URI.create(url.toString() + "protected").toURL()));
+            assertEquals(302, webResponse.getStatusCode());
+            assertNull(webClient.getCookieManager().getCookie("q_session"));
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    protected static void deleteTokenStates() {
+        RestAssured
+                .given()
+                .get("public/delete-db-state-manager-table-content")
+                .then()
+                .statusCode(204);
+    }
+
     protected static void assertTokenStateCount(Integer tokenStateCount) {
         RestAssured
                 .given()

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/PublicResource.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/PublicResource.java
@@ -42,6 +42,15 @@ public class PublicResource {
                 .toCompletionStage());
     }
 
+    @Path("/delete-db-state-manager-table-content")
+    @GET
+    public Uni<Void> deleteDbStateManagerRows() {
+        return Uni.createFrom().completionStage(pool
+                .withTransaction(client -> client.query("DELETE FROM oidc_db_token_state_manager").execute())
+                .toCompletionStage())
+                .replaceWithVoid();
+    }
+
     @Path("/db-state-manager-tokens")
     @GET
     public Uni<String> getDbStateManagerTokens() {

--- a/extensions/oidc-db-token-state-manager/runtime/src/main/java/io/quarkus/oidc/db/token/state/manager/runtime/OidcDbTokenStateManager.java
+++ b/extensions/oidc-db-token-state-manager/runtime/src/main/java/io/quarkus/oidc/db/token/state/manager/runtime/OidcDbTokenStateManager.java
@@ -12,7 +12,6 @@ import io.quarkus.oidc.AuthorizationCodeTokens;
 import io.quarkus.oidc.OidcRequestContext;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.TokenStateManager;
-import io.quarkus.security.AuthenticationCompletionException;
 import io.quarkus.security.AuthenticationFailedException;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
@@ -27,6 +26,7 @@ public class OidcDbTokenStateManager implements TokenStateManager {
     private static final Logger LOG = Logger.getLogger(OidcDbTokenStateManager.class);
     private static final String TOKEN_STATE_INSERT_FAILED = "Failed to insert token state into database";
     private static final String FAILED_TO_ACQUIRE_TOKEN = "Failed to acquire authorization code tokens";
+    private static final String TOKENS_NOT_AVAILABLE = "Authorization code tokens are not available in the database";
 
     private static final String ID_TOKEN_COLUMN = "id_token";
     private static final String ACCESS_TOKEN_COLUMN = "access_token";
@@ -96,7 +96,7 @@ public class OidcDbTokenStateManager implements TokenStateManager {
                 .onFailure().transform(new Function<Throwable, Throwable>() {
                     @Override
                     public Throwable apply(Throwable throwable) {
-                        return new AuthenticationCompletionException(FAILED_TO_ACQUIRE_TOKEN, throwable);
+                        return new AuthenticationFailedException(FAILED_TO_ACQUIRE_TOKEN, throwable);
                     }
                 })
                 .flatMap(new Function<RowSet<Row>, Uni<? extends AuthorizationCodeTokens>>() {
@@ -116,7 +116,7 @@ public class OidcDbTokenStateManager implements TokenStateManager {
                                                 firstRow.getString(ACCESS_TOKEN_SCOPE_COLUMN)));
                             }
                         }
-                        return Uni.createFrom().failure(new AuthenticationCompletionException(FAILED_TO_ACQUIRE_TOKEN));
+                        return Uni.createFrom().failure(new AuthenticationFailedException(TOKENS_NOT_AVAILABLE));
                     }
                 })
                 .memoize().indefinitely();

--- a/extensions/oidc-redis-token-state-manager/deployment/src/test/java/io/quarkus/oidc/redis/token/state/manager/deployment/AbstractRedisTokenStateManagerTest.java
+++ b/extensions/oidc-redis-token-state-manager/deployment/src/test/java/io/quarkus/oidc/redis/token/state/manager/deployment/AbstractRedisTokenStateManagerTest.java
@@ -77,6 +77,44 @@ public abstract class AbstractRedisTokenStateManagerTest {
         }
     }
 
+    @Test
+    public void testTokenStateIsNoLongerAvailable() throws IOException {
+        try (final WebClient webClient = createWebClient()) {
+
+            HtmlPage page = webClient.getPage(url.toString() + "protected");
+
+            assertEquals("Sign in to quarkus", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+
+            loginForm.getButtonByName("login").click();
+
+            assertTokenStateCount(1);
+
+            // Redis may have evicted the token state, the user must be redirected to re-authenticate
+            deleteTokenStates();
+
+            webClient.getOptions().setRedirectEnabled(false);
+            WebResponse webResponse = webClient
+                    .loadWebResponse(new WebRequest(URI.create(url.toString() + "protected").toURL()));
+            assertEquals(302, webResponse.getStatusCode());
+            assertNull(webClient.getCookieManager().getCookie("q_session"));
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    protected static void deleteTokenStates() {
+        RestAssured
+                .given()
+                .get("public/delete-oidc-token-states")
+                .then()
+                .statusCode(200);
+    }
+
     protected static void assertTokenStateCount(Integer tokenStateCount) {
         RestAssured
                 .given()

--- a/extensions/oidc-redis-token-state-manager/deployment/src/test/java/io/quarkus/oidc/redis/token/state/manager/deployment/PublicResource.java
+++ b/extensions/oidc-redis-token-state-manager/deployment/src/test/java/io/quarkus/oidc/redis/token/state/manager/deployment/PublicResource.java
@@ -32,4 +32,12 @@ public class PublicResource {
         return dataSource.key().keys("oidc:token:*").map(l -> (long) l.size());
     }
 
+    @Path("delete-oidc-token-states")
+    @GET
+    public Uni<Integer> deleteOidcTokenStates() {
+        return dataSource.key().keys("oidc:token:*")
+                .flatMap(keys -> keys.isEmpty() ? Uni.createFrom().item(0)
+                        : dataSource.key().del(keys.toArray(new String[0])).replaceWith(keys.size()));
+    }
+
 }

--- a/extensions/oidc-redis-token-state-manager/runtime/src/main/java/io/quarkus/oidc/redis/token/state/manager/runtime/OidcRedisTokenStateManager.java
+++ b/extensions/oidc-redis-token-state-manager/runtime/src/main/java/io/quarkus/oidc/redis/token/state/manager/runtime/OidcRedisTokenStateManager.java
@@ -12,7 +12,6 @@ import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.TokenStateManager;
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.value.SetArgs;
-import io.quarkus.security.AuthenticationCompletionException;
 import io.quarkus.security.AuthenticationFailedException;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
@@ -20,6 +19,8 @@ import io.vertx.ext.web.RoutingContext;
 final class OidcRedisTokenStateManager implements TokenStateManager {
 
     private static final String REDIS_KEY_PREFIX = "oidc:token:";
+    private static final String FAILED_TO_ACQUIRE_TOKENS = "Failed to acquire authorization code tokens";
+    private static final String TOKENS_NOT_AVAILABLE = "Authorization code tokens are not available in Redis";
     private final ReactiveRedisDataSource dataSource;
 
     OidcRedisTokenStateManager(ReactiveRedisDataSource dataSource) {
@@ -37,8 +38,9 @@ final class OidcRedisTokenStateManager implements TokenStateManager {
     public Uni<AuthorizationCodeTokens> getTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig, String tokenState,
             OidcRequestContext<AuthorizationCodeTokens> requestContext) {
         return dataSource.value(AuthorizationCodeTokensRecord.class).get(toTokenKey(tokenState))
-                .onItem().ifNotNull().transform(AuthorizationCodeTokensRecord::toTokens)
-                .onFailure().transform(AuthenticationCompletionException::new);
+                .onFailure().transform(t -> new AuthenticationFailedException(FAILED_TO_ACQUIRE_TOKENS, t))
+                .onItem().ifNull().failWith(() -> new AuthenticationFailedException(TOKENS_NOT_AVAILABLE))
+                .onItem().ifNotNull().transform(AuthorizationCodeTokensRecord::toTokens);
     }
 
     @Override

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowMissingTokenStateTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowMissingTokenStateTest.java
@@ -1,0 +1,71 @@
+package io.quarkus.oidc.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
+
+@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+public class CodeFlowMissingTokenStateTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(ProtectedResource.class, MissingTokenStateManager.class,
+                            MissingTokenStateResource.class)
+                    .addAsResource("application-missing-token-state.properties", "application.properties"));
+
+    @Test
+    public void testTokenStateManagerReturnsNullTokens() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+
+            HtmlPage page = webClient.getPage("http://localhost:8081/protected");
+
+            assertEquals("Sign in to quarkus", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+
+            page = loginForm.getButtonByName("login").click();
+
+            assertEquals("alice", page.getBody().asNormalizedText());
+            assertTrue(hasSessionCookie(webClient));
+
+            // the token state is no longer available, the user must be redirected to re-authenticate
+            TextPage textPage = webClient.getPage("http://localhost:8081/lose-token-state");
+            assertEquals("token state lost", textPage.getContent());
+
+            webClient.getOptions().setRedirectEnabled(false);
+            webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+
+            textPage = webClient.getPage("http://localhost:8081/protected");
+            assertEquals(302, textPage.getWebResponse().getStatusCode());
+            assertFalse(hasSessionCookie(webClient));
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    private static boolean hasSessionCookie(WebClient webClient) {
+        return webClient.getCookieManager().getCookies().stream().anyMatch(c -> c.getName().startsWith("q_session"));
+    }
+
+    private WebClient createWebClient() {
+        WebClient webClient = new WebClient();
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        return webClient;
+    }
+}

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/MissingTokenStateManager.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/MissingTokenStateManager.java
@@ -1,0 +1,56 @@
+package io.quarkus.oidc.test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
+
+import io.quarkus.oidc.AuthorizationCodeTokens;
+import io.quarkus.oidc.OidcRequestContext;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.TokenStateManager;
+import io.quarkus.oidc.runtime.DefaultTokenStateManager;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Token state manager which simulates an external storage that has lost the token state,
+ * by returning a null value from {@link #getTokens} instead of failing with an exception.
+ */
+@ApplicationScoped
+@Alternative
+@Priority(1)
+public class MissingTokenStateManager implements TokenStateManager {
+
+    private final AtomicBoolean tokenStateIsMissing = new AtomicBoolean();
+
+    @Inject
+    DefaultTokenStateManager tokenStateManager;
+
+    void loseTokenState() {
+        tokenStateIsMissing.set(true);
+    }
+
+    @Override
+    public Uni<String> createTokenState(RoutingContext routingContext, OidcTenantConfig oidcConfig,
+            AuthorizationCodeTokens tokens, OidcRequestContext<String> requestContext) {
+        return tokenStateManager.createTokenState(routingContext, oidcConfig, tokens, requestContext);
+    }
+
+    @Override
+    public Uni<AuthorizationCodeTokens> getTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig,
+            String tokenState, OidcRequestContext<AuthorizationCodeTokens> requestContext) {
+        if (tokenStateIsMissing.get()) {
+            return Uni.createFrom().nullItem();
+        }
+        return tokenStateManager.getTokens(routingContext, oidcConfig, tokenState, requestContext);
+    }
+
+    @Override
+    public Uni<Void> deleteTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig, String tokenState,
+            OidcRequestContext<Void> requestContext) {
+        return tokenStateManager.deleteTokens(routingContext, oidcConfig, tokenState, requestContext);
+    }
+}

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/MissingTokenStateResource.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/MissingTokenStateResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.oidc.test;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/lose-token-state")
+public class MissingTokenStateResource {
+
+    @Inject
+    MissingTokenStateManager tokenStateManager;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String loseTokenState() {
+        tokenStateManager.loseTokenState();
+        return "token state lost";
+    }
+}

--- a/extensions/oidc/deployment/src/test/resources/application-missing-token-state.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-missing-token-state.properties
@@ -1,0 +1,9 @@
+# Disable Dev Services, we use a test resource manager
+quarkus.keycloak.devservices.enabled=false
+
+quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.client-id=quarkus-web-app
+quarkus.oidc.credentials.secret=secret
+quarkus.oidc.application-type=web-app
+
+quarkus.log.category."org.htmlunit".level=ERROR

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TokenStateManager.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TokenStateManager.java
@@ -29,13 +29,18 @@ public interface TokenStateManager {
 
     /**
      * Convert the token state into the authorization code flow tokens.
+     * <p>
+     * The token state may no longer be available, for example, when the tokens were kept in an external
+     * storage which has since evicted or removed them. In this case the implementation must either return
+     * a null value or fail with {@link io.quarkus.security.AuthenticationFailedException}: both are treated
+     * the same way and force the user to re-authenticate with the OIDC provider.
      *
      * @param routingContext the request context
      * @param oidcConfig the tenant configuration
      * @param tokenState the token state
      * @param requestContext the request context
      *
-     * @return the authorization code flow tokens
+     * @return the authorization code flow tokens, may be null if the token state is no longer available
      */
     Uni<AuthorizationCodeTokens> getTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig,
             String tokenState, OidcRequestContext<AuthorizationCodeTokens> requestContext);

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import org.eclipse.microprofile.jwt.Claims;
@@ -365,6 +366,15 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
         context.put(TenantConfigContext.class.getName(), configContext);
         return resolver.getTokenStateManager().getTokens(context, configContext.oidcConfig(),
                 sessionCookie, getTokenStateRequestContext)
+                // TokenStateManager implementations are allowed to report the missing token state
+                // by returning a null value instead of failing with AuthenticationFailedException
+                .onItem().ifNull().failWith(new Supplier<Throwable>() {
+                    @Override
+                    public Throwable get() {
+                        LOG.debug("Session token state is not available, reauthentication is required");
+                        return new AuthenticationFailedException("Authorization code flow tokens are not available");
+                    }
+                })
                 .onFailure(Throwable.class)
                 .recoverWithUni(
                         new Function<Throwable, Uni<? extends AuthorizationCodeTokens>>() {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
and the AI/LLM usage policy at https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md
-->
When the authorization code tokens are stored server-side, the storage can
legitimately no longer have them: 
- the Redis TTL elapsed before the sessioncookie did
- the key was evicted or the instance restarted
- the user logged out and an old cookie was replayed
- the cookie value is simply arbitrary.

`OidcRedisTokenStateManager#getTokens` emitted `null` in that case.
`CodeAuthenticationMechanism#reAuthenticate` only recover from a failure, not
from a null item, so the tokens were dereferenced and the request failed with an
NPE and an HTTP 500. Because the recovery path was bypassed, the session cookie
was never cleared and every subsequent request failed the same way until the
user cleared their cookies manually. An unauthenticated client could trigger it by sending an
arbitrary `q_session` cookie.

Both server-side token state managers now fail with `AuthenticationFailedException`
when the state is absent, so the session cookie is removed and the user is
redirected to the OIDC provider. `CodeAuthenticationMechanism` also treats a `null`
result the same way, so third-party `TokenStateManager` implementations cannot hit
the same trap, and the `TokenStateManager` Javadoc and the code flow guide now
document that both `null` and `AuthenticationFailedException` are permitted.

Note that `OidcDbTokenStateManager` previously raised `AuthenticationCompletionException`
when the query returned no rows, resulting in a 401 instead of re-authentication;
it now behaves like the Redis one.

Fixes #56165

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

