### PR TITLE
Upgrade Jackson to 3.1.4 in BOM

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -91,7 +91,8 @@
         <graal-sdk.version>23.1.2</graal-sdk.version>
         <gizmo.version>1.10.1</gizmo.version>
         <gizmo2.version>2.1.1</gizmo2.version>
-        <jackson-bom.version>2.22.2</jackson-bom.version>
+        <jackson-bom.version>3.1.4</jackson-bom.version>
+        <jackson2-bom.version>2.22.2</jackson2-bom.version>
         <commons-logging-jboss-logging.version>2.0.0.Final</commons-logging-jboss-logging.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <commons-codec.version>1.22.1</commons-codec.version>
@@ -385,11 +386,19 @@
             </dependency>
 
             <!-- Jackson dependencies, imported as a BOM -->
-            <!-- TODO: remove -->
+            <dependency>
+                <groupId>tools.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <!-- Jackson 2.x dependencies, imported as a BOM, still enforced while some components have not yet migrated to Jackson 3.x -->
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>${jackson-bom.version}</version>
+                <version>${jackson2-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Forgotten when @geoand updated main to Jackson 3.x

Running CI in my fork, then I'll remove draft state here.