### PR TITLE
Decouple types discovery and generation of reflection-free Jackson serializers

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -119,8 +120,14 @@ public abstract class JacksonCodeGenerator {
     protected final BuildProducer<GeneratedClassBuildItem> generatedClassBuildItemBuildProducer;
     protected final IndexView jandexIndex;
 
-    protected final Set<String> generatedClassNames = new HashSet<>();
-    protected final Deque<ClassInfo> toBeGenerated = new ArrayDeque<>();
+    private final Set<String> generatedClassNames = new HashSet<>();
+    private final Deque<TypeEntry> toBeGenerated = new ArrayDeque<>();
+
+    record TypeEntry(ClassInfo classInfo, Map<String, Type> typeBindings) {
+        TypeEntry(ClassInfo classInfo) {
+            this(classInfo, Map.of());
+        }
+    }
 
     protected JacksonCodeGenerator(BuildProducer<GeneratedClassBuildItem> generatedClassBuildItemBuildProducer,
             IndexView jandexIndex) {
@@ -130,17 +137,20 @@ public abstract class JacksonCodeGenerator {
 
     protected abstract String getSuperClassName();
 
-    protected String[] getInterfacesNames(ClassInfo classInfo) {
-        return EMPTY_STRING_ARRAY;
-    }
-
     protected abstract String getClassSuffix();
 
     public Collection<String> create(Collection<ClassInfo> classInfos) {
+        return createFromTypes(classInfos.stream()
+                .map(ci -> org.jboss.jandex.Type.create(ci.name(), Type.Kind.CLASS))
+                .toList());
+    }
+
+    public Collection<String> createFromTypes(Collection<Type> types) {
         Set<String> createdClasses = new HashSet<>();
-        for (ClassInfo classInfo : classInfos) {
-            if (shouldGenerateCodeFor(classInfo)) {
-                toBeGenerated.add(classInfo);
+        for (Type type : types) {
+            ClassInfo classInfo = jandexIndex.getClassByName(type.name());
+            if (classInfo != null && shouldGenerateCodeFor(classInfo)) {
+                toBeGenerated.add(new TypeEntry(classInfo, computeBindings(classInfo, type, Map.of())));
             }
         }
 
@@ -151,7 +161,8 @@ public abstract class JacksonCodeGenerator {
         return createdClasses;
     }
 
-    private Optional<String> create(ClassInfo classInfo) {
+    private Optional<String> create(TypeEntry entry) {
+        ClassInfo classInfo = entry.classInfo();
         String beanClassName = classInfo.name().toString();
         if (vetoedClass(classInfo, beanClassName) || !generatedClassNames.add(beanClassName)) {
             return Optional.empty();
@@ -167,10 +178,10 @@ public abstract class JacksonCodeGenerator {
 
         try (ClassCreator classCreator = new ClassCreator(
                 new GeneratedClassGizmoAdaptor(generatedClassBuildItemBuildProducer, true), generatedClassName, null,
-                getSuperClassName(), getInterfacesNames(classInfo))) {
+                getSuperClassName())) {
 
             createConstructor(classCreator, beanClassName);
-            boolean valid = createSerializationMethod(classInfo, classCreator, beanClassName);
+            boolean valid = createSerializationMethod(classInfo, classCreator, beanClassName, entry.typeBindings());
             return valid ? Optional.of(generatedClassName) : Optional.empty();
         }
     }
@@ -183,7 +194,56 @@ public abstract class JacksonCodeGenerator {
         constructor.returnVoid();
     }
 
-    protected abstract boolean createSerializationMethod(ClassInfo classInfo, ClassCreator classCreator, String beanClassName);
+    protected abstract boolean createSerializationMethod(ClassInfo classInfo, ClassCreator classCreator, String beanClassName,
+            Map<String, Type> typeBindings);
+
+    protected abstract boolean discoverFieldTypes(ClassInfo classInfo, String beanClassName,
+            Map<String, Type> typeBindings);
+
+    protected Set<String> discoverIgnoredProperties(ClassInfo classInfo) {
+        Set<String> ignoredProperties = new HashSet<>(getIgnoredProperties(classInfo));
+        MethodInfo anyGetterMethod = findAnyGetterMethod(classInfo);
+        if (anyGetterMethod != null) {
+            ignoredProperties.add(anyGetterBackingFieldName(anyGetterMethod));
+        } else {
+            FieldInfo anyGetterField = findAnyGetterField(classInfo);
+            if (anyGetterField != null) {
+                ignoredProperties.add(anyGetterField.name());
+            }
+        }
+        return ignoredProperties;
+    }
+
+    Set<String> discoverTypes(ClassInfo rootType) {
+        return discoverTypes(rootType, Map.of());
+    }
+
+    Set<String> discoverTypes(ClassInfo rootType, Map<String, Type> typeBindings) {
+        Set<String> discoveredTypes = new HashSet<>();
+
+        if (shouldGenerateCodeFor(rootType)) {
+            toBeGenerated.add(new TypeEntry(rootType, typeBindings));
+        }
+
+        while (!toBeGenerated.isEmpty()) {
+            TypeEntry entry = toBeGenerated.removeFirst();
+            ClassInfo classInfo = entry.classInfo();
+            String beanClassName = classInfo.name().toString();
+
+            if (vetoedClass(classInfo, beanClassName) || !generatedClassNames.add(beanClassName)) {
+                continue;
+            }
+            if (findUnknownAnnotation(classInfo).isPresent()) {
+                continue;
+            }
+
+            if (discoverFieldTypes(classInfo, beanClassName, entry.typeBindings())) {
+                discoveredTypes.add(beanClassName);
+            }
+        }
+
+        return discoveredTypes;
+    }
 
     protected Collection<FieldInfo> classFields(ClassInfo classInfo) {
         Collection<FieldInfo> fields = new ArrayList<>();
@@ -245,7 +305,7 @@ public abstract class JacksonCodeGenerator {
                 || className.startsWith("tools.jackson.databind.");
     }
 
-    private Optional<String> findUnknownAnnotation(ClassInfo classInfo) {
+    protected Optional<String> findUnknownAnnotation(ClassInfo classInfo) {
         Optional<String> unknown = classInfo.annotations().stream()
                 .map(a -> a.name().toString())
                 .filter(FieldSpecs::isUnknownAnnotation)
@@ -281,35 +341,48 @@ public abstract class JacksonCodeGenerator {
     private static final DotName SET_NAME = DotName.createSimple(Set.class);
     protected static final DotName MAP_NAME = DotName.createSimple(Map.class);
 
-    protected FieldKind registerTypeToBeGenerated(Type fieldType, String typeName) {
+    protected FieldKind classifyFieldType(Type fieldType, String typeName) {
         if (fieldType instanceof TypeVariable) {
             return FieldKind.TYPE_VARIABLE;
         }
-        if (fieldType instanceof ArrayType aType) {
-            registerTypeToBeGenerated(aType.constituent());
+        if (fieldType instanceof ArrayType) {
             return FieldKind.ARRAY;
         }
         if (fieldType instanceof ParameterizedType pType) {
             if (pType.arguments().size() == 1) {
                 if (isAssignableTo(typeName, SET_NAME)) {
-                    registerTypeToBeGenerated(pType.arguments().get(0));
                     return FieldKind.SET;
                 }
                 if (typeName.equals("java.lang.Iterable") || isAssignableTo(typeName, COLLECTION_NAME)) {
-                    registerTypeToBeGenerated(pType.arguments().get(0));
                     return FieldKind.LIST;
                 }
-                registerTypeToBeGenerated(pType.arguments().get(0));
                 return FieldKind.WRAPPER;
             }
             if (pType.arguments().size() == 2 && isAssignableTo(typeName, MAP_NAME)) {
-                registerTypeToBeGenerated(pType.arguments().get(0));
-                registerTypeToBeGenerated(pType.arguments().get(1));
                 return FieldKind.MAP;
             }
         }
-        registerTypeToBeGenerated(typeName);
         return FieldKind.OBJECT;
+    }
+
+    protected void registerTypeToBeGenerated(Type fieldType, String typeName, Map<String, Type> typeBindings) {
+        switch (classifyFieldType(fieldType, typeName)) {
+            case TYPE_VARIABLE -> {
+                Type resolved = typeBindings.get(((TypeVariable) fieldType).identifier());
+                if (resolved != null) {
+                    registerTypeToBeGenerated(resolved, resolved.name().toString(), typeBindings);
+                }
+            }
+            case ARRAY -> registerTypeToBeGenerated(((ArrayType) fieldType).constituent(), typeBindings);
+            case SET, LIST, WRAPPER ->
+                registerTypeToBeGenerated(((ParameterizedType) fieldType).arguments().get(0), typeBindings);
+            case MAP -> {
+                ParameterizedType pType = (ParameterizedType) fieldType;
+                registerTypeToBeGenerated(pType.arguments().get(0), typeBindings);
+                registerTypeToBeGenerated(pType.arguments().get(1), typeBindings);
+            }
+            case OBJECT -> registerTypeToBeGenerated(typeName);
+        }
     }
 
     protected boolean isAssignableTo(String typeName, DotName targetName) {
@@ -333,12 +406,19 @@ public abstract class JacksonCodeGenerator {
         return false;
     }
 
-    private void registerTypeToBeGenerated(Type type) {
+    private void registerTypeToBeGenerated(Type type, Map<String, Type> typeBindings) {
+        if (type instanceof TypeVariable tv) {
+            Type resolved = typeBindings.get(tv.identifier());
+            if (resolved != null) {
+                registerTypeToBeGenerated(resolved, typeBindings);
+            }
+            return;
+        }
         // a type argument can be parameterized itself, like the List<Foo> in a Map<String, List<Foo>>,
         // so recurse to reach the Foo nested in it
         if (type instanceof ParameterizedType pType) {
             for (Type argument : pType.arguments()) {
-                registerTypeToBeGenerated(argument);
+                registerTypeToBeGenerated(argument, typeBindings);
             }
         }
         registerTypeToBeGenerated(type.name().toString());
@@ -358,8 +438,31 @@ public abstract class JacksonCodeGenerator {
             return;
         }
         if (shouldGenerateCodeFor(classInfo)) {
-            toBeGenerated.add(classInfo);
+            toBeGenerated.add(new TypeEntry(classInfo));
         }
+    }
+
+    private Map<String, Type> computeBindings(ClassInfo classInfo, Type type, Map<String, Type> parentBindings) {
+        if (!(type instanceof ParameterizedType pType)) {
+            return Map.of();
+        }
+        List<TypeVariable> typeParams = classInfo.typeParameters();
+        List<Type> typeArgs = pType.arguments();
+        if (typeParams.isEmpty() || typeArgs.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Type> bindings = new HashMap<>();
+        for (int i = 0; i < typeParams.size() && i < typeArgs.size(); i++) {
+            Type argType = typeArgs.get(i);
+            if (argType instanceof TypeVariable tv) {
+                Type resolved = parentBindings.get(tv.identifier());
+                if (resolved != null) {
+                    argType = resolved;
+                }
+            }
+            bindings.put(typeParams.get(i).identifier(), argType);
+        }
+        return bindings;
     }
 
     private static boolean isRuntimeAccessible(ClassInfo classInfo, String className) {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
@@ -235,12 +235,66 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
         return "$quarkusjacksondeserializer";
     }
 
-    protected String[] getInterfacesNames(ClassInfo classInfo) {
-        return new String[0];
+    @Override
+    protected boolean discoverFieldTypes(ClassInfo classInfo, String beanClassName, Map<String, Type> typeBindings) {
+        Optional<MethodInfo> ctorOpt = findConstructor(classInfo);
+        if (ctorOpt.isEmpty()) {
+            return false;
+        }
+
+        if (!isClassFormatShapeArray(classInfo) && isAssignableTo(beanClassName, MAP_NAME)) {
+            return true;
+        }
+
+        MethodInfo ctor = ctorOpt.get();
+        PropertyNamingStrategy namingStrategy = getNamingStrategy(classInfo);
+
+        if (ctor.parametersCount() > 0) {
+            for (MethodParameterInfo paramInfo : ctor.parameters()) {
+                FieldSpecs fieldSpecs = fieldSpecsFromFieldParam(classInfo, paramInfo, namingStrategy);
+                registerTypeToBeGenerated(fieldSpecs.fieldType, fieldSpecs.fieldType.name().toString(), typeBindings);
+            }
+        }
+
+        Set<String> ignoredProperties = discoverIgnoredProperties(classInfo);
+
+        Set<String> processedFields = new HashSet<>();
+        Set<String> boundFieldNames = new HashSet<>();
+
+        for (FieldInfo fieldInfo : classFields(classInfo)) {
+            FieldSpecs fieldSpecs = fieldSpecsFromField(classInfo, ctor, fieldInfo, namingStrategy);
+            if (fieldSpecs != null) {
+                boundFieldNames.add(fieldSpecs.fieldName);
+            }
+            if (fieldSpecs != null && processedFields.add(fieldSpecs.jsonName)) {
+                if (!fieldSpecs.isIgnoredField() && !fieldSpecs.isBackReference()
+                        && !isFieldTypeIgnored(fieldSpecs) && !ignoredProperties.contains(fieldSpecs.jsonName)) {
+                    registerTypeToBeGenerated(fieldSpecs.fieldType, fieldSpecs.fieldType.name().toString(), typeBindings);
+                }
+            }
+        }
+
+        for (MethodInfo methodInfo : classMethods(classInfo)) {
+            FieldSpecs fieldSpecs = fieldSpecsFromMethod(methodInfo, namingStrategy);
+            if (fieldSpecs != null && !boundFieldNames.contains(fieldSpecs.fieldName)
+                    && processedFields.add(fieldSpecs.jsonName)) {
+                if (!fieldSpecs.isIgnoredField() && !fieldSpecs.isBackReference()
+                        && !isFieldTypeIgnored(fieldSpecs) && !ignoredProperties.contains(fieldSpecs.jsonName)) {
+                    registerTypeToBeGenerated(fieldSpecs.fieldType, fieldSpecs.fieldType.name().toString(), typeBindings);
+                }
+            }
+        }
+
+        return true;
     }
 
     @Override
-    protected boolean createSerializationMethod(ClassInfo classInfo, ClassCreator classCreator, String beanClassName) {
+    protected boolean createSerializationMethod(ClassInfo classInfo, ClassCreator classCreator, String beanClassName,
+            Map<String, Type> typeBindings) {
+        if (!discoverFieldTypes(classInfo, beanClassName, typeBindings)) {
+            return false;
+        }
+
         MethodCreator deserialize = classCreator
                 .getMethodCreator("deserialize", Object.class, JsonParser.class, DeserializationContext.class)
                 .setModifiers(ACC_PUBLIC)
@@ -906,7 +960,7 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
             return null;
         }
 
-        FieldKind fieldKind = registerTypeToBeGenerated(fieldType, fieldTypeName);
+        FieldKind fieldKind = classifyFieldType(fieldType, fieldTypeName);
         ResultHandle typeHandle = switch (fieldKind) {
             case TYPE_VARIABLE -> readTypeVariable(classCreator, bytecode, fieldType.asTypeVariable(), typeParametersIndex);
             case LIST, SET, WRAPPER, MAP -> {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
@@ -191,9 +191,16 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
 
     @Override
     public Collection<String> create(Collection<ClassInfo> classInfos) {
-        Collection<String> createdClasses = super.create(classInfos);
+        Collection<String> result = super.create(classInfos);
         createFieldNamesClass();
-        return createdClasses;
+        return result;
+    }
+
+    @Override
+    public Collection<String> createFromTypes(Collection<Type> types) {
+        Collection<String> result = super.createFromTypes(types);
+        createFieldNamesClass();
+        return result;
     }
 
     private void createFieldNamesClass() {
@@ -225,6 +232,39 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
     }
 
     @Override
+    protected boolean discoverFieldTypes(ClassInfo classInfo, String beanClassName, Map<String, Type> typeBindings) {
+        var jsonValueFieldSpecs = jsonValueFieldSpecs(classInfo);
+        if (jsonValueFieldSpecs.isEmpty() && classInfo.hasAnnotation(JsonValue.class)) {
+            return false;
+        }
+        if (jsonValueFieldSpecs.isPresent()) {
+            return true;
+        }
+        boolean isArrayShape = isClassFormatShapeArray(classInfo);
+        if (!isArrayShape && isAssignableTo(beanClassName, MAP_NAME)) {
+            return true;
+        }
+
+        Set<String> ignoredProperties = discoverIgnoredProperties(classInfo);
+
+        PropertyNamingStrategy namingStrategy = getNamingStrategy(classInfo);
+        List<FieldSpecs> allFieldSpecs = collectAllFieldSpecs(classInfo, namingStrategy);
+        Set<String> serializedFields = new HashSet<>();
+
+        for (FieldSpecs fieldSpecs : allFieldSpecs) {
+            if (serializedFields.add(fieldSpecs.jsonName)) {
+                if (fieldSpecs.isIgnoredField() || ignoredProperties.contains(fieldSpecs.jsonName)
+                        || fieldSpecs.isBackReference() || isFieldTypeIgnored(fieldSpecs)) {
+                    continue;
+                }
+                registerTypeToBeGenerated(fieldSpecs.fieldType, fieldSpecs.fieldType.name().toString(), typeBindings);
+            }
+        }
+
+        return true;
+    }
+
+    @Override
     protected String getSuperClassName() {
         return SUPER_CLASS_NAME;
     }
@@ -235,12 +275,13 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
     }
 
     @Override
-    protected boolean createSerializationMethod(ClassInfo classInfo, ClassCreator classCreator, String beanClassName) {
-        var jsonValueFieldSpecs = jsonValueFieldSpecs(classInfo);
-        if (jsonValueFieldSpecs == null) {
+    protected boolean createSerializationMethod(ClassInfo classInfo, ClassCreator classCreator, String beanClassName,
+            Map<String, Type> typeBindings) {
+        if (!discoverFieldTypes(classInfo, beanClassName, typeBindings)) {
             return false;
         }
 
+        var jsonValueFieldSpecs = jsonValueFieldSpecs(classInfo);
         boolean isJsonValue = jsonValueFieldSpecs.isPresent();
         boolean isArrayShape = !isJsonValue && isClassFormatShapeArray(classInfo);
         boolean isMapSubclass = !isJsonValue && !isArrayShape && isAssignableTo(beanClassName, MAP_NAME);
@@ -346,13 +387,7 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
                 .findFirst().map(FieldSpecs::new);
 
         if (jsonValueFieldFieldSpecs.isPresent()) {
-            return jsonValueMethodFieldSpecs.isPresent() ? null : jsonValueFieldFieldSpecs;
-        }
-        //  If none valid reflection-free JsonValue annotated target has been found,but
-        //  a non-public element annotated is present, just use standard Jackson
-        //  serializer
-        if (jsonValueMethodFieldSpecs.isEmpty() && jsonValueAnnotationFound) {
-            return null;
+            return jsonValueMethodFieldSpecs.isPresent() ? Optional.empty() : jsonValueFieldFieldSpecs;
         }
         return jsonValueMethodFieldSpecs;
     }
@@ -610,8 +645,6 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
         bytecode = checkInclude(bytecode, ctx, arg, fieldSpecs, classInclude);
 
         if (fieldSpecs.isUnwrapped()) {
-            String typeName = fieldSpecs.fieldType.name().toString();
-            registerTypeToBeGenerated(fieldSpecs.fieldType, typeName);
             MethodDescriptor serializeUnwrapped = MethodDescriptor.ofMethod(JacksonMapperUtil.class.getName(),
                     "serializeUnwrapped", void.class, Object.class, JsonGenerator.class,
                     SerializationContext.class, Set.class, String.class, String.class);
@@ -820,7 +853,7 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
         } else {
             FieldKind fieldKind = null;
             if (pkgName != null) {
-                fieldKind = registerTypeToBeGenerated(fieldSpecs.fieldType, typeName);
+                fieldKind = classifyFieldType(fieldSpecs.fieldType, typeName);
                 writeFieldName(fieldSpecs, bytecode, ctx, pkgName);
             }
 

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
@@ -407,39 +407,44 @@ public class ResteasyReactiveJacksonProcessor {
             additionalUnwrapTypes.add(item.getWrapperType());
         }
 
-        Map<String, ClassInfo> serializedClasses = new HashMap<>();
-        Map<String, ClassInfo> deserializedClasses = new HashMap<>();
+        Map<String, Type> serializedTypes = new HashMap<>();
+        Map<String, Type> deserializedTypes = new HashMap<>();
 
         for (ResteasyReactiveResourceMethodEntriesBuildItem.Entry entry : resourceMethodEntries.getEntries()) {
             MethodInfo methodInfo = entry.getMethodInfo();
-            ClassInfo effectiveReturnClassInfo = getEffectiveClassInfo(methodInfo.returnType(), indexView,
-                    additionalUnwrapTypes);
-            if (effectiveReturnClassInfo != null && !effectiveReturnClassInfo.isEnum()) {
-                serializedClasses.put(effectiveReturnClassInfo.name().toString(), effectiveReturnClassInfo);
+            Type effectiveReturnType = getEffectiveType(methodInfo.returnType(), additionalUnwrapTypes);
+            if (effectiveReturnType != null) {
+                ClassInfo classInfo = indexView.getClassByName(effectiveReturnType.name());
+                if (classInfo != null && !classInfo.isEnum()) {
+                    serializedTypes.put(classInfo.name().toString(), effectiveReturnType);
+                }
             }
 
             if (methodInfo.hasAnnotation(POST.class) || methodInfo.hasAnnotation(PUT.class)
                     || methodInfo.hasAnnotation(PATCH.class)) {
                 for (Type paramType : methodInfo.parameterTypes()) {
-                    ClassInfo effectiveParamClassInfo = getEffectiveClassInfo(paramType, indexView, additionalUnwrapTypes);
-                    if (effectiveParamClassInfo != null) {
-                        deserializedClasses.put(effectiveParamClassInfo.name().toString(), effectiveParamClassInfo);
+                    Type effectiveParamType = getEffectiveType(paramType, additionalUnwrapTypes);
+                    if (effectiveParamType != null) {
+                        ClassInfo classInfo = indexView.getClassByName(effectiveParamType.name());
+                        if (classInfo != null) {
+                            deserializedTypes.put(classInfo.name().toString(), effectiveParamType);
+                        }
                     }
                 }
             }
         }
 
-        if (!serializedClasses.isEmpty()) {
+        if (!serializedTypes.isEmpty()) {
             JacksonSerializerFactory factory = new JacksonSerializerFactory(generatedClassBuildItemBuildProducer,
                     index.getComputingIndex());
-            factory.create(serializedClasses.values())
+            factory.createFromTypes(serializedTypes.values())
                     .forEach(recorder::recordGeneratedSerializer);
         }
 
-        if (!deserializedClasses.isEmpty()) {
+        if (!deserializedTypes.isEmpty()) {
             JacksonDeserializerFactory factory = new JacksonDeserializerFactory(generatedClassBuildItemBuildProducer,
                     index.getComputingIndex());
-            factory.create(deserializedClasses.values())
+            factory.createFromTypes(deserializedTypes.values())
                     .forEach(recorder::recordGeneratedDeserializer);
         }
     }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactoryDiscoveryTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactoryDiscoveryTest.java
@@ -1,0 +1,242 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.jboss.jandex.Type;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class JacksonDeserializerFactoryDiscoveryTest {
+
+    @Test
+    void primitiveFieldsOnly() {
+        Index index = index(SimplePojo.class);
+        Set<String> types = discover(index, SimplePojo.class);
+
+        assertThat(types).containsExactlyInAnyOrder(SimplePojo.class.getName());
+    }
+
+    @Test
+    void nestedObject() {
+        Index index = index(Root.class, Nested.class);
+        Set<String> types = discover(index, Root.class);
+
+        assertThat(types).containsExactlyInAnyOrder(Root.class.getName(), Nested.class.getName());
+    }
+
+    @Test
+    void listOfObjects() {
+        Index index = index(WithList.class, Item.class);
+        Set<String> types = discover(index, WithList.class);
+
+        assertThat(types).containsExactlyInAnyOrder(WithList.class.getName(), Item.class.getName());
+    }
+
+    @Test
+    void mapWithObjectValues() {
+        Index index = index(WithMap.class, Item.class);
+        Set<String> types = discover(index, WithMap.class);
+
+        assertThat(types).containsExactlyInAnyOrder(WithMap.class.getName(), Item.class.getName());
+    }
+
+    @Test
+    void ignoredFieldNotDiscovered() {
+        Index index = index(WithIgnoredField.class, Item.class);
+        Set<String> types = discover(index, WithIgnoredField.class);
+
+        assertThat(types).containsExactlyInAnyOrder(WithIgnoredField.class.getName());
+    }
+
+    @Test
+    void backReferenceFieldNotDiscovered() {
+        Index index = index(WithBackReference.class, Item.class);
+        Set<String> types = discover(index, WithBackReference.class);
+
+        assertThat(types).containsExactlyInAnyOrder(WithBackReference.class.getName());
+    }
+
+    @Test
+    void transitiveDiscovery() {
+        Index index = index(Level1.class, Level2.class, Level3.class);
+        Set<String> types = discover(index, Level1.class);
+
+        assertThat(types).containsExactlyInAnyOrder(
+                Level1.class.getName(), Level2.class.getName(), Level3.class.getName());
+    }
+
+    @Test
+    void constructorParamsDiscovered() {
+        Index index = index(WithCreator.class, Item.class);
+        Set<String> types = discover(index, WithCreator.class);
+
+        assertThat(types).containsExactlyInAnyOrder(WithCreator.class.getName(), Item.class.getName());
+    }
+
+    @Test
+    void noConstructorNotDiscovered() {
+        Index index = index(NoDefaultConstructor.class);
+        Set<String> types = discover(index, NoDefaultConstructor.class);
+
+        assertThat(types).isEmpty();
+    }
+
+    @Test
+    void genericDtoTypeArgumentDiscovered() {
+        Index index = index(PageDTO.class, OtherDTO.class);
+        Map<String, Type> bindings = Map.of("T",
+                Type.create(org.jboss.jandex.DotName.createSimple(OtherDTO.class.getName()), Type.Kind.CLASS));
+        Set<String> types = discover(index, PageDTO.class, bindings);
+
+        assertThat(types).containsExactlyInAnyOrder(
+                PageDTO.class.getName(), OtherDTO.class.getName());
+    }
+
+    @Test
+    void sealedInterfaceField() {
+        Index index = index(WithSealedField.class, Shape.class, Circle.class, Square.class);
+        Set<String> types = discover(index, WithSealedField.class);
+
+        assertThat(types).containsExactlyInAnyOrder(
+                WithSealedField.class.getName(), Circle.class.getName(), Square.class.getName());
+    }
+
+    // --- helpers ---
+
+    private Set<String> discover(Index index, Class<?> rootClass) {
+        return discover(index, rootClass, Map.of());
+    }
+
+    private Set<String> discover(Index index, Class<?> rootClass, Map<String, Type> typeBindings) {
+        JacksonDeserializerFactory factory = new JacksonDeserializerFactory(item -> {
+        }, index);
+        ClassInfo rootType = index.getClassByName(rootClass.getName());
+        return factory.discoverTypes(rootType, typeBindings);
+    }
+
+    private static Index index(Class<?>... classes) {
+        Indexer indexer = new Indexer();
+        for (Class<?> clazz : classes) {
+            try (InputStream stream = JacksonDeserializerFactoryDiscoveryTest.class.getClassLoader()
+                    .getResourceAsStream(clazz.getName().replace('.', '/') + ".class")) {
+                indexer.index(stream);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return indexer.complete();
+    }
+
+    // --- model classes ---
+
+    public static class SimplePojo {
+        public String name;
+        public int age;
+    }
+
+    public static class Root {
+        public String name;
+        public Nested nested;
+    }
+
+    public static class Nested {
+        public String value;
+    }
+
+    public static class WithList {
+        public List<Item> items;
+    }
+
+    public static class WithMap {
+        public Map<String, Item> entries;
+    }
+
+    public static class Item {
+        public String name;
+    }
+
+    public static class WithIgnoredField {
+        public String name;
+        @JsonIgnore
+        public Item ignored;
+    }
+
+    public static class WithBackReference {
+        public String name;
+        @JsonBackReference
+        public Item parent;
+    }
+
+    public static class Level1 {
+        public Level2 next;
+    }
+
+    public static class Level2 {
+        public Level3 deep;
+    }
+
+    public static class Level3 {
+        public String value;
+    }
+
+    public static class WithCreator {
+        public String name;
+        public Item item;
+
+        public WithCreator() {
+        }
+
+        @JsonCreator
+        public WithCreator(@JsonProperty("name") String name, @JsonProperty("item") Item item) {
+            this.name = name;
+            this.item = item;
+        }
+    }
+
+    public static class NoDefaultConstructor {
+        public String value;
+
+        public NoDefaultConstructor(String value) {
+            this.value = value;
+        }
+    }
+
+    public static class PageDTO<T> {
+        public int number;
+        public int size;
+        public List<T> content;
+    }
+
+    public static class OtherDTO {
+        public String value;
+    }
+
+    public sealed interface Shape permits Circle, Square {
+    }
+
+    public static final class Circle implements Shape {
+        public double radius;
+    }
+
+    public static final class Square implements Shape {
+        public double side;
+    }
+
+    public static class WithSealedField {
+        public String name;
+        public Shape shape;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactoryDiscoveryTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactoryDiscoveryTest.java
@@ -1,0 +1,230 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.jboss.jandex.Type;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public class JacksonSerializerFactoryDiscoveryTest {
+
+    @Test
+    void primitiveFieldsOnly() {
+        Index index = index(SimplePojo.class);
+        Set<String> types = discover(index, SimplePojo.class);
+
+        assertThat(types).containsExactlyInAnyOrder(SimplePojo.class.getName());
+    }
+
+    @Test
+    void nestedObject() {
+        Index index = index(Root.class, Nested.class);
+        Set<String> types = discover(index, Root.class);
+
+        assertThat(types).containsExactlyInAnyOrder(Root.class.getName(), Nested.class.getName());
+    }
+
+    @Test
+    void listOfObjects() {
+        Index index = index(WithList.class, Item.class);
+        Set<String> types = discover(index, WithList.class);
+
+        assertThat(types).containsExactlyInAnyOrder(WithList.class.getName(), Item.class.getName());
+    }
+
+    @Test
+    void mapWithObjectValues() {
+        Index index = index(WithMap.class, Item.class);
+        Set<String> types = discover(index, WithMap.class);
+
+        assertThat(types).containsExactlyInAnyOrder(WithMap.class.getName(), Item.class.getName());
+    }
+
+    @Test
+    void nestedParameterizedType() {
+        Index index = index(WithNestedList.class, Item.class);
+        Set<String> types = discover(index, WithNestedList.class);
+
+        assertThat(types).containsExactlyInAnyOrder(WithNestedList.class.getName(), Item.class.getName());
+    }
+
+    @Test
+    void ignoredFieldNotDiscovered() {
+        Index index = index(WithIgnoredField.class, Item.class);
+        Set<String> types = discover(index, WithIgnoredField.class);
+
+        assertThat(types).containsExactlyInAnyOrder(WithIgnoredField.class.getName());
+    }
+
+    @Test
+    void backReferenceFieldNotDiscovered() {
+        Index index = index(WithBackReference.class, Item.class);
+        Set<String> types = discover(index, WithBackReference.class);
+
+        assertThat(types).containsExactlyInAnyOrder(WithBackReference.class.getName());
+    }
+
+    @Test
+    void sealedInterfaceField() {
+        Index index = index(WithSealedField.class, Shape.class, Circle.class, Square.class);
+        Set<String> types = discover(index, WithSealedField.class);
+
+        assertThat(types).containsExactlyInAnyOrder(
+                WithSealedField.class.getName(), Circle.class.getName(), Square.class.getName());
+    }
+
+    @Test
+    void transitiveDiscovery() {
+        Index index = index(Level1.class, Level2.class, Level3.class);
+        Set<String> types = discover(index, Level1.class);
+
+        assertThat(types).containsExactlyInAnyOrder(
+                Level1.class.getName(), Level2.class.getName(), Level3.class.getName());
+    }
+
+    @Test
+    void genericDtoTypeArgumentDiscovered() {
+        Index index = index(PageDTO.class, OtherDTO.class);
+        Map<String, Type> bindings = Map.of("T",
+                Type.create(org.jboss.jandex.DotName.createSimple(OtherDTO.class.getName()), Type.Kind.CLASS));
+        Set<String> types = discover(index, PageDTO.class, bindings);
+
+        assertThat(types).containsExactlyInAnyOrder(
+                PageDTO.class.getName(), OtherDTO.class.getName());
+    }
+
+    @Test
+    void jsonValueClass() {
+        Index index = index(WithJsonValue.class);
+        Set<String> types = discover(index, WithJsonValue.class);
+
+        assertThat(types).containsExactlyInAnyOrder(WithJsonValue.class.getName());
+    }
+
+    // --- helpers ---
+
+    private Set<String> discover(Index index, Class<?> rootClass) {
+        return discover(index, rootClass, Map.of());
+    }
+
+    private Set<String> discover(Index index, Class<?> rootClass, Map<String, Type> typeBindings) {
+        JacksonSerializerFactory factory = new JacksonSerializerFactory(item -> {
+        }, index);
+        ClassInfo rootType = index.getClassByName(rootClass.getName());
+        return factory.discoverTypes(rootType, typeBindings);
+    }
+
+    private static Index index(Class<?>... classes) {
+        Indexer indexer = new Indexer();
+        for (Class<?> clazz : classes) {
+            try (InputStream stream = JacksonSerializerFactoryDiscoveryTest.class.getClassLoader()
+                    .getResourceAsStream(clazz.getName().replace('.', '/') + ".class")) {
+                indexer.index(stream);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return indexer.complete();
+    }
+
+    // --- model classes ---
+
+    public static class SimplePojo {
+        public String name;
+        public int age;
+    }
+
+    public static class Root {
+        public String name;
+        public Nested nested;
+    }
+
+    public static class Nested {
+        public String value;
+    }
+
+    public static class WithList {
+        public List<Item> items;
+    }
+
+    public static class WithMap {
+        public Map<String, Item> entries;
+    }
+
+    public static class WithNestedList {
+        public List<List<Item>> nested;
+    }
+
+    public static class Item {
+        public String name;
+    }
+
+    public static class WithIgnoredField {
+        public String name;
+        @JsonIgnore
+        public Item ignored;
+    }
+
+    public static class WithBackReference {
+        public String name;
+        @JsonBackReference
+        public Item parent;
+    }
+
+    public sealed interface Shape permits Circle, Square {
+    }
+
+    public static final class Circle implements Shape {
+        public double radius;
+    }
+
+    public static final class Square implements Shape {
+        public double side;
+    }
+
+    public static class WithSealedField {
+        public String name;
+        public Shape shape;
+    }
+
+    public static class Level1 {
+        public Level2 next;
+    }
+
+    public static class Level2 {
+        public Level3 deep;
+    }
+
+    public static class Level3 {
+        public String value;
+    }
+
+    public static class PageDTO<T> {
+        public int number;
+        public int size;
+        public List<T> content;
+    }
+
+    public static class OtherDTO {
+        public String value;
+    }
+
+    public static class WithJsonValue {
+        @JsonValue
+        public String getValue() {
+            return "test";
+        }
+    }
+}


### PR DESCRIPTION
Related to #56013

The main goal of this pull request is extracting the type discovery logic from the reflection-free Jackson serializer/deserializer generation, so that it could be tested in a separated and independent way.

In particular it adds a new `discoverTypes()` method to the `JacksonCodeGenerator` that returns the set of class names that would be selected for code generation from a given root type, without actually generating bytecode. This enables unit testing the discovery logic in isolation. 

Moreover it also fixes the missing type discovery explicitly outlined in this comment https://github.com/quarkusio/quarkus/discussions/56013#discussioncomment-18133485 by binding a type variable symbol to its actual type.

For now I'm not adding any mechanism to explicitly mark a specific class for reflection free serializer generation because I'd like that the discovery could be as automatic as possible. I will eventually add it only if and when we will find that there is a situation where it is impossible to automatically infer it.