### PR TITLE
Fix Redis cache backend type resolution

### DIFF
--- a/extensions/infinispan-cache/deployment/src/test/java/io/quarkus/cache/infinispan/MixedCacheBackendsTest.java
+++ b/extensions/infinispan-cache/deployment/src/test/java/io/quarkus/cache/infinispan/MixedCacheBackendsTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.cache.infinispan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.Cache;
+import io.quarkus.cache.CacheName;
+import io.quarkus.cache.CacheResult;
+import io.quarkus.cache.CaffeineCache;
+import io.quarkus.cache.infinispan.runtime.InfinispanCacheImpl;
+import io.quarkus.test.QuarkusExtensionTest;
+
+class MixedCacheBackendsTest {
+
+    private static final String CAFFEINE_CACHE_NAME = "caffeine-cache";
+    private static final String INFINISPAN_CACHE_NAME = "infinispan-cache";
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClass(CachedService.class))
+            .overrideConfigKey("quarkus.cache.type", "caffeine")
+            .overrideConfigKey("quarkus.cache.infinispan-cache.type", "infinispan");
+
+    @Inject
+    @CacheName(CAFFEINE_CACHE_NAME)
+    Cache caffeineCache;
+
+    @Inject
+    @CacheName(INFINISPAN_CACHE_NAME)
+    Cache infinispanCache;
+
+    @Test
+    void usesConfiguredBackendForEachCache() {
+        assertThat(caffeineCache).isInstanceOf(CaffeineCache.class);
+        assertThat(infinispanCache).isInstanceOf(InfinispanCacheImpl.class);
+    }
+
+    @ApplicationScoped
+    static class CachedService {
+
+        @CacheResult(cacheName = INFINISPAN_CACHE_NAME)
+        String cached(String key) {
+            return key;
+        }
+    }
+}

--- a/extensions/redis-cache/deployment/src/main/java/io/quarkus/cache/redis/deployment/RedisCacheProcessor.java
+++ b/extensions/redis-cache/deployment/src/main/java/io/quarkus/cache/redis/deployment/RedisCacheProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.cache.redis.deployment;
 
+import static io.quarkus.cache.redis.runtime.RedisCacheBuildRecorder.REDIS_CACHE_TYPE;
 import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 import static org.jboss.jandex.AnnotationTarget.Kind.METHOD;
@@ -30,6 +31,7 @@ import io.quarkus.cache.deployment.CacheNamesBuildItem;
 import io.quarkus.cache.redis.runtime.RedisCacheBuildRecorder;
 import io.quarkus.cache.redis.runtime.RedisCacheBuildTimeConfig;
 import io.quarkus.cache.redis.runtime.RedisCachesBuildTimeConfig;
+import io.quarkus.cache.runtime.CacheBuildConfig;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
@@ -72,11 +74,15 @@ public class RedisCacheProcessor {
     @BuildStep
     @Record(STATIC_INIT)
     void determineKeyValueTypes(RedisCacheBuildRecorder recorder, CombinedIndexBuildItem combinedIndex,
-            CacheNamesBuildItem cacheNamesBuildItem, RedisCachesBuildTimeConfig buildConfig) {
+            CacheNamesBuildItem cacheNamesBuildItem, CacheBuildConfig cacheBuildConfig,
+            RedisCachesBuildTimeConfig buildConfig) {
 
         Map<String, java.lang.reflect.Type> keyTypes = new HashMap<>();
         RedisCacheBuildTimeConfig defaultBuildTimeConfig = buildConfig.defaultConfig();
         for (String cacheName : cacheNamesBuildItem.getNames()) {
+            if (!isRedisCache(cacheName, cacheBuildConfig)) {
+                continue;
+            }
             RedisCacheBuildTimeConfig namedBuildTimeConfig = buildConfig.cachesConfig().get(cacheName);
 
             if (namedBuildTimeConfig != null && namedBuildTimeConfig.keyType().isPresent()) {
@@ -93,6 +99,9 @@ public class RedisCacheProcessor {
         Optional<String> defaultValueType = buildConfig.defaultConfig().valueType();
         Set<String> cacheNames = cacheNamesBuildItem.getNames();
         for (String cacheName : cacheNames) {
+            if (!isRedisCache(cacheName, cacheBuildConfig)) {
+                continue;
+            }
             String valueType = null;
             RedisCacheBuildTimeConfig cacheSpecificGroup = buildConfig.cachesConfig().get(cacheName);
             if (cacheSpecificGroup == null) {
@@ -119,6 +128,12 @@ public class RedisCacheProcessor {
             }
         }
         recorder.setCacheValueTypes(valueTypes);
+    }
+
+    private static boolean isRedisCache(String cacheName, CacheBuildConfig cacheBuildConfig) {
+        CacheBuildConfig.CacheTypeBuildConfig cacheTypeConfig = cacheBuildConfig.cacheTypeByName().get(cacheName);
+        String cacheType = cacheTypeConfig != null ? cacheTypeConfig.type() : cacheBuildConfig.type();
+        return REDIS_CACHE_TYPE.equals(cacheType);
     }
 
     private static Map<String, Type> valueTypesFromCacheResultAnnotation(CombinedIndexBuildItem combinedIndex) {

--- a/extensions/redis-cache/deployment/src/test/java/io/quarkus/cache/redis/deployment/MixedCacheBackendsTest.java
+++ b/extensions/redis-cache/deployment/src/test/java/io/quarkus/cache/redis/deployment/MixedCacheBackendsTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.cache.redis.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.Cache;
+import io.quarkus.cache.CacheName;
+import io.quarkus.cache.CacheResult;
+import io.quarkus.cache.CaffeineCache;
+import io.quarkus.cache.redis.runtime.RedisCache;
+import io.quarkus.test.QuarkusExtensionTest;
+
+class MixedCacheBackendsTest {
+
+    private static final String CAFFEINE_CACHE_NAME = "caffeine-cache";
+    private static final String REDIS_CACHE_NAME = "redis-cache";
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClass(CachedService.class))
+            .overrideConfigKey("quarkus.cache.type", "caffeine")
+            .overrideConfigKey("quarkus.cache.redis-cache.type", "redis");
+
+    @Inject
+    @CacheName(CAFFEINE_CACHE_NAME)
+    Cache caffeineCache;
+
+    @Inject
+    @CacheName(REDIS_CACHE_NAME)
+    Cache redisCache;
+
+    @Test
+    void usesConfiguredBackendForEachCache() {
+        assertThat(caffeineCache).isInstanceOf(CaffeineCache.class);
+        assertThat(redisCache).isInstanceOf(RedisCache.class);
+    }
+
+    @ApplicationScoped
+    static class CachedService {
+
+        @CacheResult(cacheName = REDIS_CACHE_NAME)
+        String cached(String key) {
+            return key;
+        }
+    }
+}

--- a/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheBuildRecorder.java
+++ b/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheBuildRecorder.java
@@ -16,6 +16,8 @@ import io.quarkus.runtime.annotations.Recorder;
 @Recorder
 public class RedisCacheBuildRecorder {
 
+    public static final String REDIS_CACHE_TYPE = "redis";
+
     private static final Logger LOGGER = Logger.getLogger(RedisCacheBuildRecorder.class);
 
     private final RedisCachesBuildTimeConfig buildConfig;
@@ -34,7 +36,7 @@ public class RedisCacheBuildRecorder {
         return new CacheManagerInfo() {
             @Override
             public boolean supports(Context context) {
-                return context.cacheEnabled() && "redis".equals(context.cacheType()); // TODO: fix constant
+                return context.cacheEnabled() && REDIS_CACHE_TYPE.equals(context.cacheType());
             }
 
             @Override


### PR DESCRIPTION
When Caffeine is the default cache backend and Redis is configured for specific caches, Redis attempted to resolve value types for every discovered cache. This caused startup failures for Caffeine caches discovered through `@CacheName`, unless an unnecessary Redis `value-type` was configured.

Redis type resolution now considers only caches whose effective backend is Redis, honoring both the default backend and per-cache backend configuration.

* Fixes #56182 