### PR TITLE
Run Roq tests on PRs that change docs

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -133,3 +133,172 @@ jobs:
           path: |
             build-reports.zip
           retention-days: 7
+
+  test-doc-site:
+    name: "Documentation Site Tests"
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    needs: build-doc
+    # Only meaningful on PRs: push builds lack a gh-pages baseline for the
+    # link-scope diff, and the nightly sync in quarkusio.github.io covers smoke testing.
+    if: github.event_name == 'pull_request' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))
+    steps:
+      - name: Checkout quarkusio.github.io
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: quarkusio/quarkusio.github.io
+          # gh-pages is needed by the link-scope step to diff changed HTML files
+          fetch-depth: 5000
+          fetch-tags: false
+
+      - name: Checkout quarkus (for sync-web-site.sh)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: quarkus-main
+
+      - name: Download documentation artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: documentation
+          path: documentation-temp
+
+      - name: Sync documentation into site
+        # Always use the sync script from the checked-out quarkus repo, not the
+        # one baked into the artifact (which may be stale on rebases).
+        run: |
+          rm -f ./documentation-temp/docs/sync-web-site.sh
+          cp -a ./quarkus-main/docs/sync-web-site.sh ./documentation-temp/docs/
+          chmod 755 ./documentation-temp/docs/sync-web-site.sh
+          ./documentation-temp/docs/sync-web-site.sh main ${PWD}
+          rm -rf documentation-temp quarkus-main
+
+      - name: Set up JDK
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          java-version: '25'
+          distribution: temurin
+          cache: maven
+
+      - name: Cache npm packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: ${{ runner.os }}-npm-
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pom.xml') }}
+
+      # TODO remove this once the plugin is in Roq
+      - name: Build TOC plugin
+        run: ./roq-plugin-toc/build.sh
+
+      # TODO: Remove once https://github.com/quarkiverse/quarkus-roq/issues/1178 is fixed and Roq is upgraded
+      - name: Patch Roq AsciiDoc tag handling
+        run: |
+          mvn -B dependency:resolve -q
+          bash patches/apply-roq-include-fix.sh
+
+      - name: Build with Maven
+        run: QUARKUS_ROQ_GENERATOR_BATCH=true QUARKUS_PROFILE=only-latest-guides mvn -B package quarkus:run -DskipTests
+
+      - name: Compile tests
+        run: mvn -B test-compile
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install --with-deps --only-shell chromium"
+
+      - uses: jbangdev/setup-jbang@main
+
+      - name: Start Java test server
+        run: |
+          jbang trust add https://repo1.maven.org/maven2/io/quarkiverse/roq/quarkus-roq-cli/
+          jbang roq@quarkiverse/quarkus-roq serve target/roq/ -p 8090 &
+
+      - name: Run smoke tests
+        run: mvn -B test -Dtest.url=http://localhost:8090
+        env:
+          PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS: 1
+
+      - name: Determine link checker scope
+        id: link_scope
+        run: |
+          # Compare the built guides against what is currently on gh-pages.
+          # version/main/ is excluded: it is overwritten daily by the nightly
+          # sync and will almost always differ regardless of this PR's changes.
+          git fetch origin gh-pages --filter=blob:none 2>/dev/null || {
+            echo "mode=full" >> $GITHUB_OUTPUT
+            echo "Could not fetch gh-pages, running full link check"
+            exit 0
+          }
+
+          git worktree add --detach /tmp/gh-pages origin/gh-pages 2>/dev/null || {
+            echo "mode=full" >> $GITHUB_OUTPUT
+            echo "Could not check out gh-pages, running full link check"
+            exit 0
+          }
+
+          git -C /tmp/gh-pages sparse-checkout set --no-cone '*.html'
+
+          RSYNC_OUT=$(rsync -rcn --out-format='%n' \
+            --include='*/' --include='*.html' --exclude='*' \
+            target/roq/ /tmp/gh-pages/ 2>/dev/null) || {
+            echo "mode=full" >> $GITHUB_OUTPUT
+            echo "Site comparison failed, running full link check"
+            git worktree remove /tmp/gh-pages 2>/dev/null || true
+            exit 0
+          }
+
+          CHANGED=$(echo "$RSYNC_OUT" | grep '\.html$' | grep -v '^version/main/' || true)
+
+          git worktree remove /tmp/gh-pages 2>/dev/null || true
+
+          if [ -z "$CHANGED" ]; then
+            echo "mode=skip" >> $GITHUB_OUTPUT
+            echo "No HTML files changed outside version/main/, skipping link crawl"
+            exit 0
+          fi
+
+          COUNT=$(echo "$CHANGED" | wc -l | tr -d ' ')
+          echo "$COUNT changed HTML file(s)"
+          echo "$CHANGED" | sed 's|/[^/]*$||' | sort | uniq -c | sort -rn | head -20
+
+          if [ "$COUNT" -gt 200 ]; then
+            echo "mode=full" >> $GITHUB_OUTPUT
+            echo "More than 200 files changed, running full link check"
+          else
+            PATHS=$(echo "$CHANGED" | sed 's|index\.html$||; s|^|/|' | tr '\n' ',' | sed 's/,$//')
+            echo "mode=partial" >> $GITHUB_OUTPUT
+            echo "paths=$PATHS" >> $GITHUB_OUTPUT
+            echo "Targeted check: $PATHS"
+          fi
+
+      - name: Run link crawler
+        if: steps.link_scope.outputs.mode != 'skip'
+        run: |
+          CHANGED_PATHS_ARG=""
+          if [ "${{ steps.link_scope.outputs.mode }}" = "partial" ]; then
+            CHANGED_PATHS_ARG="-Dtest.crawl.changed-paths=${{ steps.link_scope.outputs.paths }}"
+          fi
+          mvn -B test -Pe2e -Dtest.url=http://localhost:8090 \
+            -Dtest.crawl.check-external=false \
+            -Dtest.crawl.exclude-paths=/version/2,/version/3,/version/4,/version/5,/version/main \
+            $CHANGED_PATHS_ARG
+        env:
+          PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS: 1
+
+      - name: Upload build reports
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: "build-reports-${{ github.run_attempt }}-Documentation Site Tests"
+          path: |
+            target/*-reports/TEST-*.xml
+            target/build-report.json
+            README.md
+          retention-days: 7


### PR DESCRIPTION
We want to be catching docs problems early, rather than waiting until problems hit the quarkusio repo. Although we run asciidoc checks in CI, they let through a surprising number of bad links. 

This change does have the drawback of lengthening docs CIs, but we don't run those for every change, and I think the extra time will be something like 8m. 