### PR TITLE
Support selecting the client address from the `X-Forwarded-For` header

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -853,6 +853,57 @@ Supported forwarding address headers are:
 * `X-Forwarded-Ssl`
 * `X-Forwarded-Prefix`
 
+[[x-forwarded-for-selection]]
+=== Selecting the X-Forwarded-For client address
+
+By default, Quarkus takes the client address from the leftmost `X-Forwarded-For` value.
+When a proxy appends the client address rather than overwriting the header, the leftmost value is supplied by the client and cannot be trusted.
+Set `quarkus.http.proxy.x-forwarded-for-index` to select the value by its position from the right, where `1` is the rightmost value:
+
+[source,properties]
+----
+quarkus.http.proxy.proxy-address-forwarding=true
+quarkus.http.proxy.allow-x-forwarded=true
+quarkus.http.proxy.trusted-proxies=127.0.0.1
+quarkus.http.proxy.x-forwarded-for-index=1 <1>
+----
+<1> Set the index to the number of values your proxies append to `X-Forwarded-For`. One appended value places the client at index `1`, two appended values at index `2`.
+
+The index counts non-empty values only and merges repeated `X-Forwarded-For` header lines in the order received.
+When the header holds at least one value but fewer than the index, the request is rejected with a `400 Bad Request` response.
+When the header is absent or contains only empty values, the connection peer address is used.
+Selection applies to `X-Forwarded-For` only and cannot be combined with `quarkus.http.proxy.allow-forwarded`.
+
+WARNING: Select a value only when Quarkus is reachable exclusively through trusted proxies, because a client that connects directly can forge any value. The index must equal the number of values the proxies append; a lower index selects a client-supplied value.
+
+When a fixed index is not enough, for example to read a vendor header or to walk a chain of trusted addresses, provide a CDI bean that implements the `io.quarkus.vertx.http.XForwardedForSelector` interface:
+
+[source,java]
+----
+import io.quarkus.vertx.http.XForwardedForSelector;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class ClientIpSelector implements XForwardedForSelector {
+
+    @Override
+    public String select(Context context) {
+        String clientIp = context.headers().get("X-Real-Client-IP");
+        if (clientIp != null) {
+            return clientIp;
+        }
+        return context.connectionPeer().host(); <1>
+    }
+}
+----
+<1> Falls back to the direct connection address. Returning `null` or a blank value instead rejects the request with a `400 Bad Request` response.
+
+The selector runs only when the request carries at least one non-empty `X-Forwarded-For` value.
+When the header is absent or contains only empty values, the selector is not invoked and the connection peer address is used.
+
+NOTE: At most one such bean may exist, and it cannot be combined with `quarkus.http.proxy.x-forwarded-for-index` or `quarkus.http.proxy.allow-forwarded`.
+
 [[same-site-cookie]]
 == SameSite cookies
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -66,6 +66,7 @@ import io.quarkus.tls.deployment.spi.TlsRegistryBuildItem;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.quarkus.vertx.core.deployment.EventLoopCountBuildItem;
 import io.quarkus.vertx.http.HttpServerConfigCustomizer;
+import io.quarkus.vertx.http.XForwardedForSelector;
 import io.quarkus.vertx.http.deployment.HttpSecurityProcessor.HttpSecurityConfigSetupCompleteBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
 import io.quarkus.vertx.http.deployment.spi.FrameworkEndpointsBuildItem;
@@ -189,6 +190,11 @@ class VertxHttpProcessor {
     @BuildStep
     UnremovableBeanBuildItem shouldNotRemoveHttpServerConfigCustomizers() {
         return UnremovableBeanBuildItem.beanTypes(HttpServerConfigCustomizer.class);
+    }
+
+    @BuildStep
+    UnremovableBeanBuildItem shouldNotRemoveXForwardedForSelector() {
+        return UnremovableBeanBuildItem.beanTypes(XForwardedForSelector.class);
     }
 
     @BuildStep

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedForHeaderTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedForHeaderTest.java
@@ -118,4 +118,11 @@ public class ForwardedForHeaderTest {
                 .body(Matchers.containsString("[2001:db8:85a3:8d3::]:101"));
     }
 
+    @Test
+    public void testMultipleForwardedForValuesUsesLeftmostByDefault() {
+        RestAssured.given().header("X-Forwarded-For", "1.1.1.1, 2.2.2.2").get("/forward").then()
+                .body(Matchers.containsString("1.1.1.1"))
+                .body(Matchers.not(Matchers.containsString("2.2.2.2")));
+    }
+
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementHostValidationWithXForwardedHostTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementHostValidationWithXForwardedHostTest.java
@@ -1,8 +1,10 @@
 package io.quarkus.vertx.http.management;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 import java.net.URL;
 
@@ -35,6 +37,9 @@ public class ManagementHostValidationWithXForwardedHostTest {
     @TestHTTPResource(value = "/my-route", management = true)
     URL myRoute;
 
+    @TestHTTPResource(value = "/remote-addr", management = true)
+    URL remoteAddrRoute;
+
     @Test
     void somePublicApiHostRequest() {
         given().header("Host", "some-public-api")
@@ -52,11 +57,32 @@ public class ManagementHostValidationWithXForwardedHostTest {
                 .body(equalTo("test route"));
     }
 
+    @Test
+    void xForwardedForSetsRemoteAddressOnManagement() {
+        given().header("X-Forwarded-Host", "public-api.com")
+                .header("X-Forwarded-For", "192.168.42.123")
+                .get(remoteAddrRoute).then()
+                .statusCode(200)
+                .body(containsString("192.168.42.123"));
+    }
+
+    @Test
+    void xForwardedForUsesLeftmostValueByDefaultOnManagement() {
+        given().header("X-Forwarded-Host", "public-api.com")
+                .header("X-Forwarded-For", "1.1.1.1, 2.2.2.2")
+                .get(remoteAddrRoute).then()
+                .statusCode(200)
+                .body(containsString("1.1.1.1"))
+                .body(not(containsString("2.2.2.2")));
+    }
+
     @Singleton
     static class MyObserver {
 
         public void registerManagementRoutes(@Observes ManagementInterface mi) {
             mi.router().get("/management/my-route").handler(rc -> rc.response().end("test route"));
+            mi.router().get("/management/remote-addr")
+                    .handler(rc -> rc.response().end(rc.request().remoteAddress().toString()));
         }
     }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/CustomXForwardedForSelector.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/CustomXForwardedForSelector.java
@@ -1,0 +1,40 @@
+package io.quarkus.vertx.http.proxy;
+
+import java.util.List;
+
+import jakarta.inject.Singleton;
+
+import io.quarkus.vertx.http.XForwardedForSelector;
+import io.vertx.core.MultiMap;
+
+@Singleton
+class CustomXForwardedForSelector implements XForwardedForSelector {
+
+    @Override
+    public String select(Context context) {
+        MultiMap headers = context.headers();
+        if (headers.contains("X-Test-Throw")) {
+            throw new RuntimeException("selector failure");
+        }
+        if (headers.contains("X-Test-Reject")) {
+            return null;
+        }
+        if (headers.contains("X-Test-Empty")) {
+            return "";
+        }
+        if (headers.contains("X-Test-Blank")) {
+            return "   ";
+        }
+        if (headers.contains("X-Test-Padded")) {
+            return "  1.2.3.4  ";
+        }
+        if (headers.contains("X-Test-Peer")) {
+            return context.connectionPeer().host();
+        }
+        if (headers.contains("X-Test-Header")) {
+            return headers.get("CF-Connecting-IP");
+        }
+        List<String> values = context.xForwardedForValues();
+        return values.isEmpty() ? null : values.get(values.size() - 1);
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/XForwardedForCustomSelectorTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/XForwardedForCustomSelectorTest.java
@@ -1,0 +1,121 @@
+package io.quarkus.vertx.http.proxy;
+
+import java.net.URL;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.ForwardedHandlerInitializer;
+import io.quarkus.vertx.http.ManagementInterface;
+import io.restassured.RestAssured;
+
+class XForwardedForCustomSelectorTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(ForwardedHandlerInitializer.class, CustomXForwardedForSelector.class,
+                    ManagementRoutes.class))
+            .withConfiguration("""
+                    quarkus.http.proxy.proxy-address-forwarding=true
+                    quarkus.http.proxy.allow-x-forwarded=true
+                    quarkus.http.proxy.trusted-proxies=127.0.0.1
+                    quarkus.management.enabled=true
+                    quarkus.management.root-path=/management
+                    quarkus.management.proxy.proxy-address-forwarding=true
+                    quarkus.management.proxy.allow-x-forwarded=true
+                    quarkus.management.proxy.trusted-proxies=127.0.0.1
+                    """);
+
+    @TestHTTPResource(value = "/my-route", management = true)
+    URL managementRoute;
+
+    @Test
+    void beanSelectsValue() {
+        RestAssured.given().header("X-Forwarded-For", "7.7.7.7, 1.2.3.4").get("/forward").then()
+                .statusCode(200)
+                .body(Matchers.containsString("1.2.3.4"))
+                .body(Matchers.not(Matchers.containsString("7.7.7.7")));
+    }
+
+    @Test
+    void beanCanReturnConnectionPeer() {
+        RestAssured.given().header("X-Forwarded-For", "7.7.7.7, 1.2.3.4").header("X-Test-Peer", "true").get("/forward")
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("127.0.0.1"));
+    }
+
+    @Test
+    void beanCanRejectWithBadRequest() {
+        RestAssured.given().header("X-Forwarded-For", "7.7.7.7, 1.2.3.4").header("X-Test-Reject", "true").get("/forward")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void beanCanReadOtherHeaders() {
+        RestAssured.given().header("X-Forwarded-For", "7.7.7.7, 1.2.3.4").header("X-Test-Header", "true")
+                .header("CF-Connecting-IP", "9.9.9.9").get("/forward").then()
+                .statusCode(200)
+                .body(Matchers.containsString("9.9.9.9"));
+    }
+
+    @Test
+    void beanFailsClosedWhenItThrows() {
+        RestAssured.given().header("X-Forwarded-For", "7.7.7.7, 1.2.3.4").header("X-Test-Throw", "true").get("/forward")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void beanRejectsEmptyReturnValueWithBadRequest() {
+        RestAssured.given().header("X-Forwarded-For", "7.7.7.7, 1.2.3.4").header("X-Test-Empty", "true").get("/forward")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void beanRejectsBlankReturnValueWithBadRequest() {
+        RestAssured.given().header("X-Forwarded-For", "7.7.7.7, 1.2.3.4").header("X-Test-Blank", "true").get("/forward")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void beanReturnValueIsTrimmedBeforeUse() {
+        RestAssured.given().header("X-Forwarded-For", "7.7.7.7, 1.2.3.4").header("X-Test-Padded", "true").get("/forward")
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("|1.2.3.4:"))
+                .body(Matchers.not(Matchers.containsString("  1.2.3.4  ")));
+    }
+
+    @Test
+    void beanNotInvokedWhenHeaderAbsent() {
+        RestAssured.given().header("X-Test-Reject", "true").get("/forward").then()
+                .statusCode(200)
+                .body(Matchers.containsString("127.0.0.1"));
+    }
+
+    @Test
+    void beanSelectsValueOnManagementInterface() {
+        RestAssured.given().header("X-Forwarded-For", "7.7.7.7, 1.2.3.4").get(managementRoute).then()
+                .statusCode(200)
+                .body(Matchers.containsString("1.2.3.4"))
+                .body(Matchers.not(Matchers.containsString("7.7.7.7")));
+    }
+
+    @Singleton
+    static class ManagementRoutes {
+        public void register(@Observes ManagementInterface mi) {
+            mi.router().get("/management/my-route")
+                    .handler(rc -> rc.response().end(rc.request().remoteAddress().toString()));
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/XForwardedForCustomSelectorUntrustedPeerTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/XForwardedForCustomSelectorUntrustedPeerTest.java
@@ -1,0 +1,30 @@
+package io.quarkus.vertx.http.proxy;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.vertx.http.ForwardedHandlerInitializer;
+import io.restassured.RestAssured;
+
+class XForwardedForCustomSelectorUntrustedPeerTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(ForwardedHandlerInitializer.class, CustomXForwardedForSelector.class))
+            .withConfiguration("""
+                    quarkus.http.proxy.proxy-address-forwarding=true
+                    quarkus.http.proxy.allow-x-forwarded=true
+                    quarkus.http.proxy.trusted-proxies=10.20.30.40
+                    """);
+
+    @Test
+    void doesNotInvokeSelectorForUntrustedPeer() {
+        RestAssured.given().header("X-Forwarded-For", "7.7.7.7, 1.2.3.4").header("X-Test-Reject", "true").get("/forward")
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("127.0.0.1"))
+                .body(Matchers.not(Matchers.containsString("1.2.3.4")));
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/XForwardedForIndexAndSelectorBeanConflictTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/XForwardedForIndexAndSelectorBeanConflictTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.vertx.http.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.vertx.http.ForwardedHandlerInitializer;
+
+class XForwardedForIndexAndSelectorBeanConflictTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(
+                    jar -> jar.addClasses(ForwardedHandlerInitializer.class, CustomXForwardedForSelector.class))
+            .withConfiguration("""
+                    quarkus.http.proxy.proxy-address-forwarding=true
+                    quarkus.http.proxy.allow-x-forwarded=true
+                    quarkus.http.proxy.trusted-proxies=127.0.0.1
+                    quarkus.http.proxy.x-forwarded-for-index=1
+                    """)
+            .assertException(t -> assertThat(t)
+                    .hasMessageContaining("quarkus.http.proxy.x-forwarded-for-index")
+                    .hasMessageContaining(CustomXForwardedForSelector.class.getName())
+                    .hasMessageContaining("mutually exclusive"));
+
+    @Test
+    void testStartupFails() {
+        fail("Application should not have started");
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/XForwardedForIndexForbidsAllowForwardedTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/XForwardedForIndexForbidsAllowForwardedTest.java
@@ -1,0 +1,32 @@
+package io.quarkus.vertx.http.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.vertx.http.ForwardedHandlerInitializer;
+
+class XForwardedForIndexForbidsAllowForwardedTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(ForwardedHandlerInitializer.class))
+            .withConfiguration("""
+                    quarkus.http.proxy.proxy-address-forwarding=true
+                    quarkus.http.proxy.allow-x-forwarded=true
+                    quarkus.http.proxy.allow-forwarded=true
+                    quarkus.http.proxy.trusted-proxies=127.0.0.1
+                    quarkus.http.proxy.x-forwarded-for-index=1
+                    """)
+            .assertException(t -> assertThat(t)
+                    .hasMessageContaining("quarkus.http.proxy.x-forwarded-for-index")
+                    .hasMessageContaining("quarkus.http.proxy.allow-forwarded"));
+
+    @Test
+    void testStartupFails() {
+        fail("Application should not have started");
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/XForwardedForIndexInvalidValueTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/XForwardedForIndexInvalidValueTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.vertx.http.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.vertx.http.ForwardedHandlerInitializer;
+
+class XForwardedForIndexInvalidValueTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(ForwardedHandlerInitializer.class))
+            .withConfiguration("""
+                    quarkus.http.proxy.proxy-address-forwarding=true
+                    quarkus.http.proxy.allow-x-forwarded=true
+                    quarkus.http.proxy.trusted-proxies=127.0.0.1
+                    quarkus.http.proxy.x-forwarded-for-index=0
+                    """)
+            .assertException(t -> assertThat(t)
+                    .hasMessageContaining("quarkus.http.proxy.x-forwarded-for-index")
+                    .hasMessageContaining("greater than 0"));
+
+    @Test
+    void testStartupFails() {
+        fail("Application should not have started");
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/XForwardedForIndexTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/XForwardedForIndexTest.java
@@ -1,0 +1,157 @@
+package io.quarkus.vertx.http.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.ForwardedHandlerInitializer;
+import io.quarkus.vertx.http.ManagementInterface;
+import io.restassured.RestAssured;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+
+class XForwardedForIndexTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(ForwardedHandlerInitializer.class, ManagementRoutes.class))
+            .withConfiguration("""
+                    quarkus.http.proxy.proxy-address-forwarding=true
+                    quarkus.http.proxy.allow-x-forwarded=true
+                    quarkus.http.proxy.trusted-proxies=127.0.0.1
+                    quarkus.http.proxy.x-forwarded-for-index=1
+                    quarkus.management.enabled=true
+                    quarkus.management.root-path=/management
+                    quarkus.management.proxy.proxy-address-forwarding=true
+                    quarkus.management.proxy.allow-x-forwarded=true
+                    quarkus.management.proxy.trusted-proxies=127.0.0.1
+                    quarkus.management.proxy.x-forwarded-for-index=3
+                    """);
+
+    @TestHTTPResource
+    URL url;
+
+    @TestHTTPResource(value = "/my-route", management = true)
+    URL managementRoute;
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    void selectsRightmostValueWithoutPort() {
+        RestAssured.given().header("X-Forwarded-For", "7.7.7.7, 192.168.42.123").get("/forward").then()
+                .statusCode(200)
+                .body(Matchers.containsString("192.168.42.123"))
+                .body(Matchers.not(Matchers.containsString("7.7.7.7")));
+    }
+
+    @Test
+    void preservesRightmostIpv4WithPort() {
+        RestAssured.given().header("X-Forwarded-For", "7.7.7.7, 192.168.42.123:4444").get("/forward").then()
+                .statusCode(200)
+                .body(Matchers.containsString("192.168.42.123:4444"));
+    }
+
+    @Test
+    void preservesRightmostIpv6() {
+        RestAssured.given().header("X-Forwarded-For", "1.1.1.1, 2001:db8:85a3::12").get("/forward").then()
+                .statusCode(200)
+                .body(Matchers.containsString("2001:db8:85a3::12"));
+    }
+
+    @Test
+    void preservesRightmostIpv6WithPort() {
+        RestAssured.given().header("X-Forwarded-For", "1.1.1.1, [2001:db8:85a3:8d3::]:101").get("/forward").then()
+                .statusCode(200)
+                .body(Matchers.containsString("[2001:db8:85a3:8d3::]:101"));
+    }
+
+    @Test
+    void trimsWhitespaceAndSkipsEmptyValuesSelectingRightmost() {
+        RestAssured.given().header("X-Forwarded-For", " 7.7.7.7 , , 192.168.42.123 ").get("/forward").then()
+                .statusCode(200)
+                .body(Matchers.containsString("192.168.42.123"))
+                .body(Matchers.not(Matchers.containsString("7.7.7.7")));
+    }
+
+    @Test
+    void skipsLeadingAndTrailingEmptyValuesSelectingRightmost() {
+        RestAssured.given().header("X-Forwarded-For", " , , 7.7.7.7, 192.168.42.123, , ").get("/forward").then()
+                .statusCode(200)
+                .body(Matchers.containsString("192.168.42.123"))
+                .body(Matchers.not(Matchers.containsString("7.7.7.7")));
+    }
+
+    @Test
+    void absentHeaderUsesConnectionPeer() {
+        RestAssured.given().get("/forward").then()
+                .statusCode(200)
+                .body(Matchers.containsString("127.0.0.1"));
+    }
+
+    @Test
+    void mergesMultipleHeaderLinesSelectingRightmost() {
+        var httpClient = vertx.createHttpClient();
+        try {
+            String body = httpClient
+                    .request(HttpMethod.GET, url.getPort(), url.getHost(), "/forward")
+                    .compose(request -> {
+                        request.putHeader("X-Forwarded-For", "7.7.7.7, 8.8.8.8");
+                        request.headers().add("X-Forwarded-For", "9.9.9.9");
+                        return request.send();
+                    })
+                    .compose(HttpClientResponse::body)
+                    .await()
+                    .toString();
+            assertThat(body).contains("9.9.9.9").doesNotContain("8.8.8.8").doesNotContain("7.7.7.7");
+        } finally {
+            httpClient.close().await();
+        }
+    }
+
+    @Test
+    void selectsThirdValueFromRightOnManagementInterface() {
+        RestAssured.given().header("X-Forwarded-For", "0.0.0.0, 192.168.42.123, 2.2.2.2, 3.3.3.3").get(managementRoute)
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("192.168.42.123"))
+                .body(Matchers.not(Matchers.containsString("0.0.0.0")))
+                .body(Matchers.not(Matchers.containsString("3.3.3.3")));
+    }
+
+    @Test
+    void skipsEmptyValuesSelectingThirdFromRightOnManagementInterface() {
+        RestAssured.given().header("X-Forwarded-For", "1.1.1.1, , 192.168.42.123, , 2.2.2.2, 3.3.3.3").get(managementRoute)
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("192.168.42.123"))
+                .body(Matchers.not(Matchers.containsString("1.1.1.1")))
+                .body(Matchers.not(Matchers.containsString("2.2.2.2")))
+                .body(Matchers.not(Matchers.containsString("3.3.3.3")));
+    }
+
+    @Test
+    void rejectsWhenFewerValuesThanIndexOnManagementInterface() {
+        RestAssured.given().header("X-Forwarded-For", "1.1.1.1, 2.2.2.2").get(managementRoute).then()
+                .statusCode(400);
+    }
+
+    @Singleton
+    static class ManagementRoutes {
+        public void register(@Observes ManagementInterface mi) {
+            mi.router().get("/management/my-route")
+                    .handler(rc -> rc.response().end(rc.request().remoteAddress().toString()));
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/XForwardedForIndexTwoTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/XForwardedForIndexTwoTest.java
@@ -1,0 +1,138 @@
+package io.quarkus.vertx.http.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.ForwardedHandlerInitializer;
+import io.quarkus.vertx.http.ManagementInterface;
+import io.restassured.RestAssured;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+
+class XForwardedForIndexTwoTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(ForwardedHandlerInitializer.class, ManagementRoutes.class))
+            .withConfiguration("""
+                    quarkus.http.proxy.proxy-address-forwarding=true
+                    quarkus.http.proxy.allow-x-forwarded=true
+                    quarkus.http.proxy.trusted-proxies=127.0.0.1
+                    quarkus.http.proxy.x-forwarded-for-index=2
+                    quarkus.management.enabled=true
+                    quarkus.management.root-path=/management
+                    quarkus.management.proxy.proxy-address-forwarding=true
+                    quarkus.management.proxy.allow-x-forwarded=true
+                    quarkus.management.proxy.x-forwarded-for-index=1
+                    """);
+
+    @TestHTTPResource
+    URL url;
+
+    @TestHTTPResource(value = "/my-route", management = true)
+    URL managementRoute;
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    void selectsSecondValueFromRight() {
+        RestAssured.given().header("X-Forwarded-For", "7.7.7.7, 192.168.42.123, 10.0.0.1").get("/forward").then()
+                .statusCode(200)
+                .body(Matchers.containsString("192.168.42.123"))
+                .body(Matchers.not(Matchers.containsString("10.0.0.1")))
+                .body(Matchers.not(Matchers.containsString("7.7.7.7")));
+    }
+
+    @Test
+    void rejectsWhenFewerValuesThanIndex() {
+        RestAssured.given().header("X-Forwarded-For", "10.0.0.1").get("/forward").then()
+                .statusCode(400);
+    }
+
+    @Test
+    void mergesMultipleHeaderLinesInReceivedOrder() {
+        var httpClient = vertx.createHttpClient();
+        try {
+            String body = httpClient
+                    .request(HttpMethod.GET, url.getPort(), url.getHost(), "/forward")
+                    .compose(request -> {
+                        request.putHeader("X-Forwarded-For", "7.7.7.7, 192.168.42.123");
+                        request.headers().add("X-Forwarded-For", "10.0.0.1");
+                        return request.send();
+                    })
+                    .compose(HttpClientResponse::body)
+                    .await()
+                    .toString();
+            assertThat(body).contains("192.168.42.123").doesNotContain("10.0.0.1").doesNotContain("7.7.7.7");
+        } finally {
+            httpClient.close().await();
+        }
+    }
+
+    @Test
+    void selectsWithoutTrustedProxiesConfiguredOnManagementInterface() {
+        RestAssured.given().header("X-Forwarded-For", "7.7.7.7, 192.168.42.123").get(managementRoute).then()
+                .statusCode(200)
+                .body(Matchers.containsString("192.168.42.123"))
+                .body(Matchers.not(Matchers.containsString("7.7.7.7")));
+    }
+
+    @Test
+    void selectsLeftmostWhenIndexEqualsChainLength() {
+        RestAssured.given().header("X-Forwarded-For", "1.1.1.1, 2.2.2.2").get("/forward").then()
+                .statusCode(200)
+                .body(Matchers.containsString("1.1.1.1"))
+                .body(Matchers.not(Matchers.containsString("2.2.2.2")));
+    }
+
+    @Test
+    void skipsEmptyValuesWithIndexGreaterThanOne() {
+        RestAssured.given().header("X-Forwarded-For", "7.7.7.7, 1.1.1.1, , 2.2.2.2").get("/forward").then()
+                .statusCode(200)
+                .body(Matchers.containsString("1.1.1.1"))
+                .body(Matchers.not(Matchers.containsString("7.7.7.7")))
+                .body(Matchers.not(Matchers.containsString("2.2.2.2")));
+    }
+
+    @Test
+    void mergesMultipleHeaderLinesOnManagementInterface() {
+        var httpClient = vertx.createHttpClient();
+        try {
+            String body = httpClient
+                    .request(HttpMethod.GET, managementRoute.getPort(), managementRoute.getHost(),
+                            managementRoute.getPath())
+                    .compose(request -> {
+                        request.putHeader("X-Forwarded-For", "7.7.7.7, 8.8.8.8");
+                        request.headers().add("X-Forwarded-For", "9.9.9.9");
+                        return request.send();
+                    })
+                    .compose(HttpClientResponse::body)
+                    .await()
+                    .toString();
+            assertThat(body).contains("9.9.9.9").doesNotContain("8.8.8.8").doesNotContain("7.7.7.7");
+        } finally {
+            httpClient.close().await();
+        }
+    }
+
+    @Singleton
+    static class ManagementRoutes {
+        public void register(@Observes ManagementInterface mi) {
+            mi.router().get("/management/my-route")
+                    .handler(rc -> rc.response().end(rc.request().remoteAddress().toString()));
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/XForwardedForIndexUntrustedPeerTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/XForwardedForIndexUntrustedPeerTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.vertx.http.proxy;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.vertx.http.ForwardedHandlerInitializer;
+import io.restassured.RestAssured;
+
+class XForwardedForIndexUntrustedPeerTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(ForwardedHandlerInitializer.class))
+            .withConfiguration("""
+                    quarkus.http.proxy.proxy-address-forwarding=true
+                    quarkus.http.proxy.allow-x-forwarded=true
+                    quarkus.http.proxy.trusted-proxies=10.20.30.40
+                    quarkus.http.proxy.x-forwarded-for-index=1
+                    """);
+
+    @Test
+    void ignoresForwardedForFromUntrustedPeer() {
+        RestAssured.given().header("X-Forwarded-For", "7.7.7.7, 8.8.8.8").get("/forward").then()
+                .statusCode(200)
+                .body(Matchers.containsString("127.0.0.1"))
+                .body(Matchers.not(Matchers.containsString("8.8.8.8")))
+                .body(Matchers.not(Matchers.containsString("7.7.7.7")));
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/XForwardedForSelectorBeanForbidsAllowForwardedTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/XForwardedForSelectorBeanForbidsAllowForwardedTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.vertx.http.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.vertx.http.ForwardedHandlerInitializer;
+
+class XForwardedForSelectorBeanForbidsAllowForwardedTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(ForwardedHandlerInitializer.class, CustomXForwardedForSelector.class))
+            .withConfiguration("""
+                    quarkus.http.proxy.proxy-address-forwarding=true
+                    quarkus.http.proxy.allow-x-forwarded=true
+                    quarkus.http.proxy.allow-forwarded=true
+                    quarkus.http.proxy.trusted-proxies=127.0.0.1
+                    """)
+            .assertException(t -> assertThat(t)
+                    .hasMessageContaining(CustomXForwardedForSelector.class.getName())
+                    .hasMessageContaining("quarkus.http.proxy.allow-forwarded"));
+
+    @Test
+    void testStartupFails() {
+        fail("Application should not have started");
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/XForwardedForSelector.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/XForwardedForSelector.java
@@ -1,0 +1,40 @@
+package io.quarkus.vertx.http;
+
+import java.util.List;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.net.SocketAddress;
+
+/**
+ * Selects the client address from the {@code X-Forwarded-For} header.
+ * <p>
+ * Register a single CDI bean implementing this interface. The same bean is applied to the main HTTP interface and,
+ * when the corresponding {@code quarkus.management.proxy.*} properties are enabled, to the management interface.
+ */
+public interface XForwardedForSelector {
+
+    /**
+     * Returns the chosen client address, or {@code null} or a blank value to reject the request with a
+     * {@code 400 Bad Request}. Surrounding whitespace is trimmed from the returned address.
+     */
+    String select(Context context);
+
+    interface Context {
+
+        /**
+         * Returns the {@code X-Forwarded-For} values, merged across header lines, trimmed, without empty entries and
+         * ordered leftmost first.
+         */
+        List<String> xForwardedForValues();
+
+        /**
+         * Returns the address of the directly connecting client, which cannot be forged.
+         */
+        SocketAddress connectionPeer();
+
+        /**
+         * Returns the request headers.
+         */
+        MultiMap headers();
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedParser.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedParser.java
@@ -19,8 +19,11 @@
 
 package io.quarkus.vertx.http.runtime;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -29,7 +32,9 @@ import java.util.regex.Pattern;
 import org.jboss.logging.Logger;
 
 import io.netty.util.AsciiString;
+import io.quarkus.vertx.http.XForwardedForSelector;
 import io.smallrye.common.vertx.ContextLocals;
+import io.vertx.core.MultiMap;
 import io.vertx.core.internal.http.HttpServerRequestInternal;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;
@@ -319,16 +324,57 @@ class ForwardedParser {
             xForwardedValues.setPort(port);
         }
 
-        String forHeader = delegate.getHeader(X_FORWARDED_FOR);
-        if (forHeader != null) {
-            remoteAddress = parseFor(getFirstElement(forHeader), remoteAddress != null ? remoteAddress.port() : port);
-            xForwardedValues.setRemoteHost(remoteAddress.host());
-            xForwardedValues.setRemotePort(remoteAddress.port());
-            log.debugf("Using X-Forwarded-For to set for host to %s and for port to %d", remoteAddress.host(),
-                    remoteAddress.port());
+        XForwardedForSelector selector = forwardingProxyOptions.xForwardedForSelector;
+        if (selector != null) {
+            List<String> forValues = mergeXForwardedFor();
+            if (!forValues.isEmpty()) {
+                final String selected;
+                try {
+                    selected = selector.select(new SelectorContext(forValues));
+                } catch (RuntimeException e) {
+                    log.errorf(e, "Rejecting request: the X-Forwarded-For selector threw an exception");
+                    rejected = true;
+                    return null;
+                }
+                if (selected == null || selected.isBlank()) {
+                    log.debug("Rejecting request: the X-Forwarded-For selector returned null or a blank value");
+                    rejected = true;
+                    return null;
+                }
+                setForwardedFor(selected.strip(), xForwardedValues);
+            }
+        } else {
+            String forHeader = delegate.getHeader(X_FORWARDED_FOR);
+            if (forHeader != null) {
+                setForwardedFor(getFirstElement(forHeader), xForwardedValues);
+            }
         }
 
         return xForwardedValues;
+    }
+
+    private void setForwardedFor(String forToken, Forwarded xForwardedValues) {
+        remoteAddress = parseFor(forToken, remoteAddress != null ? remoteAddress.port() : port);
+        xForwardedValues.setRemoteHost(remoteAddress.host());
+        xForwardedValues.setRemotePort(remoteAddress.port());
+        log.debugf("Using X-Forwarded-For to set for host to %s and for port to %d", remoteAddress.host(),
+                remoteAddress.port());
+    }
+
+    private List<String> mergeXForwardedFor() {
+        List<String> values = null;
+        for (String headerLine : delegate.headers().getAll(X_FORWARDED_FOR)) {
+            for (String token : headerLine.split(",")) {
+                String trimmed = token.trim();
+                if (!trimmed.isEmpty()) {
+                    if (values == null) {
+                        values = new ArrayList<>();
+                    }
+                    values.add(trimmed);
+                }
+            }
+        }
+        return values == null ? List.of() : Collections.unmodifiableList(values);
     }
 
     private static boolean isSchemeInvalid(String scheme) {
@@ -439,6 +485,30 @@ class ForwardedParser {
         }
 
         return result;
+    }
+
+    private final class SelectorContext implements XForwardedForSelector.Context {
+
+        private final List<String> values;
+
+        private SelectorContext(List<String> values) {
+            this.values = values;
+        }
+
+        @Override
+        public List<String> xForwardedForValues() {
+            return values;
+        }
+
+        @Override
+        public SocketAddress connectionPeer() {
+            return delegate.remoteAddress();
+        }
+
+        @Override
+        public MultiMap headers() {
+            return delegate.headers().copy();
+        }
     }
 
     static class Forwarded implements ForwardedInfo {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardingProxyHandlerFactory.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardingProxyHandlerFactory.java
@@ -64,7 +64,7 @@ public record ForwardingProxyHandlerFactory(ProxyConfig proxyConfig, ClientAuth 
     public Handler<HttpServerRequest> createHandler() {
         validateTrustedProxyConfig();
 
-        ForwardingProxyOptions options = ForwardingProxyOptions.from(proxyConfig);
+        ForwardingProxyOptions options = ForwardingProxyOptions.from(proxyConfig, configPrefix);
         if (hasHostTrustCheck) {
             return new ForwardedProxyHandler(builder(proxyConfig.trustedProxies().get()), vertx, root, options);
         } else if (hasClientAuthTrustCheck) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardingProxyOptions.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardingProxyOptions.java
@@ -1,6 +1,12 @@
 package io.quarkus.vertx.http.runtime;
 
+import java.util.List;
+import java.util.OptionalInt;
+
 import io.netty.util.AsciiString;
+import io.quarkus.arc.Arc;
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.vertx.http.XForwardedForSelector;
 import io.quarkus.vertx.http.runtime.ProxyConfig.ForwardedPrecedence;
 
 public class ForwardingProxyOptions {
@@ -15,6 +21,7 @@ public class ForwardingProxyOptions {
     final boolean strictForwardedControl;
     final ForwardedPrecedence forwardedPrecedence;
     final boolean enableTrustedProxyHeader;
+    final XForwardedForSelector xForwardedForSelector;
 
     private ForwardingProxyOptions(Builder builder) {
         this.proxyAddressForwarding = builder.proxyAddressForwarding;
@@ -28,13 +35,14 @@ public class ForwardingProxyOptions {
         this.strictForwardedControl = builder.strictForwardedControl;
         this.forwardedPrecedence = builder.forwardedPrecedence;
         this.enableTrustedProxyHeader = builder.enableTrustedProxyHeader;
+        this.xForwardedForSelector = builder.xForwardedForSelector;
     }
 
     static Builder builder() {
         return new Builder();
     }
 
-    static ForwardingProxyOptions from(ProxyConfig proxyConfig) {
+    static ForwardingProxyOptions from(ProxyConfig proxyConfig, String configPrefix) {
         final boolean allowForwarded = proxyConfig.allowForwarded();
         final boolean allowXForwarded = proxyConfig.allowXForwarded().orElse(!allowForwarded);
 
@@ -51,7 +59,51 @@ public class ForwardingProxyOptions {
                 .forwardedPrecedence(proxyConfig.forwardedPrecedence())
                 .forwardedHostHeader(AsciiString.cached(proxyConfig.forwardedHostHeader()))
                 .forwardedPrefixHeader(AsciiString.cached(proxyConfig.forwardedPrefixHeader()))
+                .xForwardedForSelector(resolveXForwardedForSelector(proxyConfig, configPrefix, allowForwarded))
                 .build();
+    }
+
+    private static XForwardedForSelector resolveXForwardedForSelector(ProxyConfig proxyConfig, String configPrefix,
+            boolean allowForwarded) {
+        var selectorBeans = Arc.requireContainer().select(XForwardedForSelector.class);
+        if (selectorBeans.isAmbiguous()) {
+            throw new ConfigurationException(
+                    "Only one '" + XForwardedForSelector.class.getName() + "' CDI bean is allowed");
+        }
+        boolean hasSelectorBean = !selectorBeans.isUnsatisfied();
+        String selectorBeanClass = hasSelectorBean ? selectorBeans.getHandle().getBean().getBeanClass().getName() : null;
+
+        OptionalInt index = proxyConfig.xForwardedForIndex();
+        if (index.isPresent()) {
+            int selectedIndex = index.getAsInt();
+            if (selectedIndex < 1) {
+                throw new ConfigurationException(
+                        "'" + configPrefix + ".proxy.x-forwarded-for-index' must be greater than 0");
+            }
+            if (allowForwarded) {
+                throw new ConfigurationException("'" + configPrefix + ".proxy.x-forwarded-for-index' and '"
+                        + configPrefix + ".proxy.allow-forwarded' are mutually exclusive");
+            }
+            if (hasSelectorBean) {
+                throw new ConfigurationException("'" + configPrefix + ".proxy.x-forwarded-for-index' and the '"
+                        + selectorBeanClass + "' CDI bean are mutually exclusive");
+            }
+            return context -> {
+                List<String> values = context.xForwardedForValues();
+                int position = values.size() - selectedIndex;
+                return position >= 0 ? values.get(position) : null;
+            };
+        }
+
+        if (hasSelectorBean) {
+            if (allowForwarded) {
+                throw new ConfigurationException("The '" + selectorBeanClass + "' CDI bean and '"
+                        + configPrefix + ".proxy.allow-forwarded' are mutually exclusive");
+            }
+            return selectorBeans.get();
+        }
+
+        return null;
     }
 
     static final class Builder {
@@ -67,6 +119,7 @@ public class ForwardingProxyOptions {
         private boolean strictForwardedControl;
         private ForwardedPrecedence forwardedPrecedence;
         private boolean enableTrustedProxyHeader;
+        private XForwardedForSelector xForwardedForSelector;
 
         private Builder() {
         }
@@ -123,6 +176,11 @@ public class ForwardingProxyOptions {
 
         Builder enableTrustedProxyHeader(boolean enableTrustedProxyHeader) {
             this.enableTrustedProxyHeader = enableTrustedProxyHeader;
+            return this;
+        }
+
+        Builder xForwardedForSelector(XForwardedForSelector xForwardedForSelector) {
+            this.xForwardedForSelector = xForwardedForSelector;
             return this;
         }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.vertx.http.runtime;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
@@ -200,4 +201,13 @@ public interface ProxyConfig {
      */
     @WithDefault("reject")
     ForwardedProtoValidation forwardedProtoValidation();
+
+    /**
+     * Selects the client address from the {@code X-Forwarded-For} header as the value at this 1-based index counted from
+     * the rightmost value ({@code 1} is the rightmost, {@code 2} the second from the right). When not set, the leftmost
+     * value is used. Use only when the server is reachable exclusively through trusted proxies or trusted clients,
+     * otherwise a client that connects directly can forge the selected value. Mutually exclusive with
+     * {@code quarkus.http.proxy.allow-forwarded} and with a {@code io.quarkus.vertx.http.XForwardedForSelector} CDI bean.
+     */
+    OptionalInt xForwardedForIndex();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -630,10 +630,11 @@ public class VertxHttpRecorder {
             HttpServerCommonHandlers.applyHeaders(managementConfig.getValue().header(), mr);
             applyCompression(managementBuildTimeConfig.enableCompression(), mr);
 
-            Handler<HttpServerRequest> handler = HttpServerCommonHandlers.enforceDuplicatedContext(mr, mustResumeRequest);
-            handler = HttpServerCommonHandlers.applyProxy(managementConfig.getValue().proxy(), handler, vertx,
-                    managementBuildTimeConfig.tlsClientAuth(), managementConfig.getValue().tlsConfigurationName(),
+            Handler<HttpServerRequest> handler = HttpServerCommonHandlers.applyProxy(managementConfig.getValue().proxy(), mr,
+                    vertx, managementBuildTimeConfig.tlsClientAuth(), managementConfig.getValue().tlsConfigurationName(),
                     "quarkus.management");
+
+            handler = HttpServerCommonHandlers.enforceDuplicatedContext(handler, mustResumeRequest);
 
             int routesBeforeMiEvent = mr.getRoutes().size();
             event.select(ManagementInterface.class).fire(new ManagementInterfaceImpl(mr));


### PR DESCRIPTION
* order of management route handlers is switched so that proxy is applied before enforcing the duplicated context. it is what the main router does (not saying it is the right thing) but main motivation is that `io.quarkus.vertx.http.runtime.ResumingRequestWrapper` currently doesn't delegate the remote address, so proxied remote address wasn't exposed on the HTTP request (it made testing hard). I can fix it on the wrapper instead if you prefer
* I made few judgement calls, but I am open to changes:
  * Cannot combine `X-Forwarded-For` with `Forwarded` when this feature is enabled because that would result in mismatch when `Forwarded` `for` attribute has multiple values. 
    * Choosing `Forwarded` `for` would require a different mechanism. 
    * Noone asked for it and Keycloak doesn't need it, see https://github.com/keycloak/keycloak/issues/13261
    * `Forwarded` `for` also allows obfuscated identifiers like `hidden` or tokens like `unknown` which are not valid IPs, I am not sure that the motivation of IP spoofing would be justified in such scenarios (but it would in others..)
  * count over hops because that is what Keycloak needs and I am worried that with dynamic IPs using trusted proxy list could be difficult for many users. But that also means that if you don't have firm number of proxies (like some calls may go via 3 some 1) spoofing is still possible. Hence I allowed users to create a custom selector for such a situations
  * instead of falling back to the peer connection, I decided to reject request with 400 when selector cannot select the correct value (e.g. if you want to select 2nd from right but there is just one value). I think it is safer, aligns with our other 400s in the parser and users can provide their selector if they don't like it

---

* Closes: https://github.com/quarkusio/quarkus/issues/45005