### PR TITLE
Try to prevent unnecessary release-notes in PRs

### DIFF
--- a/.agents/skills/pull-requests/SKILL.md
+++ b/.agents/skills/pull-requests/SKILL.md
@@ -46,6 +46,8 @@ Release note: RESTEasy Reactive now supports multipart file uploads with
 progress tracking via the new `@PartProgress` annotation.
 ```
 
+*Only* do this for noteworthy features, not small enhancements or bug fixes
+
 ### Breaking changes
 
 If the change is breaking, explain in the description:


### PR DESCRIPTION
Done because I've seen plenty of PRs with release notes.

The last one I saw was https://github.com/quarkusio/quarkus/pull/56212