### PR TITLE
Fix bad mapping for Spring `@RequestHeader`

### DIFF
--- a/extensions/spring-web/resteasy-classic/tests/src/test/java/io/quarkus/spring/web/resteasy/classic/test/requestheader/RequestHeaderController.java
+++ b/extensions/spring-web/resteasy-classic/tests/src/test/java/io/quarkus/spring/web/resteasy/classic/test/requestheader/RequestHeaderController.java
@@ -1,8 +1,10 @@
 package io.quarkus.spring.web.resteasy.classic.test.requestheader;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,4 +23,18 @@ public class RequestHeaderController {
     public String getHeaderWithDefault(@RequestHeader(name = "X-Optional-Header", defaultValue = "fallback") String value) {
         return "Header: " + value;
     }
+
+    @GetMapping("/api/headers/namedByName")
+    public String getNamedByNameHeader(@RequestHeader(name = "X-Other-Header") String otherHeader) {
+        return "Other-Header: " + otherHeader;
+    }
+
+    @GetMapping("/api/headers/mixed/{id}")
+    public String mixedParams(
+            @PathVariable String id,
+            @RequestParam String filter,
+            @RequestHeader("X-Token") String token) {
+        return "id=" + id + " filter=" + filter + " token=" + token;
+    }
+
 }

--- a/extensions/spring-web/resteasy-classic/tests/src/test/java/io/quarkus/spring/web/resteasy/classic/test/requestheader/RequestHeaderControllerTest.java
+++ b/extensions/spring-web/resteasy-classic/tests/src/test/java/io/quarkus/spring/web/resteasy/classic/test/requestheader/RequestHeaderControllerTest.java
@@ -50,4 +50,26 @@ public class RequestHeaderControllerTest {
                 .statusCode(200)
                 .body(is("Header: fallback"));
     }
+
+    @Test
+    public void testNamedByNameHeader() {
+        given()
+                .header("X-Other-Header", "other-value")
+                .when().get("/api/headers/namedByName")
+                .then()
+                .statusCode(200)
+                .body(is("Other-Header: other-value"));
+    }
+
+    @Test
+    public void testMixedParams() {
+        given()
+                .header("X-Token", "secret123")
+                .queryParam("filter", "active")
+                .when().get("/api/headers/mixed/42")
+                .then()
+                .statusCode(200)
+                .body(is("id=42 filter=active token=secret123"));
+    }
+
 }

--- a/extensions/spring-web/resteasy-reactive/deployment/src/main/java/io/quarkus/spring/web/resteasy/reactive/deployment/SpringWebResteasyReactiveProcessor.java
+++ b/extensions/spring-web/resteasy-reactive/deployment/src/main/java/io/quarkus/spring/web/resteasy/reactive/deployment/SpringWebResteasyReactiveProcessor.java
@@ -52,6 +52,7 @@ import io.quarkus.resteasy.reactive.spi.ExceptionMapperBuildItem;
 import io.quarkus.resteasy.server.common.spi.AdditionalJaxRsResourceMethodParamAnnotations;
 import io.quarkus.spring.web.resteasy.reactive.runtime.ResponseEntityHandler;
 import io.quarkus.spring.web.resteasy.reactive.runtime.ResponseStatusHandler;
+import io.quarkus.spring.web.resteasy.reactive.runtime.SpringHeaderMapParamExtractor;
 import io.quarkus.spring.web.resteasy.reactive.runtime.SpringMapParamExtractor;
 import io.quarkus.spring.web.resteasy.reactive.runtime.SpringMultiValueListParamExtractor;
 import io.quarkus.spring.web.resteasy.reactive.runtime.SpringMultiValueMapParamExtractor;
@@ -468,6 +469,11 @@ public class SpringWebResteasyReactiveProcessor {
                     }
                     if (paramType.name().equals(JAVA_UTIL_MAP)) {
                         return new SpringMapParamExtractor();
+                    }
+                }
+                if (annotations.containsKey(REQUEST_HEADER)) {
+                    if (paramType.name().equals(JAVA_UTIL_MAP)) {
+                        return new SpringHeaderMapParamExtractor();
                     }
                 }
                 return null;

--- a/extensions/spring-web/resteasy-reactive/runtime/src/main/java/io/quarkus/spring/web/resteasy/reactive/runtime/SpringHeaderMapParamExtractor.java
+++ b/extensions/spring-web/resteasy-reactive/runtime/src/main/java/io/quarkus/spring/web/resteasy/reactive/runtime/SpringHeaderMapParamExtractor.java
@@ -1,0 +1,20 @@
+package io.quarkus.spring.web.resteasy.reactive.runtime;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
+
+public class SpringHeaderMapParamExtractor implements ParameterExtractor {
+
+    @Override
+    public Object extractParameter(ResteasyReactiveRequestContext context) {
+        Map<String, String> headerMap = new LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : context.serverRequest().getAllRequestHeaders()) {
+            headerMap.putIfAbsent(entry.getKey(), entry.getValue());
+        }
+        return headerMap;
+    }
+
+}

--- a/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/requestheader/RequestHeaderController.java
+++ b/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/requestheader/RequestHeaderController.java
@@ -1,8 +1,13 @@
 package io.quarkus.spring.web.requestheader;
 
+import java.util.Map;
+import java.util.TreeMap;
+
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,4 +26,26 @@ public class RequestHeaderController {
     public String getHeaderWithDefault(@RequestHeader(name = "X-Optional-Header", defaultValue = "fallback") String value) {
         return "Header: " + value;
     }
+
+    @GetMapping("/api/headers/all")
+    public String getAllHeaders(@RequestHeader Map<String, String> headers) {
+        Map<String, String> sorted = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        sorted.putAll(headers);
+        return "Headers: " + sorted;
+    }
+
+    @GetMapping("/api/headers/namedByName")
+    public String getNamedByNameHeader(@RequestHeader(name = "X-Other-Header") String otherHeader) {
+        return "Other-Header: " + otherHeader;
+    }
+
+    @GetMapping("/api/headers/mixed/{id}")
+    public String mixedParams(
+            @PathVariable String id,
+            @RequestParam String filter,
+            @RequestHeader("X-Token") String token,
+            @RequestHeader Map<String, String> allHeaders) {
+        return "id=" + id + " filter=" + filter + " token=" + token + " hasHeaders=" + !allHeaders.isEmpty();
+    }
+
 }

--- a/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/requestheader/RequestHeaderControllerTest.java
+++ b/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/requestheader/RequestHeaderControllerTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.spring.web.requestheader;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
@@ -50,4 +51,38 @@ public class RequestHeaderControllerTest {
                 .statusCode(200)
                 .body(is("Header: fallback"));
     }
+
+    @Test
+    public void testGetAllHeaders() {
+        given()
+                .header("X-Test-One", "value1")
+                .header("X-Test-Two", "value2")
+                .when().get("/api/headers/all")
+                .then()
+                .statusCode(200)
+                .body(containsString("X-Test-One=value1"))
+                .body(containsString("X-Test-Two=value2"));
+    }
+
+    @Test
+    public void testNamedByNameHeader() {
+        given()
+                .header("X-Other-Header", "other-value")
+                .when().get("/api/headers/namedByName")
+                .then()
+                .statusCode(200)
+                .body(is("Other-Header: other-value"));
+    }
+
+    @Test
+    public void testMixedParams() {
+        given()
+                .header("X-Token", "secret123")
+                .queryParam("filter", "active")
+                .when().get("/api/headers/mixed/42")
+                .then()
+                .statusCode(200)
+                .body(is("id=42 filter=active token=secret123 hasHeaders=true"));
+    }
+
 }


### PR DESCRIPTION
Fixes `@RequestHeader Map<String, String>` throwing converter error instead of injecting all HTTP headers.                                                      
                                                                                                                                                                       
Two bugs fixed:                                                                                                                                                                   
  - @RequestHeader was incorrectly mapped to @RestQueryParam instead of @RestHeaderParam.                                      
  - No custom parameter extractor existed for @RequestHeader Map<String, String> without a name, which in Spring should inject all request headers as a Map.                                                                       
           
---- 
                                                                                                                                                                         
- Fixes: #14051