### PR TITLE
Reject REST Client Response/RestResponse returned from server endpoints

### DIFF
--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ClientAndServerSharingResponseTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ClientAndServerSharingResponseTest.java
@@ -90,7 +90,11 @@ public class ClientAndServerSharingResponseTest {
         @Produces(MediaType.APPLICATION_JSON)
         @Blocking
         public Response testCase4() {
-            return headersService.dumpHeaders();
+            try (Response clientResponse = headersService.dumpHeaders()) {
+                return Response.status(clientResponse.getStatus())
+                        .entity(clientResponse.readEntity(String.class))
+                        .build();
+            }
         }
     }
 }

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ClientResponseAsServerResponseTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ClientResponseAsServerResponseTest.java
@@ -1,0 +1,84 @@
+package io.quarkus.rest.client.reactive;
+
+import static io.restassured.RestAssured.when;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.smallrye.common.annotation.Blocking;
+
+public class ClientResponseAsServerResponseTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(BackendResource.class, BackendClient.class, ProxyResource.class))
+            .overrideRuntimeConfigKey("quarkus.rest-client.backend.url",
+                    "http://localhost:${quarkus.http.test-port:8081}");
+
+    @Test
+    void testClientResponseReturnedDirectlyFromServerEndpointIsRejected() {
+        when().get("/proxy/response")
+                .then()
+                .statusCode(500);
+    }
+
+    @Test
+    void testClientRestResponseReturnedDirectlyFromServerEndpointIsRejected() {
+        when().get("/proxy/rest-response")
+                .then()
+                .statusCode(500);
+    }
+
+    @Path("/backend")
+    public static class BackendResource {
+
+        @GET
+        public String get() {
+            return "backend-response";
+        }
+    }
+
+    @Path("/backend")
+    @RegisterRestClient(configKey = "backend")
+    public interface BackendClient {
+
+        @GET
+        Response getResponse();
+
+        @GET
+        RestResponse<String> getRestResponse();
+    }
+
+    @Path("/proxy")
+    public static class ProxyResource {
+
+        private final BackendClient backendClient;
+
+        public ProxyResource(@RestClient BackendClient backendClient) {
+            this.backendClient = backendClient;
+        }
+
+        @GET
+        @Path("response")
+        @Blocking
+        public Response proxyResponse() {
+            return backendClient.getResponse();
+        }
+
+        @GET
+        @Path("rest-response")
+        @Blocking
+        public RestResponse<String> proxyRestResponse() {
+            return backendClient.getRestResponse();
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/AsyncInvokerImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/AsyncInvokerImpl.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.common.jaxrs.ConfigurationImpl;
+import org.jboss.resteasy.reactive.common.jaxrs.RestResponseImpl;
 import org.jboss.resteasy.reactive.common.util.types.Types;
 import org.jboss.resteasy.reactive.spi.ThreadSetupAction;
 
@@ -308,8 +309,13 @@ public class AsyncInvokerImpl implements AsyncInvoker, CompletionStageRxInvoker 
             return res.thenApply(new Function<>() {
                 @Override
                 public T apply(Response response) {
-                    return (T) RestResponse.ResponseBuilder.create(response.getStatusInfo(), response.getEntity())
+                    RestResponse<?> restResponse = RestResponse.ResponseBuilder
+                            .create(response.getStatusInfo(), response.getEntity())
                             .replaceAll(response.getHeaders()).build();
+                    if (restResponse instanceof RestResponseImpl<?> restResponseImpl) {
+                        restResponseImpl.setClientResponse(true);
+                    }
+                    return (T) restResponse;
                 }
             });
         } else {

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientResponseImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientResponseImpl.java
@@ -87,4 +87,9 @@ public class ClientResponseImpl extends ResponseImpl {
     public StackTraceElement[] getCallerStackTrace() {
         return restClientRequestContext.getCallerStackTrace();
     }
+
+    @Override
+    public boolean isClientResponse() {
+        return true;
+    }
 }

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientRestResponseBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientRestResponseBuilderImpl.java
@@ -34,6 +34,7 @@ public class ClientRestResponseBuilderImpl<T> extends AbstractRestResponseBuilde
         populateResponse(response);
         response.restClientRequestContext = restClientRequestContext;
         response.setEntityStream(entityStream);
+        response.setClientResponse(true);
         return response;
     }
 

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientRestResponseImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientRestResponseImpl.java
@@ -67,4 +67,5 @@ public class ClientRestResponseImpl<T> extends RestResponseImpl<T> {
             throw new ProcessingException(e);
         }
     }
+
 }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/ResponseImpl.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/ResponseImpl.java
@@ -309,4 +309,8 @@ public class ResponseImpl extends Response {
         return entityAnnotations;
     }
 
+    public boolean isClientResponse() {
+        return false;
+    }
+
 }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/RestResponseImpl.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/RestResponseImpl.java
@@ -51,6 +51,7 @@ public class RestResponseImpl<T> extends RestResponse<T> {
     protected boolean consumed;
     protected boolean closed;
     protected boolean buffered;
+    private boolean clientResponse;
 
     @Override
     public Response toResponse() {
@@ -326,6 +327,14 @@ public class RestResponseImpl<T> extends RestResponse<T> {
 
     public Annotation[] getEntityAnnotations() {
         return entityAnnotations;
+    }
+
+    public boolean isClientResponse() {
+        return clientResponse;
+    }
+
+    public void setClientResponse(boolean clientResponse) {
+        this.clientResponse = clientResponse;
     }
 
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ResponseHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ResponseHandler.java
@@ -47,6 +47,14 @@ public class ResponseHandler implements ServerRestHandler {
     public void handle(ResteasyReactiveRequestContext requestContext) throws Exception {
         Object result = requestContext.getResult();
         if (result instanceof Response existing) {
+            if (existing instanceof ResponseImpl responseImpl && responseImpl.isClientResponse()) {
+                throw new IllegalStateException(
+                        "A REST Client Response object was returned from a server endpoint. "
+                                + "This is not supported because it carries connection-specific headers "
+                                + "that are not suitable for forwarding. "
+                                + "Please create a new Response using Response.fromResponse() or "
+                                + "by extracting the status, entity and headers you need.");
+            }
             boolean mediaTypeAlreadyExists = false;
             //we already have a response
             //set it explicitly
@@ -92,6 +100,13 @@ public class ResponseHandler implements ServerRestHandler {
                 requestContext.setResponse(new LazyResponse.Existing(responseBuilder.build()));
             }
         } else if (result instanceof RestResponse<?> existing) {
+            if (existing instanceof RestResponseImpl<?> restResponseImpl && restResponseImpl.isClientResponse()) {
+                throw new IllegalStateException(
+                        "A REST Client RestResponse object was returned from a server endpoint. "
+                                + "This is not supported because it carries connection-specific headers "
+                                + "that are not suitable for forwarding. "
+                                + "Please create a new RestResponse by extracting the status, entity and headers you need.");
+            }
             boolean mediaTypeAlreadyExists = false;
             //we already have a response
             //set it explicitly

--- a/integration-tests/rest-client-reactive-http2/src/main/java/io/quarkus/it/rest/client/http2/Resource.java
+++ b/integration-tests/rest-client-reactive-http2/src/main/java/io/quarkus/it/rest/client/http2/Resource.java
@@ -34,7 +34,7 @@ public class Resource {
     public Response client() {
         Response response = client.ping();
         if (((ClientResponseImpl) response).getHttpVersion().equals("HTTP_2")) {
-            return response;
+            return Response.ok(response.readEntity(String.class)).build();
         }
 
         return Response.noContent().build();
@@ -45,7 +45,7 @@ public class Resource {
     public Response client2() {
         Response response = client2.ping();
         if (((ClientResponseImpl) response).getHttpVersion().equals("HTTP_2")) {
-            return response;
+            return Response.ok(response.readEntity(String.class)).build();
         }
 
         return Response.noContent().build();


### PR DESCRIPTION
Given how dangerous and risky it is from a security PoV, I propose rejecting re-using client responses from a REST server.

REST Client Response objects carry connection-specific hop-by-hop headers (Transfer-Encoding, Content-Length, Connection, etc.) that must not be forwarded when returned from a server endpoint. Rather than stripping individual headers, reject the client response entirely and require users to create a new Response by extracting the status, entity and headers they need.

- Add isClientResponse() marker to ResponseImpl and RestResponseImpl
- Override in ClientResponseImpl, set via flag in RestResponseImpl (since the declarative client creates RestResponseImpl through the server factory, not ClientRestResponseImpl)
- Mark client RestResponse in AsyncInvokerImpl.mapResponse() and ClientRestResponseBuilderImpl.build()
- Check and reject in ResponseHandler for both Response and RestResponse
- Fix ClientAndServerSharingResponseTest to properly extract status/entity
- Add ClientResponseAsServerResponseTest for both Response and RestResponse

Fixes part of #49896
