### PR TITLE
Remove deprecated code from `core/processor`

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/discovery/DiscoveryConfigGroup.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/discovery/DiscoveryConfigGroup.java
@@ -4,8 +4,8 @@ import io.quarkus.annotation.processor.documentation.config.model.Extension;
 
 public final class DiscoveryConfigGroup extends DiscoveryRootElement {
 
-    public DiscoveryConfigGroup(Extension extension, String binaryName, String qualifiedName, boolean configMapping) {
-        super(extension, binaryName, qualifiedName, configMapping);
+    public DiscoveryConfigGroup(Extension extension, String binaryName, String qualifiedName) {
+        super(extension, binaryName, qualifiedName);
     }
 
 }

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/discovery/DiscoveryConfigRoot.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/discovery/DiscoveryConfigRoot.java
@@ -17,8 +17,8 @@ public final class DiscoveryConfigRoot extends DiscoveryRootElement {
 
     public DiscoveryConfigRoot(Extension extension, String prefix, String overriddenDocPrefix,
             String binaryName, String qualifiedName,
-            ConfigPhase configPhase, String overriddenDocFileName, boolean configMapping) {
-        super(extension, binaryName, qualifiedName, configMapping);
+            ConfigPhase configPhase, String overriddenDocFileName) {
+        super(extension, binaryName, qualifiedName);
 
         this.prefix = prefix;
         this.overriddenDocPrefix = overriddenDocPrefix;

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/discovery/DiscoveryRootElement.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/discovery/DiscoveryRootElement.java
@@ -13,16 +13,10 @@ public sealed abstract class DiscoveryRootElement permits DiscoveryConfigRoot, D
     private final String qualifiedName;
     private final Map<String, DiscoveryConfigProperty> properties = new LinkedHashMap<>();
 
-    // TODO #42114 remove once fixed
-    // this is an approximation, we can't fully detect that in the case of config groups
-    @Deprecated(forRemoval = true)
-    private final boolean configMapping;
-
-    DiscoveryRootElement(Extension extension, String binaryName, String qualifiedName, boolean configMapping) {
+    DiscoveryRootElement(Extension extension, String binaryName, String qualifiedName) {
         this.extension = extension;
         this.binaryName = binaryName;
         this.qualifiedName = qualifiedName;
-        this.configMapping = configMapping;
     }
 
     public Extension getExtension() {
@@ -43,11 +37,6 @@ public sealed abstract class DiscoveryRootElement permits DiscoveryConfigRoot, D
 
     public Map<String, DiscoveryConfigProperty> getProperties() {
         return Collections.unmodifiableMap(properties);
-    }
-
-    @Deprecated(forRemoval = true)
-    public boolean isConfigMapping() {
-        return configMapping;
     }
 
     public String toString() {

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/AbstractConfigItem.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/AbstractConfigItem.java
@@ -43,12 +43,6 @@ public sealed abstract class AbstractConfigItem implements Comparable<AbstractCo
         return path;
     }
 
-    @Deprecated
-    @JsonIgnore
-    public String getPath$$bridge() {
-        return path.property();
-    }
-
     public String getType() {
         return type;
     }

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/ConfigProperty.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/ConfigProperty.java
@@ -4,7 +4,6 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.quarkus.annotation.processor.documentation.config.util.Types;
@@ -67,12 +66,6 @@ public final class ConfigProperty extends AbstractConfigItem {
 
     public List<PropertyPath> getAdditionalPaths() {
         return additionalPaths;
-    }
-
-    @Deprecated
-    @JsonIgnore
-    public String getEnvironmentVariable() {
-        return getPath().environmentVariable();
     }
 
     public String getTypeDescription() {

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/scanner/ConfigAnnotationScanner.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/scanner/ConfigAnnotationScanner.java
@@ -141,12 +141,11 @@ public class ConfigAnnotationScanner {
                     configMappingWithoutConfigRoot);
 
             try {
-                // we need to forge a dummy DiscoveryConfigRoot
-                // it's mostly ignored in the listeners, except for checking if it's a config mapping (for mixed modules)
+                // we need to forge a dummy DiscoveryConfigRoot, it's mostly ignored in the listeners
                 DiscoveryConfigRoot discoveryConfigRoot = new DiscoveryConfigRoot(config.getExtension(), "dummy", "dummy",
                         utils.element().getBinaryName(configMappingWithoutConfigRoot),
                         configMappingWithoutConfigRoot.getQualifiedName().toString(),
-                        ConfigPhase.BUILD_TIME, null, true);
+                        ConfigPhase.BUILD_TIME, null);
                 scanElement(configMappingWithoutConfigRootListeners, discoveryConfigRoot, configMappingWithoutConfigRoot);
             } catch (Exception e) {
                 throw new IllegalStateException(

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/scanner/ConfigMappingListener.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/scanner/ConfigMappingListener.java
@@ -120,7 +120,7 @@ public class ConfigMappingListener implements ConfigAnnotationListener {
 
         DiscoveryConfigRoot discoveryConfigRoot = new DiscoveryConfigRoot(config.getExtension(),
                 rootPrefix, overriddenDocPrefix,
-                binaryName, configRoot.getQualifiedName().toString(), configPhase, overriddenDocFileName, true);
+                binaryName, configRoot.getQualifiedName().toString(), configPhase, overriddenDocFileName);
         configCollector.addConfigRoot(discoveryConfigRoot);
         return Optional.of(discoveryConfigRoot);
     }
@@ -187,9 +187,7 @@ public class ConfigMappingListener implements ConfigAnnotationListener {
     public Optional<DiscoveryConfigGroup> onConfigGroup(TypeElement configGroup) {
         DiscoveryConfigGroup discoveryConfigGroup = new DiscoveryConfigGroup(config.getExtension(),
                 utils.element().getBinaryName(configGroup),
-                configGroup.getQualifiedName().toString(),
-                // interface config groups are considered config mappings, let's hope it's enough
-                configGroup.getKind() == ElementKind.INTERFACE);
+                configGroup.getQualifiedName().toString());
         configCollector.addResolvedConfigGroup(discoveryConfigGroup);
         return Optional.of(discoveryConfigGroup);
     }


### PR DESCRIPTION
* Remove deprecated code from DiscoveryRootElement (#42114 is now closed) - https://github.com/quarkusio/quarkus/commit/caa7525ada55bce4c0ce9fc587902d89b8d5ad4d
  The removed code has been deprecated for at least 12 months in https://github.com/quarkusio/quarkus/commit/b015c1ddc14e64aa86ea12bc54378c4b382305a5
* Remove deprecated code from AbstractConfigItem - https://github.com/quarkusio/quarkus/commit/0947c9035b34ec34812c1fd90b3658b4b9b49204
  The removed code has been deprecated for at least 12 months in https://github.com/quarkusio/quarkus/commit/7773394e93139b5c11e59a70f3977c0281277d3a
* Remove deprecated code from ConfigProperty - https://github.com/quarkusio/quarkus/commit/239b73ee455ff26beb25bb1c2127eda884e28b5d
  The removed code has been deprecated for at least 12 months in https://github.com/quarkusio/quarkus/commit/7773394e93139b5c11e59a70f3977c0281277d3a