### PR TITLE
TLS registry: fail fast when the OpenSSL engine is requested in a native executable

### DIFF
--- a/docs/src/main/asciidoc/tls-registry-reference.adoc
+++ b/docs/src/main/asciidoc/tls-registry-reference.adoc
@@ -842,6 +842,26 @@ Other operating systems and architectures (macOS, Windows, Alpine Linux, Linux o
 On those platforms, use `relaxed` with JDK 27+ for post-quantum key exchange.
 ====
 
+[IMPORTANT]
+====
+The OpenSSL engine is not available in native executables.
+Quarkus' native-image support disables `netty-tcnative`, so `quarkus.tls.ssl-engine=openssl` is rejected at startup of a native executable with a configuration error that names the property.
+This applies even when `io.smallrye:smallrye-openssl` is on the classpath and OpenSSL 3.5+ is installed.
+Post-quantum enforcement (`strict` or `client-negotiated`) in native mode therefore needs a JDK SSL engine with post-quantum support.
+If that is not possible, use JVM mode for post-quantum enforcement, as OpenSSL cannot provide it in native mode.
+
+|===
+|SSL engine |JDK PQC support |Mode |PQC enforcement available
+
+|JDK SSL |No |Native |No
+|JDK SSL |Yes |Native |Yes
+|JDK SSL |No |JVM |No
+|JDK SSL |Yes |JVM |Yes
+|OpenSSL (netty-tcnative) |- |Native |No (engine unavailable)
+|OpenSSL (netty-tcnative) |- |JVM |Yes
+|===
+====
+
 ===== SSL engine override
 
 By default, Vert.x selects the SSL engine automatically based on the enforcement policy:

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/CertificateRecorder.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/CertificateRecorder.java
@@ -14,9 +14,11 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
+import io.quarkus.runtime.ImageMode;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.tls.KeyStoreAndKeyCertOptions;
 import io.quarkus.tls.KeyStoreFactory;
 import io.quarkus.tls.KeyStoreProvider;
@@ -25,6 +27,7 @@ import io.quarkus.tls.TlsConfigurationRegistry;
 import io.quarkus.tls.TrustStoreAndTrustOptions;
 import io.quarkus.tls.TrustStoreFactory;
 import io.quarkus.tls.TrustStoreProvider;
+import io.quarkus.tls.runtime.config.SslEngineType;
 import io.quarkus.tls.runtime.config.TlsBucketConfig;
 import io.quarkus.tls.runtime.config.TlsConfig;
 import io.quarkus.tls.runtime.keystores.JKSKeyStores;
@@ -98,6 +101,7 @@ public class CertificateRecorder implements TlsConfigurationRegistry {
     }
 
     private void verifyCertificateConfig(TlsBucketConfig config, Vertx vertx, String name) {
+        verifySslEngineSupportedInNativeImage(config, name);
         final TlsConfiguration tlsConfig = verifyCertificateConfigInternal(config, vertx, name);
         certificates.put(name, tlsConfig);
 
@@ -108,6 +112,29 @@ public class CertificateRecorder implements TlsConfigurationRegistry {
             }
             reloader.add(name, certificates.get(name), config.reloadPeriod().get());
         }
+    }
+
+    /**
+     * The OpenSSL engine (netty-tcnative) is disabled by the Quarkus GraalVM substitutions, so a bucket that requests
+     * it is rejected when running as a native executable, with a message that names native mode as the cause.
+     * Without this, Vert.x fails at listen time ({@code SslContextManager.resolveEngineOptions}) with "OpenSSL is not
+     * available", which does not mention the mode.
+     */
+    static void verifySslEngineSupportedInNativeImage(TlsBucketConfig config, String name) {
+        verifySslEngineSupportedInNativeImage(config, name, ImageMode.current().isNativeImage());
+    }
+
+    // Visible for testing
+    static void verifySslEngineSupportedInNativeImage(TlsBucketConfig config, String name, boolean nativeImage) {
+        if (!nativeImage || config.sslEngine().isEmpty() || config.sslEngine().get() != SslEngineType.OPENSSL) {
+            return;
+        }
+        String key = (TlsConfig.DEFAULT_NAME.equals(name) ? "quarkus.tls." : "quarkus.tls." + name + ".") + "ssl-engine";
+        throw new ConfigurationException(
+                "TLS configuration '" + name + "' sets '" + key + "=openssl', but the OpenSSL engine "
+                        + "(netty-tcnative) is not supported in Quarkus native executables. "
+                        + "Remove the property or set it to 'jdkssl', or run the application in JVM mode.",
+                Set.of(key));
     }
 
     private static TlsConfiguration verifyCertificateConfigInternal(TlsBucketConfig config, Vertx vertx, String name) {

--- a/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/CertificateRecorderNativeImageTest.java
+++ b/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/CertificateRecorderNativeImageTest.java
@@ -1,0 +1,142 @@
+package io.quarkus.tls.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.tls.runtime.config.KeyStoreConfig;
+import io.quarkus.tls.runtime.config.PqcEnforcementPolicy;
+import io.quarkus.tls.runtime.config.SslEngineType;
+import io.quarkus.tls.runtime.config.TlsBucketConfig;
+import io.quarkus.tls.runtime.config.TlsConfig;
+import io.quarkus.tls.runtime.config.TrustStoreConfig;
+
+/**
+ * The OpenSSL engine (netty-tcnative) is disabled by the Quarkus GraalVM substitutions, so a TLS bucket that requests
+ * it must be rejected early, with a message that names native mode as the cause, instead of letting Vert.x fail at
+ * listen time with "OpenSSL is not available".
+ */
+class CertificateRecorderNativeImageTest {
+
+    private static final boolean NATIVE = true;
+    private static final boolean JVM = false;
+
+    @Test
+    void jvmModeNeverRejects() {
+        assertThatCode(() -> CertificateRecorder.verifySslEngineSupportedInNativeImage(
+                bucket(Optional.of(SslEngineType.OPENSSL), PqcEnforcementPolicy.STRICT), "foo", JVM))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void nativeModeWithJdkEngineIsAccepted() {
+        assertThatCode(() -> CertificateRecorder.verifySslEngineSupportedInNativeImage(
+                bucket(Optional.of(SslEngineType.JDKSSL), PqcEnforcementPolicy.STRICT), "foo", NATIVE))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void nativeModeWithEngineUnsetIsAccepted() {
+        // the engine Vert.x selects for the policy, and whether it supports it, is validated by Vert.x itself
+        assertThatCode(() -> CertificateRecorder.verifySslEngineSupportedInNativeImage(
+                bucket(Optional.empty(), PqcEnforcementPolicy.STRICT), "foo", NATIVE))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void nativeModeWithOpenSslEngineIsRejectedNamingTheProperty() {
+        assertThatThrownBy(() -> CertificateRecorder.verifySslEngineSupportedInNativeImage(
+                bucket(Optional.of(SslEngineType.OPENSSL), PqcEnforcementPolicy.RELAXED), "foo", NATIVE))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("quarkus.tls.foo.ssl-engine")
+                .hasMessageContaining("native");
+    }
+
+    @Test
+    void nativeModeWithOpenSslEngineOnDefaultBucketNamesTheUnnamedProperty() {
+        assertThatThrownBy(() -> CertificateRecorder.verifySslEngineSupportedInNativeImage(
+                bucket(Optional.of(SslEngineType.OPENSSL), PqcEnforcementPolicy.RELAXED), TlsConfig.DEFAULT_NAME,
+                NATIVE))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("quarkus.tls.ssl-engine")
+                .satisfies(e -> assertThat(e.getMessage()).doesNotContain("quarkus.tls.<default>"));
+    }
+
+    private static TlsBucketConfig bucket(Optional<SslEngineType> engine, PqcEnforcementPolicy policy) {
+        return new TlsBucketConfig() {
+            @Override
+            public Optional<KeyStoreConfig> keyStore() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<TrustStoreConfig> trustStore() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<List<String>> cipherSuites() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Set<String> protocols() {
+                return Set.of();
+            }
+
+            @Override
+            public Duration handshakeTimeout() {
+                return Duration.ofSeconds(10);
+            }
+
+            @Override
+            public boolean alpn() {
+                return false;
+            }
+
+            @Override
+            public PqcEnforcementPolicy pqcEnforcementPolicy() {
+                return policy;
+            }
+
+            @Override
+            public Optional<List<String>> keyExchangeGroups() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<SslEngineType> sslEngine() {
+                return engine;
+            }
+
+            @Override
+            public Optional<List<Path>> certificateRevocationList() {
+                return Optional.empty();
+            }
+
+            @Override
+            public boolean trustAll() {
+                return false;
+            }
+
+            @Override
+            public Optional<String> hostnameVerificationAlgorithm() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Duration> reloadPeriod() {
+                return Optional.empty();
+            }
+        };
+    }
+}


### PR DESCRIPTION
Since #55624 users can set `quarkus.tls.ssl-engine=openssl`. In JVM mode this works; in a native executable it fails at server listen inside Vert.x with "OpenSSL is not available", because the Netty/Vert.x GraalVM substitutions hard-code the OpenSSL engine as unavailable. The message does not say that native mode is the cause.

This makes the failure explicit:

- `CertificateRecorder`: when running as a native image, reject a TLS bucket that sets `ssl-engine=openssl` with a `ConfigurationException` naming the property and native mode. The check is in the recorder because `quarkus.tls` is runtime configuration.
- Docs: note in the TLS registry reference, with a table of which SSL engine / JDK PQC support / mode combinations provide post-quantum enforcement.

The PQC enforcement policies (`strict`, `client-negotiated`) are not checked here: Vert.x already validates that the engine it selects supports them, and once the JDK engine has post-quantum support (JEP 527, Mandrel 25 patch release) they work in native mode without OpenSSL.

Verified in a native executable (Mandrel 25): the configuration error is reported at startup instead of the Vert.x exception.

Relates to #456, #55624, #55629, #56263. A follow-up (#56265) makes the OpenSSL engine actually usable in native executables when the application ships tcnative; this check then only fires when OpenSSL really is unavailable.
