### PR TITLE
Bound remote-dev request body processing

### DIFF
--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -308,6 +308,10 @@ Now you need to connect your local agent to the remote host, using the `remote-d
 Now every time you refresh the browser you should see any changes you have made locally immediately visible in the remote
 app.
 
+Remote development HTTP requests are limited by `quarkus.http.limits.max-body-size`.
+Set this value high enough for the largest file that must be synchronized.
+If the general HTTP body limit is disabled, remote development still applies a 10 MiB limit.
+
 All the config options are shown below:
 
 include::{generated-dir}/config/quarkus-core_quarkus.live-reload.adoc[opts=optional, leveloffset=+1]

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -259,6 +259,10 @@ Now every time you refresh the browser you should see any changes you have made 
 app. This is done via an HTTP based long polling transport, that will synchronize your local workspace and the remote
 application via HTTP calls.
 
+Remote development HTTP requests are limited by `quarkus.http.limits.max-body-size`.
+Set this value high enough for the largest file that must be synchronized.
+If the general HTTP body limit is disabled, remote development still applies a 10 MiB limit.
+
 If you do not want to use the HTTP feature then you can simply run the `remote-dev` command without specifying the URL.
 In this mode the command will continuously rebuild the local application, so you can use an external tool such as odo or
 rsync to sync to the remote application.

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/HttpRemoteDevClient.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/HttpRemoteDevClient.java
@@ -5,6 +5,7 @@ import static io.quarkus.runtime.util.HashUtil.sha256;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectOutputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
@@ -100,9 +101,8 @@ public class HttpRemoteDevClient implements RemoteDevClient {
         }
 
         private void sendData(Map.Entry<String, byte[]> entry, String session) throws IOException {
-            HttpURLConnection connection;
             log.info("Sending " + entry.getKey());
-            connection = (HttpURLConnection) new URL(url + "/" + entry.getKey()).openConnection();
+            HttpURLConnection connection = (HttpURLConnection) new URL(url + "/" + entry.getKey()).openConnection();
             connection.setRequestMethod("PUT");
             connection.setDoOutput(true);
             connection.setRequestProperty(HttpHeaders.ACCEPT.toString(), DEFAULT_ACCEPT);
@@ -113,9 +113,7 @@ public class HttpRemoteDevClient implements RemoteDevClient {
                     sha256(sha256(entry.getValue()) + session + currentSessionCounter + password));
             currentSessionCounter++;
             connection.addRequestProperty(RemoteSyncHandler.QUARKUS_SESSION, session);
-            connection.getOutputStream().write(entry.getValue());
-            connection.getOutputStream().close();
-            IoUtil.readBytes(connection.getInputStream());
+            exchange(connection, entry.getValue(), "send a remote file");
         }
 
         private String doConnect(RemoteDevState initialState, Function<Set<String>, Map<String, byte[]>> initialConnectFunction)
@@ -141,18 +139,13 @@ public class HttpRemoteDevClient implements RemoteDevClient {
             connection.addRequestProperty(RemoteSyncHandler.QUARKUS_PASSWORD, sha256(dataHash + password));
             connection.setDoOutput(true);
 
-            connection.getOutputStream().write(initialData);
-            connection.getOutputStream().close();
-            String session = connection.getHeaderField(RemoteSyncHandler.QUARKUS_SESSION);
-            String error = connection.getHeaderField(RemoteSyncHandler.QUARKUS_ERROR);
-            if (error != null) {
-                throw createIOException("Server did not start a remote dev session: " + error);
-            }
+            Response response = exchange(connection, initialData, "start a remote dev session");
+            String session = response.session();
             if (session == null) {
                 throw createIOException(
                         "Server did not start a remote dev session. Make sure the environment variable 'QUARKUS_LAUNCH_DEVMODE' is set to 'true' when launching the server");
             }
-            String result = new String(IoUtil.readBytes(connection.getInputStream()), StandardCharsets.UTF_8);
+            String result = new String(response.body(), StandardCharsets.UTF_8);
             Set<String> changed = new HashSet<>();
             changed.addAll(Arrays.asList(result.split(";")));
             Map<String, byte[]> data = new LinkedHashMap<>(initialConnectFunction.apply(changed));
@@ -217,10 +210,8 @@ public class HttpRemoteDevClient implements RemoteDevClient {
                     currentSessionCounter++;
                     connection.addRequestProperty(RemoteSyncHandler.QUARKUS_SESSION, sessionId);
                     connection.setDoOutput(true);
-                    connection.getOutputStream().write(baos.toByteArray());
-
-                    IoUtil.readBytes(connection.getInputStream());
-                    int status = connection.getResponseCode();
+                    Response response = exchange(connection, baos.toByteArray(), "poll for remote changes");
+                    int status = response.status();
                     if (status == 200) {
                         SyncResult sync = changeRequestFunction.get();
                         problem = sync.getProblem();
@@ -247,14 +238,25 @@ public class HttpRemoteDevClient implements RemoteDevClient {
                                     sha256(sha256("/" + file) + sessionId + currentSessionCounter + password));
                             currentSessionCounter++;
                             connection.addRequestProperty(RemoteSyncHandler.QUARKUS_SESSION, sessionId);
-                            connection.getOutputStream().close();
-                            IoUtil.readBytes(connection.getInputStream());
+                            exchange(connection, null, "delete a remote file");
                         }
                     } else if (status == 203) {
                         //need a new session
                         sessionId = doConnect(initialState, initialConnectFunction);
                     }
                     errorCount = 0;
+                } catch (RemoteDevResponseException e) {
+                    if (e.permanent()) {
+                        log.error("Remote dev request cannot be completed", e);
+                        return;
+                    }
+                    errorCount++;
+                    log.error("Remote dev request failed", e);
+                    if (errorCount == retryMaxAttempts) {
+                        log.errorf("Connection failed after %d retries, exiting", errorCount);
+                        return;
+                    }
+                    sleepBeforeRetry(e.retryAfterMillis());
                 } catch (Throwable e) {
                     errorCount++;
                     log.error("Remote dev request failed", e);
@@ -262,18 +264,14 @@ public class HttpRemoteDevClient implements RemoteDevClient {
                         log.errorf("Connection failed after %d retries, exiting", errorCount);
                         return;
                     }
-                    try {
-                        Thread.sleep(retryIntervalMillis);
-                    } catch (InterruptedException ex) {
-
-                    }
+                    sleepBeforeRetry(retryIntervalMillis);
                 }
             }
 
         }
 
         private String waitForRestart(RemoteDevState initialState,
-                Function<Set<String>, Map<String, byte[]>> initialConnectFunction) {
+                Function<Set<String>, Map<String, byte[]>> initialConnectFunction) throws IOException {
 
             long timeout = System.currentTimeMillis() + reconnectTimeoutMillis;
             try {
@@ -281,19 +279,105 @@ public class HttpRemoteDevClient implements RemoteDevClient {
             } catch (InterruptedException e) {
 
             }
-            while (System.currentTimeMillis() < timeout) {
+            while (!closed && System.currentTimeMillis() < timeout) {
                 try {
                     HttpURLConnection connection = (HttpURLConnection) probeUrl.openConnection();
                     connection.setRequestProperty(HttpHeaders.ACCEPT.toString(), DEFAULT_ACCEPT);
                     connection.setRequestMethod("POST");
                     connection.addRequestProperty(HttpHeaders.CONTENT_TYPE.toString(), RemoteSyncHandler.APPLICATION_QUARKUS);
-                    IoUtil.readBytes(connection.getInputStream());
+                    exchange(connection, null, "probe the remote server");
                     return doConnect(initialState, initialConnectFunction);
+                } catch (RemoteDevResponseException e) {
+                    if (e.permanent()) {
+                        throw e;
+                    }
+                    sleepBeforeRetry(e.retryAfterMillis());
                 } catch (IOException e) {
-
+                    sleepBeforeRetry(retryIntervalMillis);
                 }
             }
-            throw new RuntimeException("Could not connect to remote side after restart");
+            throw createIOException(closed
+                    ? "Remote dev session closed while waiting for the remote side to restart"
+                    : "Could not connect to remote side after restart");
+        }
+
+        private Response exchange(HttpURLConnection connection, byte[] body, String operation) throws IOException {
+            try {
+                if (body != null) {
+                    connection.setFixedLengthStreamingMode(body.length);
+                    try (var output = connection.getOutputStream()) {
+                        output.write(body);
+                    }
+                }
+                int status = connection.getResponseCode();
+                byte[] responseBody;
+                InputStream input = status >= 400 ? connection.getErrorStream() : connection.getInputStream();
+                if (input == null) {
+                    responseBody = new byte[0];
+                } else {
+                    try (input) {
+                        responseBody = IoUtil.readBytes(input);
+                    }
+                }
+                String error = connection.getHeaderField(RemoteSyncHandler.QUARKUS_ERROR);
+                if (status >= 400) {
+                    String detail = error == null || error.isBlank() ? "HTTP " + status : error;
+                    boolean permanent = status == 413 || status == 415;
+                    long retryAfter = status == 503 ? retryAfterMillis(connection) : retryIntervalMillis;
+                    throw new RemoteDevResponseException(
+                            "Server could not " + operation + ": " + detail, permanent, retryAfter);
+                }
+                return new Response(status, responseBody,
+                        connection.getHeaderField(RemoteSyncHandler.QUARKUS_SESSION));
+            } finally {
+                connection.disconnect();
+            }
+        }
+
+        private long retryAfterMillis(HttpURLConnection connection) {
+            String value = connection.getHeaderField("Retry-After");
+            if (value == null) {
+                return retryIntervalMillis;
+            }
+            try {
+                long millis = Math.multiplyExact(Long.parseLong(value), 1000);
+                long maximum = reconnectTimeoutMillis > 0 ? reconnectTimeoutMillis : retryIntervalMillis;
+                return Math.min(Math.max(millis, retryIntervalMillis), maximum);
+            } catch (ArithmeticException | NumberFormatException ignored) {
+                return retryIntervalMillis;
+            }
+        }
+
+        private void sleepBeforeRetry(long delay) {
+            try {
+                Thread.sleep(delay);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        private record Response(int status, byte[] body, String session) {
+        }
+
+        private final class RemoteDevResponseException extends IOException {
+
+            private final boolean permanent;
+            private final long retryAfterMillis;
+
+            private RemoteDevResponseException(String message, boolean permanent, long retryAfterMillis) {
+                super(message);
+                this.permanent = permanent;
+                this.retryAfterMillis = retryAfterMillis;
+                setStackTrace(new StackTraceElement[] {});
+            }
+
+            private boolean permanent() {
+                return permanent;
+            }
+
+            private long retryAfterMillis() {
+                return retryAfterMillis;
+            }
         }
 
     }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/deployment/devmode/HttpRemoteDevClientTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/deployment/devmode/HttpRemoteDevClientTest.java
@@ -1,0 +1,89 @@
+package io.quarkus.vertx.http.deployment.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Closeable;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.net.httpserver.HttpServer;
+
+import io.quarkus.dev.spi.RemoteDevState;
+import io.quarkus.vertx.http.runtime.devmode.RemoteSyncHandler;
+
+class HttpRemoteDevClientTest {
+
+    @Test
+    void bodyRequestsUseFixedLengthAndResponsePolicyDistinguishesRetryableFromTerminal() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        CountDownLatch devRequest = new CountDownLatch(1);
+        AtomicInteger devRequests = new AtomicInteger();
+        AtomicLong connectLength = new AtomicLong(-1);
+        AtomicLong devLength = new AtomicLong(-1);
+        AtomicReference<String> connectTransferEncoding = new AtomicReference<>();
+        AtomicReference<String> devTransferEncoding = new AtomicReference<>();
+        server.createContext("/", exchange -> {
+            try (exchange; var input = exchange.getRequestBody()) {
+                input.readAllBytes();
+                if (exchange.getRequestURI().getPath().endsWith(RemoteSyncHandler.CONNECT)) {
+                    connectLength.set(parseContentLength(exchange.getRequestHeaders().getFirst("Content-Length")));
+                    connectTransferEncoding.set(exchange.getRequestHeaders().getFirst("Transfer-Encoding"));
+                    exchange.getResponseHeaders().set(RemoteSyncHandler.QUARKUS_SESSION, "session");
+                    exchange.sendResponseHeaders(200, 0);
+                } else if (exchange.getRequestURI().getPath().endsWith(RemoteSyncHandler.DEV)) {
+                    int request = devRequests.incrementAndGet();
+                    devLength.set(parseContentLength(exchange.getRequestHeaders().getFirst("Content-Length")));
+                    devTransferEncoding.set(exchange.getRequestHeaders().getFirst("Transfer-Encoding"));
+                    if (request == 1) {
+                        exchange.getResponseHeaders().set(RemoteSyncHandler.QUARKUS_ERROR,
+                                "Remote dev request-body capacity is temporarily unavailable");
+                        exchange.getResponseHeaders().set("Retry-After", "0");
+                        exchange.sendResponseHeaders(503, -1);
+                    } else {
+                        exchange.getResponseHeaders().set(RemoteSyncHandler.QUARKUS_ERROR,
+                                "Remote dev request body exceeds quarkus.http.limits.max-body-size");
+                        exchange.sendResponseHeaders(413, -1);
+                        devRequest.countDown();
+                    }
+                } else {
+                    exchange.sendResponseHeaders(404, -1);
+                }
+            }
+        });
+        server.start();
+
+        Closeable session = null;
+        try {
+            var client = new HttpRemoteDevClient(
+                    "http://localhost:" + server.getAddress().getPort(),
+                    "secret", Duration.ofSeconds(1), Duration.ofMillis(10), 5);
+            session = client.sendConnectRequest(new RemoteDevState(Map.of(), null), ignored -> Map.of(), () -> null);
+
+            assertThat(devRequest.await(5, TimeUnit.SECONDS)).isTrue();
+            Thread.sleep(100);
+
+            assertThat(connectLength).hasValueGreaterThan(0);
+            assertThat(devLength).hasValueGreaterThan(0);
+            assertThat(connectTransferEncoding).hasValue(null);
+            assertThat(devTransferEncoding).hasValue(null);
+            assertThat(devRequests).hasValue(2);
+        } finally {
+            if (session != null) {
+                session.close();
+            }
+            server.stop(0);
+        }
+    }
+
+    private static long parseContentLength(String value) {
+        return value == null ? -1 : Long.parseLong(value);
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -335,7 +335,7 @@ public class VertxHttpRecorder {
             if (liveReloadConfig.password().isPresent()
                     && hotReplacementContext.getDevModeType() == DevModeType.REMOTE_SERVER_SIDE) {
                 root = remoteSyncHandler = new RemoteSyncHandler(liveReloadConfig.password().get(), root,
-                        hotReplacementContext, "/");
+                        hotReplacementContext, "/", httpConfig.limits().maxBodySize());
             }
             rootHandler = root;
 
@@ -591,7 +591,7 @@ public class VertxHttpRecorder {
         if (launchMode == LaunchMode.DEVELOPMENT && liveReloadConfig.password().isPresent()
                 && hotReplacementContext.getDevModeType() == DevModeType.REMOTE_SERVER_SIDE) {
             root = remoteSyncHandler = new RemoteSyncHandler(liveReloadConfig.password().get(), root, hotReplacementContext,
-                    rootPath);
+                    rootPath, httpConfig.limits().maxBodySize());
         }
         rootHandler = root;
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteDevBodyAdmission.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteDevBodyAdmission.java
@@ -1,0 +1,64 @@
+package io.quarkus.vertx.http.runtime.devmode;
+
+final class RemoteDevBodyAdmission {
+
+    private final RemoteDevBodyLimits limits;
+    private int activeCollectors;
+    private long reservedBytes;
+
+    RemoteDevBodyAdmission(RemoteDevBodyLimits limits) {
+        this.limits = limits;
+    }
+
+    synchronized Reservation tryAcquire(long initialReservation) {
+        if (initialReservation < 0 || initialReservation > limits.requestLimit()) {
+            throw new IllegalArgumentException("Invalid remote-dev body reservation");
+        }
+        if (activeCollectors >= limits.activeCollectorLimit()
+                || initialReservation > limits.aggregateLimit() - reservedBytes) {
+            return null;
+        }
+        activeCollectors++;
+        reservedBytes += initialReservation;
+        return new Reservation(initialReservation);
+    }
+
+    synchronized boolean tryReserve(Reservation reservation, long additionalBytes) {
+        if (additionalBytes < 0 || reservation.released) {
+            throw new IllegalArgumentException("Invalid remote-dev body reservation");
+        }
+        if (additionalBytes > limits.aggregateLimit() - reservedBytes) {
+            return false;
+        }
+        reservation.reservedBytes += additionalBytes;
+        reservedBytes += additionalBytes;
+        return true;
+    }
+
+    synchronized void release(Reservation reservation) {
+        if (reservation.released) {
+            return;
+        }
+        reservation.released = true;
+        reservedBytes -= reservation.reservedBytes;
+        activeCollectors--;
+    }
+
+    synchronized int activeCollectors() {
+        return activeCollectors;
+    }
+
+    synchronized long reservedBytes() {
+        return reservedBytes;
+    }
+
+    static final class Reservation {
+
+        private long reservedBytes;
+        private boolean released;
+
+        private Reservation(long reservedBytes) {
+            this.reservedBytes = reservedBytes;
+        }
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteDevBodyCollector.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteDevBodyCollector.java
@@ -1,0 +1,313 @@
+package io.quarkus.vertx.http.runtime.devmode;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServerRequest;
+
+final class RemoteDevBodyCollector {
+
+    private final RemoteSyncHandler owner;
+    private final HttpServerRequest request;
+    private final RemoteDevBodyLimits limits;
+    private final RemoteDevBodyAdmission admission;
+    private final RemoteDevBodySpoolStore spoolStore;
+    private final Consumer<CompletedBody> completion;
+    private final long declaredLength;
+
+    private State state = State.NEW;
+    private RemoteDevBodyAdmission.Reservation reservation;
+    private RemoteDevBodySpoolStore.Spool spool;
+    private long received;
+    private boolean writePending;
+
+    private RemoteDevBodyCollector(RemoteSyncHandler owner, HttpServerRequest request, RemoteDevBodyLimits limits,
+            RemoteDevBodyAdmission admission, RemoteDevBodySpoolStore spoolStore, long declaredLength,
+            Consumer<CompletedBody> completion) {
+        this.owner = owner;
+        this.request = request;
+        this.limits = limits;
+        this.admission = admission;
+        this.spoolStore = spoolStore;
+        this.declaredLength = declaredLength;
+        this.completion = completion;
+    }
+
+    static void start(RemoteSyncHandler owner, HttpServerRequest request, RemoteDevBodyLimits limits,
+            RemoteDevBodyAdmission admission, RemoteDevBodySpoolStore spoolStore, Consumer<CompletedBody> completion) {
+        request.pause();
+        String encoding = request.getHeader(HttpHeaderNames.CONTENT_ENCODING);
+        if (encoding != null && !"identity".equalsIgnoreCase(encoding.trim())) {
+            owner.rejectBody(request, 415, "Remote dev does not support encoded request bodies");
+            return;
+        }
+        long declaredLength;
+        try {
+            declaredLength = contentLength(request.getHeader(HttpHeaderNames.CONTENT_LENGTH));
+        } catch (IllegalArgumentException e) {
+            owner.rejectBody(request, 400, "Remote dev request has an invalid Content-Length");
+            return;
+        }
+        if (declaredLength > limits.requestLimit()) {
+            owner.rejectBody(request, 413,
+                    "Remote dev request body exceeds quarkus.http.limits.max-body-size");
+            return;
+        }
+        var collector = new RemoteDevBodyCollector(owner, request, limits, admission, spoolStore, declaredLength,
+                Objects.requireNonNull(completion));
+        collector.begin();
+    }
+
+    private static long contentLength(String header) {
+        if (header == null) {
+            return -1;
+        }
+        try {
+            long length = Long.parseLong(header);
+            if (length < 0) {
+                throw new IllegalArgumentException("negative Content-Length");
+            }
+            return length;
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("invalid Content-Length", e);
+        }
+    }
+
+    private void begin() {
+        long initialReservation = declaredLength >= 0 ? declaredLength : 0;
+        reservation = admission.tryAcquire(initialReservation);
+        if (reservation == null) {
+            owner.rejectBody(request, 503, "Remote dev request-body capacity is temporarily unavailable");
+            return;
+        }
+        synchronized (this) {
+            state = State.RECEIVING;
+        }
+        owner.collectorStarted(this);
+        request.handler(this::receive)
+                .endHandler(ignored -> end())
+                .exceptionHandler(this::fail);
+        request.response().closeHandler(ignored -> cancel());
+        spoolStore.create().onComplete(result -> {
+            if (result.failed()) {
+                fail(result.cause());
+                return;
+            }
+            boolean resume;
+            synchronized (this) {
+                spool = result.result();
+                resume = state == State.RECEIVING;
+            }
+            if (resume) {
+                request.resume();
+            } else {
+                cleanupSpool(result.result());
+            }
+        });
+    }
+
+    private void receive(Buffer buffer) {
+        byte[] bytes = buffer.getBytes();
+        synchronized (this) {
+            if (state != State.RECEIVING || writePending) {
+                return;
+            }
+            if (bytes.length > limits.requestLimit() - received) {
+                reject(413, "Remote dev request body exceeds quarkus.http.limits.max-body-size");
+                return;
+            }
+            if (declaredLength >= 0 && bytes.length > declaredLength - received) {
+                reject(400, "Remote dev request body exceeds its Content-Length");
+                return;
+            }
+            if (declaredLength < 0 && !admission.tryReserve(reservation, bytes.length)) {
+                reject(503, "Remote dev request-body capacity is temporarily unavailable");
+                return;
+            }
+            received += bytes.length;
+            writePending = true;
+            request.pause();
+        }
+        executeBlocking(() -> {
+            spool.write(bytes);
+            return null;
+        }).onComplete(result -> {
+            boolean resume = false;
+            synchronized (this) {
+                writePending = false;
+                if (result.succeeded() && state == State.RECEIVING) {
+                    resume = true;
+                }
+            }
+            if (result.failed()) {
+                fail(result.cause());
+            } else if (resume) {
+                request.resume();
+            }
+        });
+    }
+
+    private void end() {
+        synchronized (this) {
+            if (state != State.RECEIVING) {
+                return;
+            }
+            if (writePending) {
+                fail(new IOException("Remote-dev request ended while a spool write was pending"));
+                return;
+            }
+            if (declaredLength >= 0 && received != declaredLength) {
+                reject(400, "Remote dev request body does not match its Content-Length");
+                return;
+            }
+            state = State.CLOSING;
+        }
+        executeBlocking(() -> {
+            spool.closeForReading();
+            return null;
+        }).onComplete(result -> {
+            if (result.failed()) {
+                fail(result.cause());
+                return;
+            }
+            CompletedBody body;
+            synchronized (this) {
+                if (state != State.CLOSING) {
+                    return;
+                }
+                state = State.COMPLETE;
+                body = new CompletedBody(this, spool, received);
+            }
+            try {
+                completion.accept(body);
+            } catch (Throwable t) {
+                body.close();
+                owner.bodyProcessingFailed(request, t);
+            }
+        });
+    }
+
+    private void reject(int status, String message) {
+        if (!terminate(State.REJECTED)) {
+            return;
+        }
+        owner.rejectBody(request, status, message);
+        cleanup();
+    }
+
+    private void fail(Throwable failure) {
+        if (!terminate(State.FAILED)) {
+            return;
+        }
+        owner.bodyCollectionFailed(request, failure);
+        cleanup();
+    }
+
+    void cancel() {
+        if (!terminate(State.CANCELLED)) {
+            return;
+        }
+        cleanup();
+    }
+
+    private synchronized boolean terminate(State terminalState) {
+        if (state == State.REJECTED || state == State.FAILED || state == State.CANCELLED) {
+            return false;
+        }
+        if (state == State.COMPLETE) {
+            return false;
+        }
+        state = terminalState;
+        request.pause();
+        return true;
+    }
+
+    private void cleanup() {
+        RemoteDevBodySpoolStore.Spool currentSpool;
+        synchronized (this) {
+            currentSpool = spool;
+        }
+        if (currentSpool == null) {
+            release();
+        } else {
+            cleanupSpool(currentSpool);
+        }
+    }
+
+    private void cleanupSpool(RemoteDevBodySpoolStore.Spool currentSpool) {
+        spoolStore.delete(currentSpool).onComplete(result -> {
+            if (result.failed()) {
+                owner.bodyCleanupFailed();
+            }
+            release();
+        });
+    }
+
+    private void release() {
+        admission.release(reservation);
+        owner.collectorClosed(this);
+    }
+
+    private void completeBody(RemoteDevBodySpoolStore.Spool completedSpool) {
+        cleanupSpool(completedSpool);
+    }
+
+    private <T> Future<T> executeBlocking(Callable<T> action) {
+        try {
+            return owner.executeBlocking(action);
+        } catch (RejectedExecutionException e) {
+            return Future.failedFuture(e);
+        }
+    }
+
+    enum State {
+        NEW,
+        RECEIVING,
+        CLOSING,
+        COMPLETE,
+        REJECTED,
+        FAILED,
+        CANCELLED
+    }
+
+    static final class CompletedBody implements AutoCloseable {
+
+        private final RemoteDevBodyCollector collector;
+        private final RemoteDevBodySpoolStore.Spool spool;
+        private final long length;
+        private final AtomicBoolean closed = new AtomicBoolean();
+
+        private CompletedBody(RemoteDevBodyCollector collector, RemoteDevBodySpoolStore.Spool spool, long length) {
+            this.collector = collector;
+            this.spool = spool;
+            this.length = length;
+        }
+
+        long length() {
+            return length;
+        }
+
+        InputStream openInputStream() throws IOException {
+            return spool.openInputStream();
+        }
+
+        byte[] readAllBytes() throws IOException {
+            return spool.readAllBytes();
+        }
+
+        @Override
+        public void close() {
+            if (closed.compareAndSet(false, true)) {
+                collector.completeBody(spool);
+            }
+        }
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteDevBodyLimits.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteDevBodyLimits.java
@@ -1,0 +1,34 @@
+package io.quarkus.vertx.http.runtime.devmode;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.configuration.MemorySize;
+
+record RemoteDevBodyLimits(long requestLimit, long aggregateLimit, int activeCollectorLimit) {
+
+    static final long DEFAULT_REQUEST_LIMIT = 10L * 1024 * 1024;
+    static final int DEFAULT_ACTIVE_COLLECTOR_LIMIT = 4;
+
+    RemoteDevBodyLimits {
+        if (requestLimit <= 0) {
+            throw new IllegalArgumentException("Remote-dev request body limit must be greater than zero");
+        }
+        if (aggregateLimit < requestLimit) {
+            throw new IllegalArgumentException("Remote-dev aggregate body limit must not be smaller than the request limit");
+        }
+        if (activeCollectorLimit <= 0) {
+            throw new IllegalArgumentException("Remote-dev active body collector limit must be greater than zero");
+        }
+    }
+
+    static RemoteDevBodyLimits from(Optional<MemorySize> configuredLimit) {
+        long requestLimit;
+        try {
+            requestLimit = configuredLimit.map(MemorySize::asLongValue).orElse(DEFAULT_REQUEST_LIMIT);
+        } catch (ArithmeticException e) {
+            throw new IllegalArgumentException("Remote-dev request body limit exceeds the supported range", e);
+        }
+        long aggregateLimit = requestLimit > Long.MAX_VALUE / 2 ? Long.MAX_VALUE : requestLimit * 2;
+        return new RemoteDevBodyLimits(requestLimit, aggregateLimit, DEFAULT_ACTIVE_COLLECTOR_LIMIT);
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteDevBodySpoolStore.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteDevBodySpoolStore.java
@@ -1,0 +1,251 @@
+package io.quarkus.vertx.http.runtime.devmode;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.RejectedExecutionException;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+
+final class RemoteDevBodySpoolStore {
+
+    private static final Set<PosixFilePermission> DIRECTORY_PERMISSIONS = EnumSet.of(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.OWNER_WRITE,
+            PosixFilePermission.OWNER_EXECUTE);
+    private static final Set<PosixFilePermission> FILE_PERMISSIONS = EnumSet.of(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.OWNER_WRITE);
+
+    private final RemoteSyncHandler owner;
+    private Path directory;
+    private boolean closed;
+    private int pendingSpoolCleanups;
+
+    RemoteDevBodySpoolStore(RemoteSyncHandler owner) {
+        this.owner = owner;
+    }
+
+    Future<Spool> create() {
+        try {
+            return owner.executeBlocking(() -> {
+                synchronized (this) {
+                    if (closed) {
+                        throw new IOException("Remote-dev body spool store is closed");
+                    }
+                    if (directory == null) {
+                        directory = createTempDirectory();
+                    }
+                    Path file = createTempFile(directory);
+                    return new Spool(file);
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            return Future.failedFuture(e);
+        }
+    }
+
+    Future<Void> delete(Spool spool) {
+        synchronized (this) {
+            pendingSpoolCleanups++;
+        }
+        return executeCleanup(() -> {
+            deleteSpool(spool);
+            return null;
+        });
+    }
+
+    synchronized Path directory() {
+        return directory;
+    }
+
+    void close() {
+        synchronized (this) {
+            closed = true;
+        }
+        try {
+            // This is a single best-effort directory operation. Collector cleanup closes active spool files asynchronously.
+            deleteDirectoryIfIdle();
+        } catch (IOException ignored) {
+            owner.bodyCleanupFailed();
+        }
+    }
+
+    private Future<Void> executeCleanup(Callable<Void> cleanup) {
+        try {
+            return owner.executeBlocking(cleanup)
+                    .recover(failure -> failure instanceof RejectedExecutionException
+                            ? executeFallbackCleanup(cleanup)
+                            : Future.failedFuture(failure));
+        } catch (RejectedExecutionException e) {
+            return executeFallbackCleanup(cleanup);
+        }
+    }
+
+    private static Future<Void> executeFallbackCleanup(Callable<Void> cleanup) {
+        // A classpath-change restart can stop the Vert.x worker executor before closing this handler.
+        // Keep that lifecycle thread and any event loop nonblocking while the old handler releases its files.
+        Promise<Void> result = Promise.promise();
+        Thread thread = new Thread(() -> {
+            try {
+                cleanup.call();
+                result.complete();
+            } catch (Exception failure) {
+                result.fail(failure);
+            }
+        }, "Quarkus remote-dev body cleanup");
+        thread.setDaemon(true);
+        try {
+            thread.start();
+        } catch (RuntimeException failure) {
+            result.tryFail(failure);
+        }
+        return result.future();
+    }
+
+    private void deleteSpool(Spool spool) throws IOException {
+        IOException failure = null;
+        try {
+            spool.delete();
+        } catch (IOException e) {
+            failure = e;
+        }
+        try {
+            spoolCleanupCompleted();
+        } catch (IOException e) {
+            if (failure == null) {
+                failure = e;
+            } else {
+                failure.addSuppressed(e);
+            }
+        }
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    private void spoolCleanupCompleted() throws IOException {
+        synchronized (this) {
+            pendingSpoolCleanups--;
+        }
+        deleteDirectoryIfIdle();
+    }
+
+    private synchronized void deleteDirectoryIfIdle() throws IOException {
+        if (pendingSpoolCleanups != 0 || directory == null) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(directory);
+            directory = null;
+        } catch (DirectoryNotEmptyException ignored) {
+            // An active collector still owns a spool. The last spool cleanup retries the directory deletion.
+        }
+    }
+
+    private static Path createTempDirectory() throws IOException {
+        if (Path.of("").getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            return Files.createTempDirectory("quarkus-remote-dev-",
+                    PosixFilePermissions.asFileAttribute(DIRECTORY_PERMISSIONS));
+        }
+        return Files.createTempDirectory("quarkus-remote-dev-");
+    }
+
+    private static Path createTempFile(Path directory) throws IOException {
+        if (directory.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            return Files.createTempFile(directory, "request-", ".body",
+                    PosixFilePermissions.asFileAttribute(FILE_PERMISSIONS));
+        }
+        return Files.createTempFile(directory, "request-", ".body");
+    }
+
+    static final class Spool {
+
+        private final Path path;
+        private FileChannel channel;
+        private boolean deleted;
+
+        private Spool(Path path) throws IOException {
+            this.path = path;
+            channel = FileChannel.open(path, StandardOpenOption.WRITE);
+        }
+
+        synchronized void write(byte[] bytes) throws IOException {
+            if (channel == null) {
+                throw new IOException("Remote-dev body spool is closed");
+            }
+            ByteBuffer buffer = ByteBuffer.wrap(bytes);
+            while (buffer.hasRemaining()) {
+                channel.write(buffer);
+            }
+        }
+
+        synchronized void closeForReading() throws IOException {
+            closeChannel();
+        }
+
+        synchronized InputStream openInputStream() throws IOException {
+            if (channel != null) {
+                throw new IOException("Remote-dev body spool is still being written");
+            }
+            if (deleted) {
+                throw new IOException("Remote-dev body spool is deleted");
+            }
+            return Files.newInputStream(path);
+        }
+
+        synchronized byte[] readAllBytes() throws IOException {
+            if (channel != null) {
+                throw new IOException("Remote-dev body spool is still being written");
+            }
+            if (deleted) {
+                throw new IOException("Remote-dev body spool is deleted");
+            }
+            return Files.readAllBytes(path);
+        }
+
+        synchronized void delete() throws IOException {
+            IOException closeFailure = null;
+            try {
+                closeChannel();
+            } catch (IOException e) {
+                closeFailure = e;
+            }
+            if (!deleted) {
+                try {
+                    Files.deleteIfExists(path);
+                    deleted = true;
+                } catch (IOException e) {
+                    if (closeFailure != null) {
+                        e.addSuppressed(closeFailure);
+                    }
+                    throw e;
+                }
+            }
+            if (closeFailure != null) {
+                throw closeFailure;
+            }
+        }
+
+        private void closeChannel() throws IOException {
+            if (channel != null) {
+                try {
+                    channel.close();
+                } finally {
+                    channel = null;
+                }
+            }
+        }
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandler.java
@@ -1,16 +1,25 @@
 package io.quarkus.vertx.http.runtime.devmode;
 
-import java.io.ByteArrayInputStream;
+import java.io.BufferedInputStream;
+import java.io.EOFException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectInputFilter;
 import java.io.ObjectInputStream;
+import java.io.ObjectStreamException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Base64;
+import java.util.HexFormat;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.jboss.logging.Logger;
@@ -18,12 +27,14 @@ import org.jboss.logging.Logger;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.quarkus.dev.spi.HotReplacementContext;
 import io.quarkus.dev.spi.RemoteDevState;
+import io.quarkus.runtime.configuration.MemorySize;
 import io.quarkus.runtime.util.HashUtil;
 import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpVersion;
 
 public class RemoteSyncHandler implements Handler<HttpServerRequest> {
 
@@ -45,6 +56,11 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
     final Handler<HttpServerRequest> next;
     final HotReplacementContext hotReplacementContext;
     final String rootPath;
+    private final RemoteDevBodyLimits bodyLimits;
+    private final RemoteDevBodyAdmission bodyAdmission;
+    private final RemoteDevBodySpoolStore bodySpoolStore;
+    private final Set<RemoteDevBodyCollector> bodyCollectors = ConcurrentHashMap.newKeySet();
+    private final AtomicBoolean closed = new AtomicBoolean();
 
     //all these are static to allow the handler to be recreated on hot reload
     //which makes lifecycle management a lot easier
@@ -54,10 +70,23 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
 
     public RemoteSyncHandler(String password, Handler<HttpServerRequest> next, HotReplacementContext hotReplacementContext,
             String rootPath) {
+        this(password, next, hotReplacementContext, rootPath, Optional.empty());
+    }
+
+    public RemoteSyncHandler(String password, Handler<HttpServerRequest> next, HotReplacementContext hotReplacementContext,
+            String rootPath, Optional<MemorySize> maxBodySize) {
+        this(password, next, hotReplacementContext, rootPath, RemoteDevBodyLimits.from(maxBodySize));
+    }
+
+    RemoteSyncHandler(String password, Handler<HttpServerRequest> next, HotReplacementContext hotReplacementContext,
+            String rootPath, RemoteDevBodyLimits bodyLimits) {
         this.password = password;
         this.next = next;
         this.hotReplacementContext = hotReplacementContext;
         this.rootPath = rootPath;
+        this.bodyLimits = bodyLimits;
+        this.bodyAdmission = new RemoteDevBodyAdmission(bodyLimits);
+        this.bodySpoolStore = new RemoteDevBodySpoolStore(this);
     }
 
     public static void doPreScan() {
@@ -81,13 +110,7 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
     public void handle(HttpServerRequest event) {
         final String type = event.headers().get(HttpHeaderNames.CONTENT_TYPE);
         if (APPLICATION_QUARKUS.equals(type)) {
-            executeBlocking(new Callable<Void>() {
-                @Override
-                public Void call() {
-                    handleRequest(event);
-                    return null;
-                }
-            });
+            handleRequest(event);
             return;
         }
         next.handle(event);
@@ -97,7 +120,10 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
         if (event.method().equals(HttpMethod.PUT)) {
             handlePut(event);
         } else if (event.method().equals(HttpMethod.DELETE)) {
-            handleDelete(event);
+            executeBlocking(() -> {
+                handleDelete(event);
+                return null;
+            });
         } else if (event.method().equals(HttpMethod.POST)) {
             if (event.path().endsWith(DEV)) {
                 handleDev(event);
@@ -118,95 +144,43 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
     }
 
     private void handleDev(HttpServerRequest event) {
-        event.bodyHandler(new Handler<Buffer>() {
-            @Override
-            public void handle(Buffer b) {
-                executeBlocking(new Callable<Void>() {
-                    @Override
-                    public Void call() {
-                        try {
-                            withAuthenticatedSession(event, b.getBytes(), () -> {
-                                Throwable problem;
-                                try (ObjectInputStream input = createFilteredObjectInputStream(b.getBytes())) {
-                                    problem = (Throwable) input.readObject();
-                                }
-                                //update the problem if it has changed
-                                if (problem != null || remoteProblem != null) {
-                                    remoteProblem = problem;
-                                    hotReplacementContext.setRemoteProblem(problem);
-                                }
-                                synchronized (RemoteSyncHandler.class) {
-                                    RemoteSyncHandler.class.notifyAll();
-                                    try {
-                                        RemoteSyncHandler.class.wait(10000);
-                                    } catch (InterruptedException e) {
-                                        Thread.currentThread().interrupt();
-                                        log.debug("interrupted", e);
-                                    }
-                                    if (checkForChanges) {
-                                        checkForChanges = false;
-                                        event.response().setStatusCode(200);
-                                    } else {
-                                        event.response().setStatusCode(204);
-                                    }
-                                    event.response().end();
-                                }
-                            });
-                        } catch (RejectedExecutionException e) {
-                            //everything is shut down
-                            //likely in the middle of a restart
-                            event.connection().close();
-                        } catch (Exception e) {
-                            log.error("Connect failed", e);
-                            event.response().setStatusCode(500).end();
-                        }
-                        return null;
-                    }
-                });
-            }
-        }).exceptionHandler(new Handler<Throwable>() {
-            @Override
-            public void handle(Throwable t) {
-                log.error("dev request failed", t);
-                event.response().setStatusCode(500).end();
-            }
-        }).resume();
+        SessionRequest sessionRequest = readSessionRequest(event);
+        if (sessionRequest == null) {
+            return;
+        }
+        collectBody(event, body -> executeBlocking(() -> {
+            processDev(event, sessionRequest, body);
+            return null;
+        }).onFailure(failure -> {
+            body.close();
+            bodyProcessingFailed(event, failure);
+        }));
     }
 
     private void handleConnect(HttpServerRequest event) {
-        event.bodyHandler(new Handler<Buffer>() {
-            @Override
-            public void handle(Buffer b) {
-                executeBlocking(() -> {
-                    processConnect(event, b);
-                    return null;
-                });
-            }
-        }).exceptionHandler(new Handler<Throwable>() {
-            @Override
-            public void handle(Throwable t) {
-                log.error("Connect failed", t);
-                event.response().setStatusCode(500).end();
-            }
-        }).resume();
+        collectBody(event, body -> executeBlocking(() -> {
+            processConnect(event, body);
+            return null;
+        }).onFailure(failure -> {
+            body.close();
+            bodyProcessingFailed(event, failure);
+        }));
     }
 
-    private void processConnect(HttpServerRequest event, Buffer body) {
+    private void processConnect(HttpServerRequest event, RemoteDevBodyCollector.CompletedBody body) {
         try {
             String rp = event.headers().get(QUARKUS_PASSWORD);
-            String bodyHash = HashUtil.sha256(body.getBytes());
+            String bodyHash = sha256(body);
             String compare = HashUtil.sha256(bodyHash + password);
             if (!constantTimeEquals(compare, rp)) {
                 log.error("Incorrect password");
                 event.response().putHeader(QUARKUS_ERROR, "Incorrect password").setStatusCode(401).end();
                 return;
             }
+            RemoteDevState state = readRemoteDevState(body);
+            body.close();
             SESSION_OPERATION_LOCK.lock();
             try {
-                RemoteDevState state;
-                try (ObjectInputStream input = createFilteredObjectInputStream(body.getBytes())) {
-                    state = (RemoteDevState) input.readObject();
-                }
                 Set<String> files = hotReplacementContext.syncState(state.getFileHashes());
                 if (state.getAugmentProblem() != null) {
                     hotReplacementContext.setRemoteProblem(state.getAugmentProblem());
@@ -223,35 +197,45 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
             } finally {
                 SESSION_OPERATION_LOCK.unlock();
             }
+        } catch (MalformedRemoteDevBodyException e) {
+            event.response().putHeader(QUARKUS_ERROR, "Malformed remote-dev request body").setStatusCode(400).end();
         } catch (Exception e) {
             log.error("Connect failed", e);
-            event.response().setStatusCode(500).end();
+            event.response().putHeader(QUARKUS_ERROR, "Remote-dev request processing failed").setStatusCode(500).end();
+        } finally {
+            body.close();
         }
     }
 
     private void handlePut(HttpServerRequest event) {
-        event.bodyHandler(new Handler<Buffer>() {
-            @Override
-            public void handle(Buffer buffer) {
-                executeBlocking(() -> {
-                    processPut(event, buffer);
-                    return null;
-                });
-            }
-        }).exceptionHandler(new Handler<Throwable>() {
-            @Override
-            public void handle(Throwable error) {
-                log.error("Failed writing live reload data", error);
-                event.response().setStatusCode(500);
-                event.response().end();
-            }
-        }).resume();
+        SessionRequest sessionRequest = readSessionRequest(event);
+        if (sessionRequest == null) {
+            return;
+        }
+        collectBody(event, body -> executeBlocking(() -> {
+            processPut(event, sessionRequest, body);
+            return null;
+        }).onFailure(failure -> {
+            body.close();
+            bodyProcessingFailed(event, failure);
+        }));
     }
 
-    private void processPut(HttpServerRequest event, Buffer buffer) {
+    private void processPut(HttpServerRequest event, SessionRequest request,
+            RemoteDevBodyCollector.CompletedBody body) {
         try {
-            if (withAuthenticatedSession(event, buffer.getBytes(),
-                    () -> hotReplacementContext.updateFile(stripRootPath(event.path()), buffer.getBytes()))) {
+            String bodyHash = sha256(body);
+            if (!authenticateSession(event, request, bodyHash)) {
+                return;
+            }
+            SessionState expected = validateSession(event, request);
+            if (expected == null) {
+                return;
+            }
+            byte[] bytes = body.readAllBytes();
+            body.close();
+            if (!commitSessionOperation(event, request, expected,
+                    () -> hotReplacementContext.updateFile(stripRootPath(event.path()), bytes))) {
                 return;
             }
         } catch (IllegalArgumentException e) {
@@ -262,6 +246,8 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
             log.error("Failed to update file", e);
             event.response().setStatusCode(500).end();
             return;
+        } finally {
+            body.close();
         }
         event.response().end();
     }
@@ -274,7 +260,16 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
 
     private void handleDelete(HttpServerRequest event) {
         try {
-            if (withAuthenticatedSession(event, event.path().getBytes(StandardCharsets.UTF_8),
+            SessionRequest request = readSessionRequest(event);
+            if (request == null) {
+                return;
+            }
+            String dataHash = HashUtil.sha256(event.path().getBytes(StandardCharsets.UTF_8));
+            if (!authenticateSession(event, request, dataHash)) {
+                return;
+            }
+            SessionState expected = validateSession(event, request);
+            if (expected == null || !commitSessionOperation(event, request, expected,
                     () -> hotReplacementContext.deleteFile(stripRootPath(event.path())))) {
                 return;
             }
@@ -288,16 +283,15 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
         }
     }
 
-    private boolean withAuthenticatedSession(HttpServerRequest event, byte[] data, CheckedOperation operation)
-            throws Exception {
+    private SessionRequest readSessionRequest(HttpServerRequest event) {
         String ses = event.headers().get(QUARKUS_SESSION);
         String sessionCount = event.headers().get(QUARKUS_SESSION_COUNT);
-        if (sessionCount == null) {
+        if (ses == null || sessionCount == null) {
             log.error("No session count provided");
             //not really sure what status code makes sense here
             //Non-Authoritative Information seems as good as any
             event.response().setStatusCode(203).end();
-            return true;
+            return null;
         }
         final int sc;
         try {
@@ -305,25 +299,27 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
         } catch (NumberFormatException e) {
             log.error("Invalid session count");
             event.response().setStatusCode(203).end();
-            return true;
+            return null;
         }
         if (sc <= 0) {
             log.error("Invalid session count");
             event.response().setStatusCode(203).end();
-            return true;
+            return null;
         }
+        return new SessionRequest(ses, sc, event.headers().get(QUARKUS_PASSWORD));
+    }
 
-        String dataHash = "";
-        if (data != null) {
-            dataHash = HashUtil.sha256(data);
-        }
-        String rp = event.headers().get(QUARKUS_PASSWORD);
-        String compare = HashUtil.sha256(dataHash + ses + sc + password);
-        if (!constantTimeEquals(compare, rp)) {
+    private boolean authenticateSession(HttpServerRequest event, SessionRequest request, String dataHash) {
+        String compare = HashUtil.sha256(dataHash + request.sessionId() + request.counter() + password);
+        if (!constantTimeEquals(compare, request.authenticator())) {
             log.error("Incorrect password");
             event.response().setStatusCode(401).end();
-            return true;
+            return false;
         }
+        return true;
+    }
+
+    private SessionState validateSession(HttpServerRequest event, SessionRequest request) {
         SESSION_OPERATION_LOCK.lock();
         try {
             long now = System.currentTimeMillis();
@@ -332,18 +328,60 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
                 sessionState = SessionState.inactive();
                 log.error("Invalid session");
                 event.response().setStatusCode(203).end();
-                return true;
+                return null;
             }
-            if (!current.id().equals(ses) || sc <= current.acceptedCounter()) {
+            if (!current.id().equals(request.sessionId()) || request.counter() <= current.acceptedCounter()) {
                 log.error("Invalid session");
                 //not really sure what status code makes sense here
                 //Non-Authoritative Information seems as good as any
                 event.response().setStatusCode(203).end();
-                return true;
+                return null;
             }
-            sessionState = new SessionState(current.id(), sc, now + SESSION_TIMEOUT_MILLIS);
+            return current;
+        } finally {
+            SESSION_OPERATION_LOCK.unlock();
+        }
+    }
+
+    private boolean acceptSession(HttpServerRequest event, SessionRequest request) {
+        SESSION_OPERATION_LOCK.lock();
+        try {
+            long now = System.currentTimeMillis();
+            SessionState current = sessionState;
+            if (!current.isActive(now) || !current.id().equals(request.sessionId())
+                    || request.counter() <= current.acceptedCounter()) {
+                if (!current.isActive(now)) {
+                    sessionState = SessionState.inactive();
+                }
+                log.error("Invalid session");
+                event.response().setStatusCode(203).end();
+                return false;
+            }
+            sessionState = new SessionState(current.id(), request.counter(), now + SESSION_TIMEOUT_MILLIS);
+            return true;
+        } finally {
+            SESSION_OPERATION_LOCK.unlock();
+        }
+    }
+
+    private boolean commitSessionOperation(HttpServerRequest event, SessionRequest request, SessionState expected,
+            CheckedOperation operation) throws Exception {
+        SESSION_OPERATION_LOCK.lock();
+        try {
+            long now = System.currentTimeMillis();
+            SessionState current = sessionState;
+            if (!current.equals(expected) || !current.isActive(now) || !current.id().equals(request.sessionId())
+                    || request.counter() <= current.acceptedCounter()) {
+                if (!current.isActive(now)) {
+                    sessionState = SessionState.inactive();
+                }
+                log.error("Invalid session");
+                event.response().setStatusCode(203).end();
+                return false;
+            }
+            sessionState = new SessionState(current.id(), request.counter(), now + SESSION_TIMEOUT_MILLIS);
             operation.run();
-            return false;
+            return true;
         } finally {
             SESSION_OPERATION_LOCK.unlock();
         }
@@ -365,8 +403,8 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
         return MessageDigest.isEqual(expectedBytes, actualBytes) & valid;
     }
 
-    void executeBlocking(Callable<Void> action) {
-        VertxCoreRecorder.getVertx().get().executeBlocking(action, false);
+    <T> Future<T> executeBlocking(Callable<T> action) {
+        return VertxCoreRecorder.getVertx().get().executeBlocking(action, false);
     }
 
     @FunctionalInterface
@@ -383,6 +421,9 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
         boolean isActive(long now) {
             return id != null && now <= expiresAt;
         }
+    }
+
+    private record SessionRequest(String sessionId, int counter, String authenticator) {
     }
 
     /**
@@ -402,10 +443,14 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
      * </ul>
      * The trailing {@code !*} rejects everything else.
      */
-    private static ObjectInputStream createFilteredObjectInputStream(byte[] data) throws IOException {
-        ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(data));
+    private static ObjectInputStream createFilteredObjectInputStream(InputStream data, long maxBytes) throws IOException {
+        ObjectInputStream ois = new ObjectInputStream(new BufferedInputStream(data));
         ois.setObjectInputFilter(ObjectInputFilter.Config.createFilter(
-                "io.quarkus.dev.spi.RemoteDevState;"
+                "maxdepth=100;"
+                        + "maxrefs=1000000;"
+                        + "maxarray=1000000;"
+                        + "maxbytes=" + maxBytes + ";"
+                        + "io.quarkus.dev.spi.RemoteDevState;"
                         + "java.lang.*;"
                         + "java.io.*;"
                         + "java.util.*;"
@@ -414,7 +459,179 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
         return ois;
     }
 
+    private RemoteDevState readRemoteDevState(RemoteDevBodyCollector.CompletedBody body)
+            throws IOException, MalformedRemoteDevBodyException {
+        Object value = readSerialized(body);
+        if (!(value instanceof RemoteDevState state)) {
+            throw new MalformedRemoteDevBodyException("Expected remote-dev state");
+        }
+        return state;
+    }
+
+    private Throwable readRemoteProblem(RemoteDevBodyCollector.CompletedBody body)
+            throws IOException, MalformedRemoteDevBodyException {
+        Object value = readSerialized(body);
+        if (value != null && !(value instanceof Throwable)) {
+            throw new MalformedRemoteDevBodyException("Expected remote-dev problem");
+        }
+        return (Throwable) value;
+    }
+
+    private Object readSerialized(RemoteDevBodyCollector.CompletedBody body)
+            throws IOException, MalformedRemoteDevBodyException {
+        try (InputStream stream = body.openInputStream();
+                ObjectInputStream input = createFilteredObjectInputStream(stream, bodyLimits.requestLimit())) {
+            return input.readObject();
+        } catch (EOFException e) {
+            throw new MalformedRemoteDevBodyException("Rejected serialized remote-dev request", e);
+        } catch (ObjectStreamException e) {
+            throw new MalformedRemoteDevBodyException("Malformed serialized remote-dev request", e);
+        } catch (ClassNotFoundException e) {
+            throw new MalformedRemoteDevBodyException("Unsupported serialized remote-dev request", e);
+        }
+    }
+
+    private static String sha256(RemoteDevBodyCollector.CompletedBody body) throws IOException {
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+        byte[] buffer = new byte[8192];
+        try (InputStream input = body.openInputStream()) {
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                digest.update(buffer, 0, read);
+            }
+        }
+        return HexFormat.of().formatHex(digest.digest());
+    }
+
+    private void processDev(HttpServerRequest event, SessionRequest request,
+            RemoteDevBodyCollector.CompletedBody body) {
+        try {
+            String bodyHash = sha256(body);
+            if (!authenticateSession(event, request, bodyHash) || !acceptSession(event, request)) {
+                return;
+            }
+            Throwable problem = readRemoteProblem(body);
+            body.close();
+            //update the problem if it has changed
+            if (problem != null || remoteProblem != null) {
+                remoteProblem = problem;
+                hotReplacementContext.setRemoteProblem(problem);
+            }
+            synchronized (RemoteSyncHandler.class) {
+                RemoteSyncHandler.class.notifyAll();
+                try {
+                    RemoteSyncHandler.class.wait(10000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    log.debug("interrupted", e);
+                }
+                if (checkForChanges) {
+                    checkForChanges = false;
+                    event.response().setStatusCode(200);
+                } else {
+                    event.response().setStatusCode(204);
+                }
+                event.response().end();
+            }
+        } catch (MalformedRemoteDevBodyException e) {
+            event.response().putHeader(QUARKUS_ERROR, "Malformed remote-dev request body").setStatusCode(400).end();
+        } catch (RejectedExecutionException e) {
+            //everything is shut down
+            //likely in the middle of a restart
+            event.connection().close();
+        } catch (Exception e) {
+            log.error("Remote-dev request failed", e);
+            event.response().putHeader(QUARKUS_ERROR, "Remote-dev request processing failed").setStatusCode(500).end();
+        } finally {
+            body.close();
+        }
+    }
+
+    private void collectBody(HttpServerRequest event,
+            java.util.function.Consumer<RemoteDevBodyCollector.CompletedBody> action) {
+        if (closed.get()) {
+            rejectBody(event, 503, "Remote dev is restarting");
+            return;
+        }
+        RemoteDevBodyCollector.start(this, event, bodyLimits, bodyAdmission, bodySpoolStore, action);
+    }
+
+    void collectorStarted(RemoteDevBodyCollector collector) {
+        bodyCollectors.add(collector);
+        if (closed.get()) {
+            collector.cancel();
+        }
+    }
+
+    void collectorClosed(RemoteDevBodyCollector collector) {
+        bodyCollectors.remove(collector);
+    }
+
+    void rejectBody(HttpServerRequest request, int status, String message) {
+        request.handler(ignored -> {
+        }).exceptionHandler(ignored -> {
+        }).endHandler(ignored -> {
+        }).resume();
+        var response = request.response().putHeader(QUARKUS_ERROR, message).setStatusCode(status);
+        if (status == 503) {
+            response.putHeader("Retry-After", "1");
+        }
+        boolean multiplexed = request.version() == HttpVersion.HTTP_2 || request.version() == HttpVersion.HTTP_3;
+        if (!multiplexed) {
+            response.putHeader(HttpHeaderNames.CONNECTION, "close");
+        }
+        Future<Void> ended = response.end();
+        if (!multiplexed) {
+            if (ended == null) {
+                request.connection().close();
+            } else {
+                ended.onComplete(ignored -> request.connection().close());
+            }
+        }
+    }
+
+    void bodyCollectionFailed(HttpServerRequest request, Throwable failure) {
+        log.error("Failed to collect remote-dev request body", failure);
+        rejectBody(request, 500, "Remote-dev request body processing failed");
+    }
+
+    void bodyProcessingFailed(HttpServerRequest request, Throwable failure) {
+        log.error("Failed to process remote-dev request body", failure);
+        request.response().putHeader(QUARKUS_ERROR, "Remote-dev request processing failed").setStatusCode(500).end();
+    }
+
+    void bodyCleanupFailed() {
+        // Do not attach the exception because file-system exceptions can expose the private spool path.
+        log.error("Failed to clean up a remote-dev request body");
+    }
+
+    Path bodySpoolDirectory() {
+        return bodySpoolStore.directory();
+    }
+
+    private static final class MalformedRemoteDevBodyException extends Exception {
+
+        private MalformedRemoteDevBodyException(String message) {
+            super(message);
+        }
+
+        private MalformedRemoteDevBodyException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
     public void close() {
+        if (closed.compareAndSet(false, true)) {
+            bodySpoolStore.close();
+            for (RemoteDevBodyCollector collector : Set.copyOf(bodyCollectors)) {
+                collector.cancel();
+            }
+        }
         synchronized (RemoteSyncHandler.class) {
             RemoteSyncHandler.class.notifyAll();
         }

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/devmode/RemoteDevBodyAdmissionTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/devmode/RemoteDevBodyAdmissionTest.java
@@ -1,0 +1,89 @@
+package io.quarkus.vertx.http.runtime.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.runtime.configuration.MemorySize;
+
+class RemoteDevBodyAdmissionTest {
+
+    @Test
+    void configuredLimitControlsRequestAndAggregateCapacity() {
+        RemoteDevBodyLimits limits = RemoteDevBodyLimits.from(Optional.of(MemorySize.of(100)));
+
+        assertThat(limits.requestLimit()).isEqualTo(100);
+        assertThat(limits.aggregateLimit()).isEqualTo(200);
+        assertThat(limits.activeCollectorLimit()).isEqualTo(4);
+    }
+
+    @Test
+    void absentLimitUsesFiniteFallback() {
+        RemoteDevBodyLimits limits = RemoteDevBodyLimits.from(Optional.empty());
+
+        assertThat(limits.requestLimit()).isEqualTo(10L * 1024 * 1024);
+        assertThat(limits.aggregateLimit()).isEqualTo(20L * 1024 * 1024);
+    }
+
+    @Test
+    void aggregateCapacityIsInclusiveAndReleasedIdempotently() {
+        RemoteDevBodyAdmission admission = new RemoteDevBodyAdmission(new RemoteDevBodyLimits(100, 200, 4));
+        RemoteDevBodyAdmission.Reservation first = admission.tryAcquire(100);
+        RemoteDevBodyAdmission.Reservation second = admission.tryAcquire(100);
+
+        assertThat(first).isNotNull();
+        assertThat(second).isNotNull();
+        RemoteDevBodyAdmission.Reservation unknown = admission.tryAcquire(0);
+        assertThat(unknown).isNotNull();
+        assertThat(admission.tryReserve(unknown, 1)).isFalse();
+        assertThat(admission.activeCollectors()).isEqualTo(3);
+        assertThat(admission.reservedBytes()).isEqualTo(200);
+
+        admission.release(first);
+        admission.release(first);
+
+        assertThat(admission.activeCollectors()).isEqualTo(2);
+        assertThat(admission.reservedBytes()).isEqualTo(100);
+        assertThat(admission.tryAcquire(100)).isNotNull();
+    }
+
+    @Test
+    void unknownLengthReservationCannotCrossAggregateCapacity() {
+        RemoteDevBodyAdmission admission = new RemoteDevBodyAdmission(new RemoteDevBodyLimits(100, 150, 4));
+        RemoteDevBodyAdmission.Reservation known = admission.tryAcquire(100);
+        RemoteDevBodyAdmission.Reservation unknown = admission.tryAcquire(0);
+
+        assertThat(admission.tryReserve(unknown, 50)).isTrue();
+        assertThat(admission.tryReserve(unknown, 1)).isFalse();
+        assertThat(admission.reservedBytes()).isEqualTo(150);
+
+        admission.release(known);
+        assertThat(admission.tryReserve(unknown, 1)).isTrue();
+        assertThat(admission.reservedBytes()).isEqualTo(51);
+    }
+
+    @Test
+    void activeCollectorLimitIsIndependentOfByteCapacity() {
+        RemoteDevBodyAdmission admission = new RemoteDevBodyAdmission(new RemoteDevBodyLimits(100, 1000, 2));
+        assertThat(admission.tryAcquire(0)).isNotNull();
+        assertThat(admission.tryAcquire(0)).isNotNull();
+        assertThat(admission.tryAcquire(0)).isNull();
+    }
+
+    @Test
+    void invalidLimitsAndReservationsAreRejected() {
+        assertThatThrownBy(() -> new RemoteDevBodyLimits(0, 1, 1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new RemoteDevBodyLimits(2, 1, 1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new RemoteDevBodyLimits(1, 1, 0))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        RemoteDevBodyAdmission admission = new RemoteDevBodyAdmission(new RemoteDevBodyLimits(10, 20, 1));
+        assertThatThrownBy(() -> admission.tryAcquire(11))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/devmode/RemoteDevBodySpoolStoreTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/devmode/RemoteDevBodySpoolStoreTest.java
@@ -1,0 +1,127 @@
+package io.quarkus.vertx.http.runtime.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.dev.spi.HotReplacementContext;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+
+class RemoteDevBodySpoolStoreTest {
+
+    @Test
+    void closeRemovesAnEmptyDirectoryWithoutTheStoppingWorkerExecutor() throws Exception {
+        StoreHarness harness = store();
+        RemoteDevBodySpoolStore store = harness.store();
+        RemoteDevBodySpoolStore.Spool spool = await(store.create());
+        Path directory = store.directory();
+        assertThat(directory).isDirectory();
+        spool.delete();
+
+        harness.rejectExecution().set(true);
+        store.close();
+
+        assertThat(store.directory()).isNull();
+        assertThat(directory).doesNotExist();
+    }
+
+    @Test
+    void shutdownCleanupDoesNotDependOnTheStoppingWorkerExecutor() throws Exception {
+        StoreHarness harness = store();
+        RemoteDevBodySpoolStore store = harness.store();
+        RemoteDevBodySpoolStore.Spool spool = await(store.create());
+        Path directory = store.directory();
+        assertThat(directory).isDirectory();
+
+        harness.rejectExecution().set(true);
+        store.close();
+        await(store.delete(spool));
+
+        assertThat(store.directory()).isNull();
+        assertThat(directory).doesNotExist();
+    }
+
+    @Test
+    void queuedCleanupRemovesDirectoryWithoutStoreClose() throws Exception {
+        StoreHarness harness = store();
+        RemoteDevBodySpoolStore store = harness.store();
+        RemoteDevBodySpoolStore.Spool spool = await(store.create());
+        Path directory = store.directory();
+        harness.deferExecution().set(true);
+
+        Future<Void> deletion = store.delete(spool);
+
+        assertThat(directory).isDirectory();
+        harness.deferredExecution().getAndSet(null).run();
+        await(deletion);
+        assertThat(store.directory()).isNull();
+        assertThat(directory).doesNotExist();
+    }
+
+    @Test
+    void lastCleanupRemovesDirectoryWhileAnotherSpoolKeepsItAlive() throws Exception {
+        StoreHarness harness = store();
+        RemoteDevBodySpoolStore store = harness.store();
+        RemoteDevBodySpoolStore.Spool first = await(store.create());
+        RemoteDevBodySpoolStore.Spool second = await(store.create());
+        Path directory = store.directory();
+
+        await(store.delete(first));
+        assertThat(directory).isDirectory();
+
+        await(store.delete(second));
+        assertThat(store.directory()).isNull();
+        assertThat(directory).doesNotExist();
+    }
+
+    private static StoreHarness store() {
+        AtomicBoolean rejectExecution = new AtomicBoolean();
+        AtomicBoolean deferExecution = new AtomicBoolean();
+        AtomicReference<Runnable> deferredExecution = new AtomicReference<>();
+        var owner = new RemoteSyncHandler("secret", ignored -> {
+        }, org.mockito.Mockito.mock(HotReplacementContext.class), "/root") {
+            @Override
+            <T> Future<T> executeBlocking(Callable<T> action) {
+                if (rejectExecution.get()) {
+                    throw new RejectedExecutionException("worker executor is stopping");
+                }
+                if (deferExecution.get()) {
+                    Promise<T> result = Promise.promise();
+                    boolean stored = deferredExecution.compareAndSet(null, () -> {
+                        try {
+                            result.complete(action.call());
+                        } catch (Exception e) {
+                            result.fail(e);
+                        }
+                    });
+                    if (!stored) {
+                        return Future.failedFuture("Only one deferred action is supported");
+                    }
+                    return result.future();
+                }
+                try {
+                    return Future.succeededFuture(action.call());
+                } catch (Exception e) {
+                    return Future.failedFuture(e);
+                }
+            }
+        };
+        return new StoreHarness(new RemoteDevBodySpoolStore(owner), rejectExecution, deferExecution, deferredExecution);
+    }
+
+    private static <T> T await(Future<T> future) throws Exception {
+        return future.toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+    }
+
+    private record StoreHarness(RemoteDevBodySpoolStore store, AtomicBoolean rejectExecution,
+            AtomicBoolean deferExecution, AtomicReference<Runnable> deferredExecution) {
+    }
+}

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandlerHttpTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandlerHttpTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.vertx.http.runtime.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.dev.spi.HotReplacementContext;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
+
+class RemoteSyncHandlerHttpTest {
+
+    @Test
+    void trueChunkedRequestCrossingLimitReturnsPayloadTooLarge() throws Exception {
+        Vertx vertx = Vertx.vertx();
+        var context = org.mockito.Mockito.mock(HotReplacementContext.class);
+        var handler = new RemoteSyncHandler("secret", request -> request.response().setStatusCode(404).end(),
+                context, "/root", new RemoteDevBodyLimits(5, 10, 4)) {
+            @Override
+            <T> Future<T> executeBlocking(Callable<T> action) {
+                return vertx.executeBlocking(action, false);
+            }
+        };
+        var server = await(vertx.createHttpServer().requestHandler(handler).listen(0));
+        var client = vertx.createHttpClient();
+        try {
+            var request = await(client.request(HttpMethod.PUT, server.actualPort(), "localhost",
+                    "/root/app/classes/com/acme/Foo.class"));
+            request.setChunked(true)
+                    .putHeader("Content-Type", RemoteSyncHandler.APPLICATION_QUARKUS)
+                    .putHeader(RemoteSyncHandler.QUARKUS_SESSION, "session")
+                    .putHeader(RemoteSyncHandler.QUARKUS_SESSION_COUNT, "1")
+                    .putHeader(RemoteSyncHandler.QUARKUS_PASSWORD, "irrelevant");
+
+            var response = await(request.send(Buffer.buffer("123456")));
+            await(response.body());
+
+            assertThat(response.statusCode()).isEqualTo(413);
+            assertThat(response.getHeader(RemoteSyncHandler.QUARKUS_ERROR))
+                    .contains("quarkus.http.limits.max-body-size");
+            org.mockito.Mockito.verify(context, org.mockito.Mockito.never()).updateFile(
+                    org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+            handler.close();
+            awaitSpoolCleanup(handler);
+        } finally {
+            handler.close();
+            await(client.close());
+            await(server.close());
+            await(vertx.close());
+        }
+    }
+
+    private static <T> T await(Future<T> future) throws Exception {
+        return future.toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+    }
+
+    private static void awaitSpoolCleanup(RemoteSyncHandler handler) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (handler.bodySpoolDirectory() != null && System.nanoTime() < deadline) {
+            Thread.sleep(10);
+        }
+        assertThat(handler.bodySpoolDirectory()).isNull();
+    }
+}

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandlerTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandlerTest.java
@@ -2,6 +2,7 @@ package io.quarkus.vertx.http.runtime.devmode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -23,6 +24,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -30,11 +33,15 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.dev.spi.HotReplacementContext;
 import io.quarkus.dev.spi.RemoteDevState;
 import io.quarkus.runtime.util.HashUtil;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpConnection;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.HttpVersion;
 
 class RemoteSyncHandlerTest {
 
@@ -122,6 +129,7 @@ class RemoteSyncHandlerTest {
 
         verify(request.response()).setStatusCode(500);
         verify(request.response()).end();
+        assertThat(RemoteSyncHandler.sessionState.acceptedCounter()).isEqualTo(1);
     }
 
     @Test
@@ -380,6 +388,92 @@ class RemoteSyncHandlerTest {
         assertThat(RemoteSyncHandler.sessionState).isEqualTo(RemoteSyncHandler.SessionState.inactive());
     }
 
+    @Test
+    void exactLimitPutIsAccepted() throws Exception {
+        byte[] data = "12345".getBytes(StandardCharsets.UTF_8);
+        var context = mock(HotReplacementContext.class);
+        var handler = handler(context, new RemoteDevBodyLimits(data.length, data.length * 2L, 4));
+
+        invokeHandlePut(handler, request("/root/app/classes/com/acme/Foo.class", data));
+
+        verify(context).updateFile("/app/classes/com/acme/Foo.class", data);
+    }
+
+    @Test
+    void observedLimitOverflowIsRejectedBeforeAuthenticationOrMutation() throws Exception {
+        byte[] data = "123456".getBytes(StandardCharsets.UTF_8);
+        var context = mock(HotReplacementContext.class);
+        var handler = handler(context, new RemoteDevBodyLimits(data.length - 1L, data.length * 2L, 4));
+        long timeout = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1);
+        RemoteSyncHandler.SessionState expected = new RemoteSyncHandler.SessionState(SESSION, 0, timeout);
+        RemoteSyncHandler.sessionState = expected;
+        HttpServerRequest request = request("/root/app/classes/com/acme/Foo.class", data,
+                SESSION, 1, authenticator(data, SESSION, 1));
+
+        invokeHandlePut(handler, request);
+
+        verify(request.response()).setStatusCode(413);
+        verify(context, never()).updateFile(any(), any());
+        assertThat(RemoteSyncHandler.sessionState).isEqualTo(expected);
+    }
+
+    @Test
+    void declaredLimitOverflowIsRejectedBeforeBodyCollection() throws Exception {
+        byte[] data = "12345".getBytes(StandardCharsets.UTF_8);
+        var context = mock(HotReplacementContext.class);
+        var handler = handler(context, new RemoteDevBodyLimits(data.length, data.length * 2L, 4));
+        HttpServerRequest request = request("/root/app/classes/com/acme/Foo.class", data);
+        request.headers().set(HttpHeaders.CONTENT_LENGTH, Integer.toString(data.length + 1));
+
+        invokeHandlePut(handler, request);
+
+        verify(request.response()).setStatusCode(413);
+        verify(context, never()).updateFile(any(), any());
+    }
+
+    @Test
+    void encodedBodyIsRejected() throws Exception {
+        byte[] data = "content".getBytes(StandardCharsets.UTF_8);
+        var context = mock(HotReplacementContext.class);
+        var handler = handler(context);
+        HttpServerRequest request = request("/root/app/classes/com/acme/Foo.class", data);
+        request.headers().set(HttpHeaders.CONTENT_ENCODING, "gzip");
+
+        invokeHandlePut(handler, request);
+
+        verify(request.response()).setStatusCode(415);
+        verify(context, never()).updateFile(any(), any());
+    }
+
+    @Test
+    void malformedConnectBodyDoesNotReplaceAnExistingSession() throws Exception {
+        var context = mock(HotReplacementContext.class);
+        var handler = handler(context);
+        long timeout = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1);
+        RemoteSyncHandler.SessionState expected = new RemoteSyncHandler.SessionState(SESSION, 7, timeout);
+        RemoteSyncHandler.sessionState = expected;
+        byte[] body = "not serialized".getBytes(StandardCharsets.UTF_8);
+        HttpServerRequest request = connectRequest(body);
+
+        invoke(handler, "handleConnect", request);
+
+        verify(request.response()).setStatusCode(400);
+        assertThat(RemoteSyncHandler.sessionState).isEqualTo(expected);
+    }
+
+    @Test
+    void rejectionDoesNotCloseAMultiplexedConnection() {
+        HttpServerRequest request = request("/root/app/classes/com/acme/Foo.class",
+                "content".getBytes(StandardCharsets.UTF_8));
+        when(request.version()).thenReturn(HttpVersion.HTTP_2);
+        var handler = handler(mock(HotReplacementContext.class));
+
+        handler.rejectBody(request, 413, "too large");
+
+        verify(request.response()).setStatusCode(413);
+        verify(request.connection(), never()).close();
+    }
+
     private HttpServerRequest request(String path, byte[] body) {
         RemoteSyncHandler.sessionState = new RemoteSyncHandler.SessionState(
                 SESSION, 0, System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1));
@@ -388,16 +482,18 @@ class RemoteSyncHandlerTest {
     }
 
     private RemoteSyncHandler handler(HotReplacementContext context) {
+        return handler(context, RemoteDevBodyLimits.from(java.util.Optional.empty()));
+    }
+
+    private RemoteSyncHandler handler(HotReplacementContext context, RemoteDevBodyLimits limits) {
         return new RemoteSyncHandler(PASSWORD, ignored -> {
-        }, context, "/root") {
+        }, context, "/root", limits) {
             @Override
-            void executeBlocking(Callable<Void> action) {
+            <T> Future<T> executeBlocking(Callable<T> action) {
                 try {
-                    action.call();
-                } catch (RuntimeException e) {
-                    throw e;
+                    return Future.succeededFuture(action.call());
                 } catch (Exception e) {
-                    throw new IllegalStateException(e);
+                    return Future.failedFuture(e);
                 }
             }
         };
@@ -412,10 +508,13 @@ class RemoteSyncHandlerTest {
         var response = mock(HttpServerResponse.class);
         when(request.path()).thenReturn(path);
         when(request.response()).thenReturn(response);
-        when(response.setStatusCode(400)).thenReturn(response);
-        when(response.setStatusCode(401)).thenReturn(response);
-        when(response.setStatusCode(203)).thenReturn(response);
-        when(response.setStatusCode(500)).thenReturn(response);
+        when(request.version()).thenReturn(HttpVersion.HTTP_1_1);
+        when(request.connection()).thenReturn(mock(HttpConnection.class));
+        when(request.pause()).thenReturn(request);
+        when(response.setStatusCode(anyInt())).thenReturn(response);
+        when(response.putHeader(any(CharSequence.class), any(CharSequence.class))).thenReturn(response);
+        when(response.closeHandler(any())).thenReturn(response);
+        when(response.end()).thenReturn(Future.succeededFuture());
         MultiMap headers = MultiMap.caseInsensitiveMultiMap()
                 .add(RemoteSyncHandler.QUARKUS_SESSION, session);
         if (sessionCounter != null) {
@@ -425,13 +524,12 @@ class RemoteSyncHandlerTest {
             headers.add(RemoteSyncHandler.QUARKUS_PASSWORD, password);
         }
         when(request.headers()).thenReturn(headers);
-        when(request.bodyHandler(any())).thenAnswer(invocation -> {
-            Handler<Buffer> bodyHandler = invocation.getArgument(0);
-            bodyHandler.handle(Buffer.buffer(body));
-            return request;
+        when(request.getHeader(any(CharSequence.class))).thenAnswer(invocation -> {
+            CharSequence name = invocation.getArgument(0);
+            return headers.get(name.toString());
         });
-        when(request.exceptionHandler(any())).thenReturn(request);
-        when(request.resume()).thenReturn(request);
+        when(response.putHeader(any(String.class), any(String.class))).thenReturn(response);
+        configureBody(request, body);
         return request;
     }
 
@@ -439,19 +537,49 @@ class RemoteSyncHandlerTest {
         var request = mock(HttpServerRequest.class);
         var response = mock(HttpServerResponse.class);
         when(request.response()).thenReturn(response);
-        when(response.setStatusCode(500)).thenReturn(response);
+        when(request.version()).thenReturn(HttpVersion.HTTP_1_1);
+        when(request.connection()).thenReturn(mock(HttpConnection.class));
+        when(request.pause()).thenReturn(request);
+        when(response.setStatusCode(anyInt())).thenReturn(response);
+        when(response.putHeader(any(CharSequence.class), any(CharSequence.class))).thenReturn(response);
+        when(response.closeHandler(any())).thenReturn(response);
+        when(response.end()).thenReturn(Future.succeededFuture());
         when(response.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         when(request.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap()
                 .add(RemoteSyncHandler.QUARKUS_PASSWORD,
                         HashUtil.sha256(HashUtil.sha256(body) + PASSWORD)));
-        when(request.bodyHandler(any())).thenAnswer(invocation -> {
-            Handler<Buffer> bodyHandler = invocation.getArgument(0);
-            bodyHandler.handle(Buffer.buffer(body));
+        when(request.getHeader(any(CharSequence.class)))
+                .thenAnswer(invocation -> {
+                    CharSequence name = invocation.getArgument(0);
+                    return request.headers().get(name.toString());
+                });
+        when(response.putHeader(any(String.class), any(String.class))).thenReturn(response);
+        configureBody(request, body);
+        return request;
+    }
+
+    private void configureBody(HttpServerRequest request, byte[] body) {
+        AtomicReference<Handler<Buffer>> bodyHandler = new AtomicReference<>();
+        AtomicReference<Handler<Void>> endHandler = new AtomicReference<>();
+        AtomicBoolean delivered = new AtomicBoolean();
+        when(request.handler(any())).thenAnswer(invocation -> {
+            bodyHandler.set(invocation.getArgument(0));
+            return request;
+        });
+        when(request.endHandler(any())).thenAnswer(invocation -> {
+            endHandler.set(invocation.getArgument(0));
             return request;
         });
         when(request.exceptionHandler(any())).thenReturn(request);
-        when(request.resume()).thenReturn(request);
-        return request;
+        when(request.resume()).thenAnswer(invocation -> {
+            Handler<Buffer> data = bodyHandler.get();
+            Handler<Void> end = endHandler.get();
+            if (body != null && data != null && end != null && delivered.compareAndSet(false, true)) {
+                data.handle(Buffer.buffer(body));
+                end.handle(null);
+            }
+            return request;
+        });
     }
 
     private String authenticator(byte[] body, String session, int sessionCounter) {


### PR DESCRIPTION
Remote-dev requests are intercepted before normal router body limits and previously accumulated complete unauthenticated bodies in memory.

Inherit the HTTP body limit with a finite fallback, spool bounded request bodies with aggregate admission and backpressure, and preserve authentication and session ordering while streaming hashes and control messages. Make oversized and capacity responses actionable to the client, close every HTTP connection, and document the effective limit.
