### PR TITLE
Honor MongoDB authSource when credentials are configured separately

### DIFF
--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/CredentialConfig.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/CredentialConfig.java
@@ -35,10 +35,10 @@ public interface CredentialConfig {
     /**
      * Configures the source of the authentication credentials.
      * This is typically the database where the credentials have been created.
-     * The value defaults to the database
-     * specified in the path portion of the connection string or in the 'database' configuration property.
-     * If the database is specified in neither place, the default value is {@code admin}. This option is only
-     * respected when using the MONGO-CR mechanism (the default).
+     * The value defaults to the {@code authSource} option in the connection string, then to the database specified in
+     * the {@code database} configuration property, then to the database specified in the path portion of the connection
+     * string. If none of these are specified, the default value is {@code admin}. This option is only respected when
+     * using the MONGO-CR mechanism (the default).
      */
     Optional<String> authSource();
 

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClients.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClients.java
@@ -14,6 +14,8 @@ import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
 
 import java.lang.annotation.Annotation;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -331,7 +333,7 @@ public class MongoClients {
             reactiveContextProviders.stream().findAny().ifPresent(settings::contextProvider);
         }
 
-        ConnectionString connectionString;
+        ConnectionString connectionString = null;
         Optional<String> maybeConnectionString = config.connectionString();
         if (maybeConnectionString.isPresent()) {
             connectionString = new ConnectionString(maybeConnectionString.get());
@@ -349,7 +351,7 @@ public class MongoClients {
         config.applicationName().ifPresent(settings::applicationName);
 
         if (config.credentials() != null) {
-            MongoCredential credential = createMongoCredential(config);
+            MongoCredential credential = createMongoCredential(config, connectionString);
             if (credential != null) {
                 settings.credential(credential);
             }
@@ -509,11 +511,11 @@ public class MongoClients {
         }
     }
 
-    private MongoCredential createMongoCredential(MongoClientConfig config) {
+    private MongoCredential createMongoCredential(MongoClientConfig config, ConnectionString connectionString) {
 
-        // get the authsource, or the database from the config, or 'admin' as it is the default auth source in mongo
-        // and null is not allowed
-        String authSource = config.credentials().authSource().orElse(config.database().orElse("admin"));
+        // Get the auth source, or a configured database, or 'admin' as it is the default auth source in MongoDB
+        // and null is not allowed.
+        String authSource = getAuthSource(config, connectionString);
         // AuthMechanism
         AuthenticationMechanism mechanism = null;
         Optional<String> maybeMechanism = config.credentials().authMechanism();
@@ -558,6 +560,45 @@ public class MongoClients {
         }
 
         return credential;
+    }
+
+    static String getAuthSource(MongoClientConfig config, ConnectionString connectionString) {
+        String authSource = config.credentials().authSource().orElse(null);
+        if (authSource != null) {
+            return authSource;
+        }
+        if (connectionString != null) {
+            authSource = getAuthSource(connectionString);
+            if (authSource != null) {
+                return authSource;
+            }
+        }
+        String database = config.database().orElse(null);
+        if (database != null) {
+            return database;
+        }
+        if (connectionString != null) {
+            database = connectionString.getDatabase();
+            if (database != null) {
+                return database;
+            }
+        }
+        return "admin";
+    }
+
+    private static String getAuthSource(ConnectionString connectionString) {
+        String value = null;
+        int optionsStart = connectionString.getConnectionString().indexOf('?');
+        if (optionsStart == -1) {
+            return null;
+        }
+        for (String option : connectionString.getConnectionString().substring(optionsStart + 1).split("&")) {
+            int valueStart = option.indexOf('=');
+            if (valueStart != -1 && option.substring(0, valueStart).equalsIgnoreCase("authSource")) {
+                value = URLDecoder.decode(option.substring(valueStart + 1), StandardCharsets.UTF_8);
+            }
+        }
+        return value;
     }
 
     private UsernamePassword determineUserNamePassword(CredentialConfig config) {

--- a/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/runtime/MongoClientsTest.java
+++ b/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/runtime/MongoClientsTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.mongodb.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import com.mongodb.ConnectionString;
+
+class MongoClientsTest {
+
+    private final MongoClientConfig config = mock(MongoClientConfig.class);
+    private final CredentialConfig credentials = mock(CredentialConfig.class);
+
+    MongoClientsTest() {
+        when(config.credentials()).thenReturn(credentials);
+        when(credentials.authSource()).thenReturn(Optional.empty());
+        when(config.database()).thenReturn(Optional.empty());
+    }
+
+    @Test
+    void shouldUseExplicitAuthSource() {
+        when(credentials.authSource()).thenReturn(Optional.of("credentials-db"));
+        when(config.database()).thenReturn(Optional.of("configured-db"));
+
+        assertThat(MongoClients.getAuthSource(config,
+                new ConnectionString("mongodb://localhost/connection-db?authSource=connection-auth-db")))
+                .isEqualTo("credentials-db");
+    }
+
+    @Test
+    void shouldUseAuthSourceFromConnectionString() {
+        when(config.database()).thenReturn(Optional.of("configured-db"));
+
+        assertThat(MongoClients.getAuthSource(config,
+                new ConnectionString("mongodb://localhost/connection-db?authSource=connection-auth-db")))
+                .isEqualTo("connection-auth-db");
+    }
+
+    @Test
+    void shouldUseConfiguredDatabaseBeforeConnectionStringDatabase() {
+        when(config.database()).thenReturn(Optional.of("configured-db"));
+
+        assertThat(MongoClients.getAuthSource(config, new ConnectionString("mongodb://localhost/connection-db")))
+                .isEqualTo("configured-db");
+    }
+
+    @Test
+    void shouldUseConnectionStringDatabase() {
+        assertThat(MongoClients.getAuthSource(config, new ConnectionString("mongodb://localhost/connection-db")))
+                .isEqualTo("connection-db");
+    }
+
+    @Test
+    void shouldUseAdminByDefault() {
+        assertThat(MongoClients.getAuthSource(config, new ConnectionString("mongodb://localhost")))
+                .isEqualTo("admin");
+    }
+}


### PR DESCRIPTION
When MongoDB credentials are configured separately from the connection string, preserve the connection string's `authSource` instead of incorrectly falling back to the application database.

The authentication source now follows the documented precedence: explicit credential configuration, connection-string `authSource`, configured database, connection-string database, and finally `admin`.

Fixes #56115