### PR TITLE
Remove deprecated code from `devtools`

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
@@ -22,9 +22,7 @@ import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.impl.RemoteRepositoryManager;
 import org.eclipse.aether.repository.RemoteRepository;
 
 import io.quarkus.bootstrap.app.CuratedApplication;
@@ -254,16 +252,6 @@ public abstract class QuarkusBootstrapMojo extends AbstractMojo {
      */
     protected List<Dependency> forcedDependencies(LaunchMode mode) {
         return List.of();
-    }
-
-    @Deprecated(forRemoval = true)
-    protected RepositorySystem repositorySystem() {
-        return bootstrapProvider.repositorySystem();
-    }
-
-    @Deprecated(forRemoval = true)
-    protected RemoteRepositoryManager remoteRepositoryManager() {
-        return bootstrapProvider.remoteRepositoryManager();
     }
 
     protected RepositorySystemSession repositorySystemSession() {

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
@@ -171,16 +171,6 @@ public class QuarkusBootstrapProvider implements Closeable {
         return bootstrapId == null ? moduleKey.toGacString() : moduleKey.toGacString() + "-" + bootstrapId;
     }
 
-    @Deprecated(forRemoval = true)
-    public RepositorySystem repositorySystem() {
-        return workspaceProvider.getRepositorySystem();
-    }
-
-    @Deprecated(forRemoval = true)
-    public RemoteRepositoryManager remoteRepositoryManager() {
-        return remoteRepoManager;
-    }
-
     public QuarkusMavenAppBootstrap bootstrapper(QuarkusBootstrapMojo mojo) {
         try {
             return appBootstrapProviders.get(getBootstrapProviderId(mojo.projectId(), mojo.bootstrapId()),


### PR DESCRIPTION
* Remove deprecated code from QuarkusBootstrapMojo - https://github.com/quarkusio/quarkus/commit/ff1a40d08a4ef556da2f9e32c3ef4649c699dab3
  The removed code has been deprecated for at least 12 months in https://github.com/quarkusio/quarkus/commit/06d5eac58c9ec1c8b262fcf3ecbf9db638bbb5ca
* Remove deprecated code from QuarkusBootstrapProvider - https://github.com/quarkusio/quarkus/commit/634e1eca90079c51487b1431e204406215d61298
  The removed code has been deprecated for at least 12 months in https://github.com/quarkusio/quarkus/commit/06d5eac58c9ec1c8b262fcf3ecbf9db638bbb5ca