### PR TITLE
Security overview guide style review (3.40)

### DIFF
--- a/docs/src/main/asciidoc/security-overview.adoc
+++ b/docs/src/main/asciidoc/security-overview.adoc
@@ -97,7 +97,6 @@ For more information, see the Quarkus xref:config.adoc#secrets-in-environment-pr
 If your Quarkus Security architecture includes Quarkus REST (formerly RESTEasy Reactive) and Jackson, Quarkus can limit the fields included in JSON serialization based on the configured security.
 For more information, see the xref:rest.adoc#secure-serialization[JSON serialization] section of the Quarkus “Writing REST services with Quarkus REST (formerly RESTEasy Reactive)” guide.
 
-
 [[rest-data-panache]]
 === Secure auto-generated resources by REST Data with Panache
 


### PR DESCRIPTION
This PR includes a sanity check and small wording fixes across the
security-overview guide.
The final version is always the result of communication with an SME.
These fixes need to be backported to a branch from which RHBQ and
IBMbQ 3.40 docs are about to be built.

Changes:
- Remove double blank line before rest-data-panache section