### PR TITLE
security-architecture guide style review (3.40)

### DIFF
--- a/docs/src/main/asciidoc/security-architecture.adoc
+++ b/docs/src/main/asciidoc/security-architecture.adoc
@@ -53,7 +53,6 @@ Because Quarkus Security is customizable, you can, for example, add authorizatio
 Registered instances of `SecurityIdentityAugmentor` are invoked during the final stage of the security authentication process.
 For more information, see the xref:security-customization.adoc#security-identity-customization[Security Identity Customization] section of the "Security Tips and Tricks" guide.
 
-
 == Supported authentication mechanisms
 
 The Quarkus Security framework supports multiple authentication mechanisms, which can also be combined.


### PR DESCRIPTION
This PR includes a sanity check and small wording fixes across the
security-architecture guide.
The final version is always the result of communication with an SME.
These fixes need to be backported to a branch from which RHBQ and
IBMbQ 3.40 docs are about to be built.

Changes:
- Remove double blank line between SecurityIdentityAugmentor and Supported authentication mechanisms sections