### PR TITLE
Add forgotten extension-status includes – and remove extension status from guides for stable extensions

### DIFF
--- a/docs/src/main/asciidoc/funqy-http.adoc
+++ b/docs/src/main/asciidoc/funqy-http.adoc
@@ -13,6 +13,8 @@ include::_attributes.adoc[]
 The guide walks through quickstart code to show you how you can deploy Funqy as a
 standalone service and invoke on Funqy functions using HTTP.
 
+include::{includes}/extension-status.adoc[]
+
 WARNING: The Funqy HTTP binding is not a replacement for REST over HTTP.  Because Funqy
 needs to be portable across a lot of different protocols and function providers its HTTP binding
 is very minimalistic and you will lose REST features like linking and the ability to leverage

--- a/docs/src/main/asciidoc/funqy.adoc
+++ b/docs/src/main/asciidoc/funqy.adoc
@@ -19,6 +19,8 @@ to in other remoting abstractions.  A nice side effect though is that Funqy is a
 as small as possible.  This means that because Funqy sacrifices a little on flexibility, you'll
 get a framework that has little to no overhead.
 
+include::{includes}/extension-status.adoc[]
+
 == Funqy Basics
 
 The Funqy API is simple.  Annotate a method with `@Funq`.  This method may only have one optional input parameter

--- a/docs/src/main/asciidoc/opentelemetry-logging.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-logging.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id=opentelemetry-logging]
 = Using OpenTelemetry Logging
-:extension-status: stable
 include::_attributes.adoc[]
 :diataxis-type: reference
 :summary: This guide explains how your Quarkus application can utilize OpenTelemetry Logging to provide centralised logging for interactive web applications.

--- a/docs/src/main/asciidoc/opentelemetry-metrics.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-metrics.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id=opentelemetry-metrics]
 = Using OpenTelemetry Metrics
-:extension-status: stable
 include::_attributes.adoc[]
 :diataxis-type: reference
 :summary: This guide explains how your Quarkus application can utilize OpenTelemetry to provide metrics for interactive web applications.

--- a/docs/src/main/asciidoc/opentelemetry-tracing.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-tracing.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id=opentelemetry-tracing]
 = Using OpenTelemetry Tracing
-:extension-status: stable
 include::_attributes.adoc[]
 :diataxis-type: reference
 :summary: This guide explains how your Quarkus application can utilize OpenTelemetry Tracing to provide distributed tracing for interactive web applications.

--- a/docs/src/main/asciidoc/opentelemetry-tracing.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-tracing.adoc
@@ -15,6 +15,8 @@ include::_attributes.adoc[]
 This guide explains how your Quarkus application can utilize https://opentelemetry.io/[OpenTelemetry] (OTel) to provide
 distributed tracing for interactive web applications.
 
+include::{includes}/extension-status.adoc[]
+
 include::{includes}/observability-include.adoc[]
 
 

--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -17,6 +17,8 @@ Observability for interactive web applications.
 
 On this page we show the signal independent features of the extension.
 
+include::{includes}/extension-status.adoc[]
+
 include::{includes}/observability-include.adoc[]
 
 [NOTE]

--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id=opentelemetry]
 = Using OpenTelemetry
-:extension-status: stable
 include::_attributes.adoc[]
 :diataxis-type: reference
 :summary: This guide explains how your Quarkus application can utilize OpenTelemetry to provide observability for interactive web applications.

--- a/docs/src/main/asciidoc/proxy-registry.adoc
+++ b/docs/src/main/asciidoc/proxy-registry.adoc
@@ -16,6 +16,8 @@ This guide covers:
 * How to configure named proxies
 * How to integrate with a Credentials Provider
 
+include::{includes}/extension-status.adoc[]
+
 == Introduction
 
 A proxy acts as an intermediary between an application and external services.

--- a/docs/src/main/asciidoc/redis-dev-services.adoc
+++ b/docs/src/main/asciidoc/redis-dev-services.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Dev Services for Redis
-:extension-status: stable
 include::_attributes.adoc[]
 :summary: Start Redis automatically in dev and test modes.
 :topics: data,redis,nosql,dev-services,testing,dev-mode

--- a/docs/src/main/asciidoc/redis-dev-services.adoc
+++ b/docs/src/main/asciidoc/redis-dev-services.adoc
@@ -18,6 +18,8 @@ When running the production version of the application, the Redis connection nee
 so if you want to include a production database config in your `application.properties` and continue to use Dev Services
 we recommend that you use the `%prod.` profile to define your Redis settings.
 
+include::{includes}/extension-status.adoc[]
+
 Dev Services for Redis relies on Docker to start the server.
 If your environment does not support Docker, you will need to start the server manually, or connect to an already running server.
 

--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -14,6 +14,8 @@ include::_attributes.adoc[]
 Redis is an in-memory data store used as a database, cache, streaming engine, and message broker.
 The Quarkus Redis extension allows integrating Quarkus applications with Redis.
 
+include::{includes}/extension-status.adoc[]
+
 To use this extension, the user must be familiar with Redis, especially understanding the mechanism of commands and how they are organized.
 Typically, we recommend:
 

--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Redis extension reference guide
-:extension-status: stable
 include::_attributes.adoc[]
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/redis.adoc
+++ b/docs/src/main/asciidoc/redis.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using the Redis Client
-:extension-status: stable
 include::_attributes.adoc[]
 :topics: data,redis,nosql
 :extensions: io.quarkus:quarkus-redis-client

--- a/docs/src/main/asciidoc/signals.adoc
+++ b/docs/src/main/asciidoc/signals.adoc
@@ -16,6 +16,8 @@ include::_attributes.adoc[]
 Signals allow application components to interact in a loosely coupled fashion, by emitting and receiving _signals_.
 A signal is an object -- optionally augmented with qualifiers and metadata -- that is emitted by one component and delivered to one or more _receivers_.
 
+include::{includes}/extension-status.adoc[]
+
 Resolution:: The extension provides a type-safe resolution model, inspired by the https://jakarta.ee/specifications/cdi/4.1/jakarta-cdi-spec-4.1#events[CDI events].
 Emission Modes:: Inspired by the https://vertx.io/docs/vertx-core/java/#event_bus[Vert.x EventBus], the API supports unicast (point-to-point) and request-reply patterns in addition to the traditional multicast (publish-subscribe) pattern.
 Execution Model:: Receivers are always executed asynchronously and support both blocking and non-blocking logic. The execution model is determined from the method return type and annotations such as `@Blocking`, `@NonBlocking`, and `@RunOnVirtualThread`, following Quarkus conventions.

--- a/docs/src/main/asciidoc/stork-registration.adoc
+++ b/docs/src/main/asciidoc/stork-registration.adoc
@@ -11,6 +11,8 @@ include::_attributes.adoc[]
 
 This guide explains how to enable automatic registration and deregistration of a Quarkus application using SmallRye Stork and Consul, with minimal or no configuration.
 
+include::{includes}/extension-status.adoc[]
+
 == Overview
 
 SmallRye Stork supports service registration backends like Consul and Eureka.

--- a/docs/src/main/asciidoc/telemetry-micrometer-to-opentelemetry.adoc
+++ b/docs/src/main/asciidoc/telemetry-micrometer-to-opentelemetry.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 [id=telemetry-micrometer-opentelemetry]
 = Micrometer and OpenTelemetry extension
 include::_attributes.adoc[]
-:extension-status: stable
 :diataxis-type: reference
 :summary: Guide to send Micrometer data to OpenTelemetry.
 :topics: observability,opentelemetry,metrics,micrometer,tracing,logs

--- a/docs/src/main/asciidoc/update-quarkus.adoc
+++ b/docs/src/main/asciidoc/update-quarkus.adoc
@@ -14,6 +14,8 @@ You can update or upgrade your {project-name} projects to the latest version of 
 
 The update command primarily employs OpenRewrite recipes to automate updates for most project dependencies, source code, and documentation.
 
+include::{includes}/extension-status.adoc[]
+
 [IMPORTANT]
 ====
 The update command automates only a subset of the migration.


### PR DESCRIPTION
The `extension-status` treeprocessor emits a status badge (`experimental` /`preview` / `stable` / `deprecated`) on any guide that sets the`:extension-status:` document attribute. That badge is an anchor link to`#extension-status-note`. The `#extension-status-note` anchor only exists if theguide **also** pulls in the note block via:

```asciidoc
include::{includes}/extension-status.adoc[]
```

Several guides set `:extension-status:` but never add that include, so the badge links to an anchor that is never rendered. PR quarkusio/quarkusio.github.io#2892 works around this by auto-injecting the note. This is an alternate approach, and arguably better; just make each guide add the include
itself.

Caught by quarkusio/quarkusio.github.io#2713