### PR TITLE
Register @ConfigProperties classes for reflection

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/MicroProfileConfigProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/MicroProfileConfigProcessor.java
@@ -263,10 +263,12 @@ public class MicroProfileConfigProcessor {
     @BuildStep
     void generateConfigProperties(
             List<ConfigPropertiesBuildItem> configProperties,
-            BuildProducer<GeneratedConfigClassBuildItem> configClasses) {
+            BuildProducer<GeneratedConfigClassBuildItem> configClasses,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
 
         for (ConfigPropertiesBuildItem properties : configProperties) {
             configClasses.produce(GeneratedConfigClassBuildItem.of(properties.getConfigClass().name()));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(properties.getConfigClassName()).methods().build());
         }
     }
 

--- a/integration-tests/smallrye-config/src/main/java/io/quarkus/it/smallrye/config/ServerProperties.java
+++ b/integration-tests/smallrye-config/src/main/java/io/quarkus/it/smallrye/config/ServerProperties.java
@@ -2,9 +2,6 @@ package io.quarkus.it.smallrye.config;
 
 import org.eclipse.microprofile.config.inject.ConfigProperties;
 
-import io.quarkus.runtime.annotations.RegisterForReflection;
-
-@RegisterForReflection
 @ConfigProperties(prefix = "http.server")
 public class ServerProperties {
     private String host;


### PR DESCRIPTION
`@ConfigProperties` classes must have a no-args constructor and methods registered for reflection so we can recreate the instance. The change in https://github.com/quarkusio/quarkus/pull/55089 accidentally dropped the automatic registration, and we didn't notice because the integration test class had a `@RegisterForReflection`, so it still worked. 

- Fixes #56276 

- Caused by #55089