### PR TITLE
Use MongoDB connection string database as the Panache default

### DIFF
--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -103,16 +103,17 @@ Then add the relevant configuration properties in `{config-file}`.
 ----
 # configure the MongoDB client for a replica set of two nodes
 quarkus.mongodb.connection-string = mongodb://mongo1:27017,mongo2:27017
-# mandatory if you don't specify the name of the database using @MongoEntity
+# optional if the connection string or @MongoEntity specifies the database
 quarkus.mongodb.database = person
 ----
 
 The `quarkus.mongodb.database` property will be used by MongoDB with Panache to determine the name of the database where your entities will be persisted (if not overridden by `@MongoEntity`).
+If this property is not set, MongoDB with Panache uses the database from the connection string if any.
 
 The `@MongoEntity` annotation allows configuring:
 
 * the name of the client for multitenant application, see xref:mongodb.adoc#multiple-mongodb-clients[Multiple MongoDB Clients]. Otherwise, the default client will be used.
-* the name of the database, otherwise the `quarkus.mongodb.database` property or a link:{mongodb-doc-root-url}#multitenancy[`MongoDatabaseResolver`] implementation will be used.
+* the name of the database, otherwise a link:{mongodb-doc-root-url}#multitenancy[`MongoDatabaseResolver`] implementation, the `quarkus.mongodb.database` property, or the database from the connection string will be used.
 * the name of the collection, otherwise the simple name of the class will be used.
 
 For advanced configuration of the MongoDB client, you can follow the xref:mongodb.adoc#configuring-the-mongodb-database[Configuring the MongoDB database guide].
@@ -1273,8 +1274,8 @@ public class CustomMongoDatabaseResolver implements MongoDatabaseResolver {
 
 [IMPORTANT]
 ====
-The database selection priority order is as follow: `@MongoEntity(database="mizain")`, `MongoDatabaseResolver`,
-and then `quarkus.mongodb.database` property.
+The database selection priority order is as follows: `@MongoEntity(database="mizain")`, `MongoDatabaseResolver`,
+the `quarkus.mongodb.database` property, and then the database from the connection string.
 ====
 
 [NOTE]

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/MongoEntity.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/MongoEntity.java
@@ -17,8 +17,8 @@ public @interface MongoEntity {
     String collection() default "";
 
     /**
-     * The name of the database (if not set the default from the property
-     * <code>quarkus.mongodb.database</code> will be used).
+     * The name of the database (if not set, the database from the configuration property or the connection string will be
+     * used).
      */
     String database() default "";
 

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/BeanUtils.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/BeanUtils.java
@@ -6,6 +6,8 @@ import java.util.function.Predicate;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 
+import com.mongodb.ConnectionString;
+
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InjectableInstance;
@@ -49,21 +51,30 @@ public final class BeanUtils {
         if (mongoClientConfig.database().isPresent()) {
             return mongoClientConfig.database().get();
         }
-        mongoClientConfig = mongoConfig.clients().get(MongoConfig.DEFAULT_CLIENT_NAME);
-        if (mongoClientConfig.database().isPresent()) {
-            return mongoClientConfig.database().get();
+        MongoClientConfig defaultMongoClientConfig = mongoConfig.clients().get(MongoConfig.DEFAULT_CLIENT_NAME);
+        if (defaultMongoClientConfig.database().isPresent()) {
+            return defaultMongoClientConfig.database().get();
+        }
+        if (mongoClientConfig.connectionString().isPresent()) {
+            String database = new ConnectionString(mongoClientConfig.connectionString().get()).getDatabase();
+            if (database != null) {
+                return database;
+            }
         }
 
         if (mongoEntity == null) {
             throw new IllegalArgumentException(
-                    "The database property was not configured for the default Mongo Client (via 'quarkus.mongodb.database'");
+                    "The database was not configured for the default Mongo Client via 'quarkus.mongodb.database' "
+                            + "or the connection string");
         }
         if (mongoEntity.clientName().isEmpty()) {
             throw new IllegalArgumentException("The database attribute was not set for the @MongoEntity annotation "
-                    + "and neither was the database property configured for the default Mongo Client (via 'quarkus.mongodb.database')");
+                    + "and the database was not configured for the default Mongo Client via 'quarkus.mongodb.database' "
+                    + "or the connection string");
         }
         throw new IllegalArgumentException(String.format(
-                "The database attribute was not set for the @MongoEntity annotation neither was the database property configured for the named Mongo Client (via 'quarkus.mongodb.%s.database')",
+                "The database attribute was not set for the @MongoEntity annotation and the database was not configured "
+                        + "for the named Mongo Client via 'quarkus.mongodb.%s.database' or the connection string",
                 mongoEntity.clientName()));
     }
 

--- a/extensions/panache/mongodb-panache/deployment/src/test/java/io/quarkus/mongodb/panache/MongoDatabaseFromConnectionStringTest.java
+++ b/extensions/panache/mongodb-panache/deployment/src/test/java/io/quarkus/mongodb/panache/MongoDatabaseFromConnectionStringTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.mongodb.panache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.mongodb.panache.common.MongoEntity;
+import io.quarkus.mongodb.panache.reactive.ReactivePanacheMongoEntity;
+import io.quarkus.test.QuarkusExtensionTest;
+
+class MongoDatabaseFromConnectionStringTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(DefaultEntity.class, DefaultReactiveEntity.class, NamedEntity.class,
+                            NamedReactiveEntity.class, ConfiguredEntity.class, ConfiguredReactiveEntity.class)
+                    .addAsResource(new StringAsset("""
+                            quarkus.mongodb.devservices.enabled=false
+                            quarkus.mongodb.connection-string=mongodb://localhost:27018/default-uri-db
+                            quarkus.mongodb.named.connection-string=mongodb://localhost:27018/named-uri-db
+                            quarkus.mongodb.configured.connection-string=mongodb://localhost:27018/ignored-uri-db
+                            quarkus.mongodb.configured.database=configured-db
+                            """), "application.properties"));
+
+    @Test
+    void usesDatabaseFromDefaultClientConnectionString() {
+        assertEquals("default-uri-db", DefaultEntity.mongoDatabase().getName());
+        assertEquals("default-uri-db", DefaultReactiveEntity.mongoDatabase().getName());
+    }
+
+    @Test
+    void usesDatabaseFromNamedClientConnectionString() {
+        assertEquals("named-uri-db", NamedEntity.mongoDatabase().getName());
+        assertEquals("named-uri-db", NamedReactiveEntity.mongoDatabase().getName());
+    }
+
+    @Test
+    void explicitDatabaseTakesPriorityOverConnectionString() {
+        assertEquals("configured-db", ConfiguredEntity.mongoDatabase().getName());
+        assertEquals("configured-db", ConfiguredReactiveEntity.mongoDatabase().getName());
+    }
+
+    static class DefaultEntity extends PanacheMongoEntity {
+    }
+
+    static class DefaultReactiveEntity extends ReactivePanacheMongoEntity {
+    }
+
+    @MongoEntity(clientName = "named")
+    static class NamedEntity extends PanacheMongoEntity {
+    }
+
+    @MongoEntity(clientName = "named")
+    static class NamedReactiveEntity extends ReactivePanacheMongoEntity {
+    }
+
+    @MongoEntity(clientName = "configured")
+    static class ConfiguredEntity extends PanacheMongoEntity {
+    }
+
+    @MongoEntity(clientName = "configured")
+    static class ConfiguredReactiveEntity extends ReactivePanacheMongoEntity {
+    }
+}


### PR DESCRIPTION
### What

Allow MongoDB Panache to use the database path from a connection string as its final database fallback.

### Why

Panache currently requires `quarkus.mongodb.database` even when the connection string already identifies the database. This duplicates configuration and allows the values to become inconsistent.

### How

* When an entity, `MongoDatabaseResolver`, and explicit database configuration provide no database, Panache reads it from the corresponding client’s connection string. Existing precedence remains unchanged.

* The behavior supports default and named clients in both imperative and reactive Panache. Documentation, Javadoc, and regression tests cover the resolution order and explicit configuration precedence.

```mermaid
flowchart TD
      A{Client database?}
      A -- Yes --> B[Use client database]
      A -- No --> C{Default database?}
      C -- Yes --> D[Use default database]
      C -- No --> E{Database in client URI?}
      E -- Yes --> F[Use URI database]
      E -- No --> G[Handle missing database]
```


- Fixes: https://github.com/quarkusio/quarkus/issues/56116