### PR TITLE
docs: fix typo exisits -> exists

### DIFF
--- a/docs/src/main/asciidoc/dev-ui.adoc
+++ b/docs/src/main/asciidoc/dev-ui.adoc
@@ -1739,7 +1739,7 @@ To do this you can return/produce a `WorkspaceActionBuildItem` in your processor
 <3> Here the code that will execute if the user selects this action. You will receive some input (see the `Input` section below)
 <4> How the result should be displayed (see the `Display` section below)
 <5> What the result type would be (see the `DisplayType` section below)
-<6> Optional filter if this action only applies to certain items. Takes a regex as input, and some predefined regexes exisits in the the `Patterns` class
+<6> Optional filter if this action only applies to certain items. Takes a regex as input, and some predefined regexes exists in the the `Patterns` class
 
 ==== Input
 


### PR DESCRIPTION
Corrects the misspelling `exisits` -> `exists` in `docs/src/main/asciidoc/dev-ui.adoc`.

Documentation only, no behaviour change.