### PR TITLE
Allow enabling virtual threads by default for REST endpoints

### DIFF
--- a/docs/src/main/asciidoc/rest-virtual-threads.adoc
+++ b/docs/src/main/asciidoc/rest-virtual-threads.adoc
@@ -243,6 +243,99 @@ It's essential to understand what happened behind the scene:
 6. The method returns the result. The virtual thread terminates.
 7. The result is captured by Quarkus and written in the HTTP response
 
+== Use virtual threads for every endpoint
+
+Annotating every endpoint with `@RunOnVirtualThread` can be cumbersome when you want your whole application to use virtual threads.
+There are two ways to switch the default execution model for all endpoints at once: a configuration property and an annotated JAX-RS `Application` class.
+
+[WARNING]
+====
+Before switching all endpoints to virtual threads, make sure your application and its dependencies do not suffer from thread pinning or carrier thread monopolization.
+For more information, see the Quarkus xref:virtual-threads.adoc[Virtual thread support reference] guide.
+Thread pinning caused by `synchronized` blocks is resolved in JDK 24 and later, so we recommend running on JDK 24 or later when enabling virtual threads globally.
+You can detect pinning in your tests, as shown in the section below.
+====
+
+=== Use the configuration property
+
+You can enable virtual threads for all endpoints with a single build-time property:
+
+[source, properties]
+----
+quarkus.rest.virtual-threads=true
+----
+
+When enabled, every endpoint that would otherwise be executed on a worker thread is executed on a virtual thread instead.
+The regular execution model rules still apply:
+
+* Endpoints considered non-blocking, for instance because they return `Uni`, `Multi` or `CompletionStage`, keep running on the event loop.
+* Explicit `@Blocking`, `@NonBlocking` and `@RunOnVirtualThread` annotations on the endpoint method or resource class always take precedence.
+  So, if a specific endpoint is not safe to run on a virtual thread, annotate it with `@Blocking` to keep it on a worker thread.
+* An execution model annotation on the JAX-RS `Application` class takes precedence over this property.
+
+=== Annotate the JAX-RS Application class
+
+Alternatively, you can declare the default execution model in code.
+Quarkus does not require a JAX-RS `Application` class, but you can add one and annotate it with `@RunOnVirtualThread`:
+
+[source, java]
+----
+package org.acme;
+
+import jakarta.ws.rs.core.Application;
+
+import io.smallrye.common.annotation.RunOnVirtualThread;
+
+@RunOnVirtualThread
+public class MyApplication extends Application {
+}
+----
+
+Every endpoint without an explicit `@Blocking` annotation is then executed on a virtual thread.
+Unlike the configuration property, this approach also moves endpoints with a non-blocking signature, such as endpoints returning `Uni`, to a virtual thread.
+The same applies to endpoints annotated with `@NonBlocking`; in this case, a warning is logged at startup.
+An application can only have one `Application` class.
+
+=== Choose between the two approaches
+
+The following table summarizes on which thread an endpoint is executed, depending on how it is declared:
+
+.Execution model depending on the endpoint declaration
+[cols="2,1,1,1"]
+|===
+|Endpoint |Default |`quarkus.rest.virtual-threads=true` |`@RunOnVirtualThread` on `Application`
+
+|No annotation, blocking signature (returns `String`, a POJO, ...)
+|Worker thread
+|Virtual thread
+|Virtual thread
+
+|No annotation, non-blocking signature (returns `Uni`, `Multi`, `CompletionStage`, ...)
+|Event loop
+|Event loop
+|Virtual thread
+
+|`@Blocking`
+|Worker thread
+|Worker thread
+|Worker thread
+
+|`@NonBlocking`
+|Event loop
+|Event loop
+|Virtual thread (a warning is logged)
+
+|`@RunOnVirtualThread`
+|Virtual thread
+|Virtual thread
+|Virtual thread
+|===
+
+=== Revert to worker threads without code changes
+
+If you run into problems, you do not need to remove the property or the annotation to compare against the worker thread model.
+Setting `quarkus.virtual-threads.enabled=false` executes all the endpoints marked to run on virtual threads on worker threads instead.
+
 == Verify pinning using tests
 
 In the `pom.xml,` we added an `argLine` argument to the surefire and failsafe plugins:

--- a/docs/src/main/asciidoc/rest-virtual-threads.adoc
+++ b/docs/src/main/asciidoc/rest-virtual-threads.adoc
@@ -262,7 +262,7 @@ You can enable virtual threads for all endpoints with a single build-time proper
 
 [source, properties]
 ----
-quarkus.rest.virtual-threads=true
+quarkus.rest.default-blocking-execution-mode=virtual-thread
 ----
 
 When enabled, every endpoint that would otherwise be executed on a worker thread is executed on a virtual thread instead.
@@ -303,7 +303,7 @@ The following table summarizes on which thread an endpoint is executed, dependin
 .Execution model depending on the endpoint declaration
 [cols="2,1,1,1"]
 |===
-|Endpoint |Default |`quarkus.rest.virtual-threads=true` |`@RunOnVirtualThread` on `Application`
+|Endpoint |Default |`quarkus.rest.default-blocking-execution-mode=virtual-thread` |`@RunOnVirtualThread` on `Application`
 
 |No annotation, blocking signature (returns `String`, a POJO, ...)
 |Worker thread

--- a/docs/src/main/asciidoc/virtual-threads.adoc
+++ b/docs/src/main/asciidoc/virtual-threads.adoc
@@ -298,6 +298,29 @@ The following table summarizes the options:
 
 Note that all three models can be used in a single application.
 
+==== Use virtual threads by default
+
+Instead of annotating every endpoint, you can make virtual threads the default execution model for all your REST endpoints.
+Either set the build-time property `quarkus.rest.virtual-threads=true`, or create a JAX-RS `Application` class annotated with `@RunOnVirtualThread`:
+
+[source,java]
+----
+package org.acme;
+
+import jakarta.ws.rs.core.Application;
+
+import io.smallrye.common.annotation.RunOnVirtualThread;
+
+@RunOnVirtualThread
+public class MyApplication extends Application {
+}
+----
+
+In both cases, individual endpoints can opt out with an explicit `@Blocking` annotation.
+The two approaches differ in how they treat endpoints considered non-blocking, so review the semantics before choosing one.
+Before doing this, make sure your application does not suffer from pinning or monopolization, as described below.
+For more information, see the Quarkus xref:rest-virtual-threads.adoc[Use virtual threads in REST applications] guide.
+
 == Use virtual thread friendly clients
 
 As mentioned in the xref:why-not[Why not run everything on virtual threads?] section, the Java ecosystem is not entirely ready for virtual threads.

--- a/docs/src/main/asciidoc/virtual-threads.adoc
+++ b/docs/src/main/asciidoc/virtual-threads.adoc
@@ -301,7 +301,7 @@ Note that all three models can be used in a single application.
 ==== Use virtual threads by default
 
 Instead of annotating every endpoint, you can make virtual threads the default execution model for all your REST endpoints.
-Either set the build-time property `quarkus.rest.virtual-threads=true`, or create a JAX-RS `Application` class annotated with `@RunOnVirtualThread`:
+Either set the build-time property `quarkus.rest.default-blocking-execution-mode=virtual-thread`, or create a JAX-RS `Application` class annotated with `@RunOnVirtualThread`:
 
 [source,java]
 ----

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -545,12 +545,13 @@ public class ResteasyReactiveProcessor {
                     resourceInterceptorsBuildItem.getResourceInterceptors());
 
             boolean defaultRunOnVirtualThread = false;
-            if (serverConfig.virtualThreads()) {
+            if (serverConfig.defaultBlockingExecutionMode().isVirtualThread()) {
                 if (appResult.getBlockingDefault() == BlockingDefault.AUTOMATIC) {
                     defaultRunOnVirtualThread = true;
                 } else {
-                    log.warnf("The 'quarkus.rest.virtual-threads' property is ignored because an annotation on the"
-                            + " 'Application' class already set the execution model to '%s'",
+                    log.warnf(
+                            "The 'quarkus.rest.default-blocking-execution-mode' property is ignored because an annotation on the"
+                                    + " 'Application' class already set the execution model to '%s'",
                             appResult.getBlockingDefault());
                 }
             }

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -87,6 +87,7 @@ import org.jboss.resteasy.reactive.common.model.ResourceWriter;
 import org.jboss.resteasy.reactive.common.processor.AdditionalReaderWriter;
 import org.jboss.resteasy.reactive.common.processor.AdditionalReaders;
 import org.jboss.resteasy.reactive.common.processor.AdditionalWriters;
+import org.jboss.resteasy.reactive.common.processor.BlockingDefault;
 import org.jboss.resteasy.reactive.common.processor.DefaultProducesHandler;
 import org.jboss.resteasy.reactive.common.processor.EndpointIndexer;
 import org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames;
@@ -464,6 +465,7 @@ public class ResteasyReactiveProcessor {
             BeanArchiveIndexBuildItem beanArchiveIndexBuildItem,
             BeanContainerBuildItem beanContainerBuildItem,
             ResteasyReactiveConfig config,
+            ResteasyReactiveServerConfig serverConfig,
             Optional<ResourceScanningResultBuildItem> resourceScanningResultBuildItem,
             BuildProducer<GeneratedClassBuildItem> generatedClassBuildItemBuildProducer,
             BuildProducer<BytecodeTransformerBuildItem> bytecodeTransformerBuildItemBuildProducer,
@@ -542,6 +544,17 @@ public class ResteasyReactiveProcessor {
             final boolean filtersAccessResourceMethod = filtersAccessResourceMethod(
                     resourceInterceptorsBuildItem.getResourceInterceptors());
 
+            boolean defaultRunOnVirtualThread = false;
+            if (serverConfig.virtualThreads()) {
+                if (appResult.getBlockingDefault() == BlockingDefault.AUTOMATIC) {
+                    defaultRunOnVirtualThread = true;
+                } else {
+                    log.warnf("The 'quarkus.rest.virtual-threads' property is ignored because an annotation on the"
+                            + " 'Application' class already set the execution model to '%s'",
+                            appResult.getBlockingDefault());
+                }
+            }
+
             BiConsumer<String, BiFunction<String, ClassVisitor, ClassVisitor>> transformationConsumer = (name,
                     function) -> bytecodeTransformerBuildItemBuildProducer
                             .produce(new BytecodeTransformerBuildItem(name, function));
@@ -566,6 +579,7 @@ public class ResteasyReactiveProcessor {
                     .setInjectableBeans(injectableBeans)
                     .setAdditionalWriters(additionalWriters)
                     .setDefaultBlocking(appResult.getBlockingDefault())
+                    .setDefaultRunOnVirtualThread(defaultRunOnVirtualThread)
                     .setRemovesTrailingSlash(config.removesTrailingSlash())
                     .setApplicationScanningResult(appResult)
                     .setMultipartReturnTypeIndexerExtension(

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveServerConfig.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveServerConfig.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.virtual.threads.DefaultExecutionMode;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 
@@ -21,18 +22,19 @@ public interface ResteasyReactiveServerConfig {
     Optional<String> path();
 
     /**
-     * When enabled, endpoints that would otherwise be executed on a worker thread, meaning
-     * blocking endpoints without an explicit {@code @Blocking}, {@code @NonBlocking} or
-     * {@code @RunOnVirtualThread} annotation, are executed on virtual threads instead.
+     * The execution mode used for blocking endpoints without an explicit {@code @Blocking},
+     * {@code @NonBlocking} or {@code @RunOnVirtualThread} annotation.
      * <p>
-     * Endpoints considered non-blocking, for instance because they return a reactive type,
-     * keep running on the event loop, and explicit annotations on the endpoint method, the
-     * resource class or the {@code Application} class always take precedence.
+     * When set to {@code virtual-thread}, such endpoints are executed on virtual threads
+     * instead of worker threads. Endpoints considered non-blocking, for instance because
+     * they return a reactive type, keep running on the event loop, and explicit annotations
+     * on the endpoint method, the resource class or the {@code Application} class always
+     * take precedence.
      * <p>
-     * Before enabling this, make sure the application does not suffer from thread pinning
+     * Before changing this, make sure the application does not suffer from thread pinning
      * (mostly resolved since JDK 24) or carrier thread monopolization. See the virtual
      * threads guide for more details on how to monitor this with JFR events.
      */
-    @WithDefault("false")
-    boolean virtualThreads();
+    @WithDefault("worker")
+    DefaultExecutionMode defaultBlockingExecutionMode();
 }

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveServerConfig.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveServerConfig.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 @ConfigMapping(prefix = "quarkus.rest")
 @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
@@ -18,4 +19,20 @@ public interface ResteasyReactiveServerConfig {
      * This value is always resolved relative to {@code quarkus.http.root-path}.
      */
     Optional<String> path();
+
+    /**
+     * When enabled, endpoints that would otherwise be executed on a worker thread, meaning
+     * blocking endpoints without an explicit {@code @Blocking}, {@code @NonBlocking} or
+     * {@code @RunOnVirtualThread} annotation, are executed on virtual threads instead.
+     * <p>
+     * Endpoints considered non-blocking, for instance because they return a reactive type,
+     * keep running on the event loop, and explicit annotations on the endpoint method, the
+     * resource class or the {@code Application} class always take precedence.
+     * <p>
+     * Before enabling this, make sure the application does not suffer from thread pinning
+     * (mostly resolved since JDK 24) or carrier thread monopolization. See the virtual
+     * threads guide for more details on how to monitor this with JFR events.
+     */
+    @WithDefault("false")
+    boolean virtualThreads();
 }

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/VirtualThreadsConfigTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/VirtualThreadsConfigTest.java
@@ -8,7 +8,6 @@ import java.util.logging.LogRecord;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.core.Application;
 
 import org.hamcrest.Matchers;
 import org.jboss.resteasy.reactive.common.processor.TargetJavaVersion;
@@ -21,10 +20,11 @@ import io.quarkus.resteasy.reactive.server.spi.TargetJavaVersionBuildItem;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.common.annotation.RunOnVirtualThread;
 import io.smallrye.mutiny.Uni;
 
-public class ApplicationWithRunOnVirtualThreadTest {
+public class VirtualThreadsConfigTest {
 
     @RegisterExtension
     static QuarkusExtensionTest test = new QuarkusExtensionTest()
@@ -32,6 +32,7 @@ public class ApplicationWithRunOnVirtualThreadTest {
             .addBuildChainCustomizer(buildChainBuilder -> buildChainBuilder.addBuildStep(context -> {
                 context.produce(new TargetJavaVersionBuildItem(new DummyTargetJavaVersion()));
             }).produces(TargetJavaVersionBuildItem.class).build())
+            .overrideConfigKey("quarkus.rest.virtual-threads", "true")
             .setLogRecordPredicate(record -> record.getLevel().equals(Level.SEVERE)
                     && record.getLoggerName()
                             .equals("org.jboss.resteasy.reactive.server.core.startup.RuntimeResourceDeployment"))
@@ -40,30 +41,29 @@ public class ApplicationWithRunOnVirtualThreadTest {
                 @Override
                 public JavaArchive get() {
                     return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(VirtualThreadApplication.class, ThreadNameResource.class);
+                            .addClasses(ThreadNameResource.class);
                 }
             });
 
     @Test
     public void test() {
+        // blocking signature without an annotation defaults to a virtual thread
         RestAssured.get("/tname/default")
                 .then().body(Matchers.containsString("virtual"), Matchers.not(Matchers.containsString("executor")));
 
+        // an explicit @Blocking annotation keeps the endpoint on a worker thread
         RestAssured.get("/tname/blocking")
                 .then().body(Matchers.containsString("executor"), Matchers.not(Matchers.containsString("virtual")));
 
         RestAssured.get("/tname/virtual")
                 .then().body(Matchers.containsString("virtual"), Matchers.not(Matchers.containsString("executor")));
 
-        // unlike 'quarkus.rest.virtual-threads', the annotated Application class also moves
-        // endpoints with a non-blocking signature to a virtual thread
+        // non-blocking endpoints stay on the event loop
+        RestAssured.get("/tname/nonblocking")
+                .then().body(Matchers.containsString("eventloop"), Matchers.not(Matchers.containsString("virtual")));
+
         RestAssured.get("/tname/uni")
-                .then().body(Matchers.containsString("virtual"), Matchers.not(Matchers.containsString("executor")));
-    }
-
-    @RunOnVirtualThread
-    public static class VirtualThreadApplication extends Application {
-
+                .then().body(Matchers.containsString("eventloop"), Matchers.not(Matchers.containsString("virtual")));
     }
 
     @Path("tname")
@@ -86,6 +86,13 @@ public class ApplicationWithRunOnVirtualThreadTest {
         @Path("virtual")
         @GET
         public String virtual() {
+            return Thread.currentThread().getName();
+        }
+
+        @NonBlocking
+        @Path("nonblocking")
+        @GET
+        public String nonBlocking() {
             return Thread.currentThread().getName();
         }
 

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/VirtualThreadsConfigTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/VirtualThreadsConfigTest.java
@@ -32,7 +32,7 @@ public class VirtualThreadsConfigTest {
             .addBuildChainCustomizer(buildChainBuilder -> buildChainBuilder.addBuildStep(context -> {
                 context.produce(new TargetJavaVersionBuildItem(new DummyTargetJavaVersion()));
             }).produces(TargetJavaVersionBuildItem.class).build())
-            .overrideConfigKey("quarkus.rest.virtual-threads", "true")
+            .overrideConfigKey("quarkus.rest.default-blocking-execution-mode", "virtual-thread")
             .setLogRecordPredicate(record -> record.getLevel().equals(Level.SEVERE)
                     && record.getLoggerName()
                             .equals("org.jboss.resteasy.reactive.server.core.startup.RuntimeResourceDeployment"))

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/VirtualThreadsConfigWithApplicationAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/VirtualThreadsConfigWithApplicationAnnotationTest.java
@@ -20,7 +20,7 @@ public class VirtualThreadsConfigWithApplicationAnnotationTest {
 
     @RegisterExtension
     static QuarkusExtensionTest test = new QuarkusExtensionTest()
-            .overrideConfigKey("quarkus.rest.virtual-threads", "true")
+            .overrideConfigKey("quarkus.rest.default-blocking-execution-mode", "virtual-thread")
             .setArchiveProducer(new Supplier<>() {
                 @Override
                 public JavaArchive get() {

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/VirtualThreadsConfigWithApplicationAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/VirtualThreadsConfigWithApplicationAnnotationTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.resteasy.reactive.server.test.simple;
+
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Application;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+import io.smallrye.common.annotation.NonBlocking;
+
+public class VirtualThreadsConfigWithApplicationAnnotationTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .overrideConfigKey("quarkus.rest.virtual-threads", "true")
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(NonBlockingApplication.class, ThreadNameResource.class);
+                }
+            });
+
+    @Test
+    public void test() {
+        // the annotation on the Application class wins over 'quarkus.rest.virtual-threads'
+        RestAssured.get("/tname/default")
+                .then().body(Matchers.containsString("eventloop"), Matchers.not(Matchers.containsString("virtual")));
+    }
+
+    @NonBlocking
+    public static class NonBlockingApplication extends Application {
+
+    }
+
+    @Path("tname")
+    public static class ThreadNameResource {
+
+        @Path("default")
+        @GET
+        public String threadName() {
+            return Thread.currentThread().getName();
+        }
+    }
+
+}

--- a/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/DefaultExecutionMode.java
+++ b/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/DefaultExecutionMode.java
@@ -1,0 +1,22 @@
+package io.quarkus.virtual.threads;
+
+/**
+ * The default execution mode used for blocking methods that do not declare an explicit execution model
+ * annotation, such as {@code @Blocking}, {@code @NonBlocking} or {@code @RunOnVirtualThread}.
+ */
+public enum DefaultExecutionMode {
+
+    /**
+     * Blocking methods without an explicit execution model annotation are executed on a worker thread.
+     */
+    WORKER,
+
+    /**
+     * Blocking methods without an explicit execution model annotation are executed on a virtual thread.
+     */
+    VIRTUAL_THREAD;
+
+    public boolean isVirtualThread() {
+        return this == VIRTUAL_THREAD;
+    }
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -220,6 +220,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
     private final Map<DotName, String> httpAnnotationToMethod;
     private final AdditionalWriters additionalWriters;
     private final BlockingDefault defaultBlocking;
+    private final boolean defaultRunOnVirtualThread;
     private final Map<DotName, Map<String, String>> classLevelExceptionMappers;
     private final Function<String, BeanFactory<Object>> factoryCreator;
     private final Consumer<ResourceMethodCallbackEntry> resourceMethodCallback;
@@ -250,6 +251,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
         this.additionalWriters = builder.additionalWriters;
         this.hasRuntimeConverters = builder.hasRuntimeConverters;
         this.defaultBlocking = builder.defaultBlocking;
+        this.defaultRunOnVirtualThread = builder.defaultRunOnVirtualThread;
         this.classLevelExceptionMappers = builder.classLevelExceptionMappers;
         this.factoryCreator = builder.factoryCreator;
         this.resourceMethodCallback = builder.resourceMethodCallback;
@@ -903,8 +905,13 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
         } else {
             if (blockingAnnotation != null) {
                 return false;
+            } else if (defaultValue == BlockingDefault.RUN_ON_VIRTUAL_THREAD) {
+                return true;
             } else {
-                return defaultValue == BlockingDefault.RUN_ON_VIRTUAL_THREAD;
+                // no annotation on the method or its class: honor the configured default,
+                // but only for methods that were determined to be blocking, so that
+                // non-blocking (e.g. reactive return type) methods stay on the event loop
+                return defaultRunOnVirtualThread && blocking;
             }
         }
     }
@@ -1770,6 +1777,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
     public static abstract class Builder<T extends EndpointIndexer<T, ?, METHOD>, B extends Builder<T, B, METHOD>, METHOD extends ResourceMethod> {
         private Function<String, BeanFactory<Object>> factoryCreator;
         private BlockingDefault defaultBlocking = BlockingDefault.AUTOMATIC;
+        private boolean defaultRunOnVirtualThread = false;
         private IndexView index;
         private IndexView applicationIndex;
         private Map<String, String> existingConverters = new HashMap<>();
@@ -1815,6 +1823,16 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
 
         public B setDefaultBlocking(BlockingDefault defaultBlocking) {
             this.defaultBlocking = defaultBlocking;
+            return (B) this;
+        }
+
+        /**
+         * When set to {@code true}, methods that are considered blocking and carry no explicit
+         * execution model annotation are executed on a virtual thread instead of a worker thread.
+         * Only effective when the blocking default is {@link BlockingDefault#AUTOMATIC}.
+         */
+        public B setDefaultRunOnVirtualThread(boolean defaultRunOnVirtualThread) {
+            this.defaultRunOnVirtualThread = defaultRunOnVirtualThread;
             return (B) this;
         }
 


### PR DESCRIPTION
Annotating every endpoint with `@RunOnVirtualThread` is cumbersome when an application wants virtual threads everywhere. Spring Boot offers a single property for this, and the discussion in #51031 settled on per-extension opt-in properties for Quarkus, starting with the REST layer.

This adds the build-time property `quarkus.rest.default-blocking-execution-mode` (values `worker`, the default, and `virtual-thread`). When set to `virtual-thread`, endpoints that would otherwise be executed on a worker thread are executed on a virtual thread instead. Endpoints considered non-blocking because of their signature keep running on the event loop, and explicit `@Blocking`, `@NonBlocking` and `@RunOnVirtualThread` annotations take precedence, so a single endpoint can opt out with `@Blocking`. An execution model annotation on the JAX-RS `Application` class wins over the property. The `DefaultExecutionMode` enum lives in the `quarkus-virtual-threads` module so other extensions can adopt the same property shape.

The property is intentionally not identical to putting `@RunOnVirtualThread` on the `Application` class: that annotation, like `@Blocking`/`@NonBlocking` at the same level, sets a hard default that also moves reactive-signature and `@NonBlocking` endpoints to virtual threads. The property is the safer switch for mixed applications. Both approaches and their differences are documented in a comparison table in the REST virtual threads guide, and the existing `quarkus.virtual-threads.enabled=false` escape hatch reverts everything to worker threads without code changes.