### PR TITLE
Fix strict TLS key exchange group selection

### DIFF
--- a/docs/src/main/asciidoc/tls-registry-reference.adoc
+++ b/docs/src/main/asciidoc/tls-registry-reference.adoc
@@ -802,6 +802,7 @@ Use this when you want post-quantum key exchange where available without breakin
 
 `strict`:: The server only accepts connections that use a post-quantum key exchange group.
 Clients that do not negotiate a post-quantum group are rejected.
+When `key-exchange-groups` is set, only the post-quantum groups in that list are accepted; classical groups in the list are ignored.
 Use this when all clients are known to support post-quantum cryptography.
 
 [IMPORTANT]
@@ -811,7 +812,8 @@ Setting `pqc-enforcement-policy` to `client-negotiated` or `strict` activates th
 With the default `relaxed` policy, Vert.x uses the JDK SSL engine, which ignores any post-quantum key-exchange groups before JDK 27 — meaning that configuring post-quantum groups without also setting the enforcement policy results in no post-quantum key exchange at all.
 On JDK 27+, the JDK natively supports `X25519MLKEM768` and post-quantum key exchange works without changing the enforcement policy.
 
-Quarkus logs a warning at startup if you configure a post-quantum group with `relaxed` policy to help catch this misconfiguration.
+Quarkus logs a warning at startup if you configure key exchange groups with the `relaxed` policy because the policy does not require post-quantum key exchange.
+An explicitly selected engine can still honor the configured groups.
 ====
 
 [NOTE]

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
@@ -38,6 +38,8 @@ import io.vertx.core.net.TrustOptions;
 public class VertxCertificateHolder implements TlsConfiguration {
 
     private static final Logger LOGGER = Logger.getLogger(VertxCertificateHolder.class.getName());
+    private static final List<String> PQC_KEY_EXCHANGE_GROUPS = List.of("X25519MLKEM768", "SecP256r1MLKEM768",
+            "SecP384r1MLKEM1024");
 
     private final TlsBucketConfig config;
     private final List<Buffer> crls;
@@ -129,16 +131,33 @@ public class VertxCertificateHolder implements TlsConfiguration {
         options.setKeyCertOptions(getKeyStoreOptions());
         options.setTrustOptions(getTrustStoreOptions());
         options.setUseAlpn(config().alpn());
+        io.vertx.core.net.PqcEnforcementPolicy pqcEnforcementPolicy = toVertxPqcPolicy(config().pqcEnforcementPolicy());
         if (config().keyExchangeGroups().isPresent()) {
-            options.setKeyExchangeGroups(config().keyExchangeGroups().get());
+            List<String> keyExchangeGroups = config().keyExchangeGroups().get();
+            if (config().pqcEnforcementPolicy() == PqcEnforcementPolicy.STRICT) {
+                List<String> configuredPqcGroups = new ArrayList<>();
+                for (String keyExchangeGroup : keyExchangeGroups) {
+                    String pqcKeyExchangeGroup = canonicalPqcKeyExchangeGroup(keyExchangeGroup);
+                    if (pqcKeyExchangeGroup != null) {
+                        configuredPqcGroups.add(pqcKeyExchangeGroup);
+                    }
+                }
+                if (!configuredPqcGroups.isEmpty()) {
+                    // Vert.x expands STRICT to all supported PQC groups. CLIENT_NEGOTIATED preserves the explicit list;
+                    // limiting that list to PQC groups provides the requested strict behavior.
+                    keyExchangeGroups = configuredPqcGroups;
+                    pqcEnforcementPolicy = io.vertx.core.net.PqcEnforcementPolicy.CLIENT_NEGOTIATED;
+                }
+            }
+            options.setKeyExchangeGroups(keyExchangeGroups);
         }
-        options.setPqcEnforcementPolicy(toVertxPqcPolicy(config().pqcEnforcementPolicy()));
+        options.setPqcEnforcementPolicy(pqcEnforcementPolicy);
 
         if (config().keyExchangeGroups().isPresent()
                 && config().pqcEnforcementPolicy() == PqcEnforcementPolicy.RELAXED) {
             LOGGER.warnf("TLS bucket '%s' configures post-quantum key exchange groups with a 'relaxed' enforcement policy. "
-                    + "The post-quantum groups will be ignored because 'relaxed' does not enforce post-quantum key exchange. "
-                    + "Use 'strict' or 'client-negotiated' to enable post-quantum cryptography.", name);
+                    + "The configured SSL engine might use the groups, but 'relaxed' does not require post-quantum key exchange. "
+                    + "Use 'strict' to require post-quantum cryptography.", name);
         }
         options.setSslHandshakeTimeoutUnit(TimeUnit.SECONDS);
         options.setSslHandshakeTimeout(config().handshakeTimeout().toSeconds());
@@ -153,6 +172,15 @@ public class VertxCertificateHolder implements TlsConfiguration {
         for (String cipher : config().cipherSuites().orElse(Collections.emptyList())) {
             options.addEnabledCipherSuite(cipher);
         }
+    }
+
+    private static String canonicalPqcKeyExchangeGroup(String group) {
+        for (String pqcGroup : PQC_KEY_EXCHANGE_GROUPS) {
+            if (pqcGroup.equalsIgnoreCase(group)) {
+                return pqcGroup;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/VertxCertificateHolderTest.java
+++ b/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/VertxCertificateHolderTest.java
@@ -101,12 +101,13 @@ class VertxCertificateHolderTest {
     @Test
     void testKeyExchangeGroups() {
         assertEquals(1, holder.getServerSSLOptions().getKeyExchangeGroups().size());
-        assertTrue(holder.getServerSSLOptions().getKeyExchangeGroups().contains("x25519mlkem768"));
+        assertTrue(holder.getServerSSLOptions().getKeyExchangeGroups().contains("X25519MLKEM768"));
     }
 
     @Test
     void testPqcEnforcementPolicy() {
-        assertEquals(io.vertx.core.net.PqcEnforcementPolicy.STRICT, holder.getServerSSLOptions().getPqcEnforcementPolicy());
+        assertEquals(io.vertx.core.net.PqcEnforcementPolicy.CLIENT_NEGOTIATED,
+                holder.getServerSSLOptions().getPqcEnforcementPolicy());
     }
 
     @Test

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/HybridKeyExchangeTest.java
@@ -12,7 +12,6 @@ import javax.net.ssl.SSLException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -69,7 +68,6 @@ public class HybridKeyExchangeTest extends AbstractHybridKeyExchangeTest {
     }
 
     @Test
-    @Disabled("Blocked by Vert.x SslEngineUtils.resolveKeyExchangeGroups fix")
     void testClientWithOnlyUnadvertisedPqcGroupFails() {
         WebClientOptions options = new WebClientOptions();
         options.setSsl(true);
@@ -88,7 +86,6 @@ public class HybridKeyExchangeTest extends AbstractHybridKeyExchangeTest {
     }
 
     @Test
-    @Disabled("Blocked by Vert.x SslEngineUtils.resolveKeyExchangeGroups fix")
     void testClientWithUnadvertisedPqcGroupFailsInStrictMode() {
         // Client offers SecP256r1MLKEM768 (not advertised by the server) with X25519 as a fallback.
         // Strict mode only advertises X25519MLKEM768, so there is no common group — handshake fails.


### PR DESCRIPTION
When strict PQC enforcement is enabled, Vert.x expands an explicitly configured key exchange group into all supported PQC groups. As a result, clients can negotiate a PQC group that was not allowed by `quarkus.tls.key-exchange-groups`.

Preserve the explicitly configured PQC groups while retaining strict enforcement, and clarify the behavior of strict and relaxed policies in the TLS registry documentation.

Part of #56262