### PR TITLE
Allow enabling virtual threads by default for scheduled methods

### DIFF
--- a/docs/src/main/asciidoc/scheduler-reference.adoc
+++ b/docs/src/main/asciidoc/scheduler-reference.adoc
@@ -644,6 +644,33 @@ In this case, the method is invoked on a virtual thread.
 The method must return `void` and your Java runtime must provide support for virtual threads.
 Read xref:./virtual-threads.adoc[the virtual thread guide] for more details.
 
+=== Use virtual threads for every scheduled method
+
+Instead of annotating every scheduled method, you can enable virtual threads for all of them with a single build-time property:
+
+[source, properties]
+----
+quarkus.scheduler.virtual-threads=true
+----
+
+When enabled, every scheduled method that would otherwise be executed on a worker thread is executed on a virtual thread instead.
+The regular execution model rules still apply:
+
+* Scheduled methods considered non-blocking, because they return `CompletionStage<Void>` or `Uni<Void>`, or are Kotlin suspend functions, keep running on the event loop.
+* Explicit `@Blocking`, `@NonBlocking` and `@RunOnVirtualThread` annotations on the scheduled method always take precedence.
+  So, if a specific scheduled method is not safe to run on a virtual thread, annotate it with `@Blocking` to keep it on a worker thread.
+
+[WARNING]
+====
+Before enabling this property, make sure your application and its dependencies do not suffer from thread pinning or carrier thread monopolization.
+For more information, see the Quarkus xref:./virtual-threads.adoc[Virtual thread support reference] guide.
+====
+
+[NOTE]
+====
+When the xref:./quartz.adoc[Quartz extension] is used with `quarkus.quartz.run-blocking-scheduled-method-on-quartz-thread=true`, scheduled methods marked to run on virtual threads are executed on a Quartz thread instead.
+====
+
 == Assign a user and roles to a scheduled task
 
 You can use the `@RunAsUser` annotation on methods annotated with the `@Scheduled` annotation to configure the `SecurityIdentity` for the task execution.

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/ScheduledBusinessMethodItem.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/ScheduledBusinessMethodItem.java
@@ -30,12 +30,20 @@ public final class ScheduledBusinessMethodItem extends MultiBuildItem implements
 
     public ScheduledBusinessMethodItem(BeanInfo bean, MethodInfo method, List<AnnotationInstance> schedules,
             boolean hasNonBlockingAnnotation, boolean hasRunOnVirtualThreadAnnotation) {
+        this(bean, method, schedules, hasNonBlockingAnnotation, hasRunOnVirtualThreadAnnotation, false, false);
+    }
+
+    public ScheduledBusinessMethodItem(BeanInfo bean, MethodInfo method, List<AnnotationInstance> schedules,
+            boolean hasNonBlockingAnnotation, boolean hasRunOnVirtualThreadAnnotation, boolean hasBlockingAnnotation,
+            boolean defaultRunOnVirtualThread) {
         this.bean = bean;
         this.method = method;
         this.schedules = schedules;
         this.nonBlocking = hasNonBlockingAnnotation || SchedulerDotNames.COMPLETION_STAGE.equals(method.returnType().name())
                 || SchedulerDotNames.UNI.equals(method.returnType().name()) || KotlinUtil.isSuspendMethod(method);
-        this.runOnVirtualThread = hasRunOnVirtualThreadAnnotation;
+        // the configured default only applies to blocking methods without an explicit execution model annotation
+        this.runOnVirtualThread = hasRunOnVirtualThreadAnnotation
+                || (defaultRunOnVirtualThread && !nonBlocking && !hasBlockingAnnotation);
     }
 
     /**

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerDotNames.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerDotNames.java
@@ -5,6 +5,7 @@ import java.util.concurrent.CompletionStage;
 import org.jboss.jandex.DotName;
 
 import io.quarkus.scheduler.Scheduled;
+import io.smallrye.common.annotation.Blocking;
 import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.common.annotation.RunOnVirtualThread;
 
@@ -14,6 +15,7 @@ class SchedulerDotNames {
     static final DotName SCHEDULES_NAME = DotName.createSimple(Scheduled.Schedules.class.getName());
     static final DotName SKIP_NEVER_NAME = DotName.createSimple(Scheduled.Never.class.getName());
     static final DotName SKIP_PREDICATE = DotName.createSimple(Scheduled.SkipPredicate.class.getName());
+    static final DotName BLOCKING = DotName.createSimple(Blocking.class.getName());
     static final DotName NON_BLOCKING = DotName.createSimple(NonBlocking.class.getName());
     static final DotName UNI = DotName.createSimple("io.smallrye.mutiny.Uni");
     static final DotName COMPLETION_STAGE = DotName.createSimple(CompletionStage.class.getName());

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
@@ -178,7 +178,8 @@ public class SchedulerProcessor {
     }
 
     @BuildStep
-    void collectScheduledMethods(BeanArchiveIndexBuildItem beanArchives, BeanDiscoveryFinishedBuildItem beanDiscovery,
+    void collectScheduledMethods(SchedulerConfig config, BeanArchiveIndexBuildItem beanArchives,
+            BeanDiscoveryFinishedBuildItem beanDiscovery,
             TransformedAnnotationsBuildItem transformedAnnotations,
             BuildProducer<ScheduledBusinessMethodItem> scheduledBusinessMethods) {
 
@@ -219,19 +220,22 @@ public class SchedulerProcessor {
             MethodInfo method = e.getKey();
             scheduledBusinessMethods.produce(new ScheduledBusinessMethodItem(null, method, e.getValue(),
                     transformedAnnotations.hasAnnotation(method, SchedulerDotNames.NON_BLOCKING),
-                    transformedAnnotations.hasAnnotation(method, SchedulerDotNames.RUN_ON_VIRTUAL_THREAD)));
+                    transformedAnnotations.hasAnnotation(method, SchedulerDotNames.RUN_ON_VIRTUAL_THREAD),
+                    transformedAnnotations.hasAnnotation(method, SchedulerDotNames.BLOCKING),
+                    config.virtualThreads()));
             LOGGER.debugf("Found scheduled static method %s declared on %s", method, method.declaringClass().name());
         }
 
         // Then collect all business methods annotated with @Scheduled
         for (BeanInfo bean : beanDiscovery.beanStream().classBeans()) {
-            collectScheduledMethods(beanArchives.getIndex(), transformedAnnotations, bean,
+            collectScheduledMethods(config, beanArchives.getIndex(), transformedAnnotations, bean,
                     bean.getTarget().get().asClass(),
                     scheduledBusinessMethods);
         }
     }
 
-    private void collectScheduledMethods(IndexView index, TransformedAnnotationsBuildItem transformedAnnotations, BeanInfo bean,
+    private void collectScheduledMethods(SchedulerConfig config, IndexView index,
+            TransformedAnnotationsBuildItem transformedAnnotations, BeanInfo bean,
             ClassInfo beanClass, BuildProducer<ScheduledBusinessMethodItem> scheduledBusinessMethods) {
 
         for (MethodInfo method : beanClass.methods()) {
@@ -259,7 +263,9 @@ public class SchedulerProcessor {
             if (schedules != null) {
                 scheduledBusinessMethods.produce(new ScheduledBusinessMethodItem(bean, method, schedules,
                         transformedAnnotations.hasAnnotation(method, SchedulerDotNames.NON_BLOCKING),
-                        transformedAnnotations.hasAnnotation(method, SchedulerDotNames.RUN_ON_VIRTUAL_THREAD)));
+                        transformedAnnotations.hasAnnotation(method, SchedulerDotNames.RUN_ON_VIRTUAL_THREAD),
+                        transformedAnnotations.hasAnnotation(method, SchedulerDotNames.BLOCKING),
+                        config.virtualThreads()));
                 LOGGER.debugf("Found scheduled business method %s declared on %s", method, bean);
             }
         }

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/VirtualThreadsConfigTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/VirtualThreadsConfigTest.java
@@ -1,0 +1,89 @@
+package io.quarkus.scheduler.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import io.smallrye.mutiny.Uni;
+
+public class VirtualThreadsConfigTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClasses(Jobs.class))
+            .overrideConfigKey("quarkus.scheduler.virtual-threads", "true");
+
+    @Test
+    public void testExecutionModels() throws InterruptedException {
+        for (Map.Entry<String, CountDownLatch> e : Jobs.LATCHES.entrySet()) {
+            assertTrue(e.getValue().await(5, TimeUnit.SECONDS), "Job not executed: " + e.getKey());
+        }
+        // blocking jobs without an explicit execution model annotation default to a virtual thread
+        assertThat(Jobs.VIRTUAL.get("default")).isTrue();
+        assertThat(Jobs.VIRTUAL.get("virtual")).isTrue();
+        // an explicit @Blocking annotation keeps the job on a worker thread
+        assertThat(Jobs.VIRTUAL.get("blocking")).isFalse();
+        // non-blocking jobs keep running on the event loop
+        assertThat(Jobs.VIRTUAL.get("nonBlocking")).isFalse();
+        assertThat(Jobs.VIRTUAL.get("uni")).isFalse();
+    }
+
+    static class Jobs {
+
+        static final Map<String, CountDownLatch> LATCHES = Map.of(
+                "default", new CountDownLatch(1),
+                "blocking", new CountDownLatch(1),
+                "nonBlocking", new CountDownLatch(1),
+                "uni", new CountDownLatch(1),
+                "virtual", new CountDownLatch(1));
+
+        static final Map<String, Boolean> VIRTUAL = new ConcurrentHashMap<>();
+
+        static void record(String name) {
+            VIRTUAL.putIfAbsent(name, Thread.currentThread().isVirtual());
+            LATCHES.get(name).countDown();
+        }
+
+        @Scheduled(every = "0.2s")
+        void defaultJob() {
+            record("default");
+        }
+
+        @Blocking
+        @Scheduled(every = "0.2s")
+        void blockingJob() {
+            record("blocking");
+        }
+
+        @NonBlocking
+        @Scheduled(every = "0.2s")
+        void nonBlockingJob() {
+            record("nonBlocking");
+        }
+
+        @Scheduled(every = "0.2s")
+        Uni<Void> uniJob() {
+            record("uni");
+            return Uni.createFrom().voidItem();
+        }
+
+        @RunOnVirtualThread
+        @Scheduled(every = "0.2s")
+        void virtualJob() {
+            record("virtual");
+        }
+    }
+
+}

--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SchedulerConfig.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SchedulerConfig.java
@@ -47,4 +47,20 @@ public interface SchedulerConfig {
     @WithDefault("false")
     boolean useCompositeScheduler();
 
+    /**
+     * When enabled, scheduled methods that would otherwise be executed on a worker thread, meaning blocking
+     * scheduled methods without an explicit {@code @Blocking}, {@code @NonBlocking} or {@code @RunOnVirtualThread}
+     * annotation, are executed on virtual threads instead.
+     * <p>
+     * Scheduled methods considered non-blocking, for instance because they return {@code CompletionStage} or
+     * {@code Uni}, keep running on the event loop, and explicit annotations on the scheduled method always take
+     * precedence.
+     * <p>
+     * Before enabling this, make sure the application does not suffer from thread pinning (mostly resolved since
+     * JDK 24) or carrier thread monopolization. See the virtual threads guide for more details on how to monitor
+     * this with JFR events.
+     */
+    @WithDefault("false")
+    boolean virtualThreads();
+
 }


### PR DESCRIPTION
Following the same per-extension pattern as #56294 (Quarkus REST), agreed in the #51031 discussion, this adds the build-time property `quarkus.scheduler.virtual-threads` (default `false`) for the scheduler.

When enabled, scheduled methods that would otherwise be executed on a worker thread are executed on a virtual thread instead. Scheduled methods considered non-blocking (returning `CompletionStage<Void>` or `Uni<Void>`, or Kotlin suspend functions) keep running on the event loop, and explicit `@Blocking`, `@NonBlocking` and `@RunOnVirtualThread` annotations take precedence. As part of this, `@Blocking` on a `@Scheduled` method now acts as the per-method opt-out back to the worker pool; it was previously accepted (it is listed in `ExecutionModelAnnotationsAllowedBuildItem`) but silently ignored.

Quartz needs no changes since both schedulers consume the same generated invoker; the Quartz suite passes with this change. One pre-existing interaction is documented rather than changed: `quarkus.quartz.run-blocking-scheduled-method-on-quartz-thread=true` skips the offloading invoker and therefore also overrides virtual thread dispatch, which was already the case for `@RunOnVirtualThread` before this PR.

Relates to #51031.