### PR TITLE
Keycloak Admin Client: use Jackson 2 modules until we get client based on Jackson 3

### DIFF
--- a/extensions/keycloak-admin-rest-client/runtime/pom.xml
+++ b/extensions/keycloak-admin-rest-client/runtime/pom.xml
@@ -59,14 +59,6 @@
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.fasterxml.jackson.datatype</groupId>
-                    <artifactId>jackson-datatype-jdk8</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.datatype</groupId>
-                    <artifactId>jackson-datatype-jsr310</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
                     <artifactId>jackson-jakarta-rs-yaml-provider</artifactId>
                 </exclusion>

--- a/extensions/keycloak-admin-resteasy-client/runtime/pom.xml
+++ b/extensions/keycloak-admin-resteasy-client/runtime/pom.xml
@@ -67,14 +67,6 @@
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.fasterxml.jackson.datatype</groupId>
-                    <artifactId>jackson-datatype-jdk8</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.datatype</groupId>
-                    <artifactId>jackson-datatype-jsr310</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
                     <artifactId>jackson-jakarta-rs-yaml-provider</artifactId>
                 </exclusion>

--- a/integration-tests/smallrye-jwt/pom.xml
+++ b/integration-tests/smallrye-jwt/pom.xml
@@ -38,7 +38,24 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-keycloak-admin-rest-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-jwt-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-keycloak-admin-rest-client-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/smallrye-jwt/src/main/java/io/quarkus/it/keycloak/KeycloakAdminClientResource.java
+++ b/integration-tests/smallrye-jwt/src/main/java/io/quarkus/it/keycloak/KeycloakAdminClientResource.java
@@ -1,0 +1,31 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.idm.ClientProfilesRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+
+@Path("/keycloak-admin-client")
+public class KeycloakAdminClientResource {
+
+    @Inject
+    Keycloak keycloak;
+
+    @PUT
+    @Path("/empty-realm-client-profiles")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String putEmptyRealmClientProfiles() {
+        RealmRepresentation realm = keycloak.realm("quarkus").toRepresentation();
+        // we want to create serialization and/or deserialization so that object mapper is initialized
+        realm.setParsedClientProfiles(new ClientProfilesRepresentation());
+        keycloak.realm("quarkus").update(realm);
+        ClientProfilesRepresentation profiles = realm.getParsedClientProfiles();
+        int profilesCount = profiles == null ? -1 : 0;
+        return realm.getRealm() + ":" + profilesCount;
+    }
+}

--- a/integration-tests/smallrye-jwt/src/main/resources/application.properties
+++ b/integration-tests/smallrye-jwt/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 smallrye.jwt.new-token.issuer=https://quarkus.io/issuer
+quarkus.keycloak.devservices.enabled=false

--- a/integration-tests/smallrye-jwt/src/test/java/io/quarkus/it/keycloak/KeycloakAdminClientTest.java
+++ b/integration-tests/smallrye-jwt/src/test/java/io/quarkus/it/keycloak/KeycloakAdminClientTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.it.keycloak;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+@TestProfile(KeycloakAdminClientTest.EnableKeycloakDevServicesProfile.class)
+@EnabledIfSystemProperty(named = "test-containers", matches = "true", disabledReason = "Requires Keycloak")
+@QuarkusTest
+public class KeycloakAdminClientTest {
+
+    @Test
+    void putEmptyRealmClientProfiles() {
+        when().put("/keycloak-admin-client/empty-realm-client-profiles")
+                .then()
+                .statusCode(200)
+                .body(is("quarkus:0"));
+    }
+
+    public static final class EnableKeycloakDevServicesProfile implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quarkus.keycloak.devservices.enabled", "true");
+        }
+    }
+}


### PR DESCRIPTION
* I have looked into bytecode transformations or just excluding these 2 modules, but `JsonSerialization` is too integrated into model representations and utils
* it is just a temporary workaround until https://github.com/keycloak/keycloak-client/tree/main/admin-client-jackson3 is released, I'll ask for it
* you can't reproduce it in `integration-tests/keycloak-authorization` as that one still has these types via authorization, nor you can reproduce it in `extensions/keycloak-admin-rest-client/deployment/src/test` because there these modules come from `extensions/devservices/keycloak/pom.xml`

---

* closes: https://github.com/quarkusio/quarkus/issues/56274

