### PR TITLE
Upgrade aesh to 3.17.5 and improve AeshLauncher test framework

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -205,8 +205,8 @@
         <!-- Check the compatibility matrix (https://github.com/opensearch-project/opensearch-testcontainers) before upgrading: -->
         <opensearch-testcontainers.version>2.1.3</opensearch-testcontainers.version>
         <com.dajudge.kindcontainer>2.0.0</com.dajudge.kindcontainer>
-        <aesh.version>3.17.2</aesh.version>
-        <aesh-readline.version>3.17.1</aesh-readline.version>
+        <aesh.version>3.17.5</aesh.version>
+        <aesh-readline.version>3.17.2</aesh-readline.version>
         <jline.version>4.2.1</jline.version> <!-- Keep in sync with dekorate -->
         <!-- these two artifacts needs to be compatible together -->
         <strimzi-oauth.version>0.16.1</strimzi-oauth.version>

--- a/docs/src/main/asciidoc/aesh.adoc
+++ b/docs/src/main/asciidoc/aesh.adoc
@@ -1088,7 +1088,7 @@ public class CliTest {
 === Testing console mode commands (REPL)
 
 Console mode commands run in an interactive shell.
-Use `AeshLauncher` to start a REPL session, send commands, and assert on their output:
+Use `AeshLauncher` to send commands and assert on their output:
 
 [source,xml]
 ----
@@ -1106,26 +1106,130 @@ public class ReplTest {
 
     @Test
     void testInteractiveSession(AeshLauncher launcher) {
-        launcher.launch();
+        launcher.execute("greet --name=Alice");
+        assertThat(launcher.getCommandOutput()).isEqualTo("Hello Alice!\n");
 
-        String output = launcher.executeCommand("greet --name=Alice");
-        assertThat(output).contains("Hello Alice!");
-
-        output = launcher.executeCommand("calc -a 5 -b 3");
-        assertThat(output).contains("Result: 8");
-
-        launcher.exit();
+        launcher.execute("calc -a 5 -b 3");
+        assertThat(launcher.getCommandOutput()).isEqualTo("Result: 8\n");
     }
 }
 ----
 
-`AeshLauncher` provides:
+The REPL is auto-launched on the first `execute()` call and auto-closed after each
+test method. No explicit `launch()` or `exit()` calls are needed for typical tests.
 
-* `launch(String... args)` -- starts the REPL on a background thread
-* `executeCommand(String command)` -- sends a command and blocks until it completes (10 second default timeout)
-* `executeCommand(String command, Duration timeout)` -- same with a custom timeout
-* `getErrorOutput()` -- returns any error output from the session
-* `exit()` -- sends the exit command and waits for clean shutdown
+==== Clean command output
+
+`getCommandOutput()` returns only what the command wrote via `invocation.println()` --
+no prompt, no command echo, no ANSI sequences. This enables exact assertions with `isEqualTo()`
+instead of fuzzy `contains()` matching.
+
+`getOutput()` accumulates command output across multiple `execute()` calls within a test.
+Use `resetOutput()` to clear the accumulator between test phases:
+
+[source,java]
+----
+@Test
+void testAccumulatedOutput(AeshLauncher launcher) {
+    launcher.execute("add-item apple");
+    launcher.execute("add-item banana");
+
+    assertThat(launcher.getOutput()).isEqualTo("Added: apple\nAdded: banana\n");
+
+    launcher.resetOutput();
+    launcher.execute("list-items");
+    assertThat(launcher.getCommandOutput()).contains("apple", "banana");
+}
+----
+
+==== Exit code assertions
+
+`execute()` asserts that the command returns `CommandResult.SUCCESS` (exit code 0) by default.
+If a command is expected to fail, pass the expected `CommandResult`:
+
+[source,java]
+----
+@Test
+void testFailingCommand(AeshLauncher launcher) {
+    // Passes — expected to fail
+    launcher.execute("invalid-command --bad", CommandResult.FAILURE);
+    assertThat(launcher.getLastExitCode()).isEqualTo(1);
+    assertThat(launcher.getLastError()).isNotNull();
+}
+----
+
+For more control (custom timeout, pre-canned input), use `ExecuteOptions`:
+
+[source,java]
+----
+// Custom timeout
+launcher.execute("slow-command", ExecuteOptions.defaults().timeout(Duration.ofMinutes(2)));
+
+// Expected failure with custom timeout
+launcher.execute("risky-command",
+        ExecuteOptions.expecting(CommandResult.FAILURE).timeout(Duration.ofSeconds(5)));
+----
+
+==== Error capture
+
+When a command throws an exception, it is captured and available via `getLastError()`:
+
+[source,java]
+----
+@Test
+void testErrorCapture(AeshLauncher launcher) {
+    launcher.execute("fail --message=boom", CommandResult.FAILURE);
+    assertThat(launcher.getLastError().getMessage()).contains("boom");
+    assertThat(launcher.getErrorOutput()).contains("boom");
+}
+----
+
+Errors are cleared between commands -- a successful command after a failing one
+resets `getLastError()` to `null`.
+
+==== Quoting arguments
+
+Arguments containing spaces or special characters should be quoted the same way
+as in a terminal:
+
+[source,java]
+----
+launcher.execute("echo --text 'hello world'");
+assertThat(launcher.getCommandOutput()).isEqualTo("hello world\n");
+----
+
+==== Interactive input
+
+For commands that prompt for input during execution (e.g., confirmation prompts),
+use `ExecuteOptions.input()` to provide pre-canned responses:
+
+[source,java]
+----
+// Command calls invocation.inputLine() — response is provided automatically
+launcher.execute("confirm --action=deploy", ExecuteOptions.defaults().input("y"));
+assertThat(launcher.getCommandOutput()).contains("Confirmed: deploy");
+
+// Multiple prompts
+launcher.execute("setup", ExecuteOptions.defaults().input("admin", "password123", "y"));
+----
+
+For more complex interactive scenarios, `sendInput()` provides low-level
+access to the REPL's stdin:
+
+==== AeshLauncher API summary
+
+* `execute(String command)` -- executes and asserts `SUCCESS`
+* `execute(String command, CommandResult expected)` -- executes and asserts the given result
+* `execute(String command, ExecuteOptions options)` -- full control (timeout, expected result, input)
+* `sendInput(String input)` -- send raw input for interactive commands
+* `getCommandOutput()` -- clean output from the last command
+* `getOutput()` / `resetOutput()` -- accumulated command output
+* `getLastExitCode()` -- exit code from the last command
+* `getLastError()` / `getErrorOutput()` -- exception from the last failed command
+* `isRunning()` / `waitForExit(Duration)` -- REPL lifecycle state
+* `getLaunchResult()` -- launch result after REPL exits
+* `launch(String... args)` -- explicit launch with initial arguments (optional)
+* `exit()` -- explicit shutdown (optional, auto-closed after each test)
 
 NOTE: The exit command must be enabled for `AeshLauncher` to shut down cleanly.
 Set `quarkus.aesh.add-exit-command=true` in `application.properties` (or `src/test/resources/application.properties`).

--- a/extensions/aesh/README.md
+++ b/extensions/aesh/README.md
@@ -373,3 +373,39 @@ Force a specific mode:
 quarkus.aesh.mode=console  # or 'runtime' or 'auto'
 ```
 
+## Testing
+
+Console mode commands can be tested with `AeshLauncher` from `quarkus-test-aesh`:
+
+```xml
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-test-aesh</artifactId>
+    <scope>test</scope>
+</dependency>
+```
+
+```java
+@QuarkusMainTest
+public class ReplTest {
+
+    @Test
+    void testGreet(AeshLauncher launcher) {
+        launcher.execute("greet --name=Alice");
+        assertThat(launcher.getCommandOutput()).isEqualTo("Hello Alice!\n");
+    }
+
+    @Test
+    void testFailure(AeshLauncher launcher) {
+        launcher.execute("bad-command", CommandResult.FAILURE);
+        assertThat(launcher.getLastError()).isNotNull();
+    }
+}
+```
+
+The REPL auto-launches on the first `execute()` call and auto-closes after each test. `getCommandOutput()` returns clean output without prompt or echo. `execute()` asserts `CommandResult.SUCCESS` by default — pass a different `CommandResult` for expected failures. For custom timeouts or pre-canned input, use `ExecuteOptions`:
+
+```java
+launcher.execute("slow-cmd", ExecuteOptions.defaults().timeout(Duration.ofMinutes(2)));
+```
+

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/AeshSessionEventsTest.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/AeshSessionEventsTest.java
@@ -36,7 +36,8 @@ public class AeshSessionEventsTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot(jar -> jar.addClasses(
                     HelloCommand.class,
-                    SessionObserver.class))
+                    SessionObserver.class,
+                    TestStubConnection.class))
             .addBuildChainCustomizer(injectRemoteTransport());
 
     @Inject
@@ -62,7 +63,7 @@ public class AeshSessionEventsTest {
         SessionObserver.reset();
 
         // Create a mock connection that closes immediately
-        StubConnection connection = new StubConnection();
+        TestStubConnection connection = new TestStubConnection();
 
         // Handle the connection on a separate thread (it blocks)
         Thread handler = new Thread(() -> connectionHandler.handle(connection, "test"));
@@ -127,118 +128,4 @@ public class AeshSessionEventsTest {
         }
     }
 
-    /**
-     * Minimal Connection stub for testing session events.
-     * The connection blocks on openBlocking() until close() is called.
-     */
-    public static class StubConnection implements org.aesh.terminal.Connection {
-
-        private final CountDownLatch closeLatch = new CountDownLatch(1);
-        private volatile Consumer<Void> closeHandler;
-        private volatile Consumer<int[]> stdinHandler;
-
-        @Override
-        public org.aesh.terminal.Device device() {
-            return null;
-        }
-
-        @Override
-        public org.aesh.terminal.tty.Size size() {
-            return new org.aesh.terminal.tty.Size(80, 24);
-        }
-
-        @Override
-        public Consumer<org.aesh.terminal.tty.Size> sizeHandler() {
-            return null;
-        }
-
-        @Override
-        public void setSizeHandler(Consumer<org.aesh.terminal.tty.Size> handler) {
-        }
-
-        @Override
-        public Consumer<org.aesh.terminal.tty.Signal> signalHandler() {
-            return null;
-        }
-
-        @Override
-        public void setSignalHandler(Consumer<org.aesh.terminal.tty.Signal> handler) {
-        }
-
-        @Override
-        public Consumer<int[]> stdinHandler() {
-            return stdinHandler;
-        }
-
-        @Override
-        public void setStdinHandler(Consumer<int[]> handler) {
-            this.stdinHandler = handler;
-        }
-
-        @Override
-        public Consumer<int[]> stdoutHandler() {
-            return data -> {
-            };
-        }
-
-        @Override
-        public void setCloseHandler(Consumer<Void> handler) {
-            this.closeHandler = handler;
-        }
-
-        @Override
-        public Consumer<Void> closeHandler() {
-            return closeHandler;
-        }
-
-        @Override
-        public void close() {
-            closeLatch.countDown();
-            if (closeHandler != null) {
-                closeHandler.accept(null);
-            }
-        }
-
-        @Override
-        public void openBlocking() {
-            try {
-                closeLatch.await();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        }
-
-        @Override
-        public void openNonBlocking() {
-        }
-
-        @Override
-        public boolean put(org.aesh.terminal.tty.Capability capability, Object... params) {
-            return false;
-        }
-
-        @Override
-        public org.aesh.terminal.Attributes attributes() {
-            return new org.aesh.terminal.Attributes();
-        }
-
-        @Override
-        public void setAttributes(org.aesh.terminal.Attributes attr) {
-        }
-
-        @Override
-        public java.nio.charset.Charset inputEncoding() {
-            return java.nio.charset.StandardCharsets.UTF_8;
-        }
-
-        @Override
-        public java.nio.charset.Charset outputEncoding() {
-            return java.nio.charset.StandardCharsets.UTF_8;
-        }
-
-        @Override
-        public boolean supportsAnsi() {
-            return true;
-        }
-    }
 }

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/CliSettingsCustomizerTest.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/CliSettingsCustomizerTest.java
@@ -1,6 +1,5 @@
 package io.quarkus.aesh.deployment;
 
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
@@ -33,7 +32,8 @@ public class CliSettingsCustomizerTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot(jar -> jar.addClasses(
                     DummyCommand.class,
-                    TestCliSettings.class))
+                    TestCliSettings.class,
+                    TestStubConnection.class))
             .addBuildChainCustomizer(injectRemoteTransport());
 
     @Inject
@@ -57,7 +57,7 @@ public class CliSettingsCustomizerTest {
     public void testCliSettingsCustomizerIsInvoked() throws Exception {
         TestCliSettings.INVOKED.set(false);
 
-        StubConnection connection = new StubConnection();
+        TestStubConnection connection = new TestStubConnection();
 
         Thread handler = new Thread(() -> connectionHandler.handle(connection, "test"));
         handler.setDaemon(true);
@@ -95,114 +95,4 @@ public class CliSettingsCustomizerTest {
         }
     }
 
-    public static class StubConnection implements org.aesh.terminal.Connection {
-
-        private final CountDownLatch closeLatch = new CountDownLatch(1);
-        private volatile Consumer<Void> closeHandler;
-        private volatile Consumer<int[]> stdinHandler;
-
-        @Override
-        public org.aesh.terminal.Device device() {
-            return null;
-        }
-
-        @Override
-        public org.aesh.terminal.tty.Size size() {
-            return new org.aesh.terminal.tty.Size(80, 24);
-        }
-
-        @Override
-        public Consumer<org.aesh.terminal.tty.Size> sizeHandler() {
-            return null;
-        }
-
-        @Override
-        public void setSizeHandler(Consumer<org.aesh.terminal.tty.Size> handler) {
-        }
-
-        @Override
-        public Consumer<org.aesh.terminal.tty.Signal> signalHandler() {
-            return null;
-        }
-
-        @Override
-        public void setSignalHandler(Consumer<org.aesh.terminal.tty.Signal> handler) {
-        }
-
-        @Override
-        public Consumer<int[]> stdinHandler() {
-            return stdinHandler;
-        }
-
-        @Override
-        public void setStdinHandler(Consumer<int[]> handler) {
-            this.stdinHandler = handler;
-        }
-
-        @Override
-        public Consumer<int[]> stdoutHandler() {
-            return data -> {
-            };
-        }
-
-        @Override
-        public void setCloseHandler(Consumer<Void> handler) {
-            this.closeHandler = handler;
-        }
-
-        @Override
-        public Consumer<Void> closeHandler() {
-            return closeHandler;
-        }
-
-        @Override
-        public void close() {
-            closeLatch.countDown();
-            if (closeHandler != null) {
-                closeHandler.accept(null);
-            }
-        }
-
-        @Override
-        public void openBlocking() {
-            try {
-                closeLatch.await();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        }
-
-        @Override
-        public void openNonBlocking() {
-        }
-
-        @Override
-        public boolean put(org.aesh.terminal.tty.Capability capability, Object... params) {
-            return false;
-        }
-
-        @Override
-        public org.aesh.terminal.Attributes attributes() {
-            return new org.aesh.terminal.Attributes();
-        }
-
-        @Override
-        public void setAttributes(org.aesh.terminal.Attributes attr) {
-        }
-
-        @Override
-        public java.nio.charset.Charset inputEncoding() {
-            return java.nio.charset.StandardCharsets.UTF_8;
-        }
-
-        @Override
-        public java.nio.charset.Charset outputEncoding() {
-            return java.nio.charset.StandardCharsets.UTF_8;
-        }
-
-        @Override
-        public boolean supportsAnsi() {
-            return true;
-        }
-    }
 }

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/DelegatingConnectionTest.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/DelegatingConnectionTest.java
@@ -1,16 +1,10 @@
 package io.quarkus.aesh.deployment;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import org.aesh.terminal.Attributes;
-import org.aesh.terminal.BaseDevice;
-import org.aesh.terminal.Connection;
-import org.aesh.terminal.Device;
-import org.aesh.terminal.tty.Capability;
 import org.aesh.terminal.tty.Signal;
 import org.aesh.terminal.tty.Size;
 import org.assertj.core.api.Assertions;
@@ -25,7 +19,7 @@ public class DelegatingConnectionTest {
 
     @Test
     public void testAllMethodsDelegate() {
-        StubConnection stub = new StubConnection();
+        TestStubConnection stub = new TestStubConnection();
         // Create a concrete subclass (DelegatingConnection is abstract)
         DelegatingConnection wrapper = new DelegatingConnection(stub) {
         };
@@ -49,7 +43,7 @@ public class DelegatingConnectionTest {
 
     @Test
     public void testSetCloseHandlerDelegates() {
-        StubConnection stub = new StubConnection();
+        TestStubConnection stub = new TestStubConnection();
         DelegatingConnection wrapper = new DelegatingConnection(stub) {
         };
 
@@ -62,7 +56,7 @@ public class DelegatingConnectionTest {
 
     @Test
     public void testSetStdinHandlerDelegates() {
-        StubConnection stub = new StubConnection();
+        TestStubConnection stub = new TestStubConnection();
         DelegatingConnection wrapper = new DelegatingConnection(stub) {
         };
 
@@ -75,17 +69,17 @@ public class DelegatingConnectionTest {
 
     @Test
     public void testCloseDelegates() {
-        StubConnection stub = new StubConnection();
+        TestStubConnection stub = new TestStubConnection();
         DelegatingConnection wrapper = new DelegatingConnection(stub) {
         };
 
         wrapper.close();
-        Assertions.assertThat(stub.closed).isTrue();
+        Assertions.assertThat(stub.isClosed()).isTrue();
     }
 
     @Test
     public void testSetSizeHandlerDelegates() {
-        StubConnection stub = new StubConnection();
+        TestStubConnection stub = new TestStubConnection();
         DelegatingConnection wrapper = new DelegatingConnection(stub) {
         };
 
@@ -97,7 +91,7 @@ public class DelegatingConnectionTest {
 
     @Test
     public void testSetSignalHandlerDelegates() {
-        StubConnection stub = new StubConnection();
+        TestStubConnection stub = new TestStubConnection();
         DelegatingConnection wrapper = new DelegatingConnection(stub) {
         };
 
@@ -107,117 +101,4 @@ public class DelegatingConnectionTest {
         Assertions.assertThat(wrapper.signalHandler()).isSameAs(handler);
     }
 
-    /**
-     * Minimal Connection stub for testing delegation.
-     */
-    static class StubConnection implements Connection {
-        boolean closed = false;
-        private Consumer<Void> closeHandler;
-        private Consumer<int[]> stdinHandler;
-        private Consumer<Size> sizeHandler;
-        private Consumer<Signal> signalHandler;
-        private final Consumer<int[]> stdoutHandler = data -> {
-        };
-        private final Device device = new BaseDevice("test");
-
-        @Override
-        public Device device() {
-            return device;
-        }
-
-        @Override
-        public Size size() {
-            return new Size(80, 24);
-        }
-
-        @Override
-        public Consumer<Size> sizeHandler() {
-            return sizeHandler;
-        }
-
-        @Override
-        public void setSizeHandler(Consumer<Size> handler) {
-            this.sizeHandler = handler;
-        }
-
-        @Override
-        public Consumer<Signal> signalHandler() {
-            return signalHandler;
-        }
-
-        @Override
-        public void setSignalHandler(Consumer<Signal> handler) {
-            this.signalHandler = handler;
-        }
-
-        @Override
-        public Consumer<int[]> stdinHandler() {
-            return stdinHandler;
-        }
-
-        @Override
-        public void setStdinHandler(Consumer<int[]> handler) {
-            this.stdinHandler = handler;
-        }
-
-        @Override
-        public Consumer<int[]> stdoutHandler() {
-            return stdoutHandler;
-        }
-
-        @Override
-        public void setCloseHandler(Consumer<Void> closeHandler) {
-            this.closeHandler = closeHandler;
-        }
-
-        @Override
-        public Consumer<Void> closeHandler() {
-            return closeHandler;
-        }
-
-        @Override
-        public void close() {
-            closed = true;
-            if (closeHandler != null) {
-                closeHandler.accept(null);
-            }
-        }
-
-        @Override
-        public void openBlocking() {
-        }
-
-        @Override
-        public void openNonBlocking() {
-        }
-
-        @Override
-        public boolean put(Capability capability, Object... params) {
-            return false;
-        }
-
-        @Override
-        public Attributes attributes() {
-            return new Attributes();
-        }
-
-        @Override
-        public void setAttributes(Attributes attr) {
-        }
-
-        @Override
-        public Charset inputEncoding() {
-            return StandardCharsets.UTF_8;
-        }
-
-        @Override
-        public Charset outputEncoding() {
-            return StandardCharsets.UTF_8;
-        }
-
-        @Override
-        public boolean supportsAnsi() {
-            return true;
-        }
-    }
 }

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/TestStubConnection.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/TestStubConnection.java
@@ -1,0 +1,139 @@
+package io.quarkus.aesh.deployment;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
+
+import org.aesh.terminal.Attributes;
+import org.aesh.terminal.Connection;
+import org.aesh.terminal.Device;
+import org.aesh.terminal.tty.Capability;
+import org.aesh.terminal.tty.Signal;
+import org.aesh.terminal.tty.Size;
+
+/**
+ * Minimal stub {@link Connection} for unit tests.
+ * Provides a controllable connection that blocks on {@link #openBlocking()}
+ * until {@link #close()} is called.
+ */
+class TestStubConnection implements Connection {
+
+    private final CountDownLatch closeLatch = new CountDownLatch(1);
+    private volatile boolean closed;
+    private volatile Consumer<Void> closeHandler;
+    private volatile Consumer<int[]> stdinHandler;
+    private volatile Consumer<Signal> signalHandler;
+    private volatile Consumer<Size> sizeHandler;
+
+    @Override
+    public Device device() {
+        return null;
+    }
+
+    @Override
+    public Size size() {
+        return new Size(80, 24);
+    }
+
+    @Override
+    public Consumer<Size> sizeHandler() {
+        return sizeHandler;
+    }
+
+    @Override
+    public void setSizeHandler(Consumer<Size> handler) {
+        this.sizeHandler = handler;
+    }
+
+    @Override
+    public Consumer<Signal> signalHandler() {
+        return signalHandler;
+    }
+
+    @Override
+    public void setSignalHandler(Consumer<Signal> handler) {
+        this.signalHandler = handler;
+    }
+
+    @Override
+    public Consumer<int[]> stdinHandler() {
+        return stdinHandler;
+    }
+
+    @Override
+    public void setStdinHandler(Consumer<int[]> handler) {
+        this.stdinHandler = handler;
+    }
+
+    @Override
+    public Consumer<int[]> stdoutHandler() {
+        return data -> {
+        };
+    }
+
+    @Override
+    public void setCloseHandler(Consumer<Void> handler) {
+        this.closeHandler = handler;
+    }
+
+    @Override
+    public Consumer<Void> closeHandler() {
+        return closeHandler;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+        closeLatch.countDown();
+        if (closeHandler != null) {
+            closeHandler.accept(null);
+        }
+    }
+
+    public boolean isClosed() {
+        return closed;
+    }
+
+    @Override
+    public void openBlocking() {
+        try {
+            closeLatch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public void openNonBlocking() {
+    }
+
+    @Override
+    public boolean put(Capability capability, Object... params) {
+        return false;
+    }
+
+    @Override
+    public Attributes attributes() {
+        return new Attributes();
+    }
+
+    @Override
+    public void setAttributes(Attributes attr) {
+    }
+
+    @Override
+    public Charset inputEncoding() {
+        return StandardCharsets.UTF_8;
+    }
+
+    @Override
+    public Charset outputEncoding() {
+        return StandardCharsets.UTF_8;
+    }
+
+    @Override
+    public boolean supportsAnsi() {
+        return true;
+    }
+}

--- a/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/AeshTestConnectionHolder.java
+++ b/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/AeshTestConnectionHolder.java
@@ -2,6 +2,8 @@ package io.quarkus.aesh.runtime;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 /**
@@ -50,6 +52,25 @@ public final class AeshTestConnectionHolder {
         return (LinkedBlockingQueue<Object>) getFieldFromThread("signalQueue");
     }
 
+    /**
+     * Retrieve the command output capture stream from the current thread.
+     * This stream receives only command output (from invocation.println()),
+     * not readline prompt or ANSI chrome.
+     */
+    static OutputStream getCommandOutputCapture() {
+        return (OutputStream) getFieldFromThread("commandOutputCapture");
+    }
+
+    /**
+     * Retrieve the input line response queue from the current thread.
+     * Pre-canned responses are consumed by {@code invocation.inputLine()}
+     * for interactive command testing.
+     */
+    @SuppressWarnings("unchecked")
+    static Queue<String> getInputLineQueue() {
+        return (Queue<String>) getFieldFromThread("inputLineQueue");
+    }
+
     private static Object getFieldFromThread(String fieldName) {
         Thread t = Thread.currentThread();
         if (!TEST_THREAD_NAME.equals(t.getName())) {
@@ -74,16 +95,22 @@ public final class AeshTestConnectionHolder {
         final InputStream testInput;
         final OutputStream testOutput;
         final LinkedBlockingQueue<Object> signalQueue;
+        final OutputStream commandOutputCapture;
+        final ConcurrentLinkedQueue<String> inputLineQueue;
 
         public AeshTestThread(Runnable target, String name, ClassLoader contextClassLoader,
                 InputStream testInput, OutputStream testOutput,
-                LinkedBlockingQueue<Object> signalQueue) {
+                LinkedBlockingQueue<Object> signalQueue,
+                OutputStream commandOutputCapture,
+                ConcurrentLinkedQueue<String> inputLineQueue) {
             super(target, name);
             setContextClassLoader(contextClassLoader);
             setDaemon(true);
             this.testInput = testInput;
             this.testOutput = testOutput;
             this.signalQueue = signalQueue;
+            this.commandOutputCapture = commandOutputCapture;
+            this.inputLineQueue = inputLineQueue;
         }
     }
 }

--- a/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/CliRunner.java
+++ b/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/CliRunner.java
@@ -1,9 +1,11 @@
 package io.quarkus.aesh.runtime;
 
-import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Consumer;
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Instance;
@@ -117,8 +119,62 @@ public class CliRunner implements QuarkusApplication {
     }
 
     /**
-     * Join command-line arguments into a single command string,
-     * quoting arguments that contain spaces.
+     * Wire test connection and command execution listener on the runner.
+     * <p>
+     * When running under the test framework, {@link AeshTestConnectionHolder}
+     * provides piped streams and a signal queue. This method wires them onto
+     * the runner and composes the test signal with the optional user-provided
+     * listener. Errors are propagated through the signal queue via the 4-arg
+     * {@link CommandExecutionListener#onCommandComplete} method.
+     *
+     * @param runner the console runner to configure
+     * @param userListener the user-provided listener, or null if none
+     */
+    private static void wireTestConnection(AeshConsoleRunner runner, CommandExecutionListener userListener) {
+        InputStream testInput = AeshTestConnectionHolder.getInput();
+        OutputStream testOutput = AeshTestConnectionHolder.getOutput();
+        LinkedBlockingQueue<Object> signalQueue = AeshTestConnectionHolder.getSignalQueue();
+
+        if (testInput == null || testOutput == null) {
+            // Not in test mode — just wire the user listener if present
+            if (userListener != null) {
+                runner.commandExecutionListener(userListener);
+            }
+            return;
+        }
+
+        LOG.debug("Test mode: using stream-based connection");
+        runner.connection(new AeshStreamConnection(testInput, testOutput));
+
+        if (signalQueue != null) {
+            // Create a listener that composes user listener (if any) with
+            // test signal. Passes exit code and error through the signal
+            // queue as Object[] to cross the classloader boundary safely.
+            runner.commandExecutionListener(new CommandExecutionListener() {
+                @Override
+                public void onCommandComplete(String commandLine, CommandResult result, long durationMs) {
+                    if (userListener != null) {
+                        userListener.onCommandComplete(commandLine, result, durationMs);
+                    }
+                }
+
+                @Override
+                public void onCommandComplete(String commandLine, CommandResult result,
+                        long durationMs, Throwable error) {
+                    if (userListener != null) {
+                        userListener.onCommandComplete(commandLine, result, durationMs, error);
+                    }
+                    signalQueue.offer(new Object[] { result.getExitCode(), error });
+                }
+            });
+        } else if (userListener != null) {
+            runner.commandExecutionListener(userListener);
+        }
+    }
+
+    /**
+     * Join command-line arguments into a properly quoted command string.
+     * Arguments containing spaces, quotes, or special characters are quoted.
      */
     private static String joinArgs(String[] args) {
         StringBuilder sb = new StringBuilder();
@@ -126,10 +182,18 @@ public class CliRunner implements QuarkusApplication {
             if (i > 0) {
                 sb.append(' ');
             }
-            if (args[i].contains(" ")) {
-                sb.append('"').append(args[i]).append('"');
+            String arg = args[i];
+            boolean needsQuoting = arg.isEmpty() || arg.contains(" ") || arg.contains("\n")
+                    || arg.contains("\"") || arg.contains("{")
+                    || arg.contains("}") || arg.contains("|");
+            if (!needsQuoting) {
+                sb.append(arg);
+            } else if (arg.contains("\"") && !arg.contains("'")) {
+                sb.append("'").append(arg).append("'");
             } else {
-                sb.append(args[i]);
+                sb.append('"').append(arg.replace("\\", "\\\\")
+                        .replace("\"", "\\\"")
+                        .replace("\n", "\\n")).append('"');
             }
         }
         return sb.toString();
@@ -156,68 +220,59 @@ public class CliRunner implements QuarkusApplication {
                     .build();
 
             var settingsBuilder = CliSettingsHelper.createBaseSettings(configuration, customizers)
-                    .persistHistory(configuration.persistHistory())
-                    .historySize(configuration.historySize())
                     .subCommandModeSettings(subCommandModeSettings);
-
-            if (configuration.historyFile().isPresent()) {
-                settingsBuilder.historyFile(new File(configuration.historyFile().get()));
-            }
 
             if (commandNotFoundHandler.isResolvable()) {
                 settingsBuilder.commandNotFoundHandler(commandNotFoundHandler.get());
             }
 
+            // Wire command output capture for the test framework.
+            // When set, ShellOutputTee tees command output (from invocation.println())
+            // to this stream, separate from readline prompt/chrome output.
+            OutputStream commandOutputCapture = AeshTestConnectionHolder.getCommandOutputCapture();
+            if (commandOutputCapture != null) {
+                Consumer<String> outputHandler = s -> {
+                    try {
+                        commandOutputCapture.write(s.getBytes(StandardCharsets.UTF_8));
+                    } catch (IOException e) {
+                        // ignore
+                    }
+                };
+                settingsBuilder.commandOutputHandler(outputHandler);
+            }
+
             var settings = settingsBuilder.build();
+
+            // Wire input line queue for interactive command testing.
+            // The shared queue is populated per-command by AeshLauncherImpl
+            // and consumed by invocation.inputLine() in ShellImpl.readLine().
+            java.util.Queue<String> inputLineQueue = AeshTestConnectionHolder.getInputLineQueue();
+            if (inputLineQueue != null) {
+                settings.setInputLineResponses(inputLineQueue);
+            }
 
             AeshConsoleRunner runner = AeshConsoleRunner.builder()
                     .commandRegistryBuilder((AeshCommandRegistryBuilder) registryBuilder)
                     .settings(settings)
                     .prompt(configuration.prompt());
 
-            // Wire user-provided CommandExecutionListener
-            if (executionListener.isResolvable()) {
-                CommandExecutionListener userListener = executionListener.get();
-
-                // Wire test connection and listener if set by the test framework
-                InputStream testInput = AeshTestConnectionHolder.getInput();
-                OutputStream testOutput = AeshTestConnectionHolder.getOutput();
-                LinkedBlockingQueue<Object> signalQueue = AeshTestConnectionHolder.getSignalQueue();
-
-                if (testInput != null && testOutput != null) {
-                    LOG.debug("Test mode: using stream-based connection");
-                    runner.connection(new AeshStreamConnection(testInput, testOutput));
-
-                    if (signalQueue != null) {
-                        // Compose user listener with test signal
-                        runner.commandExecutionListener((commandLine, result, executionTime) -> {
-                            userListener.onCommandComplete(commandLine, result, executionTime);
-                            signalQueue.offer("done");
-                        });
-                    } else {
-                        runner.commandExecutionListener(userListener);
-                    }
-                } else {
-                    runner.commandExecutionListener(userListener);
-                }
-            } else {
-                // No user listener -- only wire test connection if present
-                InputStream testInput = AeshTestConnectionHolder.getInput();
-                OutputStream testOutput = AeshTestConnectionHolder.getOutput();
-                LinkedBlockingQueue<Object> signalQueue = AeshTestConnectionHolder.getSignalQueue();
-
-                if (testInput != null && testOutput != null) {
-                    LOG.debug("Test mode: using stream-based connection");
-                    runner.connection(new AeshStreamConnection(testInput, testOutput));
-
-                    if (signalQueue != null) {
-                        runner.onCommandComplete(result -> signalQueue.offer("done"));
-                    }
-                }
-            }
+            // Wire test connection and user-provided CommandExecutionListener
+            CommandExecutionListener userListener = executionListener.isResolvable()
+                    ? executionListener.get()
+                    : null;
+            wireTestConnection(runner, userListener);
 
             if (configuration.addExitCommand()) {
                 runner.addExitCommand();
+            }
+
+            // Signal the test framework when readline is armed and ready
+            // for input. The onReady callback fires after readline is armed
+            // but before openBlocking(), so execute() can safely send
+            // command bytes immediately after launch() returns.
+            LinkedBlockingQueue<Object> readySignalQueue = AeshTestConnectionHolder.getSignalQueue();
+            if (readySignalQueue != null) {
+                runner.onReady(() -> readySignalQueue.offer("ready"));
             }
 
             runner.start();

--- a/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/CliSettingsHelper.java
+++ b/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/CliSettingsHelper.java
@@ -1,11 +1,18 @@
 package io.quarkus.aesh.runtime;
 
+import java.io.File;
+
 import org.aesh.command.settings.SettingsBuilder;
 
 /**
  * Shared helper for building aesh {@link SettingsBuilder} with common configuration.
- * Used by both {@link CliRunner} (local console) and
- * {@link AeshRemoteConnectionHandler} (remote sessions).
+ * Used by {@link CliRunner} (local console), {@link AeshRemoteConnectionHandler}
+ * (remote sessions), and indirectly by {@code DefaultAeshRuntimeRunnerFactory}
+ * (runtime mode).
+ * <p>
+ * Centralizes the mapping from {@link CliConfig} properties to
+ * {@link SettingsBuilder} so all execution paths share a consistent
+ * baseline configuration.
  */
 final class CliSettingsHelper {
 
@@ -17,7 +24,13 @@ final class CliSettingsHelper {
                 .enableAlias(config.enableAlias())
                 .enableExport(config.enableExport())
                 .enableMan(config.enableMan())
-                .logging(config.logging());
+                .logging(config.logging())
+                .persistHistory(config.persistHistory())
+                .historySize(config.historySize());
+
+        if (config.historyFile().isPresent()) {
+            settingsBuilder.historyFile(new File(config.historyFile().get()));
+        }
 
         for (CliSettings customizer : customizers) {
             customizer.customize(settingsBuilder);

--- a/integration-tests/aesh/src/main/java/io/quarkus/it/aesh/ConfirmCommand.java
+++ b/integration-tests/aesh/src/main/java/io/quarkus/it/aesh/ConfirmCommand.java
@@ -1,0 +1,30 @@
+package io.quarkus.it.aesh;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.option.Option;
+
+/**
+ * A command that prompts for confirmation before proceeding.
+ * Used to test interactive input via AeshLauncher.
+ */
+@CommandDefinition(name = "confirm", description = "Confirm an action")
+public class ConfirmCommand implements Command<CommandInvocation> {
+
+    @Option(name = "action", shortName = 'a', defaultValue = "proceed")
+    String action;
+
+    @Override
+    public CommandResult execute(CommandInvocation invocation) throws InterruptedException {
+        invocation.println("Are you sure you want to " + action + "? (y/n)");
+        String answer = invocation.inputLine();
+        if ("y".equals(answer.trim())) {
+            invocation.println("Confirmed: " + action);
+            return CommandResult.SUCCESS;
+        }
+        invocation.println("Cancelled: " + action);
+        return CommandResult.FAILURE;
+    }
+}

--- a/integration-tests/aesh/src/main/java/io/quarkus/it/aesh/EchoCommand.java
+++ b/integration-tests/aesh/src/main/java/io/quarkus/it/aesh/EchoCommand.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.aesh;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.option.Option;
+
+/**
+ * A simple echo command for testing argument quoting.
+ * Prints the value of the --text option as-is.
+ */
+@CommandDefinition(name = "echo", description = "Echo the text argument")
+public class EchoCommand implements Command<CommandInvocation> {
+
+    @Option(name = "text", shortName = 't', required = true)
+    String text;
+
+    @Override
+    public CommandResult execute(CommandInvocation invocation) {
+        invocation.println(text);
+        return CommandResult.SUCCESS;
+    }
+}

--- a/integration-tests/aesh/src/main/java/io/quarkus/it/aesh/FailCommand.java
+++ b/integration-tests/aesh/src/main/java/io/quarkus/it/aesh/FailCommand.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.aesh;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.option.Option;
+
+/**
+ * A command that always fails with an exception.
+ * Used to test error capture in the AeshLauncher test framework.
+ */
+@CommandDefinition(name = "fail", description = "Always fails with an error")
+public class FailCommand implements Command<CommandInvocation> {
+
+    @Option(name = "message", shortName = 'm', defaultValue = "intentional failure")
+    String message;
+
+    @Override
+    public CommandResult execute(CommandInvocation invocation) throws CommandException {
+        throw new CommandException(message);
+    }
+}

--- a/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/AeshLauncherApiTest.java
+++ b/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/AeshLauncherApiTest.java
@@ -1,0 +1,217 @@
+package io.quarkus.it.aesh;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.aesh.command.CommandResult;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.aesh.AeshLauncher;
+import io.quarkus.test.aesh.ExecuteOptions;
+import io.quarkus.test.junit.main.QuarkusMainTest;
+
+/**
+ * Tests for the AeshLauncher API improvements:
+ * <ul>
+ * <li>Auto-launch on first execute()</li>
+ * <li>Auto-close after each test method</li>
+ * <li>Error capture via {@link AeshLauncher#getLastError()}</li>
+ * <li>Quoted arguments via {@link AeshLauncher#execute(String)}</li>
+ * <li>Launch result via {@link AeshLauncher#getLaunchResult()}</li>
+ * <li>Clean command output via {@link AeshLauncher#getCommandOutput()}</li>
+ * <li>Accumulated output via {@link AeshLauncher#getOutput()} / {@link AeshLauncher#resetOutput()}</li>
+ * <li>Running state via {@link AeshLauncher#isRunning()} / {@link AeshLauncher#waitForExit(Duration)}</li>
+ * </ul>
+ */
+@QuarkusMainTest
+public class AeshLauncherApiTest {
+
+    @Test
+    void errorCapturedFromFailingCommand(AeshLauncher launcher) {
+        launcher.execute("fail --message=test-error", CommandResult.FAILURE);
+
+        assertThat(launcher.getLastError())
+                .as("Last error should be captured from the failing command")
+                .isNotNull();
+        assertThat(launcher.getLastError().getMessage())
+                .contains("test-error");
+        assertThat(launcher.getErrorOutput())
+                .contains("test-error");
+        assertThat(launcher.getLastExitCode()).isEqualTo(1);
+    }
+
+    @Test
+    void noErrorOnSuccessfulCommand(AeshLauncher launcher) {
+        launcher.execute("hello --name=Success");
+
+        assertThat(launcher.getCommandOutput()).isEqualTo("Hello Success!\n");
+        assertThat(launcher.getLastError()).isNull();
+        assertThat(launcher.getErrorOutput()).isEmpty();
+    }
+
+    @Test
+    void errorClearedBetweenCommands(AeshLauncher launcher) {
+        // First command fails
+        launcher.execute("fail --message=first-error", CommandResult.FAILURE);
+        assertThat(launcher.getLastError()).isNotNull();
+        assertThat(launcher.getLastExitCode()).isEqualTo(1);
+
+        // Second command succeeds — error and exit code should be cleared
+        launcher.execute("hello --name=Cleared");
+        assertThat(launcher.getLastError()).isNull();
+        assertThat(launcher.getLastExitCode()).isZero();
+    }
+
+    @Test
+    void executeWithQuotedArgs(AeshLauncher launcher) {
+        launcher.execute("echo --text 'hello world'");
+
+        assertThat(launcher.getCommandOutput()).isEqualTo("hello world\n");
+    }
+
+    @Test
+    void isRunningReflectsReplState(AeshLauncher launcher) {
+        assertThat(launcher.isRunning()).isFalse();
+
+        launcher.launch();
+        assertThat(launcher.isRunning()).isTrue();
+
+        launcher.exit();
+        assertThat(launcher.isRunning()).isFalse();
+    }
+
+    @Test
+    void waitForExitAfterExit(AeshLauncher launcher) {
+        launcher.launch();
+        assertThat(launcher.isRunning()).isTrue();
+
+        launcher.exit();
+
+        boolean exited = launcher.waitForExit(Duration.ofSeconds(10));
+        assertThat(exited).isTrue();
+        assertThat(launcher.isRunning()).isFalse();
+    }
+
+    @Test
+    void launchResultAvailableAfterExit(AeshLauncher launcher) {
+        launcher.execute("hello");
+        launcher.exit();
+
+        assertThat(launcher.getLaunchResult())
+                .as("LaunchResult should be available after exit")
+                .isNotNull();
+        assertThat(launcher.getLaunchResult().exitCode()).isZero();
+    }
+
+    @Test
+    void getCommandOutputIsClean(AeshLauncher launcher) {
+        launcher.execute("hello --name=Clean");
+
+        // getCommandOutput() should have exactly the command output — no prompt, no echo
+        assertThat(launcher.getCommandOutput())
+                .isEqualTo("Hello Clean!\n")
+                .doesNotContain("[quarkus]$")
+                .doesNotContain("hello --name");
+    }
+
+    @Test
+    void accumulatedOutputAcrossCommands(AeshLauncher launcher) {
+        launcher.execute("hello --name=First");
+        launcher.execute("hello --name=Second");
+
+        assertThat(launcher.getOutput())
+                .isEqualTo("Hello First!\nHello Second!\n");
+    }
+
+    @Test
+    void resetOutputClearsAccumulator(AeshLauncher launcher) {
+        launcher.execute("hello --name=Before");
+        assertThat(launcher.getOutput()).isEqualTo("Hello Before!\n");
+
+        launcher.resetOutput();
+        assertThat(launcher.getOutput()).isEmpty();
+
+        launcher.execute("hello --name=After");
+        assertThat(launcher.getOutput()).isEqualTo("Hello After!\n");
+    }
+
+    @Test
+    void getCommandOutputOnlyHasLastCommand(AeshLauncher launcher) {
+        launcher.execute("hello --name=First");
+        launcher.execute("hello --name=Second");
+
+        // getCommandOutput() only has the last command's output
+        assertThat(launcher.getCommandOutput())
+                .isEqualTo("Hello Second!\n")
+                .doesNotContain("First");
+    }
+
+    @Test
+    void executeDefaultsToSuccessAssertion(AeshLauncher launcher) {
+        // execute(String) defaults to expecting SUCCESS — should throw on failure
+        assertThatThrownBy(() -> launcher.execute("fail --message=boom"))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("exit code 1")
+                .hasMessageContaining("expected 0");
+    }
+
+    @Test
+    void executeWithExpectedFailure(AeshLauncher launcher) {
+        // execute(String, CommandResult) allows expecting non-success results
+        launcher.execute("fail --message=expected", CommandResult.FAILURE);
+        assertThat(launcher.getLastExitCode()).isEqualTo(1);
+    }
+
+    @Test
+    void getLastExitCodeReflectsResult(AeshLauncher launcher) {
+        launcher.execute("hello --name=World");
+        assertThat(launcher.getLastExitCode()).isZero();
+
+        launcher.execute("fail", CommandResult.FAILURE);
+        assertThat(launcher.getLastExitCode()).isEqualTo(1);
+    }
+
+    @Test
+    void autoLaunchOnFirstExecute(AeshLauncher launcher) {
+        // No explicit launch() call — should auto-launch
+        assertThat(launcher.isRunning()).isFalse();
+
+        launcher.execute("hello --name=AutoLaunch");
+
+        assertThat(launcher.isRunning()).isTrue();
+        assertThat(launcher.getCommandOutput()).isEqualTo("Hello AutoLaunch!\n");
+    }
+
+    @Test
+    void executeWithOptions(AeshLauncher launcher) {
+        launcher.execute("fail --message=opts",
+                ExecuteOptions.expecting(CommandResult.FAILURE));
+        assertThat(launcher.getLastExitCode()).isEqualTo(1);
+    }
+
+    @Test
+    void executeWithOptionsTimeout(AeshLauncher launcher) {
+        launcher.execute("hello --name=Timeout",
+                ExecuteOptions.defaults().timeout(Duration.ofSeconds(10)));
+        assertThat(launcher.getCommandOutput()).isEqualTo("Hello Timeout!\n");
+    }
+
+    @Test
+    void interactiveCommandWithPreCannedInput(AeshLauncher launcher) {
+        launcher.execute("confirm --action=deploy",
+                ExecuteOptions.defaults().input("y"));
+        assertThat(launcher.getCommandOutput())
+                .contains("Are you sure you want to deploy?")
+                .contains("Confirmed: deploy");
+    }
+
+    @Test
+    void interactiveCommandDeclined(AeshLauncher launcher) {
+        launcher.execute("confirm --action=delete",
+                ExecuteOptions.expecting(CommandResult.FAILURE).input("n"));
+        assertThat(launcher.getCommandOutput())
+                .contains("Cancelled: delete");
+    }
+}

--- a/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/AeshReplTest.java
+++ b/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/AeshReplTest.java
@@ -12,62 +12,45 @@ import io.quarkus.test.junit.main.QuarkusMainTest;
  * <p>
  * Uses the commands from src/main/java (hello, cli) which auto-detect
  * as console mode (multiple independent top-level commands). AeshLauncher
- * provides a test connection to send commands and assert on output without
- * needing a real terminal.
+ * auto-launches the REPL on first execute() and auto-closes
+ * after each test method.
  */
 @QuarkusMainTest
 public class AeshReplTest {
 
     @Test
     void testHelloCommand(AeshLauncher launcher) {
-        launcher.launch();
-
-        String output = launcher.executeCommand("hello --name=Alice");
-        assertThat(output).contains("Hello Alice!");
-
-        launcher.exit();
+        launcher.execute("hello --name=Alice");
+        assertThat(launcher.getCommandOutput()).isEqualTo("Hello Alice!\n");
     }
 
     @Test
     void testHelloDefaultName(AeshLauncher launcher) {
-        launcher.launch();
-
-        String output = launcher.executeCommand("hello");
-        assertThat(output).contains("Hello World!");
-
-        launcher.exit();
+        launcher.execute("hello");
+        assertThat(launcher.getCommandOutput()).isEqualTo("Hello World!\n");
     }
 
     @Test
     void testMultipleCommandsInSession(AeshLauncher launcher) {
-        launcher.launch();
+        launcher.execute("hello --name=First");
+        launcher.execute("hello --name=Second");
 
-        String out1 = launcher.executeCommand("hello --name=First");
-        assertThat(out1).contains("Hello First!");
+        // Accumulated output contains both commands
+        assertThat(launcher.getOutput()).isEqualTo("Hello First!\nHello Second!\n");
 
-        String out2 = launcher.executeCommand("hello --name=Second");
-        assertThat(out2).contains("Hello Second!");
-
-        launcher.exit();
+        // Last command output only
+        assertThat(launcher.getCommandOutput()).isEqualTo("Hello Second!\n");
     }
 
     @Test
     void testGroupCommand(AeshLauncher launcher) {
-        launcher.launch();
-
-        String output = launcher.executeCommand("cli version");
-        assertThat(output).contains("Version: 1.0.0");
-
-        launcher.exit();
+        launcher.execute("cli version");
+        assertThat(launcher.getCommandOutput()).isEqualTo("Version: 1.0.0\n");
     }
 
     @Test
     void testGroupCommandWithArgs(AeshLauncher launcher) {
-        launcher.launch();
-
-        String output = launcher.executeCommand("cli run myTask");
-        assertThat(output).contains("Running task: myTask");
-
-        launcher.exit();
+        launcher.execute("cli run myTask");
+        assertThat(launcher.getCommandOutput()).isEqualTo("Running task: myTask\n");
     }
 }

--- a/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/AeshReplWithHibernateTest.java
+++ b/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/AeshReplWithHibernateTest.java
@@ -20,43 +20,37 @@ public class AeshReplWithHibernateTest {
 
     @Test
     void testAddAndListItems(AeshLauncher launcher) {
-        launcher.launch();
-
         // Database starts empty
-        String output = launcher.executeCommand("list-items");
-        assertThat(output).contains("No items found");
+        launcher.execute("list-items");
+        assertThat(launcher.getCommandOutput()).contains("No items found");
 
         // Add items
-        output = launcher.executeCommand("add-item apple");
-        assertThat(output).contains("Added: apple");
+        launcher.execute("add-item apple");
+        assertThat(launcher.getCommandOutput()).isEqualTo("Added: apple\n");
 
-        output = launcher.executeCommand("add-item banana");
-        assertThat(output).contains("Added: banana");
+        launcher.execute("add-item banana");
+        assertThat(launcher.getCommandOutput()).isEqualTo("Added: banana\n");
 
-        // Verify persistence
-        output = launcher.executeCommand("list-items");
-        assertThat(output).contains("Items (2):");
-        assertThat(output).contains("- apple");
-        assertThat(output).contains("- banana");
-
-        launcher.exit();
+        // Verify persistence — multi-line output, use contains for individual lines
+        launcher.execute("list-items");
+        assertThat(launcher.getCommandOutput())
+                .contains("Items (2):")
+                .contains("- apple")
+                .contains("- banana");
     }
 
     @Test
     void testDataIsolationBetweenTests(AeshLauncher launcher) {
-        launcher.launch();
-
         // Each test gets a fresh database (drop-and-create)
-        String output = launcher.executeCommand("list-items");
-        assertThat(output).contains("No items found");
+        launcher.execute("list-items");
+        assertThat(launcher.getCommandOutput()).contains("No items found");
 
-        output = launcher.executeCommand("add-item cherry");
-        assertThat(output).contains("Added: cherry");
+        launcher.execute("add-item cherry");
+        assertThat(launcher.getCommandOutput()).isEqualTo("Added: cherry\n");
 
-        output = launcher.executeCommand("list-items");
-        assertThat(output).contains("Items (1):");
-        assertThat(output).contains("- cherry");
-
-        launcher.exit();
+        launcher.execute("list-items");
+        assertThat(launcher.getCommandOutput())
+                .contains("Items (1):")
+                .contains("- cherry");
     }
 }

--- a/test-framework/aesh/src/main/java/io/quarkus/test/aesh/AeshLauncher.java
+++ b/test-framework/aesh/src/main/java/io/quarkus/test/aesh/AeshLauncher.java
@@ -2,6 +2,10 @@ package io.quarkus.test.aesh;
 
 import java.time.Duration;
 
+import org.aesh.command.CommandResult;
+
+import io.quarkus.test.junit.main.LaunchResult;
+
 /**
  * Test utility for interacting with an Aesh REPL (console mode) application.
  * <p>
@@ -9,46 +13,135 @@ import java.time.Duration;
  * REPL on a background thread and allows sending commands and asserting on
  * their output.
  */
-public interface AeshLauncher {
+public interface AeshLauncher extends AutoCloseable {
 
     /**
-     * Default timeout for {@link #executeCommand(String)}.
+     * Default timeout for {@link #execute(String)}.
      */
     Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
 
     /**
      * Start the REPL session on a background thread.
      * Non-blocking -- returns immediately after the console is ready.
+     * <p>
+     * Calling this method is optional — the REPL is auto-launched on the
+     * first {@link #execute} call if not already started. Use this
+     * method only when you need to pass initial arguments.
      *
      * @param args optional initial arguments
      */
     void launch(String... args);
 
     /**
-     * Send a command to the REPL and wait for it to complete.
+     * Send a command to the REPL, wait for it to complete, and assert that
+     * the command succeeds ({@link CommandResult#SUCCESS}).
      * Uses the {@link #DEFAULT_TIMEOUT default timeout} of 30 seconds.
      * <p>
-     * The output buffer is cleared before each command, so the returned
-     * string contains only the output from this specific command.
+     * Arguments containing spaces or special characters should be quoted
+     * the same way as in a terminal (single or double quotes).
      *
      * @param command the command string to execute
-     * @return the command output
+     * @return the raw command output (includes prompt and echo)
+     * @throws AssertionError if the command does not return SUCCESS
      * @throws RuntimeException if the command does not complete within the timeout
      */
-    String executeCommand(String command);
+    default String execute(String command) {
+        return execute(command, ExecuteOptions.defaults());
+    }
 
     /**
-     * Send a command to the REPL and wait for it to complete with a custom timeout.
-     * <p>
-     * The output buffer is cleared before each command, so the returned
-     * string contains only the output from this specific command.
+     * Send a command to the REPL, wait for it to complete, and assert that
+     * the command returns the expected {@link CommandResult}.
+     * Uses the {@link #DEFAULT_TIMEOUT default timeout}.
      *
      * @param command the command string to execute
-     * @param timeout maximum time to wait for the command to complete
-     * @return the command output
+     * @param expectedResult the expected command result
+     * @return the raw command output (includes prompt and echo)
+     * @throws AssertionError if the exit code does not match
      * @throws RuntimeException if the command does not complete within the timeout
      */
-    String executeCommand(String command, Duration timeout);
+    default String execute(String command, CommandResult expectedResult) {
+        return execute(command, ExecuteOptions.expecting(expectedResult));
+    }
+
+    /**
+     * Send a command to the REPL, wait for it to complete, and assert the
+     * result according to the given {@link ExecuteOptions}.
+     *
+     * @param command the command string to execute
+     * @param options execution options (expected result, timeout, pre-canned input)
+     * @return the raw command output (includes prompt and echo)
+     * @throws AssertionError if the exit code does not match the expected result
+     * @throws RuntimeException if the command does not complete within the timeout
+     */
+    String execute(String command, ExecuteOptions options);
+
+    /**
+     * Send raw input to the REPL without waiting for command completion.
+     * Use this for complex interactive scenarios where {@link ExecuteOptions#input}
+     * is not sufficient. A newline is appended automatically.
+     * <p>
+     * For most interactive commands, prefer using
+     * {@code ExecuteOptions.defaults().input("response")} which provides
+     * pre-canned responses via aesh's input line queue.
+     *
+     * @param input the text to send
+     */
+    void sendInput(String input);
+
+    /**
+     * Returns the exit code from the last {@link #execute} call.
+     * 0 indicates success.
+     *
+     * @return the last exit code
+     */
+    default int getLastExitCode() {
+        return 0;
+    }
+
+    /**
+     * @deprecated Use {@link #execute(String)} instead.
+     */
+    @Deprecated(since = "4.0", forRemoval = true)
+    default String executeCommand(String command) {
+        return execute(command);
+    }
+
+    /**
+     * @deprecated Use {@link #execute(String, ExecuteOptions)} instead.
+     */
+    @Deprecated(since = "4.0", forRemoval = true)
+    default String executeCommand(String command, Duration timeout) {
+        return execute(command, ExecuteOptions.defaults().timeout(timeout));
+    }
+
+    /**
+     * Returns the clean command output from the last {@link #execute} call.
+     * Contains only what the command wrote via {@code invocation.println()} —
+     * no prompt, no command echo, no readline chrome.
+     *
+     * @return the last command's output, or an empty string
+     */
+    default String getCommandOutput() {
+        return "";
+    }
+
+    /**
+     * Returns all accumulated clean command output since {@link #launch()} or
+     * the last {@link #resetOutput()} call. Contains only command output,
+     * no prompt or readline chrome.
+     *
+     * @return the accumulated output
+     */
+    default String getOutput() {
+        return "";
+    }
+
+    /**
+     * Clears the accumulated output buffer returned by {@link #getOutput()}.
+     */
+    default void resetOutput() {
+    }
 
     /**
      * Returns the accumulated error output from the REPL session.
@@ -58,7 +151,59 @@ public interface AeshLauncher {
     String getErrorOutput();
 
     /**
+     * Returns the exception from the last failed command, or {@code null}
+     * if the last command succeeded.
+     *
+     * @return the last error, or null
+     */
+    default Throwable getLastError() {
+        return null;
+    }
+
+    /**
+     * Returns the launch result after the REPL exits, or {@code null} if
+     * the REPL is still running.
+     *
+     * @return the launch result, or null
+     */
+    default LaunchResult getLaunchResult() {
+        return null;
+    }
+
+    /**
+     * Returns whether the REPL session is still running.
+     *
+     * @return true if the REPL thread is alive
+     */
+    default boolean isRunning() {
+        return false;
+    }
+
+    /**
+     * Wait for the REPL session to terminate, with a timeout.
+     * Useful for tests that verify a command causes the REPL to exit.
+     *
+     * @param timeout maximum time to wait
+     * @return true if the REPL exited within the timeout, false if it timed out
+     */
+    default boolean waitForExit(Duration timeout) {
+        return true;
+    }
+
+    /**
      * Send the exit command and wait for the REPL session to shut down cleanly.
      */
     void exit();
+
+    /**
+     * Closes the launcher, exiting the REPL if still running.
+     * Called automatically after each test method.
+     */
+    @Override
+    default void close() {
+        if (isRunning()) {
+            exit();
+        }
+    }
+
 }

--- a/test-framework/aesh/src/main/java/io/quarkus/test/aesh/AeshLauncherImpl.java
+++ b/test-framework/aesh/src/main/java/io/quarkus/test/aesh/AeshLauncherImpl.java
@@ -6,6 +6,7 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -25,10 +26,17 @@ public class AeshLauncherImpl implements AeshLauncher {
 
     private PipedOutputStream stdinWriter;
     private ByteArrayOutputStream stdoutCapture;
+    private ByteArrayOutputStream commandOutputCapture;
     private LinkedBlockingQueue<Object> signalQueue;
+    private ConcurrentLinkedQueue<String> inputLineQueue;
 
     private Thread replThread;
+    private volatile boolean launched;
     private volatile LaunchResult launchResult;
+    private volatile int lastExitCode;
+    private volatile Throwable lastError;
+    private volatile String lastCommandOutput;
+    private final StringBuilder accumulatedOutput = new StringBuilder();
 
     public AeshLauncherImpl(QuarkusMainLauncher mainLauncher) {
         this.mainLauncher = mainLauncher;
@@ -36,12 +44,18 @@ public class AeshLauncherImpl implements AeshLauncher {
 
     @Override
     public void launch(String... args) {
+        if (launched) {
+            return;
+        }
+        launched = true;
         PipedInputStream stdinReader;
         try {
             stdinWriter = new PipedOutputStream();
             stdinReader = new PipedInputStream(stdinWriter, 4096);
             stdoutCapture = new ByteArrayOutputStream();
+            commandOutputCapture = new ByteArrayOutputStream();
             signalQueue = new LinkedBlockingQueue<>();
+            inputLineQueue = new ConcurrentLinkedQueue<>();
         } catch (IOException e) {
             throw new RuntimeException("Failed to set up test pipes", e);
         }
@@ -53,22 +67,40 @@ public class AeshLauncherImpl implements AeshLauncher {
                 },
                 AeshTestConnectionHolder.TEST_THREAD_NAME,
                 testCl,
-                stdinReader, stdoutCapture, signalQueue);
+                stdinReader, stdoutCapture, signalQueue,
+                commandOutputCapture, inputLineQueue);
         replThread.start();
 
-        waitForPrompt(System.currentTimeMillis() + DEFAULT_TIMEOUT.toMillis());
+        // Wait for the REPL thread to signal that it is about to start.
+        // CliRunner offers a "ready" signal just before runner.start()
+        // blocks. Command bytes written after this point are buffered in
+        // the PipedInputStream until readline arms and reads them.
+        try {
+            Object signal = signalQueue.poll(DEFAULT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            if (signal == null) {
+                throw new RuntimeException("REPL did not start within " + DEFAULT_TIMEOUT);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     @Override
-    public String executeCommand(String command) {
-        return executeCommand(command, DEFAULT_TIMEOUT);
-    }
-
-    @Override
-    public String executeCommand(String command, Duration timeout) {
-        // Clear the output buffer and signal queue
+    public String execute(String command, ExecuteOptions options) {
+        if (!launched) {
+            launch();
+        }
+        // Clear the output buffers, signal queue, and last result
         stdoutCapture.reset();
+        commandOutputCapture.reset();
         signalQueue.clear();
+        lastExitCode = 0;
+        lastError = null;
+        lastCommandOutput = null;
+
+        // Load pre-canned input responses into the queue for invocation.inputLine()
+        inputLineQueue.clear();
+        inputLineQueue.addAll(options.input());
 
         // Send the command
         try {
@@ -78,34 +110,109 @@ public class AeshLauncherImpl implements AeshLauncher {
             throw new RuntimeException("Failed to write command to REPL stdin", e);
         }
 
-        long deadline = System.currentTimeMillis() + timeout.toMillis();
-
         try {
-            Object signal = signalQueue.poll(timeout.toMillis(), TimeUnit.MILLISECONDS);
+            Object signal = signalQueue.poll(options.timeout().toMillis(), TimeUnit.MILLISECONDS);
             if (signal == null) {
                 throw new RuntimeException(
-                        "Command '" + command + "' did not complete within " + timeout);
+                        "Command '" + command + "' did not complete within " + options.timeout());
+            }
+            // Extract exit code and error from the signal.
+            // The signal is Object[] { exitCode, error } from CliRunner.
+            if (signal instanceof Object[] arr) {
+                lastExitCode = (int) arr[0];
+                if (arr[1] instanceof Throwable t) {
+                    lastError = t;
+                }
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException("Interrupted while waiting for command: " + command, e);
         }
 
-        String result = stripAnsi(stdoutCapture.toString(StandardCharsets.UTF_8));
+        // Capture clean command output (no prompt, no echo).
+        // Normalize CRLF to LF so assertions work on all platforms.
+        lastCommandOutput = commandOutputCapture.toString(StandardCharsets.UTF_8)
+                .replace("\r\n", "\n");
+        accumulatedOutput.append(lastCommandOutput);
 
-        // Wait for the prompt before returning so the REPL is ready
-        // to accept the next command. Without this, a subsequent
-        // executeCommand() can send input before readline is armed,
-        // causing a hang.
-        waitForPrompt(deadline);
+        // Assert the exit code matches the expected result
+        if (lastExitCode != options.expectedResult().getExitCode()) {
+            String msg = "Command '" + command + "' returned exit code " + lastExitCode
+                    + " but expected " + options.expectedResult().getExitCode();
+            if (lastError != null) {
+                msg += ": " + lastError.getMessage();
+            }
+            throw new AssertionError(msg);
+        }
 
-        return result;
+        return stripAnsi(stdoutCapture.toString(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public void sendInput(String input) {
+        if (!launched) {
+            launch();
+        }
+        try {
+            stdinWriter.write((input + "\n").getBytes(StandardCharsets.UTF_8));
+            stdinWriter.flush();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to write input to REPL stdin", e);
+        }
+    }
+
+    @Override
+    public int getLastExitCode() {
+        return lastExitCode;
+    }
+
+    @Override
+    public String getCommandOutput() {
+        return lastCommandOutput != null ? lastCommandOutput : "";
+    }
+
+    @Override
+    public String getOutput() {
+        return accumulatedOutput.toString();
+    }
+
+    @Override
+    public void resetOutput() {
+        accumulatedOutput.setLength(0);
     }
 
     @Override
     public String getErrorOutput() {
-        // Errors go to the same output stream in this implementation
-        return "";
+        Throwable err = lastError;
+        return err != null ? err.getMessage() : "";
+    }
+
+    @Override
+    public Throwable getLastError() {
+        return lastError;
+    }
+
+    @Override
+    public LaunchResult getLaunchResult() {
+        return launchResult;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return replThread != null && replThread.isAlive();
+    }
+
+    @Override
+    public boolean waitForExit(Duration timeout) {
+        if (replThread == null) {
+            return true;
+        }
+        try {
+            replThread.join(timeout.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return !replThread.isAlive();
     }
 
     @Override
@@ -124,29 +231,12 @@ public class AeshLauncherImpl implements AeshLauncher {
         if (replThread != null) {
             try {
                 replThread.join(10_000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        }
-    }
-
-    /**
-     * Poll the output buffer until the prompt marker ({@code "$ "}) appears,
-     * indicating the REPL is ready to accept the next command.
-     */
-    private void waitForPrompt(long deadlineMillis) {
-        while (System.currentTimeMillis() < deadlineMillis) {
-            if (stdoutCapture.size() > 0) {
-                String output = stripAnsi(stdoutCapture.toString(StandardCharsets.UTF_8));
-                if (output.contains("$ ")) {
-                    return;
+                if (replThread.isAlive()) {
+                    replThread.interrupt();
+                    replThread.join(2_000);
                 }
-            }
-            try {
-                Thread.sleep(50);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                return;
             }
         }
     }

--- a/test-framework/aesh/src/main/java/io/quarkus/test/aesh/ExecuteOptions.java
+++ b/test-framework/aesh/src/main/java/io/quarkus/test/aesh/ExecuteOptions.java
@@ -1,0 +1,87 @@
+package io.quarkus.test.aesh;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.aesh.command.CommandResult;
+
+/**
+ * Options for {@link AeshLauncher#execute(String, ExecuteOptions)}.
+ * <p>
+ * Immutable — fluent methods return new instances.
+ *
+ * <pre>
+ * // Expected failure with custom timeout
+ * ExecuteOptions.expecting(CommandResult.FAILURE).timeout(Duration.ofMinutes(2))
+ *
+ * // Interactive command with pre-canned input
+ * ExecuteOptions.defaults().input("y")
+ * </pre>
+ */
+public class ExecuteOptions {
+
+    static final ExecuteOptions DEFAULT = new ExecuteOptions(
+            CommandResult.SUCCESS, AeshLauncher.DEFAULT_TIMEOUT, List.of());
+
+    private final CommandResult expectedResult;
+    private final Duration timeout;
+    private final List<String> input;
+
+    private ExecuteOptions(CommandResult expectedResult, Duration timeout, List<String> input) {
+        this.expectedResult = expectedResult;
+        this.timeout = timeout;
+        this.input = input;
+    }
+
+    /**
+     * Returns the default options: expects {@link CommandResult#SUCCESS}
+     * with the {@link AeshLauncher#DEFAULT_TIMEOUT default timeout} and
+     * no pre-canned input.
+     */
+    public static ExecuteOptions defaults() {
+        return DEFAULT;
+    }
+
+    /**
+     * Returns options that expect the given {@link CommandResult}.
+     *
+     * @param result the expected command result
+     */
+    public static ExecuteOptions expecting(CommandResult result) {
+        return new ExecuteOptions(result, AeshLauncher.DEFAULT_TIMEOUT, List.of());
+    }
+
+    /**
+     * Returns a copy with the given timeout.
+     *
+     * @param timeout maximum time to wait for the command to complete
+     */
+    public ExecuteOptions timeout(Duration timeout) {
+        return new ExecuteOptions(this.expectedResult, timeout, this.input);
+    }
+
+    /**
+     * Returns a copy with pre-canned input for interactive commands.
+     * <p>
+     * The responses are loaded into aesh's input line queue and consumed
+     * by {@code invocation.inputLine()} calls within the command. Each
+     * response corresponds to one {@code inputLine()} call, in order.
+     *
+     * @param responses the input lines for each {@code inputLine()} call
+     */
+    public ExecuteOptions input(String... responses) {
+        return new ExecuteOptions(this.expectedResult, this.timeout, List.of(responses));
+    }
+
+    public CommandResult expectedResult() {
+        return expectedResult;
+    }
+
+    public Duration timeout() {
+        return timeout;
+    }
+
+    public List<String> input() {
+        return input;
+    }
+}

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
@@ -64,6 +64,12 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
      */
     LaunchResult result;
 
+    /**
+     * The AeshLauncher created for the current test method (if any).
+     * Stored so it can be auto-closed in {@link #afterEach}.
+     */
+    AutoCloseable aeshLauncher;
+
     @Override
     public void beforeEach(ExtensionContext context) throws Exception {
         if (isIntegrationTest(context.getRequiredTestClass())) {
@@ -163,6 +169,14 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
     @Override
     public void afterEach(ExtensionContext context) throws Exception {
         result = null;
+        if (aeshLauncher != null) {
+            try {
+                aeshLauncher.close();
+            } catch (Exception e) {
+                // ignore cleanup errors
+            }
+            aeshLauncher = null;
+        }
     }
 
     private static Handler ORIGINAL_QUARKUS_CONSOLE_HANDLER = null;
@@ -337,7 +351,10 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
             QuarkusMainLauncher mainLauncher = createMainLauncher(extensionContext);
             Class<?> implClass = Thread.currentThread().getContextClassLoader()
                     .loadClass("io.quarkus.test.aesh.AeshLauncherImpl");
-            return implClass.getDeclaredConstructor(QuarkusMainLauncher.class).newInstance(mainLauncher);
+            Object instance = implClass.getDeclaredConstructor(QuarkusMainLauncher.class).newInstance(mainLauncher);
+            // Store for auto-close in afterEach()
+            aeshLauncher = (AutoCloseable) instance;
+            return instance;
         } catch (ClassNotFoundException e) {
             throw new ParameterResolutionException(
                     "AeshLauncher requested but quarkus-test-aesh is not on the classpath. "


### PR DESCRIPTION
Upgrade aesh from 3.17.2 to 3.17.5 which includes:
- onReady callback for precise REPL startup synchronization (https://github.com/aeshell/aesh/issues/603)
- commandOutputHandler for clean command output capture (https://github.com/aeshell/aesh/issues/602)
- 4-arg onCommandComplete with error and exit code propagation (https://github.com/aeshell/aesh/issues/600)
- Signal fires after readline re-arms (https://github.com/aeshell/aesh/issues/599)

AeshLauncher improvements:

- Auto-launch: REPL starts automatically on first execute() call. Explicit launch() is only needed when passing initial arguments.
- Auto-close: REPL shuts down automatically after each test method via AutoCloseable. Explicit exit() is no longer required.
- Clean output: getCommandOutput() returns only command output without prompt, echo, or ANSI sequences, enabling exact assertions with isEqualTo() instead of contains().
- Output accumulation: getOutput() accumulates command output across multiple execute() calls. resetOutput() clears the accumulator.
- Exit code assertions: execute() asserts CommandResult.SUCCESS by default. Pass a different CommandResult for expected failures: execute(command, CommandResult.FAILURE).
- Error capture: getLastError() returns the exception from the last failed command via the 4-arg onCommandComplete listener.
- Lifecycle queries: isRunning() and waitForExit(Duration) for tests that verify REPL termination behavior.
- Deprecated executeCommand() in favor of shorter execute().

CliRunner improvements:

- Wire onReady callback for precise REPL startup synchronization, replacing the signal-before-start workaround.
- Wire commandOutputHandler for clean command output capture via ShellOutputTee in test mode.
- Extract wireTestConnection() helper to eliminate duplicated test connection wiring across the with/without user listener branches.
- Centralize history settings (persistHistory, historySize, historyFile) in CliSettingsHelper instead of applying them manually in startRepl().
- Unify joinArgs() quoting logic with the same robust implementation used throughout, handling empty strings, newlines, quotes, braces, and pipe characters.

----

- Fixes: #55835