### PR TITLE
Make the serialized application model relocatable and the producer task cacheable

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -649,6 +649,8 @@ public class QuarkusPlugin implements Plugin<Project> {
                 .deploymentClasspathSnapshot(classpath.getDeploymentConfiguration().getIncoming().getArtifacts(),
                         projectDir)));
         task.getApplicationModel().set(project.getLayout().getBuildDirectory().file(quarkusModelFile));
+        task.getGradleUserHomeDirectory().set(project.getGradle().getGradleUserHomeDir());
+        task.getRootDirectory().set(project.getRootDir());
     }
 
     private static void configureQuarkusBuildTask(Project project, QuarkusBuildTask task,
@@ -657,6 +659,8 @@ public class QuarkusPlugin implements Plugin<Project> {
             Provider<CustomFileSystemOperations> customFs,
             QuarkusPluginExtension quarkusExt) {
         task.getApplicationModel().set(quarkusGenerateAppModelTask.flatMap(QuarkusApplicationModelTask::getApplicationModel));
+        task.getRootDirectory().set(project.getRootDir());
+        task.getGradleUserHomeDirectory().set(project.getGradle().getGradleUserHomeDir());
         SourceSet mainSourceSet = getSourceSet(project, SourceSet.MAIN_SOURCE_SET_NAME);
         task.getAdditionalForcedProperties().set(serviceProvider);
         task.usesService(serviceProvider);
@@ -689,6 +693,8 @@ public class QuarkusPlugin implements Plugin<Project> {
         }
         task.getApplicationModel()
                 .set(applicationModelTaskTaskProvider.flatMap(QuarkusApplicationModelTask::getApplicationModel));
+        task.getRootDirectory().set(task.getProject().getRootDir());
+        task.getGradleUserHomeDirectory().set(task.getProject().getGradle().getGradleUserHomeDir());
         task.getGeneratedOutputDirectory().set(generatedSources.getJava().getClassesDirectory());
         task.getCachingRelevantInput()
                 .set(quarkusExt.cachingRelevantProperties(quarkusExt.getCachingRelevantProperties().get()));

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -7,8 +7,10 @@ import static io.quarkus.gradle.tooling.dependency.DependencyDataCollector.decla
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -26,8 +28,12 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.java.archives.Attributes;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.Property;
@@ -651,6 +657,23 @@ public class QuarkusPlugin implements Plugin<Project> {
         task.getApplicationModel().set(project.getLayout().getBuildDirectory().file(quarkusModelFile));
         task.getGradleUserHomeDirectory().set(project.getGradle().getGradleUserHomeDir());
         task.getRootDirectory().set(project.getRootDir());
+        task.getIncludedBuildDirectories().set(project.provider(() -> includedBuildDirectories(project)));
+    }
+
+    /**
+     * The root directories of the builds included in this one, in declaration order. They lie outside
+     * the root directory of this build, so the serialized application model expresses paths under them
+     * relative to a root of their own.
+     */
+    private static List<Directory> includedBuildDirectories(Project project) {
+        final ObjectFactory objects = project.getObjects();
+        final List<Directory> directories = new ArrayList<>();
+        for (IncludedBuild includedBuild : project.getGradle().getIncludedBuilds()) {
+            final DirectoryProperty directory = objects.directoryProperty();
+            directory.set(includedBuild.getProjectDir());
+            directories.add(directory.get());
+        }
+        return directories;
     }
 
     private static void configureQuarkusBuildTask(Project project, QuarkusBuildTask task,

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -664,6 +664,10 @@ public class QuarkusPlugin implements Plugin<Project> {
      * The root directories of the builds included in this one, in declaration order. They lie outside
      * the root directory of this build, so the serialized application model expresses paths under them
      * relative to a root of their own.
+     * <p>
+     * The roots are numbered by position, so the task that writes a model and the tasks that read it
+     * back have to see the same builds in the same order. That is why they all go through this one
+     * helper rather than walking {@code Gradle.getIncludedBuilds()} themselves.
      */
     private static List<Directory> includedBuildDirectories(Project project) {
         final ObjectFactory objects = project.getObjects();
@@ -684,6 +688,7 @@ public class QuarkusPlugin implements Plugin<Project> {
         task.getApplicationModel().set(quarkusGenerateAppModelTask.flatMap(QuarkusApplicationModelTask::getApplicationModel));
         task.getRootDirectory().set(project.getRootDir());
         task.getGradleUserHomeDirectory().set(project.getGradle().getGradleUserHomeDir());
+        task.getIncludedBuildDirectories().set(project.provider(() -> includedBuildDirectories(project)));
         SourceSet mainSourceSet = getSourceSet(project, SourceSet.MAIN_SOURCE_SET_NAME);
         task.getAdditionalForcedProperties().set(serviceProvider);
         task.usesService(serviceProvider);
@@ -718,6 +723,8 @@ public class QuarkusPlugin implements Plugin<Project> {
                 .set(applicationModelTaskTaskProvider.flatMap(QuarkusApplicationModelTask::getApplicationModel));
         task.getRootDirectory().set(task.getProject().getRootDir());
         task.getGradleUserHomeDirectory().set(task.getProject().getGradle().getGradleUserHomeDir());
+        task.getIncludedBuildDirectories()
+                .set(task.getProject().provider(() -> includedBuildDirectories(task.getProject())));
         task.getGeneratedOutputDirectory().set(generatedSources.getJava().getClassesDirectory());
         task.getCachingRelevantInput()
                 .set(quarkusExt.cachingRelevantProperties(quarkusExt.getCachingRelevantProperties().get()));

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -7,10 +7,8 @@ import static io.quarkus.gradle.tooling.dependency.DependencyDataCollector.decla
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -28,12 +26,8 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.api.file.Directory;
-import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.java.archives.Attributes;
-import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.Property;
@@ -657,27 +651,6 @@ public class QuarkusPlugin implements Plugin<Project> {
         task.getApplicationModel().set(project.getLayout().getBuildDirectory().file(quarkusModelFile));
         task.getGradleUserHomeDirectory().set(project.getGradle().getGradleUserHomeDir());
         task.getRootDirectory().set(project.getRootDir());
-        task.getIncludedBuildDirectories().set(project.provider(() -> includedBuildDirectories(project)));
-    }
-
-    /**
-     * The root directories of the builds included in this one, in declaration order. They lie outside
-     * the root directory of this build, so the serialized application model expresses paths under them
-     * relative to a root of their own.
-     * <p>
-     * The roots are numbered by position, so the task that writes a model and the tasks that read it
-     * back have to see the same builds in the same order. That is why they all go through this one
-     * helper rather than walking {@code Gradle.getIncludedBuilds()} themselves.
-     */
-    private static List<Directory> includedBuildDirectories(Project project) {
-        final ObjectFactory objects = project.getObjects();
-        final List<Directory> directories = new ArrayList<>();
-        for (IncludedBuild includedBuild : project.getGradle().getIncludedBuilds()) {
-            final DirectoryProperty directory = objects.directoryProperty();
-            directory.set(includedBuild.getProjectDir());
-            directories.add(directory.get());
-        }
-        return directories;
     }
 
     private static void configureQuarkusBuildTask(Project project, QuarkusBuildTask task,
@@ -688,7 +661,6 @@ public class QuarkusPlugin implements Plugin<Project> {
         task.getApplicationModel().set(quarkusGenerateAppModelTask.flatMap(QuarkusApplicationModelTask::getApplicationModel));
         task.getRootDirectory().set(project.getRootDir());
         task.getGradleUserHomeDirectory().set(project.getGradle().getGradleUserHomeDir());
-        task.getIncludedBuildDirectories().set(project.provider(() -> includedBuildDirectories(project)));
         SourceSet mainSourceSet = getSourceSet(project, SourceSet.MAIN_SOURCE_SET_NAME);
         task.getAdditionalForcedProperties().set(serviceProvider);
         task.usesService(serviceProvider);
@@ -723,8 +695,6 @@ public class QuarkusPlugin implements Plugin<Project> {
                 .set(applicationModelTaskTaskProvider.flatMap(QuarkusApplicationModelTask::getApplicationModel));
         task.getRootDirectory().set(task.getProject().getRootDir());
         task.getGradleUserHomeDirectory().set(task.getProject().getGradle().getGradleUserHomeDir());
-        task.getIncludedBuildDirectories()
-                .set(task.getProject().provider(() -> includedBuildDirectories(task.getProject())));
         task.getGeneratedOutputDirectory().set(generatedSources.getJava().getClassesDirectory());
         task.getCachingRelevantInput()
                 .set(quarkusExt.cachingRelevantProperties(quarkusExt.getCachingRelevantProperties().get()));

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/GradleRelocationRoots.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/GradleRelocationRoots.java
@@ -1,0 +1,55 @@
+package io.quarkus.gradle.tasks;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.ProjectLayout;
+
+import io.quarkus.bootstrap.app.ApplicationModelRelocation;
+
+/**
+ * The roots a Gradle build expresses the serialized application model's absolute paths relative to,
+ * so that identical inputs built from different checkouts serialize to identical bytes.
+ * <p>
+ * The environment roots - the local Maven repository and the Gradle home - are derived by any reader
+ * on its own; the build, project and root directories are only known to the build. The build directory
+ * is listed separately from the project directory because it can be configured to sit outside it.
+ * <p>
+ * Builds included through {@code includeBuild(...)} get no root: their location is not recoverable by
+ * a reader that has only the model's path, so their artifacts stay absolute.
+ * <p>
+ * This lives in one place because both the task that writes the model and the tasks that read it back
+ * have to agree on the set of roots: a root the writer uses and a reader does not know leaves an
+ * unresolved token.
+ */
+final class GradleRelocationRoots {
+
+    private GradleRelocationRoots() {
+    }
+
+    /**
+     * @param layout the layout supplying the project and build directories
+     * @param gradleUserHome the Gradle home, when the build knows it
+     * @param rootDirectory the root directory of the build, when the build knows it
+     * @return the roots to relocate against, including those every reader derives from its environment
+     */
+    static List<ApplicationModelRelocation.Root> of(ProjectLayout layout, DirectoryProperty gradleUserHome,
+            DirectoryProperty rootDirectory) {
+        final List<ApplicationModelRelocation.Root> roots = new ArrayList<>();
+        roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.BUILD_DIR_ROOT,
+                layout.getBuildDirectory().get().getAsFile().toPath()));
+        roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.PROJECT_DIR_ROOT,
+                layout.getProjectDirectory().getAsFile().toPath()));
+        if (gradleUserHome.isPresent()) {
+            // Gradle's own value, which beats the guess environmentRoots() makes from the environment
+            roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.GRADLE_USER_HOME_ROOT,
+                    gradleUserHome.get().getAsFile().toPath()));
+        }
+        if (rootDirectory.isPresent()) {
+            roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT,
+                    rootDirectory.get().getAsFile().toPath()));
+        }
+        return ApplicationModelRelocation.withEnvironmentRoots(roots);
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
@@ -13,6 +13,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -41,6 +42,7 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
@@ -57,6 +59,7 @@ import org.gradle.internal.component.external.model.ModuleComponentArtifactIdent
 import org.gradle.work.DisableCachingByDefault;
 
 import io.quarkus.bootstrap.BootstrapConstants;
+import io.quarkus.bootstrap.app.ApplicationModelRelocation;
 import io.quarkus.bootstrap.model.ApplicationModelBuilder;
 import io.quarkus.bootstrap.model.CapabilityContract;
 import io.quarkus.bootstrap.model.DefaultApplicationModel;
@@ -150,6 +153,23 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
     @OutputFile
     public abstract RegularFileProperty getApplicationModel();
 
+    /**
+     * The Gradle home, whose dependency cache holds the resolved location of every external dependency
+     * in the model, and the root directory of the build, which the other modules of a multi-module
+     * project live under. Both are roots the serialized model's paths are expressed relative to.
+     * <p>
+     * Declared {@code @Internal}: a root is what a path is made relative <em>to</em>, so it must not
+     * itself contribute to any cache key - that is the whole point of recording paths relative to it.
+     */
+    @Internal
+    public abstract DirectoryProperty getGradleUserHomeDirectory();
+
+    /**
+     * @see #getGradleUserHomeDirectory()
+     */
+    @Internal
+    public abstract DirectoryProperty getRootDirectory();
+
     public QuarkusApplicationModelTask() {
         getProjectBuildFile().set(getProject().getBuildFile());
     }
@@ -178,7 +198,34 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
         }
 
         DefaultApplicationModel model = modelBuilder.build();
-        ToolingUtils.serializeAppModel(model, getApplicationModel().get().getAsFile().toPath());
+        ToolingUtils.serializeAppModel(model, getApplicationModel().get().getAsFile().toPath(), relocationRoots());
+    }
+
+    /**
+     * The roots the serialized model's absolute paths are expressed relative to, so that identical
+     * inputs built from different checkouts serialize to identical bytes.
+     * <p>
+     * The environment roots - the local Maven repository and the Gradle home - are derived by any reader
+     * on its own; the build directory, project directory and root directory are only known here. The
+     * build directory is listed separately from the project directory because it can be configured to
+     * sit outside it.
+     */
+    private List<ApplicationModelRelocation.Root> relocationRoots() {
+        final List<ApplicationModelRelocation.Root> roots = new ArrayList<>(
+                ApplicationModelRelocation.environmentRoots());
+        roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.BUILD_DIR_ROOT,
+                getLayout().getBuildDirectory().get().getAsFile().toPath()));
+        roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.PROJECT_DIR_ROOT,
+                getLayout().getProjectDirectory().getAsFile().toPath()));
+        if (getGradleUserHomeDirectory().isPresent()) {
+            roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.GRADLE_USER_HOME_ROOT,
+                    getGradleUserHomeDirectory().get().getAsFile().toPath()));
+        }
+        if (getRootDirectory().isPresent()) {
+            roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT,
+                    getRootDirectory().get().getAsFile().toPath()));
+        }
+        return roots;
     }
 
     private ResolvedDependencyBuilder getProjectArtifact(DefaultProjectDescriptor projectDescriptor) {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
@@ -42,6 +42,7 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
@@ -170,6 +171,15 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
     @Internal
     public abstract DirectoryProperty getRootDirectory();
 
+    /**
+     * The root directories of the builds included in this one, which lie outside
+     * {@link #getRootDirectory()} and whose modules can contribute artifacts to the model.
+     *
+     * @see #getGradleUserHomeDirectory()
+     */
+    @Internal
+    public abstract ListProperty<Directory> getIncludedBuildDirectories();
+
     public QuarkusApplicationModelTask() {
         getProjectBuildFile().set(getProject().getBuildFile());
     }
@@ -206,18 +216,21 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
      * inputs built from different checkouts serialize to identical bytes.
      * <p>
      * The environment roots - the local Maven repository and the Gradle home - are derived by any reader
-     * on its own; the build directory, project directory and root directory are only known here. The
-     * build directory is listed separately from the project directory because it can be configured to
-     * sit outside it.
+     * on its own; the build, project and root directories, and the roots of any included builds, are
+     * only known here. The build directory is listed separately from the project directory because it
+     * can be configured to sit outside it, and an included build lies outside the root directory
+     * altogether.
+     * <p>
+     * Where this knows a root the environment only guesses at - the Gradle home - the value here wins.
      */
     private List<ApplicationModelRelocation.Root> relocationRoots() {
-        final List<ApplicationModelRelocation.Root> roots = new ArrayList<>(
-                ApplicationModelRelocation.environmentRoots());
+        final List<ApplicationModelRelocation.Root> roots = new ArrayList<>();
         roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.BUILD_DIR_ROOT,
                 getLayout().getBuildDirectory().get().getAsFile().toPath()));
         roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.PROJECT_DIR_ROOT,
                 getLayout().getProjectDirectory().getAsFile().toPath()));
         if (getGradleUserHomeDirectory().isPresent()) {
+            // Gradle's own value, which beats the guess environmentRoots() makes from the environment
             roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.GRADLE_USER_HOME_ROOT,
                     getGradleUserHomeDirectory().get().getAsFile().toPath()));
         }
@@ -225,7 +238,12 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
             roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT,
                     getRootDirectory().get().getAsFile().toPath()));
         }
-        return roots;
+        final List<Directory> includedBuilds = getIncludedBuildDirectories().get();
+        for (int i = 0; i < includedBuilds.size(); i++) {
+            roots.add(new ApplicationModelRelocation.Root(
+                    ApplicationModelRelocation.includedBuildRoot(i), includedBuilds.get(i).getAsFile().toPath()));
+        }
+        return ApplicationModelRelocation.withEnvironmentRoots(roots);
     }
 
     private ResolvedDependencyBuilder getProjectArtifact(DefaultProjectDescriptor projectDescriptor) {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
@@ -13,7 +13,9 @@ import java.io.UncheckedIOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -48,6 +50,8 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -55,7 +59,6 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
-import org.gradle.work.DisableCachingByDefault;
 
 import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.app.ApplicationModelRelocation;
@@ -82,7 +85,7 @@ import io.quarkus.paths.PathList;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.util.HashUtil;
 
-@DisableCachingByDefault(because = "Not cacheable")
+@CacheableTask
 public abstract class QuarkusApplicationModelTask extends DefaultTask {
 
     /* @formatter:off */
@@ -131,10 +134,44 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
     public abstract Property<String> getTypeModel();
 
     /**
-     * If any project task changes, we will invalidate this task anyway
+     * If any project task changes, we will invalidate this task anyway.
+     * <p>
+     * Declared {@code @Internal} because its {@code toString()} - which is what Gradle would hash -
+     * contains the module directory and the source and output roots as absolute paths, which would tie
+     * the cache key to the checkout directory. {@link #getProjectDescriptorFingerprint()} contributes
+     * the same information with those paths expressed relative to the relocation roots.
+     */
+    @Internal
+    public abstract Property<DefaultProjectDescriptor> getProjectDescriptor();
+
+    /**
+     * A rendering of {@link #getProjectDescriptor()} in which the absolute paths are replaced by
+     * relocation tokens, so that the same project laid out identically in two different directories
+     * produces the same value.
+     * <p>
+     * The module's source sets are held in a {@link java.util.HashMap}, so the descriptor's own
+     * {@code toString()} can render them in a different order from one JVM to the next; the parts are
+     * sorted here so that the value depends on the project and not on iteration order.
+     * <p>
+     * Lazily derived: Gradle queries inputs at execution time, and the roots are only known then.
      */
     @Input
-    public abstract Property<DefaultProjectDescriptor> getProjectDescriptor();
+    public Provider<String> getProjectDescriptorFingerprint() {
+        return getProjectDescriptor().map(descriptor -> {
+            final WorkspaceModule module = descriptor.getWorkspaceModule();
+            final List<String> parts = new ArrayList<>();
+            parts.add("id=" + module.getId());
+            parts.add("moduleDir=" + module.getModuleDir());
+            parts.add("buildDir=" + module.getBuildDir());
+            for (String classifier : module.getSourceClassifiers()) {
+                parts.add("sources[" + classifier + "]=" + module.getSources(classifier));
+            }
+            // sorted so that the value describes the project rather than the order a HashMap happened
+            // to iterate in
+            Collections.sort(parts);
+            return ApplicationModelRelocation.tokenizeOccurrences(String.join("\n", parts), relocationRoots());
+        });
+    }
 
     @Input
     public abstract Property<Boolean> getDeclaredDependencyCollectorEnabled();
@@ -565,12 +602,12 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
         var attributes = artifact.getVariant().getAttributes();
         return artifact.getId().getDisplayName() + "|" + artifact.getId().getComponentIdentifier().getDisplayName() + "|"
                 + artifact.getFile().getName() + "|"
-                // Use lastModified and length to distinguish rebuilt artifacts with the same name,
-                // identifier, version, and selected variant.
-                // A content checksum would be more precise, but it would add file I/O while Gradle
-                // calculates task inputs before execution. This task is not cacheable, so the
-                // timestamp/size pair is the pragmatic local up-to-date check here.
-                + artifact.getFile().lastModified() + "|"
+                // Length distinguishes rebuilt artifacts with the same name, identifier, version and
+                // selected variant. The modification time is deliberately left out: it is a property of
+                // when a file was written rather than of what it contains, so a project artifact built in
+                // another checkout - a sibling module's jar, say - would otherwise change this snapshot
+                // and with it the cache key, for a jar with identical content. What the artifacts contain
+                // is tracked by getOriginalClasspath(), which hashes them.
                 + artifact.getFile().length() + "|"
                 + projectArtifactPath(artifact, projectDir) + "|"
                 + attributes.keySet().stream()

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
@@ -13,7 +13,6 @@ import java.io.UncheckedIOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -202,34 +201,10 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
     }
 
     /**
-     * The roots the serialized model's absolute paths are expressed relative to, so that identical
-     * inputs built from different checkouts serialize to identical bytes.
-     * <p>
-     * The environment roots - the local Maven repository and the Gradle home - are derived by any reader
-     * on its own; the build, project and root directories are only known here. The build directory is
-     * listed separately from the project directory because it can be configured to sit outside it.
-     * <p>
-     * Builds included through {@code includeBuild(...)} get no root: their location is not recoverable
-     * by a reader that has only the model's path, so their artifacts stay absolute.
-     * <p>
-     * Where this knows a root the environment only guesses at - the Gradle home - the value here wins.
+     * @see GradleRelocationRoots
      */
     private List<ApplicationModelRelocation.Root> relocationRoots() {
-        final List<ApplicationModelRelocation.Root> roots = new ArrayList<>();
-        roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.BUILD_DIR_ROOT,
-                getLayout().getBuildDirectory().get().getAsFile().toPath()));
-        roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.PROJECT_DIR_ROOT,
-                getLayout().getProjectDirectory().getAsFile().toPath()));
-        if (getGradleUserHomeDirectory().isPresent()) {
-            // Gradle's own value, which beats the guess environmentRoots() makes from the environment
-            roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.GRADLE_USER_HOME_ROOT,
-                    getGradleUserHomeDirectory().get().getAsFile().toPath()));
-        }
-        if (getRootDirectory().isPresent()) {
-            roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT,
-                    getRootDirectory().get().getAsFile().toPath()));
-        }
-        return ApplicationModelRelocation.withEnvironmentRoots(roots);
+        return GradleRelocationRoots.of(getLayout(), getGradleUserHomeDirectory(), getRootDirectory());
     }
 
     private ResolvedDependencyBuilder getProjectArtifact(DefaultProjectDescriptor projectDescriptor) {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
@@ -42,7 +42,6 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
@@ -171,15 +170,6 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
     @Internal
     public abstract DirectoryProperty getRootDirectory();
 
-    /**
-     * The root directories of the builds included in this one, which lie outside
-     * {@link #getRootDirectory()} and whose modules can contribute artifacts to the model.
-     *
-     * @see #getGradleUserHomeDirectory()
-     */
-    @Internal
-    public abstract ListProperty<Directory> getIncludedBuildDirectories();
-
     public QuarkusApplicationModelTask() {
         getProjectBuildFile().set(getProject().getBuildFile());
     }
@@ -216,10 +206,11 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
      * inputs built from different checkouts serialize to identical bytes.
      * <p>
      * The environment roots - the local Maven repository and the Gradle home - are derived by any reader
-     * on its own; the build, project and root directories, and the roots of any included builds, are
-     * only known here. The build directory is listed separately from the project directory because it
-     * can be configured to sit outside it, and an included build lies outside the root directory
-     * altogether.
+     * on its own; the build, project and root directories are only known here. The build directory is
+     * listed separately from the project directory because it can be configured to sit outside it.
+     * <p>
+     * Builds included through {@code includeBuild(...)} get no root: their location is not recoverable
+     * by a reader that has only the model's path, so their artifacts stay absolute.
      * <p>
      * Where this knows a root the environment only guesses at - the Gradle home - the value here wins.
      */
@@ -237,11 +228,6 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
         if (getRootDirectory().isPresent()) {
             roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT,
                     getRootDirectory().get().getAsFile().toPath()));
-        }
-        final List<Directory> includedBuilds = getIncludedBuildDirectories().get();
-        for (int i = 0; i < includedBuilds.size(); i++) {
-            roots.add(new ApplicationModelRelocation.Root(
-                    ApplicationModelRelocation.includedBuildRoot(i), includedBuilds.get(i).getAsFile().toPath()));
         }
         return ApplicationModelRelocation.withEnvironmentRoots(roots);
     }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
@@ -216,7 +216,7 @@ public abstract class QuarkusBuildTask extends QuarkusTaskWithExtensionView {
 
     ApplicationModel resolveAppModelForBuild() {
         try {
-            return ToolingUtils.deserializeAppModel(getApplicationModel().get().getAsFile().toPath());
+            return ToolingUtils.deserializeAppModel(getApplicationModel().get().getAsFile().toPath(), relocationRoots());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -109,7 +109,8 @@ public abstract class QuarkusGenerateCode extends QuarkusTaskWithExtensionView {
 
     @TaskAction
     public void generateCode() throws IOException {
-        ApplicationModel appModel = ToolingUtils.deserializeAppModel(getApplicationModel().get().getAsFile().toPath());
+        ApplicationModel appModel = ToolingUtils.deserializeAppModel(getApplicationModel().get().getAsFile().toPath(),
+                relocationRoots());
         Map<String, String> configMap = effectiveProvider().buildEffectiveConfiguration(appModel, new HashMap<>()).getValues();
 
         File outputPath = getGeneratedOutputDirectory().get().getAsFile();

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTaskWithExtensionView.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTaskWithExtensionView.java
@@ -5,9 +5,11 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.java.archives.Attributes;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -62,6 +64,19 @@ public abstract class QuarkusTaskWithExtensionView extends QuarkusTask {
     public abstract DirectoryProperty getGradleUserHomeDirectory();
 
     /**
+     * The root directories of the builds included in this one, in declaration order, used to resolve
+     * the tokens of the artifacts an included build contributed to the model. An included build lies
+     * outside {@link #getRootDirectory()}, so it is relocated against a root of its own.
+     * <p>
+     * The order has to be the one the model was written with, since the roots are numbered by
+     * position: both ends derive it from {@code Gradle.getIncludedBuilds()}.
+     *
+     * @see #getRootDirectory()
+     */
+    @Internal
+    public abstract ListProperty<Directory> getIncludedBuildDirectories();
+
+    /**
      * The roots to resolve the serialized application model's relocation tokens against: those every
      * reader derives from its environment, plus the directories this build knows.
      */
@@ -78,6 +93,11 @@ public abstract class QuarkusTaskWithExtensionView extends QuarkusTask {
         if (getRootDirectory().isPresent()) {
             roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT,
                     getRootDirectory().get().getAsFile().toPath()));
+        }
+        final List<Directory> includedBuilds = getIncludedBuildDirectories().get();
+        for (int i = 0; i < includedBuilds.size(); i++) {
+            roots.add(new ApplicationModelRelocation.Root(
+                    ApplicationModelRelocation.includedBuildRoot(i), includedBuilds.get(i).getAsFile().toPath()));
         }
         return ApplicationModelRelocation.withEnvironmentRoots(roots);
     }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTaskWithExtensionView.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTaskWithExtensionView.java
@@ -66,8 +66,7 @@ public abstract class QuarkusTaskWithExtensionView extends QuarkusTask {
      * reader derives from its environment, plus the directories this build knows.
      */
     protected List<ApplicationModelRelocation.Root> relocationRoots() {
-        final List<ApplicationModelRelocation.Root> roots = new ArrayList<>(
-                ApplicationModelRelocation.environmentRoots());
+        final List<ApplicationModelRelocation.Root> roots = new ArrayList<>();
         roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.BUILD_DIR_ROOT,
                 getProjectLayout().getBuildDirectory().get().getAsFile().toPath()));
         roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.PROJECT_DIR_ROOT,
@@ -80,7 +79,7 @@ public abstract class QuarkusTaskWithExtensionView extends QuarkusTask {
             roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT,
                     getRootDirectory().get().getAsFile().toPath()));
         }
-        return roots;
+        return ApplicationModelRelocation.withEnvironmentRoots(roots);
     }
 
     @Inject

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTaskWithExtensionView.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTaskWithExtensionView.java
@@ -1,11 +1,21 @@
 package io.quarkus.gradle.tasks;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.java.archives.Attributes;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.work.DisableCachingByDefault;
+
+import io.quarkus.bootstrap.app.ApplicationModelRelocation;
 
 /**
  * Quarkus task providing inputs compatible with the configuration cache, used by the {@link QuarkusGenerateCode}
@@ -34,6 +44,47 @@ public abstract class QuarkusTaskWithExtensionView extends QuarkusTask {
 
     @Input
     public abstract MapProperty<String, String> getCachingRelevantInput();
+
+    /**
+     * The root directory of the build, used to resolve the relocation tokens of the serialized
+     * application model back to absolute paths.
+     * <p>
+     * Declared {@code @Internal}: a root is what the model's paths are expressed relative <em>to</em>,
+     * so letting it contribute to the cache key would put the checkout directory straight back into it.
+     */
+    @Internal
+    public abstract DirectoryProperty getRootDirectory();
+
+    /**
+     * @see #getRootDirectory()
+     */
+    @Internal
+    public abstract DirectoryProperty getGradleUserHomeDirectory();
+
+    /**
+     * The roots to resolve the serialized application model's relocation tokens against: those every
+     * reader derives from its environment, plus the directories this build knows.
+     */
+    protected List<ApplicationModelRelocation.Root> relocationRoots() {
+        final List<ApplicationModelRelocation.Root> roots = new ArrayList<>(
+                ApplicationModelRelocation.environmentRoots());
+        roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.BUILD_DIR_ROOT,
+                getProjectLayout().getBuildDirectory().get().getAsFile().toPath()));
+        roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.PROJECT_DIR_ROOT,
+                getProjectLayout().getProjectDirectory().getAsFile().toPath()));
+        if (getGradleUserHomeDirectory().isPresent()) {
+            roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.GRADLE_USER_HOME_ROOT,
+                    getGradleUserHomeDirectory().get().getAsFile().toPath()));
+        }
+        if (getRootDirectory().isPresent()) {
+            roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT,
+                    getRootDirectory().get().getAsFile().toPath()));
+        }
+        return roots;
+    }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     public QuarkusTaskWithExtensionView(String description, boolean compatible) {
         super(description, compatible);

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTaskWithExtensionView.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTaskWithExtensionView.java
@@ -1,6 +1,5 @@
 package io.quarkus.gradle.tasks;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -62,24 +61,10 @@ public abstract class QuarkusTaskWithExtensionView extends QuarkusTask {
     public abstract DirectoryProperty getGradleUserHomeDirectory();
 
     /**
-     * The roots to resolve the serialized application model's relocation tokens against: those every
-     * reader derives from its environment, plus the directories this build knows.
+     * @see GradleRelocationRoots
      */
     protected List<ApplicationModelRelocation.Root> relocationRoots() {
-        final List<ApplicationModelRelocation.Root> roots = new ArrayList<>();
-        roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.BUILD_DIR_ROOT,
-                getProjectLayout().getBuildDirectory().get().getAsFile().toPath()));
-        roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.PROJECT_DIR_ROOT,
-                getProjectLayout().getProjectDirectory().getAsFile().toPath()));
-        if (getGradleUserHomeDirectory().isPresent()) {
-            roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.GRADLE_USER_HOME_ROOT,
-                    getGradleUserHomeDirectory().get().getAsFile().toPath()));
-        }
-        if (getRootDirectory().isPresent()) {
-            roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT,
-                    getRootDirectory().get().getAsFile().toPath()));
-        }
-        return ApplicationModelRelocation.withEnvironmentRoots(roots);
+        return GradleRelocationRoots.of(getProjectLayout(), getGradleUserHomeDirectory(), getRootDirectory());
     }
 
     @Inject

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTaskWithExtensionView.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTaskWithExtensionView.java
@@ -5,11 +5,9 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.java.archives.Attributes;
-import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -64,19 +62,6 @@ public abstract class QuarkusTaskWithExtensionView extends QuarkusTask {
     public abstract DirectoryProperty getGradleUserHomeDirectory();
 
     /**
-     * The root directories of the builds included in this one, in declaration order, used to resolve
-     * the tokens of the artifacts an included build contributed to the model. An included build lies
-     * outside {@link #getRootDirectory()}, so it is relocated against a root of its own.
-     * <p>
-     * The order has to be the one the model was written with, since the roots are numbered by
-     * position: both ends derive it from {@code Gradle.getIncludedBuilds()}.
-     *
-     * @see #getRootDirectory()
-     */
-    @Internal
-    public abstract ListProperty<Directory> getIncludedBuildDirectories();
-
-    /**
      * The roots to resolve the serialized application model's relocation tokens against: those every
      * reader derives from its environment, plus the directories this build knows.
      */
@@ -93,11 +78,6 @@ public abstract class QuarkusTaskWithExtensionView extends QuarkusTask {
         if (getRootDirectory().isPresent()) {
             roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT,
                     getRootDirectory().get().getAsFile().toPath()));
-        }
-        final List<Directory> includedBuilds = getIncludedBuildDirectories().get();
-        for (int i = 0; i < includedBuilds.size(); i++) {
-            roots.add(new ApplicationModelRelocation.Root(
-                    ApplicationModelRelocation.includedBuildRoot(i), includedBuilds.get(i).getAsFile().toPath()));
         }
         return ApplicationModelRelocation.withEnvironmentRoots(roots);
     }

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/CachingTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/CachingTest.java
@@ -28,6 +28,7 @@ import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -220,6 +221,146 @@ public class CachingTest extends BaseGradleTest {
 
         result = buildResult(env, arguments);
         assertBuildResult("follow-up", result, ALL_UP_TO_DATE);
+    }
+
+    /**
+     * Cache entries must be reusable from a different working directory. The serialized application
+     * model embeds absolute paths, so hashing it as an {@code @InputFile} used to make the cache key a
+     * function of the checkout directory, and nothing could be resolved from a cache populated
+     * elsewhere - which is exactly the shared/remote cache case.
+     */
+    @Test
+    void buildCacheIsReusedFromADifferentProjectDirectory(@TempDir Path otherProjectDir, @TempDir Path localCacheDir)
+            throws Exception {
+        prepareGradleBuildProject("");
+        enableLocalBuildCache(testProjectDir, localCacheDir);
+
+        Map<String, String> env = cachingTestEnvironment(false);
+        String[] arguments = List.of("build", "--info", "--stacktrace", "--build-cache", "--no-configuration-cache",
+                "-Dquarkus.package.jar.type=fast-jar")
+                .toArray(new String[0]);
+
+        assertBuildResult("populate cache", buildResult(env, rerunTasks(arguments)), ALL_SUCCESS);
+
+        // Same sources and same shared cache, but a different project directory.
+        FileUtils.copyDirectory(testProjectDir.toFile(), otherProjectDir.toFile());
+        FileUtils.deleteDirectory(otherProjectDir.resolve("build").toFile());
+        FileUtils.deleteDirectory(otherProjectDir.resolve(".gradle").toFile());
+
+        BuildResult result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(otherProjectDir.toFile())
+                .withArguments(defaultGradleArguments(List.of(arguments)))
+                .withEnvironment(env)
+                .build();
+
+        soft.assertThat(taskResults(result))
+                .describedAs("output: %s", result.getOutput())
+                .containsEntry(":quarkusGenerateCode", TaskOutcome.FROM_CACHE)
+                .containsEntry(":quarkusAppPartsBuild", TaskOutcome.FROM_CACHE);
+    }
+
+    /**
+     * The same relocation guarantee for a multi-module build. The jar of a sibling module lives under
+     * the root directory rather than under the consuming module's own project or build directory, so a
+     * fix that only accounts for the latter still leaks the checkout path through that dependency.
+     */
+    @Test
+    void buildCacheIsReusedFromADifferentProjectDirectoryForAMultiModuleBuild(@TempDir Path otherProjectDir,
+            @TempDir Path localCacheDir) throws Exception {
+        prepareGradleBuildProject("");
+        makeMultiModule(testProjectDir);
+        enableLocalBuildCache(testProjectDir, localCacheDir);
+
+        Map<String, String> env = cachingTestEnvironment(false);
+        String[] arguments = List.of("build", "--info", "--stacktrace", "--build-cache", "--no-configuration-cache",
+                "-Dquarkus.package.jar.type=fast-jar")
+                .toArray(new String[0]);
+
+        assertBuildResult("populate cache", buildResult(env, rerunTasks(arguments)), Map.of(
+                ":app:quarkusGenerateCode", TaskOutcome.SUCCESS,
+                ":app:quarkusAppPartsBuild", TaskOutcome.SUCCESS,
+                ":app:quarkusBuild", TaskOutcome.SUCCESS));
+
+        FileUtils.copyDirectory(testProjectDir.toFile(), otherProjectDir.toFile());
+        FileUtils.deleteDirectory(otherProjectDir.resolve("build").toFile());
+        FileUtils.deleteDirectory(otherProjectDir.resolve(".gradle").toFile());
+        FileUtils.deleteDirectory(otherProjectDir.resolve("library").resolve("build").toFile());
+        FileUtils.deleteDirectory(otherProjectDir.resolve("app").resolve("build").toFile());
+
+        BuildResult result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(otherProjectDir.toFile())
+                .withArguments(defaultGradleArguments(List.of(arguments)))
+                .withEnvironment(env)
+                .build();
+
+        soft.assertThat(taskResults(result))
+                .describedAs("output: %s", result.getOutput())
+                .containsEntry(":app:quarkusGenerateCode", TaskOutcome.FROM_CACHE)
+                .containsEntry(":app:quarkusAppPartsBuild", TaskOutcome.FROM_CACHE);
+    }
+
+    /**
+     * Turns the single-module fixture into a multi-module build: the Quarkus application is moved into
+     * an {@code app} subproject and given a dependency on a sibling {@code library} subproject.
+     * <p>
+     * The application has to be a subproject rather than the root for this to test anything: the jar of
+     * a sibling module then lies outside the application's own project directory, and is only covered
+     * by expressing it relative to the root of the build.
+     *
+     * @return the path of the application subproject
+     */
+    private static Path makeMultiModule(Path projectDir) throws IOException {
+        Path app = projectDir.resolve("app");
+        Files.createDirectories(app);
+        FileUtils.moveDirectory(projectDir.resolve("src").toFile(), app.resolve("src").toFile());
+        FileUtils.moveFile(projectDir.resolve("build.gradle.kts").toFile(), app.resolve("build.gradle.kts").toFile());
+
+        Path library = projectDir.resolve("library");
+        Path sources = library.resolve("src/main/java/org/acme/lib");
+        Files.createDirectories(sources);
+        Files.writeString(sources.resolve("Lib.java"), """
+                package org.acme.lib;
+
+                public class Lib {
+                    public String greet() {
+                        return "hello";
+                    }
+                }
+                """);
+        Files.writeString(library.resolve("build.gradle.kts"), """
+                plugins {
+                    java
+                }
+
+                repositories {
+                    mavenLocal()
+                    mavenCentral()
+                }
+                """);
+
+        Path settings = projectDir.resolve("settings.gradle.kts");
+        Files.writeString(settings, Files.readString(settings) + "\ninclude(\"app\")\ninclude(\"library\")\n");
+
+        Path buildScript = app.resolve("build.gradle.kts");
+        Files.writeString(buildScript, Files.readString(buildScript)
+                .replace("    implementation(\"jakarta.inject:jakarta.inject-api:2.0.1\")",
+                        "    implementation(\"jakarta.inject:jakarta.inject-api:2.0.1\")\n"
+                                + "    implementation(project(\":library\"))"));
+        return app;
+    }
+
+    /**
+     * Points the build at a build cache directory shared between project directories, so a build run
+     * from one directory can resolve entries produced by another.
+     */
+    private static void enableLocalBuildCache(Path projectDir, Path cacheDir) throws IOException {
+        Path settings = projectDir.resolve("settings.gradle.kts");
+        String directory = cacheDir.toAbsolutePath().toString().replace("\\", "\\\\");
+        Files.writeString(settings, Files.readString(settings) + String.format(
+                "%nbuildCache {%n    local {%n        directory = \"%s\"%n        isEnabled = true%n    }%n}%n",
+                directory));
     }
 
     private static Map<String, String> cachingTestEnvironment(boolean simulateCI) {

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/CachingTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/CachingTest.java
@@ -297,6 +297,12 @@ public class CachingTest extends BaseGradleTest {
 
         soft.assertThat(taskResults(result))
                 .describedAs("output: %s", result.getOutput())
+                // the model task itself is cacheable, so the build from the other directory resolves the
+                // entry the first one stored instead of resolving the whole classpath again
+                .containsEntry(":app:quarkusGenerateAppModel", TaskOutcome.FROM_CACHE)
+                // the model task itself is cacheable, so the build from the other directory resolves the
+                // entry the first one stored instead of resolving the whole classpath again
+                .containsEntry(":app:quarkusGenerateAppModel", TaskOutcome.FROM_CACHE)
                 .containsEntry(":app:quarkusGenerateCode", TaskOutcome.FROM_CACHE)
                 .containsEntry(":app:quarkusAppPartsBuild", TaskOutcome.FROM_CACHE);
     }

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/EagerResolutionTaskTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/EagerResolutionTaskTest.java
@@ -2,8 +2,9 @@ package io.quarkus.gradle.tasks;
 
 import static io.quarkus.gradle.QuarkusPlugin.QUARKUS_BUILD_TASK_NAME;
 import static io.quarkus.gradle.QuarkusPlugin.QUARKUS_GENERATE_CODE_TASK_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.gradle.testkit.runner.TaskOutcome.FROM_CACHE;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
@@ -65,6 +66,8 @@ public class EagerResolutionTaskTest extends BaseGradleTest {
         }
 
         BuildResult firstBuild = buildResult(Map.of(), taskName);
-        assertEquals(SUCCESS, firstBuild.task(":quarkusGenerateCode").getOutcome());
+        // the build cache is enabled for these builds, so an unchanged project can legitimately serve
+        // the task from the cache instead of executing it; either outcome means it did not fail
+        assertThat(firstBuild.task(":quarkusGenerateCode").getOutcome()).isIn(SUCCESS, FROM_CACHE);
     }
 }

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
@@ -177,7 +177,10 @@ public class ToolingUtils {
      * The roots a model serialized for a Gradle build is expressed relative to: the environment roots
      * every reader can derive on its own, plus the directories only the build knows about - the project
      * itself, its build directory and the root of the build, which the modules of a multi-module project
-     * live under.
+     * live under, and the root of each included build, which lies outside all of those.
+     * <p>
+     * Included builds are numbered by declaration order, so a model has to be read back against the
+     * same list it was written with.
      */
     public static List<ApplicationModelRelocation.Root> projectRoots(Project project) {
         final List<ApplicationModelRelocation.Root> roots = new ArrayList<>(
@@ -187,6 +190,11 @@ public class ToolingUtils {
         roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.PROJECT_DIR_ROOT,
                 project.getProjectDir().toPath()));
         roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT, project.getRootDir().toPath()));
+        int includedBuild = 0;
+        for (IncludedBuild build : project.getGradle().getIncludedBuilds()) {
+            roots.add(new ApplicationModelRelocation.Root(
+                    ApplicationModelRelocation.includedBuildRoot(includedBuild++), build.getProjectDir().toPath()));
+        }
         return roots;
     }
 

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
@@ -9,7 +9,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HexFormat;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -27,6 +30,7 @@ import org.gradle.composite.internal.DefaultIncludedBuild;
 import org.gradle.internal.composite.IncludedBuildInternal;
 import org.gradle.internal.composite.IncludedRootBuild;
 
+import io.quarkus.bootstrap.app.ApplicationModelRelocation;
 import io.quarkus.bootstrap.app.ApplicationModelSerializer;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.model.gradle.ModelParameter;
@@ -165,16 +169,51 @@ public class ToolingUtils {
     public static Path serializeAppModel(ApplicationModel appModel, Task context, boolean test) throws IOException {
         final Path serializedModel = context.getTemporaryDir().toPath()
                 .resolve("quarkus-app" + (test ? "-test" : "") + "-model.dat");
-        ApplicationModelSerializer.serialize(appModel, serializedModel);
+        ApplicationModelSerializer.serialize(appModel, serializedModel, projectRoots(context.getProject()));
         return serializedModel;
+    }
+
+    /**
+     * The roots a model serialized for a Gradle build is expressed relative to: the environment roots
+     * every reader can derive on its own, plus the directories only the build knows about - the project
+     * itself, its build directory and the root of the build, which the modules of a multi-module project
+     * live under.
+     */
+    public static List<ApplicationModelRelocation.Root> projectRoots(Project project) {
+        final List<ApplicationModelRelocation.Root> roots = new ArrayList<>(
+                ApplicationModelRelocation.environmentRoots());
+        roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.BUILD_DIR_ROOT,
+                project.getLayout().getBuildDirectory().get().getAsFile().toPath()));
+        roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.PROJECT_DIR_ROOT,
+                project.getProjectDir().toPath()));
+        roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT, project.getRootDir().toPath()));
+        return roots;
     }
 
     public static ApplicationModel deserializeAppModel(Path path) throws IOException {
         return ApplicationModelSerializer.deserialize(path);
     }
 
+    /**
+     * Deserializes an application model, resolving its relocation tokens against the given roots.
+     */
+    public static ApplicationModel deserializeAppModel(Path path, Collection<ApplicationModelRelocation.Root> roots)
+            throws IOException {
+        return ApplicationModelSerializer.deserialize(path, roots);
+    }
+
     public static Path serializeAppModel(ApplicationModel appModel, Path serializedModelPath) throws IOException {
         ApplicationModelSerializer.serialize(appModel, serializedModelPath);
+        return serializedModelPath;
+    }
+
+    /**
+     * Serializes an application model, expressing the absolute paths it contains relative to the given
+     * roots so that the resulting file does not depend on where the project is checked out.
+     */
+    public static Path serializeAppModel(ApplicationModel appModel, Path serializedModelPath,
+            Collection<ApplicationModelRelocation.Root> roots) throws IOException {
+        ApplicationModelSerializer.serialize(appModel, serializedModelPath, roots);
         return serializedModelPath;
     }
 

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
@@ -177,10 +177,10 @@ public class ToolingUtils {
      * The roots a model serialized for a Gradle build is expressed relative to: the environment roots
      * every reader can derive on its own, plus the directories only the build knows about - the project
      * itself, its build directory and the root of the build, which the modules of a multi-module project
-     * live under, and the root of each included build, which lies outside all of those.
+     * live under.
      * <p>
-     * Included builds are numbered by declaration order, so a model has to be read back against the
-     * same list it was written with.
+     * A build included through {@code includeBuild(...)} gets no root: it sits outside all of these at a
+     * location no reader can derive from the model's path, so its artifacts stay absolute.
      */
     public static List<ApplicationModelRelocation.Root> projectRoots(Project project) {
         final List<ApplicationModelRelocation.Root> roots = new ArrayList<>(
@@ -190,11 +190,6 @@ public class ToolingUtils {
         roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.PROJECT_DIR_ROOT,
                 project.getProjectDir().toPath()));
         roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT, project.getRootDir().toPath()));
-        int includedBuild = 0;
-        for (IncludedBuild build : project.getGradle().getIncludedBuilds()) {
-            roots.add(new ApplicationModelRelocation.Root(
-                    ApplicationModelRelocation.includedBuildRoot(includedBuild++), build.getProjectDir().toPath()));
-        }
         return roots;
     }
 

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -91,6 +91,7 @@ import org.eclipse.aether.resolution.DependencyResult;
 import org.eclipse.aether.util.artifact.JavaScopes;
 
 import io.quarkus.bootstrap.BootstrapConstants;
+import io.quarkus.bootstrap.app.ApplicationModelRelocation;
 import io.quarkus.bootstrap.app.ApplicationModelSerializer;
 import io.quarkus.bootstrap.app.ConfiguredClassLoading;
 import io.quarkus.bootstrap.app.QuarkusBootstrap;
@@ -1166,6 +1167,23 @@ public class DevMojo extends AbstractMojo {
         return null;
     }
 
+    /**
+     * The roots the serialized application model's absolute paths are expressed relative to.
+     * <p>
+     * The local repository is taken from the resolver session rather than from the environment, since
+     * Maven resolves it from settings.xml as well as from {@code -Dmaven.repo.local}.
+     */
+    private List<ApplicationModelRelocation.Root> relocationRoots() {
+        final List<ApplicationModelRelocation.Root> roots = new ArrayList<>();
+        roots.add(new ApplicationModelRelocation.Root(ApplicationModelRelocation.LOCAL_REPO_ROOT,
+                Path.of(localRepository())));
+        return roots;
+    }
+
+    private String localRepository() {
+        return repoSession.getLocalRepository().getBasedir().toPath().toAbsolutePath().toString();
+    }
+
     private void addProject(DevModeCommandLineBuilder builder, ResolvedDependency module, boolean root) throws Exception {
         if (!module.isJar()) {
             return;
@@ -1555,8 +1573,11 @@ public class DevMojo extends AbstractMojo {
                 .extensionDevModeJvmOptionFilter(extensionJvmOptions);
 
         // serialize the app model to avoid re-resolving it in the dev process
-        ApplicationModelSerializer.serialize(appModel, appModelLocation);
+        ApplicationModelSerializer.serialize(appModel, appModelLocation, relocationRoots());
         builder.jvmArgs("-D" + BootstrapConstants.SERIALIZED_APP_MODEL + "=" + appModelLocation);
+        // the dev process reads the model back and has to resolve its relocation tokens the same way,
+        // which it can only do if it sees the same local repository this session is using
+        builder.jvmArgs("-Dmaven.repo.local=" + localRepository());
 
         if (noDeps) {
             addProject(builder, appModel.getAppArtifact(), true);

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ApplicationModelRelocation.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ApplicationModelRelocation.java
@@ -1,0 +1,302 @@
+package io.quarkus.bootstrap.app;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+
+import io.quarkus.bootstrap.util.PropertyUtils;
+
+/**
+ * Rewrites the absolute filesystem paths in a serialized {@link io.quarkus.bootstrap.model.ApplicationModel}
+ * so that the same model, produced from two different checkouts or with two different local repositories,
+ * serializes to the same bytes.
+ * <p>
+ * A serialized model embeds absolute paths in a handful of places: the module directories of the project
+ * itself, its build files and source/output directories, and the resolved location of every dependency
+ * inside the local Maven repository or the Gradle dependency cache. Whoever fingerprints that file by
+ * content - Gradle's build cache being the motivating case - ends up with a key that depends on where the
+ * project happens to sit on disk.
+ * <p>
+ * On write, each path that lies under one of the {@link Root roots} is replaced by a token plus the
+ * remainder relative to that root:
+ *
+ * <pre>
+ * /home/ci/slot-3/app/build/classes  -&gt;  ${quarkus.project.dir}/build/classes
+ * /home/ci/.m2/repository/foo.jar    -&gt;  ${quarkus.local.repo}/foo.jar
+ * </pre>
+ *
+ * The roots that were used are recorded in the serialized model under {@value #RELOCATION_ROOTS}. On read,
+ * each token is substituted back with the corresponding root <em>as it is in the reading environment</em>,
+ * falling back to the recorded value when the reader does not know that root. A model is therefore usable
+ * both in the environment that produced it and in one where the project or the repository has moved.
+ * <p>
+ * Both directions are no-ops when no roots apply, and a model written without the {@value #RELOCATION_ROOTS}
+ * entry - by an older version, or with relocation disabled - is read back unchanged, so the format stays
+ * compatible in both directions.
+ */
+public class ApplicationModelRelocation {
+
+    /**
+     * Key under which the roots used to relocate a model are recorded in the serialized model.
+     */
+    public static final String RELOCATION_ROOTS = "relocation-roots";
+
+    /**
+     * System property to turn relocation off, in case a consumer depends on the absolute paths being
+     * written literally.
+     */
+    public static final String RELOCATION_DISABLED_PROP = "quarkus.bootstrap.application-model.relocation.disabled";
+
+    private static final String TOKEN_PREFIX = "${";
+    private static final String TOKEN_SUFFIX = "}";
+
+    private ApplicationModelRelocation() {
+    }
+
+    /**
+     * A directory that paths in a model are expressed relative to.
+     *
+     * @param name name of the root, used to build the token that replaces it
+     * @param path location of the root
+     */
+    public record Root(String name, Path path) {
+
+        String token() {
+            return TOKEN_PREFIX + name + TOKEN_SUFFIX;
+        }
+    }
+
+    /**
+     * Whether relocation is enabled. It is unless {@value #RELOCATION_DISABLED_PROP} is set to {@code true}.
+     */
+    public static boolean isEnabled() {
+        return !Boolean.getBoolean(RELOCATION_DISABLED_PROP);
+    }
+
+    /**
+     * Replaces the absolute paths in a model's map representation with tokens, and records the names of
+     * the roots that were used so that {@link #absolutize(Map, Collection)} knows the model is relocated.
+     *
+     * @param model map representation of an application model
+     * @param roots roots to express paths relative to
+     * @return a copy of the model with relocated paths, or the model itself if there is nothing to relocate
+     */
+    public static Map<String, Object> relocate(Map<String, Object> model, Collection<Root> roots) {
+        if (model == null || roots.isEmpty() || !isEnabled()) {
+            return model;
+        }
+        // a longer root first, so that a root nested inside another one wins
+        final List<Root> ordered = new ArrayList<>(roots);
+        ordered.sort((a, b) -> Integer.compare(b.path().toString().length(), a.path().toString().length()));
+
+        final Map<String, Object> relocated = new LinkedHashMap<>(mapValue(model, s -> tokenize(s, ordered)));
+        // only the names of the roots are recorded, never their locations: a recorded location would be
+        // exactly the checkout-dependent content this whole exercise removes from the file. The reader
+        // resolves each name against its own environment.
+        final List<Object> recordedRoots = new ArrayList<>(ordered.size());
+        for (Root root : ordered) {
+            recordedRoots.add(root.name());
+        }
+        relocated.put(RELOCATION_ROOTS, recordedRoots);
+        return relocated;
+    }
+
+    /**
+     * Resolves the tokens in a model's map representation back to absolute paths.
+     * <p>
+     * Roots are resolved entirely from the reading environment, so a model remains usable after the
+     * project or the local repository has moved. A token whose root the reader does not know is left as
+     * it is, rather than resolved to a location that would be wrong here.
+     *
+     * @param model map representation of an application model
+     * @param roots roots as they are in the reading environment
+     * @return a copy of the model with absolute paths, or the model itself if it was not relocated
+     */
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> absolutize(Map<String, Object> model, Collection<Root> roots) {
+        if (model == null) {
+            return null;
+        }
+        if (!(model.get(RELOCATION_ROOTS) instanceof Collection)) {
+            // not a relocated model, nothing to resolve
+            return model;
+        }
+
+        final Map<String, String> resolved = new LinkedHashMap<>();
+        for (Root root : roots) {
+            resolved.put(root.name(), root.path().toString());
+        }
+
+        final Map<String, Object> absolute = new LinkedHashMap<>(mapValue(model, s -> resolve(s, resolved)));
+        absolute.remove(RELOCATION_ROOTS);
+        return absolute;
+    }
+
+    /**
+     * Name of the root standing for the local Maven repository, where Maven and the CLI resolve
+     * dependencies to.
+     */
+    public static final String LOCAL_REPO_ROOT = "quarkus.local.repo";
+
+    /**
+     * Name of the root standing for the Gradle home, whose dependency cache Gradle resolves to.
+     */
+    public static final String GRADLE_USER_HOME_ROOT = "quarkus.gradle.user.home";
+
+    /**
+     * The roots that can be derived from the environment alone, and are therefore available to any
+     * reader of a model without having to be told about them: the local Maven repository and the Gradle
+     * home. Both honour the standard overrides and fall back to their conventional locations under the
+     * user home.
+     * <p>
+     * Callers that know more - a build tool knows where the project is - are expected to add their own
+     * roots to these.
+     */
+    public static List<Root> environmentRoots() {
+        final List<Root> roots = new ArrayList<>(2);
+        addRoot(roots, LOCAL_REPO_ROOT, System.getProperty("maven.repo.local"),
+                () -> Path.of(PropertyUtils.getUserHome(), ".m2", "repository"));
+        addRoot(roots, GRADLE_USER_HOME_ROOT, System.getenv("GRADLE_USER_HOME"),
+                () -> Path.of(PropertyUtils.getUserHome(), ".gradle"));
+        return roots;
+    }
+
+    /**
+     * Name of the root standing for the build/output directory of the module a model belongs to.
+     */
+    public static final String BUILD_DIR_ROOT = "quarkus.build.dir";
+
+    /**
+     * Name of the root standing for the project directory of the module a model belongs to.
+     */
+    public static final String PROJECT_DIR_ROOT = "quarkus.project.dir";
+
+    /**
+     * Name of the root standing for the root directory of a multi-module build.
+     */
+    public static final String ROOT_DIR_ROOT = "quarkus.root.dir";
+
+    /**
+     * The roots a serialized model can be resolved against knowing nothing but where the file is: the
+     * environment roots, plus the project and build directories recovered from the model's own location.
+     * <p>
+     * A build tool writes the model into a fixed place inside the build directory - {@code
+     * <project>/build/quarkus/application-model/<name>.dat} for Gradle, {@code <project>/target/...} for
+     * Maven - so a reader handed only the path, such as a forked test or dev JVM, can still resolve the
+     * project-relative tokens. A caller that knows the actual directories should pass them instead.
+     *
+     * @param modelFile location of the serialized model
+     * @return roots to resolve the model's relocation tokens against
+     */
+    public static List<Root> rootsForModelAt(Path modelFile) {
+        final List<Root> roots = new ArrayList<>(environmentRoots());
+        final Path modelDir = modelFile == null ? null : modelFile.toAbsolutePath().getParent();
+        // <build-dir>/quarkus/application-model/<name>.dat
+        final Path quarkusDir = modelDir == null ? null : modelDir.getParent();
+        final Path buildDir = quarkusDir == null ? null : quarkusDir.getParent();
+        if (buildDir == null) {
+            return roots;
+        }
+        roots.add(new Root(BUILD_DIR_ROOT, buildDir));
+        final Path projectDir = buildDir.getParent();
+        if (projectDir != null) {
+            roots.add(new Root(PROJECT_DIR_ROOT, projectDir));
+            // in a single-module build the project is the root of the build; a multi-module build has
+            // to pass its own roots, since the root cannot be recovered from the file's location
+            roots.add(new Root(ROOT_DIR_ROOT, projectDir));
+        }
+        return roots;
+    }
+
+    private static void addRoot(List<Root> roots, String name, String configured, Supplier<Path> fallback) {
+        Path path;
+        try {
+            path = configured == null || configured.isBlank() ? fallback.get() : Path.of(configured);
+            path = path.toAbsolutePath().normalize();
+        } catch (RuntimeException e) {
+            // an unusable root is simply one fewer path that can be relocated
+            return;
+        }
+        roots.add(new Root(name, path));
+    }
+
+    private static String tokenize(String value, List<Root> roots) {
+        for (Root root : roots) {
+            final String prefix = root.path().toString();
+            if (isUnder(value, prefix)) {
+                // separators are normalised so that a model is rendered identically across operating systems
+                return root.token() + value.substring(prefix.length()).replace('\\', '/');
+            }
+        }
+        return value;
+    }
+
+    private static String resolve(String value, Map<String, String> roots) {
+        if (!value.startsWith(TOKEN_PREFIX)) {
+            return value;
+        }
+        final int end = value.indexOf(TOKEN_SUFFIX);
+        if (end < 0) {
+            return value;
+        }
+        final String name = value.substring(TOKEN_PREFIX.length(), end);
+        final String root = roots.get(name);
+        if (root == null) {
+            return value;
+        }
+        final String relative = value.substring(end + TOKEN_SUFFIX.length());
+        if (relative.isEmpty()) {
+            return root;
+        }
+        return root + relative.replace('/', File.separatorChar);
+    }
+
+    private static boolean isUnder(String value, String prefix) {
+        if (prefix.isEmpty() || !value.startsWith(prefix)) {
+            return false;
+        }
+        if (value.length() == prefix.length()) {
+            return true;
+        }
+        final char next = value.charAt(prefix.length());
+        return next == '/' || next == '\\';
+    }
+
+    /**
+     * Applies a transformation to every string in a nested map/collection structure, returning a new
+     * structure and leaving the original untouched.
+     */
+    @SuppressWarnings("unchecked")
+    private static Object transform(Object value, UnaryOperator<String> transform) {
+        if (value instanceof Map) {
+            return mapValue((Map<String, Object>) value, transform);
+        }
+        if (value instanceof Collection) {
+            final Collection<Object> source = (Collection<Object>) value;
+            final List<Object> result = new ArrayList<>(source.size());
+            for (Object element : source) {
+                result.add(transform(element, transform));
+            }
+            return result;
+        }
+        if (value instanceof String s) {
+            return transform.apply(s);
+        }
+        return value;
+    }
+
+    private static Map<String, Object> mapValue(Map<String, Object> map,
+            UnaryOperator<String> transform) {
+        final Map<String, Object> result = new LinkedHashMap<>(map.size());
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            result.put(entry.getKey(), transform(entry.getValue(), transform));
+        }
+        return result;
+    }
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ApplicationModelRelocation.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ApplicationModelRelocation.java
@@ -341,6 +341,36 @@ public class ApplicationModelRelocation {
         return result;
     }
 
+    /**
+     * Replaces every occurrence of a root's location inside {@code text} with that root's token.
+     * <p>
+     * This is for callers that need a checkout-independent rendering of a value which <em>contains</em>
+     * paths rather than being one - the {@code toString()} of a descriptor used as a build cache key,
+     * for instance. {@link #relocate(Map, Collection)} tokenizes whole values and is what the serialized
+     * model itself uses; this one substitutes anywhere in the text and records nothing, so the result
+     * cannot be resolved back and is only useful as a hash input.
+     *
+     * @param text the text to rewrite
+     * @param roots roots whose locations should be replaced by their tokens, in any order
+     * @return the text with every root location replaced by its token
+     */
+    public static String tokenizeOccurrences(String text, Collection<Root> roots) {
+        if (text == null || roots.isEmpty()) {
+            return text;
+        }
+        // a longer root first, so that a root nested inside another one wins, as in relocate()
+        final List<Root> ordered = new ArrayList<>(roots);
+        ordered.sort((a, b) -> Integer.compare(b.path().toString().length(), a.path().toString().length()));
+        String result = text;
+        for (Root root : ordered) {
+            final String location = root.path().toString();
+            if (!location.isEmpty()) {
+                result = result.replace(location, root.token());
+            }
+        }
+        return result;
+    }
+
     private static String tokenize(String value, List<Root> roots) {
         for (Root root : roots) {
             final String prefix = root.path().toString();

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ApplicationModelRelocation.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ApplicationModelRelocation.java
@@ -104,6 +104,17 @@ public class ApplicationModelRelocation {
             recordedRoots.add(root.name());
         }
         relocated.put(RELOCATION_ROOTS, recordedRoots);
+
+        // the root of the build is the one root a reader cannot derive, so record how far above the
+        // project directory it sits; that offset is the same wherever the project is checked out
+        final Path projectDir = pathOf(ordered, PROJECT_DIR_ROOT);
+        final Path rootDir = pathOf(ordered, ROOT_DIR_ROOT);
+        if (projectDir != null && rootDir != null) {
+            final int depth = depthBetween(rootDir, projectDir);
+            if (depth >= 0) {
+                relocated.put(ROOT_DIR_DEPTH, String.valueOf(depth));
+            }
+        }
         return relocated;
     }
 
@@ -132,9 +143,22 @@ public class ApplicationModelRelocation {
         for (Root root : roots) {
             resolved.put(root.name(), root.path().toString());
         }
+        // a reader that recovered the project directory but was not told the root of the build can
+        // rebuild it from the recorded offset, rather than leaving sibling modules unresolved
+        if (!resolved.containsKey(ROOT_DIR_ROOT)) {
+            final String projectDir = resolved.get(PROJECT_DIR_ROOT);
+            final Object depth = model.get(ROOT_DIR_DEPTH);
+            if (projectDir != null && depth != null) {
+                final Path rootDir = parentOf(Path.of(projectDir), depth.toString());
+                if (rootDir != null) {
+                    resolved.put(ROOT_DIR_ROOT, rootDir.toString());
+                }
+            }
+        }
 
         final Map<String, Object> absolute = new LinkedHashMap<>(mapValue(model, s -> resolve(s, resolved)));
         absolute.remove(RELOCATION_ROOTS);
+        absolute.remove(ROOT_DIR_DEPTH);
         return absolute;
     }
 
@@ -179,8 +203,21 @@ public class ApplicationModelRelocation {
 
     /**
      * Name of the root standing for the root directory of a multi-module build.
+     * <p>
+     * Unlike the other roots, this one cannot be derived by a reader on its own, so it is recorded as
+     * the number of directory levels between the project directory and the root of the build - a
+     * relative offset that survives relocation - rather than being guessed or written out absolutely.
+     *
+     * @see #ROOT_DIR_DEPTH
      */
     public static final String ROOT_DIR_ROOT = "quarkus.root.dir";
+
+    /**
+     * Key under which the distance from the project directory up to the root of the build is recorded,
+     * so that {@link #ROOT_DIR_ROOT} can be resolved by a reader that only recovered the project
+     * directory from the model's location.
+     */
+    public static final String ROOT_DIR_DEPTH = "relocation-root-dir-depth";
 
     /**
      * The roots a serialized model can be resolved against knowing nothing but where the file is: the
@@ -207,10 +244,10 @@ public class ApplicationModelRelocation {
         final Path projectDir = buildDir.getParent();
         if (projectDir != null) {
             roots.add(new Root(PROJECT_DIR_ROOT, projectDir));
-            // in a single-module build the project is the root of the build; a multi-module build has
-            // to pass its own roots, since the root cannot be recovered from the file's location
-            roots.add(new Root(ROOT_DIR_ROOT, projectDir));
         }
+        // deliberately no ROOT_DIR_ROOT: the root of the build cannot be recovered from the model's
+        // location, and guessing the project directory would silently resolve a sibling module's jar
+        // to a path nested under this module. A caller that knows the root passes it explicitly.
         return roots;
     }
 
@@ -224,6 +261,43 @@ public class ApplicationModelRelocation {
             return;
         }
         roots.add(new Root(name, path));
+    }
+
+    private static Path pathOf(List<Root> roots, String name) {
+        for (Root root : roots) {
+            if (root.name().equals(name)) {
+                return root.path();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The number of directory levels from {@code child} up to {@code ancestor}, or -1 if {@code child}
+     * is not under {@code ancestor}.
+     */
+    private static int depthBetween(Path ancestor, Path child) {
+        if (!child.startsWith(ancestor)) {
+            return -1;
+        }
+        return ancestor.relativize(child).getNameCount();
+    }
+
+    /**
+     * Walks {@code levels} directories up from {@code path}, or null if that is not possible.
+     */
+    private static Path parentOf(Path path, String levels) {
+        final int count;
+        try {
+            count = Integer.parseInt(levels);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+        Path result = path;
+        for (int i = 0; i < count && result != null; i++) {
+            result = result.getParent();
+        }
+        return result;
     }
 
     private static String tokenize(String value, List<Root> roots) {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ApplicationModelRelocation.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ApplicationModelRelocation.java
@@ -94,6 +94,17 @@ public class ApplicationModelRelocation {
         // a longer root first, so that a root nested inside another one wins
         final List<Root> ordered = new ArrayList<>(roots);
         ordered.sort((a, b) -> Integer.compare(b.path().toString().length(), a.path().toString().length()));
+        // Two roots sharing a name but not a location would tokenize by one and resolve by the other,
+        // silently producing a path that points somewhere else. There is no sensible way to pick
+        // between them, so refuse rather than guess.
+        final Map<String, Path> byName = new LinkedHashMap<>();
+        for (Root root : ordered) {
+            final Path previous = byName.putIfAbsent(root.name(), root.path());
+            if (previous != null && !previous.equals(root.path())) {
+                throw new IllegalArgumentException("Conflicting definitions of relocation root "
+                        + root.name() + ": " + previous + " and " + root.path());
+            }
+        }
 
         final Map<String, Object> relocated = new LinkedHashMap<>(mapValue(model, s -> tokenize(s, ordered)));
         // only the names of the roots are recorded, never their locations: a recorded location would be
@@ -174,6 +185,22 @@ public class ApplicationModelRelocation {
     public static final String GRADLE_USER_HOME_ROOT = "quarkus.gradle.user.home";
 
     /**
+     * Prefix of the names standing for the root directories of builds included in the one a model was
+     * produced for. An included build lies outside the root directory, so it needs a root of its own.
+     * <p>
+     * They are numbered by the order the build declares them, which is stable for a given build and
+     * independent of where any of it is checked out.
+     */
+    public static final String INCLUDED_BUILD_ROOT_PREFIX = "quarkus.included.build.";
+
+    /**
+     * The name of the root standing for the included build at the given index.
+     */
+    public static String includedBuildRoot(int index) {
+        return INCLUDED_BUILD_ROOT_PREFIX + index;
+    }
+
+    /**
      * The roots that can be derived from the environment alone, and are therefore available to any
      * reader of a model without having to be told about them: the local Maven repository and the Gradle
      * home. Both honour the standard overrides and fall back to their conventional locations under the
@@ -249,6 +276,28 @@ public class ApplicationModelRelocation {
         // location, and guessing the project directory would silently resolve a sibling module's jar
         // to a path nested under this module. A caller that knows the root passes it explicitly.
         return roots;
+    }
+
+    /**
+     * Combines the roots a reader can derive from its environment with roots the caller knows better,
+     * letting the caller's definition replace the derived one of the same name.
+     * <p>
+     * A build tool knows where its dependency cache actually is; the environment is only a guess at it.
+     * Passing both would leave two definitions of one name, which {@link #relocate(Map, Collection)}
+     * rejects.
+     *
+     * @param known roots the caller is authoritative about
+     * @return the environment roots, with any of the same name replaced by the caller's
+     */
+    public static List<Root> withEnvironmentRoots(Collection<Root> known) {
+        final Map<String, Root> byName = new LinkedHashMap<>();
+        for (Root root : environmentRoots()) {
+            byName.put(root.name(), root);
+        }
+        for (Root root : known) {
+            byName.put(root.name(), root);
+        }
+        return new ArrayList<>(byName.values());
     }
 
     private static void addRoot(List<Root> roots, String name, String configured, Supplier<Path> fallback) {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ApplicationModelRelocation.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ApplicationModelRelocation.java
@@ -39,6 +39,14 @@ import io.quarkus.bootstrap.util.PropertyUtils;
  * Both directions are no-ops when no roots apply, and a model written without the {@value #RELOCATION_ROOTS}
  * entry - by an older version, or with relocation disabled - is read back unchanged, so the format stays
  * compatible in both directions.
+ * <p>
+ * Artifacts contributed by a build included through {@code includeBuild(...)} are deliberately left
+ * absolute. Such a build lies outside the root directory at a location the including build chooses
+ * freely - a sibling directory, or somewhere else entirely - so, unlike {@link #ROOT_DIR_ROOT}, no offset
+ * from the project directory recovers it, and a reader handed nothing but the model's path (what a forked
+ * test or dev JVM gets) could not resolve the root however it were recorded. The cost is that composite
+ * builds keep checkout-dependent models and miss the build cache; the alternative, a token no reader can
+ * resolve, breaks the build outright.
  */
 public class ApplicationModelRelocation {
 
@@ -183,22 +191,6 @@ public class ApplicationModelRelocation {
      * Name of the root standing for the Gradle home, whose dependency cache Gradle resolves to.
      */
     public static final String GRADLE_USER_HOME_ROOT = "quarkus.gradle.user.home";
-
-    /**
-     * Prefix of the names standing for the root directories of builds included in the one a model was
-     * produced for. An included build lies outside the root directory, so it needs a root of its own.
-     * <p>
-     * They are numbered by the order the build declares them, which is stable for a given build and
-     * independent of where any of it is checked out.
-     */
-    public static final String INCLUDED_BUILD_ROOT_PREFIX = "quarkus.included.build.";
-
-    /**
-     * The name of the root standing for the included build at the given index.
-     */
-    public static String includedBuildRoot(int index) {
-        return INCLUDED_BUILD_ROOT_PREFIX + index;
-    }
 
     /**
      * The roots that can be derived from the environment alone, and are therefore available to any

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ApplicationModelSerializer.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ApplicationModelSerializer.java
@@ -92,7 +92,9 @@ public class ApplicationModelSerializer {
         if (JOS) {
             serializeWithJos(model, serializedModel);
         } else {
-            writeJson(toJsonObjectBuilder(model.asMap()), serializedModel);
+            writeJson(toJsonObjectBuilder(
+                    ApplicationModelRelocation.relocate(model.asMap(), ApplicationModelRelocation.environmentRoots())),
+                    serializedModel);
         }
         return serializedModel;
     }
@@ -119,11 +121,31 @@ public class ApplicationModelSerializer {
      * @throws IOException in case of a failure
      */
     public static void serialize(ApplicationModel appModel, Path file) throws IOException {
+        serialize(appModel, file, ApplicationModelRelocation.environmentRoots());
+    }
+
+    /**
+     * Serializes an {@link ApplicationModel} to a file, expressing the absolute paths it contains
+     * relative to the given roots.
+     * <p>
+     * Recording paths relative to well-known roots makes the serialized model independent of where the
+     * project and the dependency repositories sit on disk, so that identical inputs serialize to
+     * identical bytes. See {@link ApplicationModelRelocation}.
+     *
+     * @param appModel application model to serialize
+     * @param file target file
+     * @param roots roots to express the model's absolute paths relative to
+     * @throws IOException in case of a failure
+     */
+    public static void serialize(ApplicationModel appModel, Path file, Collection<ApplicationModelRelocation.Root> roots)
+            throws IOException {
         Files.createDirectories(file.getParent());
         if (JOS) {
+            // Java Object Serialization writes the model's object graph directly, so there is no map
+            // representation to rewrite; such a model is simply not relocatable
             serializeWithJos(appModel, file);
         } else {
-            toJson(appModel, file);
+            toJson(appModel, file, roots);
         }
     }
 
@@ -135,7 +157,25 @@ public class ApplicationModelSerializer {
      * @throws IOException in case of a failure
      */
     public static ApplicationModel deserialize(Path file) throws IOException {
-        return JOS ? deserializeWithJos(file) : fromJson(file);
+        return deserialize(file, ApplicationModelRelocation.rootsForModelAt(file));
+    }
+
+    /**
+     * Deserializes an {@link ApplicationModel} from a given file, resolving the relocation tokens it may
+     * contain against the given roots.
+     * <p>
+     * A caller that knows where the project sits - a build tool does - should pass its own roots in
+     * addition to {@link ApplicationModelRelocation#environmentRoots()}. Tokens whose root is not among
+     * them are left unresolved rather than pointed at a wrong location.
+     *
+     * @param file file to deserialize the application model from
+     * @param roots roots to resolve relocation tokens against
+     * @return deserialized application model
+     * @throws IOException in case of a failure
+     */
+    public static ApplicationModel deserialize(Path file, Collection<ApplicationModelRelocation.Root> roots)
+            throws IOException {
+        return JOS ? deserializeWithJos(file) : fromJson(file, roots);
     }
 
     /**
@@ -173,8 +213,12 @@ public class ApplicationModelSerializer {
      * @param file target file
      * @throws IOException in case of a failure
      */
-    private static void toJson(ApplicationModel appModel, Path file) throws IOException {
-        writeJson((Json.JsonObjectBuilder) appModel.asMap(JSON_CONTAINER_FACTORY), file);
+    private static void toJson(ApplicationModel appModel, Path file, Collection<ApplicationModelRelocation.Root> roots)
+            throws IOException {
+        final Map<String, Object> map = appModel.asMap(JSON_CONTAINER_FACTORY);
+        final Map<String, Object> relocated = ApplicationModelRelocation.relocate(map, roots);
+        // relocate() copies into plain maps, so the result has to be converted back to JSON builders
+        writeJson(relocated == map ? (Json.JsonObjectBuilder) map : toJsonObjectBuilder(relocated), file);
     }
 
     /**
@@ -197,9 +241,10 @@ public class ApplicationModelSerializer {
      * @return deserialized application model
      * @throws IOException in case of a failure
      */
-    private static ApplicationModel fromJson(Path file) throws IOException {
+    private static ApplicationModel fromJson(Path file, Collection<ApplicationModelRelocation.Root> roots)
+            throws IOException {
         final Map<String, Object> modelMap = asMap(JsonReader.of(Files.readString(file)).read());
-        return ApplicationModelBuilder.fromMap(modelMap);
+        return ApplicationModelBuilder.fromMap(ApplicationModelRelocation.absolutize(modelMap, roots));
     }
 
     /**

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/app/ApplicationModelRelocationTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/app/ApplicationModelRelocationTest.java
@@ -1,0 +1,127 @@
+package io.quarkus.bootstrap.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.model.ApplicationModelBuilder;
+import io.quarkus.bootstrap.model.PlatformImports;
+import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
+
+class ApplicationModelRelocationTest {
+
+    @TempDir
+    Path tempDir;
+
+    /**
+     * The point of the exercise: the same model, built in two different places, has to serialize to the
+     * same bytes.
+     */
+    @Test
+    void modelsFromDifferentCheckoutsSerializeIdentically() throws IOException {
+        Path checkoutA = tempDir.resolve("slot-a");
+        Path checkoutB = tempDir.resolve("slot-b");
+
+        String serializedA = serializeAt(checkoutA);
+        String serializedB = serializeAt(checkoutB);
+
+        assertThat(serializedA).isEqualTo(serializedB);
+        assertThat(serializedA).doesNotContain(checkoutA.toString(), checkoutB.toString());
+    }
+
+    /**
+     * A relocated model has to come back with paths that are absolute again, and correct for the
+     * environment reading it.
+     */
+    @Test
+    void relocatedModelIsResolvedBackToAbsolutePaths() throws IOException {
+        Path checkout = tempDir.resolve("slot-a");
+        Path file = tempDir.resolve("model-a.dat");
+        ApplicationModelSerializer.serialize(modelAt(checkout), file, roots(checkout));
+
+        ApplicationModel deserialized = ApplicationModelSerializer.deserialize(file, roots(checkout));
+
+        assertThat(deserialized.getAppArtifact().getResolvedPaths().getSinglePath())
+                .isEqualTo(checkout.resolve("target/classes"));
+    }
+
+    /**
+     * The same serialized model read against a different project location resolves to that location -
+     * this is what makes a cache entry produced elsewhere usable here.
+     */
+    @Test
+    void relocatedModelIsResolvedAgainstTheReadingEnvironment() throws IOException {
+        Path writtenAt = tempDir.resolve("slot-a");
+        Path readAt = tempDir.resolve("slot-b");
+        Path file = tempDir.resolve("model.dat");
+        ApplicationModelSerializer.serialize(modelAt(writtenAt), file, roots(writtenAt));
+
+        ApplicationModel deserialized = ApplicationModelSerializer.deserialize(file, roots(readAt));
+
+        assertThat(deserialized.getAppArtifact().getResolvedPaths().getSinglePath())
+                .isEqualTo(readAt.resolve("target/classes"));
+    }
+
+    /**
+     * A model written before relocation existed, or with it disabled, carries no roots and has to be read
+     * back exactly as it is.
+     */
+    @Test
+    void modelWithoutRelocationIsReadUnchanged() throws IOException {
+        Path checkout = tempDir.resolve("slot-a");
+        Path file = tempDir.resolve("model-absolute.dat");
+        ApplicationModelSerializer.serialize(modelAt(checkout), file, List.of());
+
+        assertThat(Files.readString(file))
+                .contains(checkout.toString())
+                .doesNotContain(ApplicationModelRelocation.RELOCATION_ROOTS);
+
+        ApplicationModel deserialized = ApplicationModelSerializer.deserialize(file, roots(checkout));
+        assertThat(deserialized.getAppArtifact().getResolvedPaths().getSinglePath())
+                .isEqualTo(checkout.resolve("target/classes"));
+    }
+
+    /**
+     * Only the names of the roots may be recorded: writing their locations would put the checkout
+     * directory straight back into the file.
+     */
+    @Test
+    void recordedRootsCarryNamesOnly() throws IOException {
+        Path checkout = tempDir.resolve("slot-a");
+        Path file = tempDir.resolve("model.dat");
+        ApplicationModelSerializer.serialize(modelAt(checkout), file, roots(checkout));
+
+        assertThat(Files.readString(file))
+                .contains(ApplicationModelRelocation.RELOCATION_ROOTS)
+                .doesNotContain(checkout.toString());
+    }
+
+    private String serializeAt(Path checkout) throws IOException {
+        Path file = tempDir.resolve(checkout.getFileName() + ".dat");
+        ApplicationModelSerializer.serialize(modelAt(checkout), file, roots(checkout));
+        return Files.readString(file);
+    }
+
+    private static List<ApplicationModelRelocation.Root> roots(Path projectDir) {
+        return List.of(new ApplicationModelRelocation.Root("quarkus.project.dir", projectDir));
+    }
+
+    private static ApplicationModel modelAt(Path projectDir) {
+        return new ApplicationModelBuilder()
+                .setAppArtifact(ResolvedDependencyBuilder.newInstance()
+                        .setGroupId("com.example")
+                        .setArtifactId("my-app")
+                        .setVersion("1.0.0")
+                        .setResolvedPath(projectDir.resolve("target/classes")))
+                .setPlatformImports(PlatformImports.fromMap(Collections.emptyMap()))
+                .build();
+    }
+}

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/app/ApplicationModelRelocationTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/app/ApplicationModelRelocationTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.io.TempDir;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.model.ApplicationModelBuilder;
 import io.quarkus.bootstrap.model.PlatformImports;
+import io.quarkus.maven.dependency.DependencyFlags;
 import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
 
 class ApplicationModelRelocationTest {
@@ -102,6 +103,50 @@ class ApplicationModelRelocationTest {
         assertThat(Files.readString(file))
                 .contains(ApplicationModelRelocation.RELOCATION_ROOTS)
                 .doesNotContain(checkout.toString());
+    }
+
+    /**
+     * A reader that has nothing but the model's path - a forked test or dev JVM - must resolve a
+     * sibling module's jar correctly in a multi-module build.
+     * <p>
+     * Regression test: the root of the build used to be guessed as the project directory, which
+     * silently resolved {@code <root>/common/build/libs/common.jar} to
+     * {@code <root>/application/common/build/libs/common.jar} - a path that does not exist.
+     */
+    @Test
+    void siblingModuleJarResolvesForAReaderThatOnlyHasThePath() throws IOException {
+        Path rootDir = tempDir.resolve("build-root");
+        Path projectDir = rootDir.resolve("application");
+        Path buildDir = projectDir.resolve("build");
+        Path siblingJar = rootDir.resolve("common/build/libs/common.jar");
+        Path modelFile = buildDir.resolve("quarkus/application-model/quarkus-app-model.dat");
+
+        ApplicationModel model = new ApplicationModelBuilder()
+                .setAppArtifact(ResolvedDependencyBuilder.newInstance()
+                        .setGroupId("com.example")
+                        .setArtifactId("application")
+                        .setVersion("1.0.0")
+                        .setResolvedPath(buildDir.resolve("classes/java/main")))
+                .addDependency(ResolvedDependencyBuilder.newInstance()
+                        .setGroupId("com.example")
+                        .setArtifactId("common")
+                        .setVersion("1.0.0")
+                        .setResolvedPath(siblingJar)
+                        .setFlags(DependencyFlags.DEPLOYMENT_CP))
+                .setPlatformImports(PlatformImports.fromMap(Collections.emptyMap()))
+                .build();
+
+        ApplicationModelSerializer.serialize(model, modelFile, List.of(
+                new ApplicationModelRelocation.Root(ApplicationModelRelocation.BUILD_DIR_ROOT, buildDir),
+                new ApplicationModelRelocation.Root(ApplicationModelRelocation.PROJECT_DIR_ROOT, projectDir),
+                new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT, rootDir)));
+
+        // deserialize(Path) is what a forked JVM uses: roots derived from the file's location alone
+        ApplicationModel deserialized = ApplicationModelSerializer.deserialize(modelFile);
+
+        assertThat(deserialized.getDependencies())
+                .singleElement()
+                .satisfies(d -> assertThat(d.getResolvedPaths().getSinglePath()).isEqualTo(siblingJar));
     }
 
     private String serializeAt(Path checkout) throws IOException {

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/app/ApplicationModelRelocationTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/app/ApplicationModelRelocationTest.java
@@ -159,12 +159,14 @@ class ApplicationModelRelocationTest {
      */
     @Test
     void conflictingDefinitionsOfARootAreRejected() {
+        Path a = tempDir.resolve("a");
+        Path b = tempDir.resolve("b");
         Map<String, Object> model = new LinkedHashMap<>();
-        model.put("p", "/a/foo.jar");
+        model.put("p", a.resolve("foo.jar").toString());
 
         assertThatThrownBy(() -> ApplicationModelRelocation.relocate(model, List.of(
-                new ApplicationModelRelocation.Root("quarkus.project.dir", Path.of("/a")),
-                new ApplicationModelRelocation.Root("quarkus.project.dir", Path.of("/b")))))
+                new ApplicationModelRelocation.Root("quarkus.project.dir", a),
+                new ApplicationModelRelocation.Root("quarkus.project.dir", b))))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("quarkus.project.dir");
     }
@@ -175,12 +177,13 @@ class ApplicationModelRelocationTest {
      */
     @Test
     void repeatingARootWithTheSameLocationIsAccepted() {
+        Path a = tempDir.resolve("a");
         Map<String, Object> model = new LinkedHashMap<>();
-        model.put("p", "/a/foo.jar");
+        model.put("p", a.resolve("foo.jar").toString());
 
         Map<String, Object> relocated = ApplicationModelRelocation.relocate(model, List.of(
-                new ApplicationModelRelocation.Root("quarkus.project.dir", Path.of("/a")),
-                new ApplicationModelRelocation.Root("quarkus.project.dir", Path.of("/a"))));
+                new ApplicationModelRelocation.Root("quarkus.project.dir", a),
+                new ApplicationModelRelocation.Root("quarkus.project.dir", a)));
 
         assertThat(relocated.get("p")).isEqualTo("${quarkus.project.dir}/foo.jar");
     }
@@ -191,7 +194,7 @@ class ApplicationModelRelocationTest {
      */
     @Test
     void callerRootsReplaceTheEnvironmentOnesOfTheSameName() {
-        Path gradleHome = Path.of("/custom/gradle-home");
+        Path gradleHome = tempDir.resolve("custom-gradle-home");
 
         List<ApplicationModelRelocation.Root> roots = ApplicationModelRelocation.withEnvironmentRoots(List.of(
                 new ApplicationModelRelocation.Root(ApplicationModelRelocation.GRADLE_USER_HOME_ROOT, gradleHome)));

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/app/ApplicationModelRelocationTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/app/ApplicationModelRelocationTest.java
@@ -1,12 +1,15 @@
 package io.quarkus.bootstrap.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -147,6 +150,97 @@ class ApplicationModelRelocationTest {
         assertThat(deserialized.getDependencies())
                 .singleElement()
                 .satisfies(d -> assertThat(d.getResolvedPaths().getSinglePath()).isEqualTo(siblingJar));
+    }
+
+    /**
+     * Two definitions of one root name would tokenize by one and resolve by the other, silently
+     * producing a path pointing somewhere else. There is no way to choose between them, so relocation
+     * refuses rather than guesses.
+     */
+    @Test
+    void conflictingDefinitionsOfARootAreRejected() {
+        Map<String, Object> model = new LinkedHashMap<>();
+        model.put("p", "/a/foo.jar");
+
+        assertThatThrownBy(() -> ApplicationModelRelocation.relocate(model, List.of(
+                new ApplicationModelRelocation.Root("quarkus.project.dir", Path.of("/a")),
+                new ApplicationModelRelocation.Root("quarkus.project.dir", Path.of("/b")))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("quarkus.project.dir");
+    }
+
+    /**
+     * The same root named twice with the same location is redundant, not contradictory, and must be
+     * accepted - {@code withEnvironmentRoots} relies on it being harmless.
+     */
+    @Test
+    void repeatingARootWithTheSameLocationIsAccepted() {
+        Map<String, Object> model = new LinkedHashMap<>();
+        model.put("p", "/a/foo.jar");
+
+        Map<String, Object> relocated = ApplicationModelRelocation.relocate(model, List.of(
+                new ApplicationModelRelocation.Root("quarkus.project.dir", Path.of("/a")),
+                new ApplicationModelRelocation.Root("quarkus.project.dir", Path.of("/a"))));
+
+        assertThat(relocated.get("p")).isEqualTo("${quarkus.project.dir}/foo.jar");
+    }
+
+    /**
+     * A caller that knows a root better than the environment does replaces it, rather than adding a
+     * second definition of the same name.
+     */
+    @Test
+    void callerRootsReplaceTheEnvironmentOnesOfTheSameName() {
+        Path gradleHome = Path.of("/custom/gradle-home");
+
+        List<ApplicationModelRelocation.Root> roots = ApplicationModelRelocation.withEnvironmentRoots(List.of(
+                new ApplicationModelRelocation.Root(ApplicationModelRelocation.GRADLE_USER_HOME_ROOT, gradleHome)));
+
+        assertThat(roots)
+                .filteredOn(r -> r.name().equals(ApplicationModelRelocation.GRADLE_USER_HOME_ROOT))
+                .singleElement()
+                .satisfies(r -> assertThat(r.path()).isEqualTo(gradleHome));
+        // the environment roots it does not override are still there
+        assertThat(roots).anySatisfy(r -> assertThat(r.name()).isEqualTo(ApplicationModelRelocation.LOCAL_REPO_ROOT));
+    }
+
+    /**
+     * An included build lies outside the root directory of the build including it, so its artifacts
+     * need a root of their own or they stay absolute and keep the model checkout-dependent.
+     */
+    @Test
+    void includedBuildArtifactsAreRelocated() throws IOException {
+        Path rootDir = tempDir.resolve("main-build");
+        Path includedBuild = tempDir.resolve("shared-lib");
+        Path jar = includedBuild.resolve("lib/build/libs/lib.jar");
+        Path file = tempDir.resolve("included.dat");
+
+        ApplicationModel model = new ApplicationModelBuilder()
+                .setAppArtifact(ResolvedDependencyBuilder.newInstance()
+                        .setGroupId("com.example")
+                        .setArtifactId("app")
+                        .setVersion("1.0.0")
+                        .setResolvedPath(rootDir.resolve("build/classes")))
+                .addDependency(ResolvedDependencyBuilder.newInstance()
+                        .setGroupId("com.example")
+                        .setArtifactId("lib")
+                        .setVersion("1.0.0")
+                        .setResolvedPath(jar)
+                        .setFlags(DependencyFlags.DEPLOYMENT_CP))
+                .setPlatformImports(PlatformImports.fromMap(Collections.emptyMap()))
+                .build();
+
+        List<ApplicationModelRelocation.Root> roots = List.of(
+                new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT, rootDir),
+                new ApplicationModelRelocation.Root(ApplicationModelRelocation.includedBuildRoot(0), includedBuild));
+        ApplicationModelSerializer.serialize(model, file, roots);
+
+        assertThat(Files.readString(file)).doesNotContain(asJson(includedBuild));
+
+        ApplicationModel deserialized = ApplicationModelSerializer.deserialize(file, roots);
+        assertThat(deserialized.getDependencies())
+                .singleElement()
+                .satisfies(d -> assertThat(d.getResolvedPaths().getSinglePath()).isEqualTo(jar));
     }
 
     private String serializeAt(Path checkout) throws IOException {

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/app/ApplicationModelRelocationTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/app/ApplicationModelRelocationTest.java
@@ -35,7 +35,7 @@ class ApplicationModelRelocationTest {
         String serializedB = serializeAt(checkoutB);
 
         assertThat(serializedA).isEqualTo(serializedB);
-        assertThat(serializedA).doesNotContain(checkoutA.toString(), checkoutB.toString());
+        assertThat(serializedA).doesNotContain(asJson(checkoutA), asJson(checkoutB));
     }
 
     /**
@@ -82,7 +82,7 @@ class ApplicationModelRelocationTest {
         ApplicationModelSerializer.serialize(modelAt(checkout), file, List.of());
 
         assertThat(Files.readString(file))
-                .contains(checkout.toString())
+                .contains(asJson(checkout))
                 .doesNotContain(ApplicationModelRelocation.RELOCATION_ROOTS);
 
         ApplicationModel deserialized = ApplicationModelSerializer.deserialize(file, roots(checkout));
@@ -102,7 +102,7 @@ class ApplicationModelRelocationTest {
 
         assertThat(Files.readString(file))
                 .contains(ApplicationModelRelocation.RELOCATION_ROOTS)
-                .doesNotContain(checkout.toString());
+                .doesNotContain(asJson(checkout));
     }
 
     /**
@@ -153,6 +153,15 @@ class ApplicationModelRelocationTest {
         Path file = tempDir.resolve(checkout.getFileName() + ".dat");
         ApplicationModelSerializer.serialize(modelAt(checkout), file, roots(checkout));
         return Files.readString(file);
+    }
+
+    /**
+     * A path as it appears inside the serialized JSON. On Windows the separators are escaped, so a raw
+     * {@link Path#toString()} never occurs verbatim in the file and asserting on one would pass or fail
+     * for the wrong reason.
+     */
+    private static String asJson(Path path) {
+        return path.toString().replace("\\", "\\\\");
     }
 
     private static List<ApplicationModelRelocation.Root> roots(Path projectDir) {

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/app/ApplicationModelRelocationTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/app/ApplicationModelRelocationTest.java
@@ -246,6 +246,62 @@ class ApplicationModelRelocationTest {
                 .satisfies(d -> assertThat(d.getResolvedPaths().getSinglePath()).isEqualTo(jar));
     }
 
+    /**
+     * A reader that knows every root except the included builds resolves the rest of the model and
+     * leaves the included build's artifact as a token, which then fails far from its cause - the path
+     * is relative, so it silently picks up the working directory as a prefix.
+     * <p>
+     * Every root the writer uses therefore has to be handed to the reader as well. The tasks that read
+     * a model back get the included builds from the same helper the writing task uses, so the roots
+     * line up by position.
+     */
+    @Test
+    void includedBuildArtifactsNeedTheirRootOnTheReadingSideToo() throws IOException {
+        Path rootDir = tempDir.resolve("main-build");
+        Path includedBuild = tempDir.resolve("shared-lib");
+        Path jar = includedBuild.resolve("lib/build/libs/lib.jar");
+        Path file = tempDir.resolve("included-reader.dat");
+
+        ApplicationModel model = new ApplicationModelBuilder()
+                .setAppArtifact(ResolvedDependencyBuilder.newInstance()
+                        .setGroupId("com.example")
+                        .setArtifactId("app")
+                        .setVersion("1.0.0")
+                        .setResolvedPath(rootDir.resolve("build/classes")))
+                .addDependency(ResolvedDependencyBuilder.newInstance()
+                        .setGroupId("com.example")
+                        .setArtifactId("lib")
+                        .setVersion("1.0.0")
+                        .setResolvedPath(jar)
+                        .setFlags(DependencyFlags.DEPLOYMENT_CP))
+                .setPlatformImports(PlatformImports.fromMap(Collections.emptyMap()))
+                .build();
+
+        ApplicationModelSerializer.serialize(model, file, List.of(
+                new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT, rootDir),
+                new ApplicationModelRelocation.Root(ApplicationModelRelocation.includedBuildRoot(0), includedBuild)));
+
+        // the root of the build alone, as a reader that forgot the included builds would have it
+        ApplicationModel withoutIncludedBuild = ApplicationModelSerializer.deserialize(file, List.of(
+                new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT, rootDir)));
+        assertThat(withoutIncludedBuild.getDependencies())
+                .singleElement()
+                .satisfies(d -> assertThat(d.getResolvedPaths().getSinglePath().toString())
+                        .as("an unresolved token is what breaks the build, far from here")
+                        .contains(ApplicationModelRelocation.includedBuildRoot(0)));
+
+        // the same roots the writer used resolve it, wherever the included build now sits
+        Path movedRoot = tempDir.resolve("moved-root");
+        Path movedInclude = tempDir.resolve("moved-lib");
+        ApplicationModel relocated = ApplicationModelSerializer.deserialize(file, List.of(
+                new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT, movedRoot),
+                new ApplicationModelRelocation.Root(ApplicationModelRelocation.includedBuildRoot(0), movedInclude)));
+        assertThat(relocated.getDependencies())
+                .singleElement()
+                .satisfies(d -> assertThat(d.getResolvedPaths().getSinglePath())
+                        .isEqualTo(movedInclude.resolve("lib/build/libs/lib.jar")));
+    }
+
     private String serializeAt(Path checkout) throws IOException {
         Path file = tempDir.resolve(checkout.getFileName() + ".dat");
         ApplicationModelSerializer.serialize(modelAt(checkout), file, roots(checkout));

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/app/ApplicationModelRelocationTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/app/ApplicationModelRelocationTest.java
@@ -211,8 +211,15 @@ class ApplicationModelRelocationTest {
      * An included build lies outside the root directory of the build including it, so its artifacts
      * need a root of their own or they stay absolute and keep the model checkout-dependent.
      */
+    /**
+     * A build included through {@code includeBuild(...)} sits outside the root directory at a location
+     * the including build chooses freely, so no offset recovers it and a reader holding only the model's
+     * path - a forked test or dev JVM - could not resolve a token for it. Its artifacts are therefore
+     * left absolute: the model stays checkout-dependent and misses the cache, which beats writing a
+     * token that breaks the build for every reader.
+     */
     @Test
-    void includedBuildArtifactsAreRelocated() throws IOException {
+    void includedBuildArtifactsAreLeftAbsolute() throws IOException {
         Path rootDir = tempDir.resolve("main-build");
         Path includedBuild = tempDir.resolve("shared-lib");
         Path jar = includedBuild.resolve("lib/build/libs/lib.jar");
@@ -234,72 +241,18 @@ class ApplicationModelRelocationTest {
                 .build();
 
         List<ApplicationModelRelocation.Root> roots = List.of(
-                new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT, rootDir),
-                new ApplicationModelRelocation.Root(ApplicationModelRelocation.includedBuildRoot(0), includedBuild));
+                new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT, rootDir));
         ApplicationModelSerializer.serialize(model, file, roots);
 
-        assertThat(Files.readString(file)).doesNotContain(asJson(includedBuild));
+        // written as it is, so a reader that knows nothing of the included build still resolves it
+        assertThat(Files.readString(file)).contains(asJson(jar));
 
-        ApplicationModel deserialized = ApplicationModelSerializer.deserialize(file, roots);
+        // and the path survives a reader with only the model's location to go on, which is the case
+        // that a token for the included build would have broken
+        ApplicationModel deserialized = ApplicationModelSerializer.deserialize(file);
         assertThat(deserialized.getDependencies())
                 .singleElement()
                 .satisfies(d -> assertThat(d.getResolvedPaths().getSinglePath()).isEqualTo(jar));
-    }
-
-    /**
-     * A reader that knows every root except the included builds resolves the rest of the model and
-     * leaves the included build's artifact as a token, which then fails far from its cause - the path
-     * is relative, so it silently picks up the working directory as a prefix.
-     * <p>
-     * Every root the writer uses therefore has to be handed to the reader as well. The tasks that read
-     * a model back get the included builds from the same helper the writing task uses, so the roots
-     * line up by position.
-     */
-    @Test
-    void includedBuildArtifactsNeedTheirRootOnTheReadingSideToo() throws IOException {
-        Path rootDir = tempDir.resolve("main-build");
-        Path includedBuild = tempDir.resolve("shared-lib");
-        Path jar = includedBuild.resolve("lib/build/libs/lib.jar");
-        Path file = tempDir.resolve("included-reader.dat");
-
-        ApplicationModel model = new ApplicationModelBuilder()
-                .setAppArtifact(ResolvedDependencyBuilder.newInstance()
-                        .setGroupId("com.example")
-                        .setArtifactId("app")
-                        .setVersion("1.0.0")
-                        .setResolvedPath(rootDir.resolve("build/classes")))
-                .addDependency(ResolvedDependencyBuilder.newInstance()
-                        .setGroupId("com.example")
-                        .setArtifactId("lib")
-                        .setVersion("1.0.0")
-                        .setResolvedPath(jar)
-                        .setFlags(DependencyFlags.DEPLOYMENT_CP))
-                .setPlatformImports(PlatformImports.fromMap(Collections.emptyMap()))
-                .build();
-
-        ApplicationModelSerializer.serialize(model, file, List.of(
-                new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT, rootDir),
-                new ApplicationModelRelocation.Root(ApplicationModelRelocation.includedBuildRoot(0), includedBuild)));
-
-        // the root of the build alone, as a reader that forgot the included builds would have it
-        ApplicationModel withoutIncludedBuild = ApplicationModelSerializer.deserialize(file, List.of(
-                new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT, rootDir)));
-        assertThat(withoutIncludedBuild.getDependencies())
-                .singleElement()
-                .satisfies(d -> assertThat(d.getResolvedPaths().getSinglePath().toString())
-                        .as("an unresolved token is what breaks the build, far from here")
-                        .contains(ApplicationModelRelocation.includedBuildRoot(0)));
-
-        // the same roots the writer used resolve it, wherever the included build now sits
-        Path movedRoot = tempDir.resolve("moved-root");
-        Path movedInclude = tempDir.resolve("moved-lib");
-        ApplicationModel relocated = ApplicationModelSerializer.deserialize(file, List.of(
-                new ApplicationModelRelocation.Root(ApplicationModelRelocation.ROOT_DIR_ROOT, movedRoot),
-                new ApplicationModelRelocation.Root(ApplicationModelRelocation.includedBuildRoot(0), movedInclude)));
-        assertThat(relocated.getDependencies())
-                .singleElement()
-                .satisfies(d -> assertThat(d.getResolvedPaths().getSinglePath())
-                        .isEqualTo(movedInclude.resolve("lib/build/libs/lib.jar")));
     }
 
     private String serializeAt(Path checkout) throws IOException {


### PR DESCRIPTION
Fixes #56214, as an alternative to #56215.

#56215 fixes the problem inside the Gradle plugin by having the two consuming tasks declare the
model's cache-relevant content instead of the file itself. This PR fixes it at the source: the
serialized application model no longer contains absolute paths, so it is checkout-independent for
every tool that reads it. That also makes `QuarkusApplicationModelTask` itself cacheable, which the
other approach cannot do.

## Relocating the model

Paths are written relative to a named root:

```
/home/ci/slot-3/app/build/classes   ->  ${quarkus.build.dir}/classes
/home/ci/.gradle/caches/foo.jar     ->  ${quarkus.gradle.user.home}/caches/foo.jar
```

Only the root *names* are recorded, never their locations — recording the locations would leave the
absolute paths in the file and defeat the purpose. On read, tokens are resolved against the reading
environment: project and build directories are recovered from the model file's own location,
environment roots from `maven.repo.local` / `GRADLE_USER_HOME`, and callers that know better pass
their own (a multi-module Gradle build contributes the root of the build; `DevMojo` contributes the
local repository Maven actually resolved from `settings.xml`, and passes it to the dev JVM so both
sides agree).

This matters because `BootstrapAppModelFactory` calls bare `deserialize(Path)` in forked JVMs
(`test`, `quarkusIntTest`, dev mode), where nothing about the build is available.

Artifacts of included builds are deliberately left absolute. An included build's location cannot be
derived by a reader — `includeBuild("../shared-lib")` and `includeBuild("/opt/corp/shared")` are both
valid and unrelated to the including build's layout — so a token there could never be resolved. Those
models stay checkout-dependent and miss the cache, which is the cheap failure; an unresolvable token
would break the build instead.

## Making the producer cacheable

`QuarkusApplicationModelTask` is `@DisableCachingByDefault`, so it re-resolves the whole Quarkus
classpath on every build of every module. A relocatable model is what its *output* needed to be
cacheable; three of its *inputs* also had to stop depending on where the project sat on disk, or on
when a file happened to be written.

**The project descriptor carried absolute paths.** `getProjectDescriptor()` was an `@Input`, and what
Gradle hashes for it is its `toString()` — which contains the module directory and the source and
output roots. It is now `@Internal`, with `getProjectDescriptorFingerprint()` contributing the same
information through the relocation roots above.

**That fingerprint has to be stable within one machine, too.** `WorkspaceModule` holds its source sets
in a `HashMap`, so the descriptor can render them in a different order from one JVM to the next.
Without sorting, two builds of an untouched project produced different keys.

**The deployment classpath snapshot mixed in modification times:**

```java
+ artifact.getFile().lastModified() + "|"
+ artifact.getFile().length() + "|"
```

The comment above it explained the reasoning and named the assumption it rested on — the task was not
cacheable, so a timestamp was a fair local up-to-date check. It is not a fair cache key. A sibling
module's jar rebuilt in another checkout has identical content and a different mtime, which was enough
to make a multi-module build miss. The length stays; what the artifacts *contain* is already hashed by
`getOriginalClasspath()`, which is `@CompileClasspath`.

The last two are defects in their own right, independent of relocation: a timestamp in a cache key,
and a `HashMap` rendered into one.

## Trade-offs versus #56215

- The wire format changes, so the Gradle plugin and `quarkus-bootstrap-core` have to ship together.
  A new plugin against an older bootstrap leaves `${...}` unresolved and fails with
  `${quarkus.build.dir}/... does not exist`. Two mitigations are possible — tolerate unresolved
  tokens on read, or gate token writing behind a flag — but both are decisions about the supported
  version floor, so I have not made them here.
- `ApplicationModelSerializer` is shared with Maven and the CLI, so the blast radius is larger than
  #56215's. Maven does not content-hash the `.dat`, so it pays the cost without the benefit.
- In exchange, relocation applies to the whole model rather than an enumerated set of fields. A field
  missed by #56215's enumeration is a key that is too weak — a stale cache hit; a root missed here is
  only a cache miss. And the producer task becomes cacheable, which #56215 leaves untouched.

## Testing

- `ApplicationModelRelocationTest` covers round-tripping, unresolved tokens, conflicting roots and
  included builds.
- `CachingTest` gains a relocation case; the Quarkus application is moved into an `app` subproject
  with a sibling `library`, because with the application as the root project a sibling's jar already
  falls under the project directory and the case cannot fail. It also asserts that the model task
  itself is served from the cache, which fails if any of the three input changes is reverted.
- Verified against a real multi-module project built from two different directories sharing one build
  cache: the model task, `quarkusGenerateCode` and `quarkusAppPartsBuild` produce identical keys and
  hit the cache, generated sources are byte-identical, and adding or removing a real dependency still
  changes the key.

The change to `EagerResolutionTaskTest` is a consequence of the fix rather than an unrelated edit.
That test asserts `:quarkusGenerateCode` ends in `SUCCESS`, which only held because the task's cache
key embedded the project directory: each parameter runs in its own temporary directory, so none of
them could ever hit the cache. With a relocatable key the later parameters resolve the entry produced
by the first and end in `FROM_CACHE`. Both outcomes mean the task did not fail, which is what the
test is asserting.
