### PR TITLE
Jar packaging includes zip dependencies

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractJarBuilder.java
@@ -299,7 +299,7 @@ public abstract class AbstractJarBuilder<T extends BuildItem> implements JarBuil
      */
     protected static boolean includeAppDependency(ResolvedDependency appDep, Optional<Set<ArtifactKey>> optionalDependencies,
             Set<ArtifactKey> removedArtifacts) {
-        if (!appDep.isJar()) {
+        if (!appDep.isJarOrZip()) {
             return false;
         }
         if (appDep.isOptional()) {

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ZipDependencyFastJarTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ZipDependencyFastJarTest.java
@@ -1,0 +1,21 @@
+package io.quarkus.deployment.runnerjar;
+
+import io.quarkus.bootstrap.resolver.TsArtifact;
+
+public class ZipDependencyFastJarTest extends BootstrapFromOriginalJarTestBase {
+
+    @Override
+    protected TsArtifact composeApplication() {
+        final TsArtifact zipDep = TsArtifact.zip("zip-dep");
+        addToExpectedLib(zipDep);
+
+        final TsArtifact jarDep = TsArtifact.jar("jar-dep");
+        addToExpectedLib(jarDep);
+
+        return TsArtifact.jar("app")
+                .addManagedDependency(platformDescriptor())
+                .addManagedDependency(platformProperties())
+                .addDependency(zipDep)
+                .addDependency(jarDep);
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ZipDependencyLegacyJarTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ZipDependencyLegacyJarTest.java
@@ -1,0 +1,63 @@
+package io.quarkus.deployment.runnerjar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import io.quarkus.bootstrap.app.AugmentResult;
+import io.quarkus.bootstrap.app.CuratedApplication;
+import io.quarkus.bootstrap.app.QuarkusBootstrap;
+import io.quarkus.bootstrap.resolver.TsArtifact;
+
+public class ZipDependencyLegacyJarTest extends BootstrapFromOriginalJarTestBase {
+
+    @Override
+    protected TsArtifact composeApplication() {
+        final TsArtifact zipDep = TsArtifact.zip("zip-dep");
+        final TsArtifact jarDep = TsArtifact.jar("jar-dep");
+
+        return TsArtifact.jar("app")
+                .addManagedDependency(platformDescriptor())
+                .addManagedDependency(platformProperties())
+                .addDependency(zipDep)
+                .addDependency(jarDep);
+    }
+
+    @Override
+    protected void testBootstrap(QuarkusBootstrap creator) throws Exception {
+        final CuratedApplication curated = creator.bootstrap();
+        AugmentResult app = curated.createAugmentor().createProductionApplication();
+        final Path libDir = app.getJar().getLibraryDir();
+        assertTrue(Files.isDirectory(libDir));
+        final Set<String> actualLib = getDirContent(libDir);
+        assertThat(actualLib).contains(
+                "io.quarkus.bootstrap.test.zip-dep-1.zip",
+                "io.quarkus.bootstrap.test.jar-dep-1.jar");
+    }
+
+    protected Set<String> getDirContent(Path dir) throws IOException {
+        final Set<String> content = new HashSet<>();
+        try (Stream<Path> stream = Files.list(dir)) {
+            final Iterator<Path> i = stream.iterator();
+            while (i.hasNext()) {
+                content.add(i.next().getFileName().toString());
+            }
+        }
+        return content;
+    }
+
+    @Override
+    protected Properties buildSystemProperties() {
+        var props = new Properties();
+        props.setProperty("quarkus.package.jar.type", "legacy-jar");
+        return props;
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ZipDependencyMutableJarTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ZipDependencyMutableJarTest.java
@@ -1,0 +1,12 @@
+package io.quarkus.deployment.runnerjar;
+
+import java.util.Properties;
+
+public class ZipDependencyMutableJarTest extends ZipDependencyFastJarTest {
+    @Override
+    protected Properties buildSystemProperties() {
+        var props = new Properties();
+        props.setProperty("quarkus.package.jar.type", "mutable-jar");
+        return props;
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ZipDependencyUberJarTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ZipDependencyUberJarTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.deployment.runnerjar;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import io.quarkus.bootstrap.app.AugmentResult;
+import io.quarkus.bootstrap.app.CuratedApplication;
+import io.quarkus.bootstrap.app.QuarkusBootstrap;
+import io.quarkus.bootstrap.resolver.TsArtifact;
+
+public class ZipDependencyUberJarTest extends BootstrapFromOriginalJarTestBase {
+
+    @Override
+    protected TsArtifact composeApplication() {
+        final TsArtifact zipDep = TsArtifact.zip("zip-dep");
+        final TsArtifact jarDep = TsArtifact.jar("jar-dep");
+
+        return TsArtifact.jar("app")
+                .addManagedDependency(platformDescriptor())
+                .addManagedDependency(platformProperties())
+                .addDependency(zipDep)
+                .addDependency(jarDep);
+    }
+
+    @Override
+    protected void testBootstrap(QuarkusBootstrap creator) throws Exception {
+        final CuratedApplication curated = creator.bootstrap();
+        AugmentResult app = curated.createAugmentor().createProductionApplication();
+        final Path runnerJar = app.getJar().getPath();
+        assertTrue(Files.exists(runnerJar));
+
+        try (JarFile jar = new JarFile(runnerJar.toFile())) {
+            JarEntry zipDepEntry = jar
+                    .getJarEntry("META-INF/maven/io.quarkus.bootstrap.test/zip-dep/pom.properties");
+            assertNotNull(zipDepEntry, "Expected zip-dep's content to be merged into the uber jar");
+
+            JarEntry jarDepEntry = jar
+                    .getJarEntry("META-INF/maven/io.quarkus.bootstrap.test/jar-dep/pom.properties");
+            assertNotNull(jarDepEntry, "Expected jar-dep's content to be merged into the uber jar");
+        }
+    }
+
+    @Override
+    protected Properties buildSystemProperties() {
+        var props = new Properties();
+        props.setProperty("quarkus.package.jar.type", "uber-jar");
+        return props;
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildDependencies.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildDependencies.java
@@ -174,7 +174,7 @@ public abstract class QuarkusBuildDependencies extends QuarkusBuildTask {
         appModel.getRuntimeDependencies().stream()
                 .filter(appDep -> {
                     // copied from io.quarkus.deployment.pkg.steps.JarResultBuildStep.includeAppDep
-                    if (!appDep.isJar()) {
+                    if (!appDep.isJarOrZip()) {
                         return false;
                     }
                     if (filterOptionalDependencies && appDep.isOptional()) {

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -1167,7 +1167,7 @@ public class DevMojo extends AbstractMojo {
     }
 
     private void addProject(DevModeCommandLineBuilder builder, ResolvedDependency module, boolean root) throws Exception {
-        if (!module.isJar()) {
+        if (!module.isJarOrZip()) {
             return;
         }
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactCoords.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactCoords.java
@@ -24,6 +24,7 @@ public interface ArtifactCoords {
 
     String TYPE_JAR = "jar";
     String TYPE_POM = "pom";
+    String TYPE_ZIP = "zip";
     String DEFAULT_CLASSIFIER = "";
 
     String getGroupId();
@@ -40,6 +41,10 @@ public interface ArtifactCoords {
 
     default boolean isJar() {
         return TYPE_JAR.equals(getType());
+    }
+
+    default boolean isJarOrZip() {
+        return isJar() || TYPE_ZIP.equals(getType());
     }
 
     default boolean isSnapshot() {

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedDependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedDependency.java
@@ -84,7 +84,7 @@ public interface ResolvedDependency extends Dependency {
         }
         if (paths.isSinglePath()) {
             final Path p = paths.getSinglePath();
-            return isJar() ? PathTree.ofDirectoryOrArchive(p, pathFilter) : PathTree.ofDirectoryOrFile(p, pathFilter);
+            return isJarOrZip() ? PathTree.ofDirectoryOrArchive(p, pathFilter) : PathTree.ofDirectoryOrFile(p, pathFilter);
         }
         final PathTree[] trees = new PathTree[paths.size()];
         int i = 0;

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
@@ -181,7 +181,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
      */
     private synchronized void processCpElement(ResolvedDependency artifact, Consumer<ClassPathElement> consumer,
             boolean useCpeCache) {
-        if (!artifact.isJar()) {
+        if (!artifact.isJarOrZip()) {
             //avoid the need for this sort of check in multiple places
             consumer.accept(ClassPathElement.EMPTY);
             return;
@@ -404,7 +404,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
     }
 
     private boolean isReloadableRuntimeDependency(ResolvedDependency dependency) {
-        return dependency.isRuntimeCp() && dependency.isJar() &&
+        return dependency.isRuntimeCp() && dependency.isJarOrZip() &&
                 (dependency.isReloadable() && appModel.getReloadableWorkspaceDependencies().contains(dependency.getKey()) ||
                         configuredClassLoading.isReloadableArtifact(dependency.getKey()));
     }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/devmode/DependenciesFilter.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/devmode/DependenciesFilter.java
@@ -20,7 +20,7 @@ public class DependenciesFilter {
         final Map<ArtifactKey, WorkspaceDependencies> modules = new HashMap<>();
         StringBuilder nonReloadable = null;
         for (ResolvedDependency d : appModel.getDependencies()) {
-            if (!d.isJar()) {
+            if (!d.isJarOrZip()) {
                 continue;
             }
             if (d.isReloadable()) {

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/TsArtifact.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/TsArtifact.java
@@ -25,6 +25,7 @@ public class TsArtifact {
     public static final String DEFAULT_VERSION = "1";
 
     public static final String TYPE_JAR = "jar";
+    public static final String TYPE_ZIP = "zip";
     public static final String TYPE_POM = "pom";
     public static final String TYPE_TXT = "txt";
 
@@ -50,6 +51,14 @@ public class TsArtifact {
 
     public static TsArtifact jar(String groupId, String artifactId, String version) {
         return new TsArtifact(groupId, artifactId, EMPTY, TYPE_JAR, version);
+    }
+
+    public static TsArtifact zip(String artifactId) {
+        return zip(artifactId, DEFAULT_VERSION);
+    }
+
+    public static TsArtifact zip(String artifactId, String version) {
+        return new TsArtifact(DEFAULT_GROUP_ID, artifactId, EMPTY, TYPE_ZIP, version);
     }
 
     public static TsArtifact pom(String artifactId) {

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/TsRepoBuilder.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/TsRepoBuilder.java
@@ -59,6 +59,7 @@ public class TsRepoBuilder {
         if (p == null) {
             switch (artifact.type) {
                 case TsArtifact.TYPE_JAR:
+                case TsArtifact.TYPE_ZIP:
                     try {
                         p = newJar()
                                 .addMavenMetadata(artifact, pomXml)


### PR DESCRIPTION
Jar packaging only accepted dependencies with `<type>jar</type>`, silently dropping `<type>zip</type>` deps from the runtime classpath. Added `ArtifactCoords.isJarOrZip()` next to the existing `isJar()` and swapped it in at the classpath-inclusion checks discussed in the issue (`AbstractJarBuilder`, `ResolvedDependency#getContentTree`, `CuratedApplication`, `DependenciesFilter`, `DevMojo`, and the Gradle equivalent). `pom` stays excluded as agreed.

Added a test per jar type (fast/legacy/mutable/uber) and confirmed each fails without the fix. Also manually built and ran a sample app with a zip dependency across all four packaging types to make sure the class actually loads at runtime, not just sits in the output dir.

* Fixes #49855