### PR TITLE
Include ConfigSource name when reporting unknown or deprecated configurations

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
@@ -27,7 +27,6 @@ import io.quarkus.runtime.ValueRegistryConfigSource;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.configuration.AbstractConfigBuilder;
 import io.quarkus.runtime.configuration.ConfigDiagnostic;
-import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.runtime.configuration.NameIterator;
 import io.quarkus.runtime.configuration.PropertiesUtil;
 import io.quarkus.runtime.configuration.QuarkusConfigFactory;
@@ -53,12 +52,6 @@ public final class RunTimeConfigurationGenerator {
     public static final MethodDescriptor C_RUN_TIME_CONFIG = ofMethod(CONFIG_CLASS_NAME,
             "runtimeConfig", void.class, ValueRegistry.class);
 
-    static final MethodDescriptor CD_IS_ERROR = ofMethod(ConfigDiagnostic.class,
-            "isError", boolean.class);
-    static final MethodDescriptor CD_GET_ERROR_KEYS = ofMethod(ConfigDiagnostic.class,
-            "getErrorKeys", Set.class);
-    static final MethodDescriptor CD_RESET_ERROR = ofMethod(ConfigDiagnostic.class,
-            "resetError", void.class);
     static final MethodDescriptor CD_REPORT_UNKNOWN = ofMethod(ConfigDiagnostic.class,
             "reportUnknown", void.class, Set.class);
     static final MethodDescriptor CD_REPORT_UNKNOWN_RUNTIME = ofMethod(ConfigDiagnostic.class,
@@ -71,12 +64,6 @@ public final class RunTimeConfigurationGenerator {
     static final MethodDescriptor NI_NEW_STRING = ofConstructor(NameIterator.class, String.class);
     static final MethodDescriptor NI_HAS_NEXT = ofMethod(NameIterator.class, "hasNext", boolean.class);
     static final MethodDescriptor NI_NEXT = ofMethod(NameIterator.class, "next", void.class);
-
-    static final MethodDescriptor OBJ_TO_STRING = ofMethod(Object.class, "toString", String.class);
-
-    static final MethodDescriptor SB_NEW = ofConstructor(StringBuilder.class);
-    static final MethodDescriptor SB_APPEND_STRING = ofMethod(StringBuilder.class,
-            "append", StringBuilder.class, String.class);
 
     static final MethodDescriptor QCF_SET_CONFIG = ofMethod(QuarkusConfigFactory.class,
             "setConfig", void.class, SmallRyeConfig.class);
@@ -198,30 +185,6 @@ public final class RunTimeConfigurationGenerator {
             // generate sweep for clinit
             configSweepLoop(mc, config, getRegisteredRoots(RUN_TIME), unknownSet);
             mc.invokeStaticMethod(CD_REPORT_UNKNOWN_RUNTIME, unknownSet);
-
-            final BytecodeCreator isError = mc.ifNonZero(mc.invokeStaticMethod(CD_IS_ERROR)).trueBranch();
-            ResultHandle niceErrorMessage = isError
-                    .invokeStaticMethod(
-                            ofMethod(ConfigDiagnostic.class, "getNiceErrorMessage", String.class));
-            ResultHandle errorKeys = isError.invokeStaticMethod(CD_GET_ERROR_KEYS);
-            isError.invokeStaticMethod(CD_RESET_ERROR);
-
-            // throw the proper exception
-            final ResultHandle finalErrorMessageBuilder = isError.newInstance(SB_NEW);
-            isError.invokeVirtualMethod(SB_APPEND_STRING, finalErrorMessageBuilder, isError
-                    .load("One or more configuration errors have prevented the application from starting. The errors are:\n"));
-            isError.invokeVirtualMethod(SB_APPEND_STRING, finalErrorMessageBuilder, niceErrorMessage);
-            final ResultHandle finalErrorMessage = isError.invokeVirtualMethod(OBJ_TO_STRING, finalErrorMessageBuilder);
-            final ResultHandle configurationException = isError
-                    .newInstance(ofConstructor(ConfigurationException.class, String.class, Set.class),
-                            finalErrorMessage, errorKeys);
-            final ResultHandle emptyStackTraceElement = isError.newArray(StackTraceElement.class, 0);
-            // empty out the stack trace in order to not make the configuration errors more visible (the stack trace contains generated classes anyway that don't provide any value)
-            isError.invokeVirtualMethod(
-                    ofMethod(ConfigurationException.class, "setStackTrace", void.class,
-                            StackTraceElement[].class),
-                    configurationException, emptyStackTraceElement);
-            isError.throwException(configurationException);
 
             mc.returnValue(null);
             mc.close();

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
@@ -13,11 +13,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Consumer;
 
 import org.eclipse.microprofile.config.Config;
@@ -36,32 +33,7 @@ import io.smallrye.config.common.utils.StringUtil;
 public final class ConfigDiagnostic {
     private static final Logger log = Logger.getLogger("io.quarkus.config");
 
-    private static final List<String> errorsMessages = new CopyOnWriteArrayList<>();
-    private static final Set<String> errorKeys = new CopyOnWriteArraySet<>();
-
     private ConfigDiagnostic() {
-    }
-
-    public static void invalidValue(String name, IllegalArgumentException ex) {
-        final String message = ex.getMessage();
-        final String loggedMessage = message != null ? message
-                : String.format("An invalid value was given for configuration key \"%s\"", name);
-        errorsMessages.add(loggedMessage);
-        errorKeys.add(name);
-    }
-
-    public static void missingValue(String name, NoSuchElementException ex) {
-        final String message = ex.getMessage();
-        final String loggedMessage = message != null ? message
-                : String.format("Configuration key \"%s\" is required, but its value is empty/missing", name);
-        errorsMessages.add(loggedMessage);
-        errorKeys.add(name);
-    }
-
-    public static void duplicate(String name) {
-        final String loggedMessage = String.format("Configuration key \"%s\" was specified more than once", name);
-        errorsMessages.add(loggedMessage);
-        errorKeys.add(name);
     }
 
     public static void deprecatedProperties(Map<String, String> deprecatedProperties) {
@@ -70,28 +42,31 @@ public final class ConfigDiagnostic {
             String propertyName = entry.getKey();
             ConfigValue configValue = config.getConfigValue(propertyName);
             if (configValue.getValue() != null && !configValue.isDefault()) {
-                ConfigDiagnostic.deprecated(propertyName, entry.getValue());
+                ConfigDiagnostic.deprecated(configValue, entry.getValue());
             }
         }
     }
 
-    public static void deprecated(String name, String javadoc) {
+    static void deprecated(ConfigValue configValue, String javadoc) {
         if (javadoc != null) {
-            log.warnf("The \"%s\" config property is deprecated and should not be used anymore. Deprecated message: %s", name,
-                    javadoc);
+            log.warnf("""
+                    Deprecated configuration property %s provided in %s; \
+                    this property is deprecated and should not be used anymore; Deprecated message: %s""",
+                    configValue.getName(), configValue.getConfigSourceName(), javadoc);
         } else {
-            log.warnf("The \"%s\" config property is deprecated and should not be used anymore.", name);
+            log.warnf("""
+                    Deprecated configuration property %s provided in %s; \
+                    this property is deprecated and should not be used anymore""",
+                    configValue.getName(), configValue.getConfigSourceName());
         }
     }
 
-    public static void unknown(String name) {
-        log.warnf(
-                "Unrecognized configuration key \"%s\" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo",
-                name);
-    }
-
-    public static void unknown(NameIterator name) {
-        unknown(name.getName());
+    static void unknown(ConfigValue configValue) {
+        log.warnf("""
+                Unrecognized configuration property %s provided in %s; \
+                it will be ignored; verify that the dependency extension for this configuration is set \
+                or that you did not make a typo""",
+                configValue.getName(), configValue.getConfigSourceName());
     }
 
     /**
@@ -153,51 +128,28 @@ public final class ConfigDiagnostic {
             if (!found) {
                 ConfigValue configValue = config.getConfigValue(property);
                 if (property.equals(configValue.getName())) {
-                    unknown(property);
+                    unknown(configValue);
                 }
             }
         }
     }
 
+    /**
+     * Used to generate bytecode by RunTimeConfigurationGenerator.
+     */
+    @SuppressWarnings("unused")
     public static void reportUnknown(Set<String> properties) {
         if (ImageMode.current() == ImageMode.NATIVE_BUILD) {
             unknownProperties(properties);
         }
     }
 
+    /**
+     * Used to generate bytecode by RunTimeConfigurationGenerator.
+     */
+    @SuppressWarnings("unused")
     public static void reportUnknownRuntime(Set<String> properties) {
         unknownProperties(properties);
-    }
-
-    /**
-     * Determine if a fatal configuration error has occurred.
-     *
-     * @return {@code true} if a fatal configuration error has occurred
-     */
-    public static boolean isError() {
-        return !errorsMessages.isEmpty();
-    }
-
-    /**
-     * Reset the config error status (for e.g. testing).
-     */
-    public static void resetError() {
-        errorKeys.clear();
-        errorsMessages.clear();
-    }
-
-    public static String getNiceErrorMessage() {
-        StringBuilder b = new StringBuilder();
-        for (String errorsMessage : errorsMessages) {
-            b.append("  - ");
-            b.append(errorsMessage);
-            b.append(System.lineSeparator());
-        }
-        return b.toString();
-    }
-
-    public static Set<String> getErrorKeys() {
-        return new HashSet<>(errorKeys);
     }
 
     private static final String APPLICATION = "application";

--- a/extensions/config-yaml/deployment/src/test/java/io/quarkus/config/yaml/deployment/UnknownQuarkusConfigPropertyTest.java
+++ b/extensions/config-yaml/deployment/src/test/java/io/quarkus/config/yaml/deployment/UnknownQuarkusConfigPropertyTest.java
@@ -23,7 +23,7 @@ public class UnknownQuarkusConfigPropertyTest {
             .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
             .assertLogRecords(logRecords -> assertTrue(logRecords.stream()
                     .map(LogRecord::getMessage)
-                    .anyMatch(message -> message.startsWith("Unrecognized configuration key"))));;
+                    .anyMatch(message -> message.startsWith("Unrecognized configuration property"))));;
 
     @Test
     void unknownConfig() {

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/offline/DevServicesOfflineStartTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/offline/DevServicesOfflineStartTest.java
@@ -21,7 +21,7 @@ public class DevServicesOfflineStartTest {
             .assertLogRecords(records -> {
                 assertThat(records) // Configuration keys mispelled
                         .extracting(LogRecord::getMessage)
-                        .noneMatch(msg -> msg.contains("Unrecognized configuration key"));
+                        .noneMatch(msg -> msg.contains("Unrecognized configuration property"));
             });
 
     @Test

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/offline/StartOfflineSchemaManagementTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/offline/StartOfflineSchemaManagementTest.java
@@ -30,7 +30,7 @@ public class StartOfflineSchemaManagementTest {
             .assertLogRecords(records -> {
                 assertThat(records) // Configuration keys mispelled
                         .extracting(LogRecord::getMessage)
-                        .noneMatch(msg -> msg.contains("Unrecognized configuration key"));
+                        .noneMatch(msg -> msg.contains("Unrecognized configuration property"));
             })
             .assertException(
                     throwable -> assertThat(throwable)

--- a/extensions/kubernetes/openshift/deployment/src/test/java/io/quarkus/openshift/deployment/config/OpenShiftConfigFallbackTest.java
+++ b/extensions/kubernetes/openshift/deployment/src/test/java/io/quarkus/openshift/deployment/config/OpenShiftConfigFallbackTest.java
@@ -38,7 +38,7 @@ public class OpenShiftConfigFallbackTest {
     void configFallback() throws Exception {
         List<LogRecord> logRecords = prodModeTestResults.getRetainedBuildLogRecords();
         Set<Object> unrecognized = logRecords.stream()
-                .filter(logRecord -> logRecord.getMessage().startsWith("Unrecognized configuration key"))
+                .filter(logRecord -> logRecord.getMessage().startsWith("Unrecognized configuration property"))
                 .map(logRecord -> Optional.ofNullable(logRecord.getParameters())
                         .map(parameters -> parameters[0])
                         .orElse(new Object[0]))

--- a/extensions/resteasy-classic/resteasy-client/deployment/src/test/java/io/quarkus/restclient/configuration/UnknownConfigTest.java
+++ b/extensions/resteasy-classic/resteasy-client/deployment/src/test/java/io/quarkus/restclient/configuration/UnknownConfigTest.java
@@ -24,7 +24,7 @@ public class UnknownConfigTest {
             .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
             .assertLogRecords(logRecords -> assertFalse(logRecords.stream()
                     .map(LogRecord::getMessage)
-                    .anyMatch(message -> message.startsWith("Unrecognized configuration key"))));
+                    .anyMatch(message -> message.startsWith("Unrecognized configuration property"))));
 
     @Inject
     RestClientsConfig restClientsConfig;

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/DeprecatedPropertiesTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/DeprecatedPropertiesTest.java
@@ -18,12 +18,14 @@ public class DeprecatedPropertiesTest {
             .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
             .assertLogRecords(logRecords -> {
                 List<LogRecord> deprecatedProperties = logRecords.stream()
-                        .filter(l -> l.getMessage().contains("config property is deprecated"))
+                        .filter(l -> l.getMessage().contains("Deprecated configuration property"))
                         .toList();
 
                 assertEquals(2, deprecatedProperties.size());
-                assertTrue(deprecatedProperties.get(0).getParameters()[0].toString().contains("quarkus.mapping.bt.deprecated"));
-                assertTrue(deprecatedProperties.get(1).getParameters()[0].toString().contains("quarkus.mapping.rt.deprecated"));
+                assertEquals("quarkus.mapping.bt.deprecated", deprecatedProperties.get(0).getParameters()[0]);
+                assertTrue(deprecatedProperties.get(0).getParameters()[1].toString().contains("application.properties"));
+                assertEquals("quarkus.mapping.rt.deprecated", deprecatedProperties.get(1).getParameters()[0]);
+                assertTrue(deprecatedProperties.get(0).getParameters()[1].toString().contains("application.properties"));
             });
 
     @Test

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/UnknownBuildConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/UnknownBuildConfigTest.java
@@ -1,12 +1,8 @@
 package io.quarkus.extest;
 
-import static java.util.stream.Collectors.toSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
@@ -32,15 +28,13 @@ public class UnknownBuildConfigTest {
 
         // These are the expected unknown properties in the test extension. This could probably be improved, because
         // these are generated with the rename test. If there is a change we know that something happened.
-        Set<Object> unrecognized = logRecords.stream()
-                .filter(logRecord -> logRecord.getMessage().startsWith("Unrecognized configuration key"))
-                .map(logRecord -> Optional.ofNullable(logRecord.getParameters())
-                        .map(parameters -> parameters[0])
-                        .orElse(new Object[0]))
-                .collect(toSet());
+        List<LogRecord> unrecognized = logRecords.stream()
+                .filter(logRecord -> logRecord.getMessage().startsWith("Unrecognized configuration property"))
+                .toList();
 
         assertEquals(2, unrecognized.size());
-        assertTrue(unrecognized.contains("quarkus.unknown.prop"));
-        assertTrue(unrecognized.contains("quarkus.build-time.unknown.prop"));
+        assertEquals("quarkus.build-time.unknown.prop", unrecognized.get(0).getParameters()[0]);
+        assertEquals("UnknownBuildPropertyConfigSource", unrecognized.get(0).getParameters()[1]);
+        assertEquals("quarkus.unknown.prop", unrecognized.get(1).getParameters()[0]);
     }
 }

--- a/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/unknown/UnknownBuildPropertyConfigSourceFactory.java
+++ b/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/unknown/UnknownBuildPropertyConfigSourceFactory.java
@@ -10,14 +10,16 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
 import io.smallrye.config.ConfigSourceContext;
 import io.smallrye.config.ConfigSourceFactory;
 import io.smallrye.config.ConfigValue;
-import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.common.MapBackedConfigSource;
 
 public class UnknownBuildPropertyConfigSourceFactory implements ConfigSourceFactory {
     @Override
     public Iterable<ConfigSource> getConfigSources(final ConfigSourceContext context) {
         ConfigValue value = context.getValue("skip.build.sources");
         if (value.getValue() == null || value.getValue().equals("false")) {
-            return List.of(new PropertiesConfigSource(Map.of("quarkus.build-time.unknown.prop", "value"), "", 100));
+            return List.of(new MapBackedConfigSource("UnknownBuildPropertyConfigSource",
+                    Map.of("quarkus.build-time.unknown.prop", "value")) {
+            });
         } else {
             return emptyList();
         }


### PR DESCRIPTION
When Quarkus warns about an unknown or deprecated configuration property, the log message now also reports which ConfigSource the property came from — making it easier to trace where a misconfiguration originates (inspired by #56198). 

Also removed leftovers from the old `ConfigRoot` implementation.