### PR TITLE
[3.33] Upgrade SmallRye GraphQL to 2.17.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -49,7 +49,7 @@
         <smallrye-config.version>3.16.0</smallrye-config.version>
         <smallrye-health.version>4.3.0</smallrye-health.version>
         <smallrye-open-api.version>4.2.4</smallrye-open-api.version>
-        <smallrye-graphql.version>2.17.0</smallrye-graphql.version>
+        <smallrye-graphql.version>2.17.1</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.10.1</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.3</smallrye-jwt.version>
         <smallrye-context-propagation.version>2.3.0</smallrye-context-propagation.version>


### PR DESCRIPTION
To fix [GHSA-jfgf-vvcv-mf69](https://github.com/smallrye/smallrye-graphql/security/advisories/GHSA-jfgf-vvcv-mf69)