### PR TITLE
Upgrade SmallRye GraphQL to 3.0.0.Beta7

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -51,7 +51,7 @@
         <smallrye-health.version>4.3.0</smallrye-health.version>
         <smallrye-modules.version>1.0.beta1</smallrye-modules.version>
         <smallrye-open-api.version>4.3.5</smallrye-open-api.version>
-        <smallrye-graphql.version>3.0.0.Beta6</smallrye-graphql.version>
+        <smallrye-graphql.version>3.0.0.Beta7</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.11.2</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.3</smallrye-jwt.version>
         <smallrye-context-propagation.version>2.3.0</smallrye-context-propagation.version>


### PR DESCRIPTION
To fix [GHSA-jfgf-vvcv-mf69](https://github.com/smallrye/smallrye-graphql/security/advisories/GHSA-jfgf-vvcv-mf69)