### PR TITLE
Implement RepositorySwitcher methods via CDI lookup

### DIFF
--- a/extensions/data/hibernate/deployment/src/test/java/io/quarkus/data/hibernate/deployment/test/FirstTest.java
+++ b/extensions/data/hibernate/deployment/src/test/java/io/quarkus/data/hibernate/deployment/test/FirstTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.data.hibernate.managed.blocking.BlockingManagedRepositoryBase;
+import io.quarkus.data.hibernate.stateless.blocking.BlockingRecordRepositoryBase;
 import io.quarkus.test.QuarkusExtensionTest;
 
 public class FirstTest {
@@ -17,7 +19,9 @@ public class FirstTest {
             .withApplicationRoot((jar) -> jar
                     .addAsResource("application-test.properties", "application.properties")
                     .addClasses(MyEntity.class, MyEntity_.class, MyEntity_.ManagedBlockingQueries_.class,
-                            MyEntity_.FindOnlyRepo_.class));
+                            MyEntity_.FindOnlyRepo_.class, MyEntity_.PanacheStatelessBlockingRepository_.class,
+                            MyEntity_.PanacheManagedReactiveRepository_.class,
+                            MyEntity_.PanacheStatelessReactiveRepository_.class));
 
     @Transactional
     void createOne() {
@@ -162,6 +166,26 @@ public class FirstTest {
                 Arc.container().select(MyEntity.FindOnlyRepo.class).getHandle().getBean().getScope());
     }
 
+    @Transactional
+    void repositorySwitching() {
+        MyEntity entity = new MyEntity();
+        entity.foo = "switch-test";
+        entity.id = 42L;
+        entity.statelessBlocking().insert();
+
+        var managedRepo = MyEntity_.managedBlocking();
+        Assertions.assertInstanceOf(BlockingManagedRepositoryBase.class, managedRepo);
+        Assertions.assertEquals(1, managedRepo.count());
+
+        var statelessRepo = managedRepo.statelessBlocking();
+        Assertions.assertInstanceOf(BlockingRecordRepositoryBase.class, statelessRepo);
+        Assertions.assertEquals(1, statelessRepo.count());
+
+        var managedAgain = statelessRepo.managedBlocking();
+        Assertions.assertInstanceOf(BlockingManagedRepositoryBase.class, managedAgain);
+        Assertions.assertEquals(1, managedAgain.count());
+    }
+
     @Test
     void testRepositories() {
         clear();
@@ -178,6 +202,8 @@ public class FirstTest {
         upsertExisting();
         upsertCheck();
         runQueries();
+        clear();
+        repositorySwitching();
     }
 
 }

--- a/extensions/data/hibernate/deployment/src/test/java/io/quarkus/data/hibernate/deployment/test/ReactiveTest.java
+++ b/extensions/data/hibernate/deployment/src/test/java/io/quarkus/data/hibernate/deployment/test/ReactiveTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.data.hibernate.managed.reactive.ReactiveManagedRepositoryBase;
+import io.quarkus.data.hibernate.stateless.reactive.ReactiveRecordRepositoryBase;
 import io.quarkus.hibernate.reactive.panache.common.WithTransaction;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.vertx.RunOnVertxContext;
@@ -20,7 +22,10 @@ public class ReactiveTest {
             .withApplicationRoot((jar) -> jar
                     .addAsResource("application-test.properties", "application.properties")
                     .addClasses(MyReactiveEntity.class, MyReactiveEntity_.class,
-                            MyReactiveEntity_.ManagedReactiveQueries_.class));
+                            MyReactiveEntity_.ManagedReactiveQueries_.class,
+                            MyReactiveEntity_.PanacheManagedBlockingRepository_.class,
+                            MyReactiveEntity_.PanacheStatelessBlockingRepository_.class,
+                            MyReactiveEntity_.PanacheStatelessReactiveRepository_.class));
 
     @WithTransaction
     Uni<Void> createOne() {
@@ -193,6 +198,41 @@ public class ReactiveTest {
                 .replaceWithVoid();
     }
 
+    @WithTransaction
+    Uni<Void> repositorySwitchingFromManaged() {
+        MyReactiveEntity entity = new MyReactiveEntity();
+        entity.foo = "switch-test";
+        return entity.persist()
+                .flatMap(v -> {
+                    var managedRepo = MyReactiveEntity_.managedReactive();
+                    Assertions.assertInstanceOf(ReactiveManagedRepositoryBase.class, managedRepo);
+                    var statelessRepo = managedRepo.statelessReactive();
+                    Assertions.assertInstanceOf(ReactiveRecordRepositoryBase.class, statelessRepo);
+                    var managedAgain = statelessRepo.managedReactive();
+                    Assertions.assertInstanceOf(ReactiveManagedRepositoryBase.class, managedAgain);
+                    return managedAgain.count();
+                })
+                .onItem().invoke(count -> Assertions.assertEquals(1L, count))
+                .replaceWithVoid();
+    }
+
+    @WithTransaction(stateless = true)
+    Uni<Void> repositorySwitchingFromStateless() {
+        return MyReactiveEntity_.statelessReactive().count()
+                .flatMap(count -> {
+                    Assertions.assertEquals(1L, count);
+                    var statelessRepo = MyReactiveEntity_.statelessReactive();
+                    Assertions.assertInstanceOf(ReactiveRecordRepositoryBase.class, statelessRepo);
+                    var managedRepo = statelessRepo.managedReactive();
+                    Assertions.assertInstanceOf(ReactiveManagedRepositoryBase.class, managedRepo);
+                    var statelessAgain = managedRepo.statelessReactive();
+                    Assertions.assertInstanceOf(ReactiveRecordRepositoryBase.class, statelessAgain);
+                    return statelessAgain.count();
+                })
+                .onItem().invoke(count -> Assertions.assertEquals(1L, count))
+                .replaceWithVoid();
+    }
+
     @Test
     void testRepositoryScopeIsApplicationScoped() {
         Assertions.assertEquals(ApplicationScoped.class,
@@ -216,6 +256,10 @@ public class ReactiveTest {
         asserter.execute(() -> upsertExisting());
         asserter.execute(() -> upsertCheck());
         asserter.execute(() -> runQueries());
+        asserter.execute(() -> clear());
+        asserter.execute(() -> repositorySwitchingFromManaged());
+        asserter.execute(() -> repositorySwitchingFromStateless());
+        asserter.execute(() -> clear());
     }
 
 }

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/RepositorySwitcher.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/RepositorySwitcher.java
@@ -1,5 +1,6 @@
 package io.quarkus.data.hibernate;
 
+import io.quarkus.arc.Arc;
 import io.quarkus.data.hibernate.managed.blocking.BlockingManagedRepositoryBase;
 import io.quarkus.data.hibernate.managed.reactive.ReactiveManagedRepositoryBase;
 import io.quarkus.data.hibernate.stateless.blocking.BlockingRecordRepositoryBase;
@@ -8,22 +9,41 @@ import io.quarkus.hibernate.orm.panache.common.runtime.AbstractJpaOperations;
 
 public interface RepositorySwitcher<Entity, Id> {
     default BlockingManagedRepositoryBase<Entity, Id> managedBlocking() {
-        // FIXME: generate in impl
-        throw AbstractJpaOperations.implementationInjectionMissing();
+        if (this instanceof BlockingManagedRepositoryBase) {
+            return (BlockingManagedRepositoryBase<Entity, Id>) this;
+        }
+        return findRepository(BlockingManagedRepositoryBase.class);
     }
 
     default ReactiveManagedRepositoryBase<Entity, Id> managedReactive() {
-        // FIXME: generate in impl
-        throw AbstractJpaOperations.implementationInjectionMissing();
+        if (this instanceof ReactiveManagedRepositoryBase) {
+            return (ReactiveManagedRepositoryBase<Entity, Id>) this;
+        }
+        return findRepository(ReactiveManagedRepositoryBase.class);
     }
 
     default BlockingRecordRepositoryBase<Entity, Id> statelessBlocking() {
-        // FIXME: generate in impl
-        throw AbstractJpaOperations.implementationInjectionMissing();
+        if (this instanceof BlockingRecordRepositoryBase) {
+            return (BlockingRecordRepositoryBase<Entity, Id>) this;
+        }
+        return findRepository(BlockingRecordRepositoryBase.class);
     }
 
     default ReactiveRecordRepositoryBase<Entity, Id> statelessReactive() {
-        // FIXME: generate in impl
-        throw AbstractJpaOperations.implementationInjectionMissing();
+        if (this instanceof ReactiveRecordRepositoryBase) {
+            return (ReactiveRecordRepositoryBase<Entity, Id>) this;
+        }
+        return findRepository(ReactiveRecordRepositoryBase.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T findRepository(Class<T> targetType) {
+        Class<?> entityClass = AbstractJpaOperations.getRepositoryEntityClass(getClass());
+        Class<? extends T> repoClass = AbstractJpaOperations.findRepositoryClass(entityClass, targetType);
+        if (repoClass == null) {
+            throw new IllegalStateException(
+                    "No " + targetType.getSimpleName() + " repository found for entity " + entityClass.getName());
+        }
+        return Arc.container().select(repoClass).get();
     }
 }

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
@@ -78,6 +78,16 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType extend
         return (Class<? extends Entity>) ret;
     }
 
+    @SuppressWarnings("unchecked")
+    public static <T> Class<? extends T> findRepositoryClass(Class<?> entityClass, Class<T> repositoryVariantType) {
+        for (Entry<Class<?>, Class<?>> entry : repositoryClassToEntityClass.entrySet()) {
+            if (entry.getValue().equals(entityClass) && repositoryVariantType.isAssignableFrom(entry.getKey())) {
+                return (Class<? extends T>) entry.getKey();
+            }
+        }
+        return null;
+    }
+
     //
     // Instance
 


### PR DESCRIPTION
Turns out to be much easier to implement than the entity switchers.

Each switching method short-circuits with instanceof when the repository is already the target variant, otherwise looks up the sibling repository bean for the same entity via the existing repositoryClassToEntityClass map and ArC container.

Fixes: #50171

