### PR TITLE
Improve example code for pausable channels

### DIFF
--- a/docs/src/main/asciidoc/messaging.adoc
+++ b/docs/src/main/asciidoc/messaging.adoc
@@ -397,16 +397,16 @@ public class PausableController {
     public void resume() {
         // Wait for the application to be ready
         // Retrieve the pausable channel
-        PausableChannel pausable = registry.getPausable("my-channel");
-        // Pause the processing of the messages
-        pausable.resume();
+        PausableChannel channel = registry.getPausable("my-channel");
+        // Resume the processing of the messages
+        channel.resume();
     }
 
     public void pause() {
         // Retrieve the pausable channel
-        PausableChannel pausable = registry.getPausable("my-channel");
+        PausableChannel channel = registry.getPausable("my-channel");
         // Pause the processing of the messages
-        pausable.pause();
+        channel.pause();
     }
 
     @Incoming("my-channel")


### PR DESCRIPTION
The example code for pausable channels contains a typo in line 401. I've fixed this and also improved readability by changing the variable name from "pausable" to simply "channel" which results in `channel.pause()` and `channel.resume()` on lines 402 and 409.  