### PR TITLE
Manage projectreactor in the bom, update to 3.8.7

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -225,6 +225,7 @@
         <importmap.version>2.0.0</importmap.version>
         <webauthn4j.version>0.30.3.RELEASE</webauthn4j.version>
         <jsoup.version>1.23.2</jsoup.version> <!-- JSoup is used by Camel and LangChain4J so be careful when updating -->
+        <reactor.version>3.8.7</reactor.version>
     </properties>
 
     <pluginRepositories>
@@ -6731,6 +6732,11 @@
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
                 <version>${jsoup.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.projectreactor</groupId>
+                <artifactId>reactor-core</artifactId>
+                <version>${reactor.version}</version>
             </dependency>
 
             <!-- Apache SSHD Netty transport (sshd-core and sshd-common already managed) -->


### PR DESCRIPTION
Fixes  [CVE-2026-47857](https://nvd.nist.gov/vuln/detail/cve-2026-47857) and [CVE-2026-47863](https://nvd.nist.gov/vuln/detail/cve-2026-47863)