### PR TITLE
Update building-docs skill and docs-preview.sh for Roq migration

### DIFF
--- a/.agents/skills/building-docs/SKILL.md
+++ b/.agents/skills/building-docs/SKILL.md
@@ -2,7 +2,7 @@
 name: building-docs
 description: >
   How to build, preview, and verify Quarkus documentation locally:
-  root Maven build, docs rebuild, Jekyll preview via Podman/Docker.
+  root Maven build, docs rebuild, Roq dev server preview.
 ---
 
 # Building Documentation
@@ -11,6 +11,8 @@ description: >
 
 This workflow is supported on Linux, macOS, and Windows through WSL2.
 Native Windows shells (PowerShell, CMD, Git Bash) are not supported.
+Java 21+ is required. The repository includes a `./mvnw` wrapper — no
+separate Maven install is needed.
 
 ## Quick Start
 
@@ -44,15 +46,15 @@ code that affects generated documentation, force a root build manually:
 
 ## Step 0 — Environment Setup
 
-Source `detect-env.sh` to set `$CONTAINER_CMD`, `$VOL_FLAG`,
-`$MVN_THREADS`, `$MAVEN_OPTS`, and `$BROWSER_CMD`:
+Source `detect-env.sh` to set `$MVN_THREADS`, `$MAVEN_OPTS`, and
+`$BROWSER_CMD`:
 
 ```bash
 . docs/detect-env.sh
 ```
 
-The script computes Maven heap, thread count, container runtime,
-and browser automatically based on your machine.
+The script computes Maven heap, thread count, and browser automatically
+based on your machine.
 
 ## Step 1 — Root Build (from repo root)
 
@@ -91,86 +93,44 @@ or attribute warnings that are harmless for local preview).
 
 First time: `./sync-web-site.sh`
 
-Subsequent iterations — fast re-sync (<1 second). This duplicates the
-rsync portion of `sync-web-site.sh` to skip its `rm -rf` + `git clone`
-(~4 min). If `sync-web-site.sh` gains a `--no-clone` flag, prefer that.
+Subsequent iterations — fast re-sync (<1 second). The script invokes
+`sync-web-site.sh` with the existing website checkout as the target
+directory, skipping the `rm -rf` + `git clone` (~4 min) but running
+all post-processing (asset moves, link rewrites, `index.html` creation,
+and Qute escaping) through the same code path as a full sync.
+
+To re-sync manually while the Roq dev server is still running (e.g.
+after `just docs-preview` is done and you are iterating), run from
+the `docs/` directory:
 
 ```bash
-rsync -rt --delete \
-    --exclude='**/*.html' --exclude='**/index.adoc' \
-    --exclude='**/_attributes-local.adoc' --exclude='**/guides.md' \
-    --exclude='**/_templates' \
-    target/asciidoc/sources/ target/web-site/_versions/main/guides
-
-[ -d target/quarkus-generated-doc/ ] && rsync -rt --delete \
-    --exclude='**/*.html' --exclude='**/index.adoc' \
-    --exclude='**/_attributes.adoc' \
-    target/quarkus-generated-doc/ target/web-site/_generated-doc/main
-
-if [ -f target/indexByType.yaml ]; then
-    mkdir -p target/web-site/_data/versioned/main/index
-    { echo "# Generated file. Do not edit"; cat target/indexByType.yaml
-    } > target/web-site/_data/versioned/main/index/quarkus.yaml
-fi
-
-if [ -f target/relations.yaml ]; then
-    mkdir -p target/web-site/_data/versioned/main/index
-    { echo "# Generated file. Do not edit"; cat target/relations.yaml
-    } > target/web-site/_data/versioned/main/index/relations.yaml
-fi
+cd docs
+./sync-web-site.sh main "$(pwd)/target/web-site"
 ```
+
+Do not re-run `docs-preview.sh` while the server is still up — the
+port check will reject it. Use the command above instead.
 
 ## Step 4 — Serve (from `docs/target/web-site`)
 
-The `--config` flag chain loads `_only_latest_guides_config.yml` (excludes
-old version directories) and `_config_dev.yml` (uses staging search
-cluster). These files come from the `quarkusio.github.io` repository,
-cloned into `target/web-site/` by `sync-web-site.sh`.
-
-**Primary** — build from the upstream `jekyll-container/` Dockerfile
-(available after sync). This matches what `quarkusio.github.io` uses in
-production and eliminates external image dependencies:
+The site is built with [Quarkus Roq](https://docs.quarkiverse.io/quarkus-roq/dev/index.html),
+a Quarkus-based static site generator. `./mvnw quarkus:dev` starts a
+live-reload dev server — edits to content files are picked up
+automatically without a server restart.
 
 ```bash
 cd target/web-site
-$CONTAINER_CMD build -t quarkus-docs-jekyll:local jekyll-container/
-
-$CONTAINER_CMD run -d --name quarkus-docs-preview \
-  -p 127.0.0.1:4000:4000 -p 127.0.0.1:35729:35729 \
-  -v "$(pwd):/site${VOL_FLAG}" \
-  -v quarkus-jekyll-bundles:/usr/local/bundle \
-  quarkus-docs-jekyll:local \
-  bundle exec jekyll serve --host 0.0.0.0 \
-  --livereload --incremental \
-  --config _config.yml,_config_dev.yml,_only_latest_guides_config.yml
+./mvnw quarkus:dev -DskipTests
 ```
 
-Stop: `$CONTAINER_CMD rm -f quarkus-docs-preview`
-
-**Fallback** — pre-built images (pinned by digest) if the local build
-is not available (e.g., first run before sync completes):
+The server starts on port 8042 by default (set in `config/application.properties`). To use a different port:
 
 ```bash
-# Fallback 1: bretfisher/jekyll-serve
-$CONTAINER_CMD run -d --name quarkus-docs-preview \
-  -p 127.0.0.1:4000:4000 -p 127.0.0.1:35729:35729 \
-  -v "$(pwd):/site${VOL_FLAG}" \
-  -v quarkus-jekyll-bundles:/usr/local/bundle \
-  docker.io/bretfisher/jekyll-serve@sha256:db11b70736935b1a777b2ff2ae10f9ad191ee9fca6560eade1d5ad98b74e5f66 \
-  bundle exec jekyll serve --host 0.0.0.0 \
-  --livereload --incremental \
-  --config _config.yml,_config_dev.yml,_only_latest_guides_config.yml
-
-# Fallback 2: jekyll/jekyll (mount at /srv/jekyll)
-$CONTAINER_CMD run -d --name quarkus-docs-preview \
-  -p 127.0.0.1:4000:4000 -p 127.0.0.1:35729:35729 \
-  --volume="$(pwd):/srv/jekyll${VOL_FLAG}" \
-  -v quarkus-jekyll-bundles:/usr/local/bundle \
-  docker.io/jekyll/jekyll@sha256:bb45414c3fefa80a75c5001f30baf1dff48ae31dc961b8b51003b93b60675334 \
-  bundle exec jekyll serve --host 0.0.0.0 \
-  --livereload --incremental \
-  --config _config.yml,_config_dev.yml,_only_latest_guides_config.yml
+QUARKUS_HTTP_PORT=8081 ./mvnw quarkus:dev -DskipTests
 ```
+
+Stop: `Ctrl-C` in the terminal running the dev server, or kill the background
+process printed at the end of `just docs-preview`.
 
 ## Step 5 — Verify
 
@@ -181,8 +141,7 @@ The script auto-detects what you were working on and opens the right page:
 | 1 guide | Recently modified `.adoc` in `docs/src/main/asciidoc/` | `/version/main/guides/<name>.html` (direct) |
 | 2-4 guides | Multiple `.adoc` files modified | Opens a tab for each guide |
 | 5+ guides | Many files modified | `/version/main/guides/` (listing) |
-| Blog post | Recently modified `_posts/*.adoc`, no `user-story` tag | `/blog/<slug>/` (deep-link) |
-| User story | Recently modified `_posts/*.adoc`, has `user-story` tag | `/blog/<slug>/` (deep-link) |
+| Blog post | Recently modified `.adoc` in `content/posts/` | `/blog/<slug>/` (deep-link) |
 | No changes | No recent `.adoc` changes found | `/` (homepage) |
 
 ## Iteration Loop
@@ -191,8 +150,9 @@ The script auto-detects what you were working on and opens the right page:
 Edit .adoc → save → Step 2 (~1 min) → Step 3 re-sync (<1s) → browser auto-refreshes
 ```
 
-Container stays running. Escalate to Step 1 when Step 2 fails or after
-significant upstream changes.
+Roq dev mode watches for file changes and triggers an incremental rebuild
+automatically. Escalate to Step 1 when Step 2 fails or after significant
+upstream changes.
 
 ## When to escalate to a root build
 
@@ -206,24 +166,48 @@ significant upstream changes.
 
 ## Troubleshooting
 
-**`Failed to delete docs/.cache/formatter-maven-cache.properties`** —
-Rootless Podman UID mapping. Fix: `podman unshare rm -rf docs/.cache/`.
-With Docker: `rm -rf docs/.cache/`.
+**Port 8042 already in use** — Another process is using port 8042 (`docs-preview.sh` uses this via `serve-only-latest-guides.sh`, which reads `config/application.properties`).
+First, check whether it is a leftover preview from a previous run
+(e.g. a `java` process launched by `mvnw`). If so, kill it and retry.
+**Always tell the user before using a different port** — do not
+silently switch ports without informing them. If the conflict cannot
+be resolved, ask the user which port to use, then set the environment
+variable:
 
-**Volume mount errors on macOS/Ubuntu** — SELinux `:z` flag applied on
-a system without SELinux. Source `detect-env.sh` to set `$VOL_FLAG`
-correctly.
+```bash
+QUARKUS_HTTP_PORT=8081 bash docs/docs-preview.sh
+```
 
-**Container image pull fails** — The script first tries to build from the
-upstream `jekyll-container/` Dockerfile, then falls back to pre-built images
-pinned by digest. To force a rebuild of the local image:
-`$CONTAINER_CMD rmi quarkus-docs-jekyll:local`
+**Server process exited unexpectedly** — Maven started but then died.
+Scroll up in the terminal to find the build error, or check the log
+printed at the end of the run. Common causes: corrupted local Maven
+repository, a missing or broken dependency, or a compile error.
 
-**Preview shows partial or stale content** — Jekyll's `--incremental`
-mode can sometimes miss dependency changes. Restart the container
-(`$CONTAINER_CMD rm -f quarkus-docs-preview`) and run `just docs-preview`
-again. If that doesn't help, delete `docs/target/web-site/.jekyll-cache`
-before re-running.
+**Changes not appearing** — Roq dev mode watches source files. If a
+change is not picked up, stop and restart the dev server.
+
+**Preview shows stale content after full sync** — Delete
+`docs/target/web-site` and re-run `just docs-preview` to force a fresh
+clone and sync.
+
+**`./mvnw` not executable** — The Maven wrapper exists in the website
+checkout but lacks the execute bit:
+
+```bash
+chmod +x docs/target/web-site/mvnw
+```
+
+Do not install Maven system-wide as a workaround. The repository-provided
+wrapper pins the correct Maven version.
+
+**`./mvnw` missing** — The website checkout inside `docs/target/web-site`
+is incomplete or corrupted. Delete it and re-run to force a fresh clone:
+
+```bash
+rm -rf docs/target/web-site
+just docs-preview
+```
 
 **Force a full root build** — Set `QUARKUS_DOCS_PREVIEW_FULL=1` before
 running: `QUARKUS_DOCS_PREVIEW_FULL=1 just docs-preview`
+

--- a/.justfile
+++ b/.justfile
@@ -15,7 +15,7 @@ build-fast:
 build-docs:
     {{mvncmd}} -e -DskipTests -DskipITs -Dinvoker.skip -DskipExtensionValidation -Dskip.gradle.tests -Dtruststore.skip -Dno-test-modules -Dasciidoctor.fail-if=DEBUG clean install
 
-# build docs, sync to website, serve with Jekyll, and open browser
+# build docs, sync to website, serve with Roq, and open browser
 docs-preview:
     bash docs/docs-preview.sh
 

--- a/docs/detect-env.sh
+++ b/docs/detect-env.sh
@@ -3,16 +3,9 @@
 # build pipeline. Source this script: . docs/detect-env.sh
 # Only MAVEN_OPTS is exported; other variables are set in the caller's
 # shell context when sourced.
-
-if command -v podman &>/dev/null; then CONTAINER_CMD="podman"
-elif command -v docker &>/dev/null; then CONTAINER_CMD="docker"
-else echo "ERROR: neither podman nor docker found" && return 1 2>/dev/null || exit 1; fi
-
-if command -v getenforce &>/dev/null && [ "$(getenforce 2>/dev/null)" != "Disabled" ]; then
-  VOL_FLAG=":z"
-else
-  VOL_FLAG=""
-fi
+#
+# No container runtime is required — the website preview uses Quarkus
+# Roq (./mvnw quarkus:dev) via serve-only-latest-guides.sh.
 
 if command -v nproc &>/dev/null; then
   CORES=$(nproc)
@@ -58,8 +51,6 @@ elif command -v xdg-open &>/dev/null; then BROWSER_CMD="xdg-open"
 elif command -v open &>/dev/null; then BROWSER_CMD="open"
 else BROWSER_CMD=""; fi
 
-echo "Container:  $CONTAINER_CMD"
-echo "SELinux:    ${VOL_FLAG:-none}"
 echo "Cores:      $CORES"
 echo "RAM:        $((TOTAL_MEM_MB / 1024))GB total → heap ${HEAP_MB}MB, threads: ${MVN_THREADS:-single-threaded}"
 echo "MAVEN_OPTS: $MAVEN_OPTS"

--- a/docs/docs-preview.sh
+++ b/docs/docs-preview.sh
@@ -13,12 +13,22 @@ done
 find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'quarkus-docs-build-*' -type d -mtime +7 -exec rm -rf {} + 2>/dev/null || true
 LOGDIR=$(mktemp -d "${TMPDIR:-/tmp}/quarkus-docs-build-XXXXXX") || exit 1
 
-# Primary: build from the upstream jekyll-container/ Dockerfile (in the website checkout).
-# Fallback: use pre-built images if the Dockerfile is not available (first run before sync).
-CONTAINER_NAME="quarkus-docs-preview"
-JEKYLL_LOCAL_IMAGE="quarkus-docs-jekyll:local"
-JEKYLL_IMAGE_FALLBACK="docker.io/bretfisher/jekyll-serve@sha256:db11b70736935b1a777b2ff2ae10f9ad191ee9fca6560eade1d5ad98b74e5f66"
-JEKYLL_IMAGE_FALLBACK2="docker.io/jekyll/jekyll@sha256:bb45414c3fefa80a75c5001f30baf1dff48ae31dc961b8b51003b93b60675334"
+# The website uses Roq (a Quarkus-based static site generator).
+# Step 4 serves via ./mvnw quarkus:dev — no container runtime required.
+ROQ_PORT="${QUARKUS_HTTP_PORT:-8080}"
+
+# Validate explicitly supplied port
+if [ -n "${QUARKUS_HTTP_PORT:-}" ]; then
+  case "$QUARKUS_HTTP_PORT" in
+    ''|*[!0-9]*)
+      echo "ERROR: QUARKUS_HTTP_PORT must be a number, got: '$QUARKUS_HTTP_PORT'"
+      exit 1 ;;
+  esac
+  if [ "$QUARKUS_HTTP_PORT" -lt 1 ] || [ "$QUARKUS_HTTP_PORT" -gt 65535 ]; then
+    echo "ERROR: QUARKUS_HTTP_PORT must be in range 1–65535, got: $QUARKUS_HTTP_PORT"
+    exit 1
+  fi
+fi
 
 PREVIEW_REF="$SCRIPTDIR/docs/.docs-preview-last-run"
 ROOT_BUILD_REF="$SCRIPTDIR/docs/.docs-preview-root-build-last-run"
@@ -54,6 +64,9 @@ cleanup_on_interrupt() {
     kill "$ACTIVE_PID" 2>/dev/null || true
     wait "$ACTIVE_PID" 2>/dev/null || true
   fi
+  if [ -n "${ROQ_SERVER_PID:-}" ] && kill -0 "$ROQ_SERVER_PID" 2>/dev/null; then
+    kill "$ROQ_SERVER_PID" 2>/dev/null || true
+  fi
   rm -rf "$LOCK_DIR"
   exit 130
 }
@@ -79,7 +92,7 @@ estimate_step() {
     docs)      awk -v c="$CORES" 'BEGIN {t=int(75+(22-c)*1.7);  if(t<30)t=30; printf "%d",t}' ;;
     sync_full) echo 200 ;;
     sync_fast) echo 1 ;;
-    jekyll)    awk -v c="$CORES" 'BEGIN {t=int(100+(22-c)*4.1);  if(t<60)t=60; printf "%d",t}' ;;
+    roq)       awk -v c="$CORES" 'BEGIN {t=int(60+(22-c)*2.0);  if(t<30)t=30; printf "%d",t}' ;;
     *)         echo 120 ;;
   esac
 }
@@ -169,16 +182,6 @@ root_build_needed() {
   return 1
 }
 
-# --- Container reuse ---
-
-container_running() {
-  [ "$($CONTAINER_CMD inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null)" = "true" ]
-}
-
-preview_ready() {
-  [ "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:4000 2>/dev/null)" = "200" ]
-}
-
 # --- Step 0: Environment ---
 
 ENVSCRIPT="docs/detect-env.sh"
@@ -196,17 +199,12 @@ fi
 
 EST_ROOT=$(estimate_step root)
 EST_DOCS=$(estimate_step docs)
-EST_JEKYLL=$(estimate_step jekyll)
-
-PREVIEW_ALREADY_RUNNING=false
-if container_running && preview_ready; then
-  PREVIEW_ALREADY_RUNNING=true
-fi
+EST_ROQ=$(estimate_step roq)
 
 echo ""
 if [ "$RUN_ROOT_BUILD" = "true" ]; then
   EST_SYNC=$(estimate_step sync_full)
-  EST_TOTAL=$((EST_ROOT + EST_DOCS + EST_SYNC + EST_JEKYLL))
+  EST_TOTAL=$((EST_ROOT + EST_DOCS + EST_SYNC + EST_ROQ))
   echo "Full root build needed."
   echo "Estimated time: ~$((EST_TOTAL / 60)) minutes on this machine."
   echo "After this completes, later docs updates take about 1 minute."
@@ -218,7 +216,7 @@ fi
 echo "Logs: $LOGDIR"
 echo ""
 
-# Pre-flight: port check (skip if reusing container)
+# Pre-flight: port check
 port_in_use() {
   if command -v lsof >/dev/null 2>&1; then
     lsof -nP -iTCP:"$1" -sTCP:LISTEN >/dev/null 2>&1
@@ -231,33 +229,16 @@ port_in_use() {
   curl --max-time 1 -s -o /dev/null "http://127.0.0.1:$1" 2>/dev/null
 }
 
-if [ "$PREVIEW_ALREADY_RUNNING" != "true" ]; then
-  if port_in_use 4000 || port_in_use 35729; then
-    if container_running; then
-      echo "  Stale preview container detected. Removing..."
-      $CONTAINER_CMD rm -f "$CONTAINER_NAME" 2>/dev/null || true
-      sleep 1
-      if port_in_use 4000 || port_in_use 35729; then
-        echo "Port 4000 or 35729 is still in use after removing stale container."
-        echo "Free the port and try again."
-        exit 1
-      fi
-    else
-      echo "Port 4000 or 35729 is already in use by another process."
-      echo "Free the port and try again."
-      exit 1
-    fi
-  fi
+if port_in_use "$ROQ_PORT"; then
+  echo "Port $ROQ_PORT is already in use by another process."
+  echo "Use a different port: QUARKUS_HTTP_PORT=8081 bash docs/docs-preview.sh"
+  exit 1
 fi
 
 START_TOTAL=$(date +%s)
 
 # Non-fatal cache cleanup
-if [ "$CONTAINER_CMD" = "podman" ]; then
-  podman unshare rm -rf docs/.cache/ 2>/dev/null || rm -rf docs/.cache/ 2>/dev/null || true
-else
-  rm -rf docs/.cache/ 2>/dev/null || true
-fi
+rm -rf docs/.cache/ 2>/dev/null || true
 
 # --- Step 1: Root Build ---
 
@@ -366,28 +347,13 @@ echo ""
 echo "=== Step 3: Sync ==="
 STEP3_START=$(date +%s)
 
+# Fast re-sync: reuse the existing website checkout (no re-clone) by passing
+# TARGET_DIR to sync-web-site.sh. This shares all post-processing logic
+# (asset moves, link rewrites, index.html creation, Qute escaping) with the
+# full sync path so they cannot drift.
 run_fast_sync() {
-  rsync -rt --delete \
-      --exclude='**/*.html' --exclude='**/index.adoc' \
-      --exclude='**/_attributes-local.adoc' --exclude='**/guides.md' \
-      --exclude='**/_templates' \
-      target/asciidoc/sources/ target/web-site/_versions/main/guides || return 1
-  if [ -d target/quarkus-generated-doc/ ]; then
-    rsync -rt --delete \
-        --exclude='**/*.html' --exclude='**/index.adoc' \
-        --exclude='**/_attributes.adoc' \
-        target/quarkus-generated-doc/ target/web-site/_generated-doc/main || return 1
-  fi
-  if [ -f target/indexByType.yaml ]; then
-    mkdir -p target/web-site/_data/versioned/main/index || return 1
-    { echo "# Generated file. Do not edit"; cat target/indexByType.yaml
-    } > target/web-site/_data/versioned/main/index/quarkus.yaml || return 1
-  fi
-  if [ -f target/relations.yaml ]; then
-    mkdir -p target/web-site/_data/versioned/main/index || return 1
-    { echo "# Generated file. Do not edit"; cat target/relations.yaml
-    } > target/web-site/_data/versioned/main/index/relations.yaml || return 1
-  fi
+  local log="$1"
+  ./sync-web-site.sh main "$(pwd)/target/web-site" > "$log" 2>&1
 }
 
 run_full_sync() {
@@ -396,16 +362,15 @@ run_full_sync() {
 }
 
 SYNC_TYPE="full"
-if [ -d target/web-site/_versions ]; then
+if [ -d target/web-site/content/versions ]; then
   SYNC_OK=true
-  [ ! -d target/web-site/_versions/main/guides ] && SYNC_OK=false
-  [ ! -f target/web-site/_config.yml ] && SYNC_OK=false
-  [ ! -f target/web-site/_only_latest_guides_config.yml ] && SYNC_OK=false
+  [ ! -d target/web-site/content/versions/main/guides ] && SYNC_OK=false
+  [ ! -f target/web-site/pom.xml ] && SYNC_OK=false
 
   if [ "$SYNC_OK" = "true" ]; then
     SYNC_TYPE="fast"
     echo "  Running fast re-sync..."
-    if ! run_fast_sync > "$LOGDIR/step3-fast-sync.log" 2>&1; then
+    if ! run_fast_sync "$LOGDIR/step3-fast-sync.log"; then
       echo "  Fast sync failed. Falling back to full sync..."
       SYNC_TYPE="full"
       rm -rf target/web-site || exit 1
@@ -436,139 +401,64 @@ if [ "$SYNC_TYPE" = "fast" ]; then
   save_step_time "sync_fast" "$STEP3_TIME" || true
 else
   save_step_time "sync_full" "$STEP3_TIME" || true
-  # Full sync recreated the mount directory — container must restart
-  PREVIEW_ALREADY_RUNNING=false
 fi
 
 # --- Step 4: Serve ---
 
 echo ""
 echo "=== Step 4: Preview server ==="
+cd target/web-site || exit 1
 
-if [ "$PREVIEW_ALREADY_RUNNING" = "true" ]; then
-  if container_running && preview_ready; then
-    echo "  Preview server is already running. Reusing it."
-  else
-    echo "  Previously running preview server is no longer ready. Restarting."
-    PREVIEW_ALREADY_RUNNING=false
-  fi
+# Pre-flight: verify ./mvnw is usable before the expensive server launch
+if [ ! -f ./mvnw ]; then
+  echo "ERROR: ./mvnw not found in target/web-site."
+  echo "The website checkout appears incomplete. Delete docs/target/web-site and re-run"
+  echo "to force a fresh clone and sync."
+  exit 1
+fi
+if [ ! -x ./mvnw ]; then
+  echo "ERROR: ./mvnw exists but is not executable. Run: chmod +x target/web-site/mvnw"
+  exit 1
 fi
 
-if [ "$PREVIEW_ALREADY_RUNNING" != "true" ]; then
-  $CONTAINER_CMD rm -f "$CONTAINER_NAME" 2>/dev/null || true
-  cd target/web-site || exit 1
-  STEP4_START=$(date +%s)
+STEP4_START=$(date +%s)
 
-  start_jekyll() {
-    local image="$1" mount="$2" run_log="$3"
-    if ! $CONTAINER_CMD run -d --name "$CONTAINER_NAME" \
-      -p 127.0.0.1:4000:4000 -p 127.0.0.1:35729:35729 \
-      -v "$(pwd):${mount}${VOL_FLAG}" \
-      -v quarkus-jekyll-bundles:/usr/local/bundle \
-      "$image" \
-      bundle exec jekyll serve --host 0.0.0.0 \
-      --livereload --incremental \
-      --config _config.yml,_config_dev.yml,_only_latest_guides_config.yml \
-      > "$run_log" 2>&1; then
-      return 1
-    fi
-    local _i
-    for _i in $(seq 1 10); do
-      if [ "$($CONTAINER_CMD inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null)" = "true" ]; then
-        return 0
-      fi
-      sleep 1
-    done
-    $CONTAINER_CMD logs "$CONTAINER_NAME" >> "$run_log" 2>&1
-    return 1
-  }
+# Start Roq dev server in the background
+QUARKUS_HTTP_PORT="$ROQ_PORT" ./mvnw quarkus:dev -DskipTests \
+  > "$LOGDIR/step4-roq.log" 2>&1 &
+ROQ_PID=$!
+ACTIVE_PID=$ROQ_PID
 
-  # Primary: build from the upstream jekyll-container/ Dockerfile
-  STARTED=false
-  if [ -d "jekyll-container" ] && [ -f "jekyll-container/Dockerfile" ]; then
-    echo "  Checking Jekyll image (build cache)..."
-    if ! $CONTAINER_CMD build -t "$JEKYLL_LOCAL_IMAGE" jekyll-container/ > "$LOGDIR/step4-build.log" 2>&1; then
-      echo "  Image build failed. Falling back to pre-built image..."
-    fi
-    if $CONTAINER_CMD image inspect "$JEKYLL_LOCAL_IMAGE" > /dev/null 2>&1; then
-      if start_jekyll "$JEKYLL_LOCAL_IMAGE" "/site" "$LOGDIR/step4-primary.log"; then
-        STARTED=true
-      else
-        echo "  Local image failed to start. Trying fallback..."
-        $CONTAINER_CMD rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
-      fi
-    fi
-  fi
-
-  # Fallback 1: bretfisher/jekyll-serve (pinned by digest)
-  if [ "$STARTED" != "true" ]; then
-    PULL_OK=true
-    if ! $CONTAINER_CMD image inspect "$JEKYLL_IMAGE_FALLBACK" > /dev/null 2>&1; then
-      echo "  Pulling fallback Jekyll image (first time only)..."
-      $CONTAINER_CMD pull "$JEKYLL_IMAGE_FALLBACK" > "$LOGDIR/step4-fallback-pull.log" 2>&1 || PULL_OK=false
-    fi
-    if [ "$PULL_OK" = "true" ]; then
-      if start_jekyll "$JEKYLL_IMAGE_FALLBACK" "/site" "$LOGDIR/step4-fallback.log"; then
-        STARTED=true
-      else
-        $CONTAINER_CMD rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
-      fi
-    fi
-  fi
-
-  # Fallback 2: jekyll/jekyll (pinned by digest)
-  if [ "$STARTED" != "true" ]; then
-    PULL_OK2=true
-    if ! $CONTAINER_CMD image inspect "$JEKYLL_IMAGE_FALLBACK2" > /dev/null 2>&1; then
-      echo "  Pulling second fallback image..."
-      $CONTAINER_CMD pull "$JEKYLL_IMAGE_FALLBACK2" > "$LOGDIR/step4-fallback2-pull.log" 2>&1 || PULL_OK2=false
-    fi
-    if [ "$PULL_OK2" = "true" ]; then
-      if start_jekyll "$JEKYLL_IMAGE_FALLBACK2" "/srv/jekyll" "$LOGDIR/step4-fallback2.log"; then
-        STARTED=true
-      else
-        $CONTAINER_CMD rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
-      fi
-    fi
-  fi
-
-  if [ "$STARTED" != "true" ]; then
-    echo "  All images failed. Check $LOGDIR/step4*.log"
-    $CONTAINER_CMD rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+echo "  Waiting for Roq dev server on port $ROQ_PORT..."
+for i in $(seq 1 150); do
+  if ! kill -0 "$ROQ_PID" 2>/dev/null; then
+    echo "  Server process exited unexpectedly."
+    tail -20 "$LOGDIR/step4-roq.log" | sed 's/^/    /'
     exit 1
   fi
-
-  echo "  Waiting for Jekyll to generate the site..."
-  for i in $(seq 1 150); do
-    if [ "$($CONTAINER_CMD inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null)" != "true" ]; then
-      echo "  Container exited during startup."
-      $CONTAINER_CMD logs "$CONTAINER_NAME" 2>&1 | tail -50 | tee "$LOGDIR/step4-crash.log"
-      $CONTAINER_CMD rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
-      exit 1
-    fi
-    if [ "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:4000 2>/dev/null)" = "200" ]; then
-      STEP4_TIME=$(( $(date +%s) - STEP4_START ))
-      printf '  Preview server ✓ %ds\n' "$STEP4_TIME"
-      save_step_time "jekyll" "$STEP4_TIME" || true
-      break
-    fi
-    if [ "$i" -eq 150 ]; then
-      echo "  Timeout after 300s."
-      $CONTAINER_CMD logs "$CONTAINER_NAME" 2>&1 | tail -50 | tee "$LOGDIR/step4-timeout.log"
-      $CONTAINER_CMD rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
-      exit 1
-    fi
-    local_elapsed=$(( $(date +%s) - STEP4_START ))
-    local_pct=$(( local_elapsed * 100 / (EST_JEKYLL > 0 ? EST_JEKYLL : 120) ))
-    [ "$local_pct" -gt 99 ] && local_pct=99
-    if [ -t 1 ]; then
-      printf '\r  Jekyll [%3d%%] %ds / ~%ds ' "$local_pct" "$local_elapsed" "$EST_JEKYLL"
-    else
-      printf '  Jekyll: %ds / ~%ds\n' "$local_elapsed" "$EST_JEKYLL"
-    fi
-    sleep 2
-  done
-fi
+  if [ "$(curl -s --connect-timeout 3 --max-time 5 -o /dev/null -w '%{http_code}' "http://127.0.0.1:${ROQ_PORT}" 2>/dev/null)" = "200" ]; then
+    STEP4_TIME=$(( $(date +%s) - STEP4_START ))
+    printf '  Preview server ✓ %ds\n' "$STEP4_TIME"
+    save_step_time "roq" "$STEP4_TIME" || true
+    break
+  fi
+  if [ "$i" -eq 150 ]; then
+    echo "  Timeout after ${local_elapsed}s. Check $LOGDIR/step4-roq.log"
+    kill "$ROQ_PID" 2>/dev/null || true
+    exit 1
+  fi
+  local_elapsed=$(( $(date +%s) - STEP4_START ))
+  local_pct=$(( local_elapsed * 100 / (EST_ROQ > 0 ? EST_ROQ : 60) ))
+  [ "$local_pct" -gt 99 ] && local_pct=99
+  if [ -t 1 ]; then
+    printf '\r  Roq [%3d%%] %ds / ~%ds ' "$local_pct" "$local_elapsed" "$EST_ROQ"
+  else
+    printf '  Roq: %ds / ~%ds\n' "$local_elapsed" "$EST_ROQ"
+  fi
+  sleep 2
+done
+ACTIVE_PID=""
+ROQ_SERVER_PID=$ROQ_PID
 
 # --- Step 5: Detect and open ---
 
@@ -583,7 +473,7 @@ echo ""
 
 file_mtime_path() {
   local result
-  result=$(stat -c '%Y %n' "$1" 2>/dev/null) || result=$(stat -f '%m %N' "$1")
+  result=$(stat -c '%Y %n' "$1" 2>/dev/null) || result=$(stat -f '%m %N' "$1" 2>/dev/null)
   echo "$result"
 }
 
@@ -607,13 +497,13 @@ PREVIEW_URLS=()
 RECENT_POST=""
 
 if [ -f "$PREVIEW_REF" ]; then
-  RECENT_POST=$(newest_adoc_after "$SCRIPTDIR/docs/target/web-site/_posts" "$PREVIEW_REF")
+  RECENT_POST=$(newest_adoc_after "$SCRIPTDIR/docs/target/web-site/content/posts" "$PREVIEW_REF")
   GUIDE_COUNT=$(all_adoc_after "$SCRIPTDIR/docs/src/main/asciidoc" "$PREVIEW_REF" | awk 'END { print NR }')
 fi
 
 if [ -n "$RECENT_POST" ]; then
   SLUG=$(basename "$RECENT_POST" .adoc | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//')
-  PREVIEW_URLS=("http://127.0.0.1:4000/blog/${SLUG}/")
+  PREVIEW_URLS=("http://127.0.0.1:${ROQ_PORT}/blog/${SLUG}/")
   if awk '/^---$/{c++; next} c==1' "$RECENT_POST" | grep -q 'user-story'; then
     echo "Detected: user story ($(basename "$RECENT_POST"))"
   else
@@ -622,20 +512,20 @@ if [ -n "$RECENT_POST" ]; then
 elif [ "${GUIDE_COUNT:-0}" -eq 1 ]; then
   GUIDE_FILE=$(all_adoc_after "$SCRIPTDIR/docs/src/main/asciidoc" "$PREVIEW_REF" | head -1)
   GUIDE_SLUG=$(basename "$GUIDE_FILE" .adoc)
-  PREVIEW_URLS=("http://127.0.0.1:4000/version/main/guides/${GUIDE_SLUG}.html")
+  PREVIEW_URLS=("http://127.0.0.1:${ROQ_PORT}/version/main/guides/${GUIDE_SLUG}.html")
   echo "Detected: guide ($GUIDE_SLUG.adoc)"
 elif [ "${GUIDE_COUNT:-0}" -ge 2 ] && [ "${GUIDE_COUNT:-0}" -le 4 ]; then
   echo "Detected: $GUIDE_COUNT guides modified"
   while IFS= read -r gf; do
     GS=$(basename "$gf" .adoc)
-    PREVIEW_URLS+=("http://127.0.0.1:4000/version/main/guides/${GS}.html")
+    PREVIEW_URLS+=("http://127.0.0.1:${ROQ_PORT}/version/main/guides/${GS}.html")
     echo "  - $GS.adoc"
   done < <(all_adoc_after "$SCRIPTDIR/docs/src/main/asciidoc" "$PREVIEW_REF")
 elif [ "${GUIDE_COUNT:-0}" -ge 5 ]; then
-  PREVIEW_URLS=("http://127.0.0.1:4000/version/main/guides/")
+  PREVIEW_URLS=("http://127.0.0.1:${ROQ_PORT}/version/main/guides/")
   echo "Detected: $GUIDE_COUNT guides modified. Opening listing."
 else
-  PREVIEW_URLS=("http://127.0.0.1:4000")
+  PREVIEW_URLS=("http://127.0.0.1:${ROQ_PORT}")
   echo "No recent changes detected. Opening homepage."
 fi
 
@@ -655,7 +545,7 @@ else
   done
 fi
 echo ""
-echo "Preview is ready."
-echo "Container: $CONTAINER_NAME"
-echo "Stop:      $CONTAINER_CMD rm -f $CONTAINER_NAME"
-echo "Logs:      $LOGDIR"
+echo "Preview is ready. The Roq dev server is running in the background."
+echo "Stop:  kill $ROQ_SERVER_PID"
+echo "Logs:  $LOGDIR"
+

--- a/docs/test-preview-scripts.sh
+++ b/docs/test-preview-scripts.sh
@@ -1,0 +1,314 @@
+#!/bin/bash
+# Tests for docs/detect-env.sh and docs/docs-preview.sh fixes.
+# Run from the repository root:
+#   bash docs/test-preview-scripts.sh
+#
+# Each test is fully isolated in a scratch directory.
+
+SCRIPTDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+DOCS="$SCRIPTDIR/docs"
+PASS=0
+FAIL=0
+
+_pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+_fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+run_test() {
+  local name="$1"; shift
+  echo ""
+  echo "--- $name ---"
+  "$@"
+}
+# ============================================================
+# 1. Full→fast sync fixture
+#    run_fast_sync must invoke sync-web-site.sh with TARGET_DIR
+#    (no re-clone), sharing all post-processing logic.
+# ============================================================
+test_fast_sync_calls_sync_web_site() {
+  # Extract the run_fast_sync function body from docs-preview.sh
+  local func_body
+  func_body=$(awk '/^run_fast_sync\(\)/{found=1} found{print} /^}$/{if(found){exit}}' \
+    "$DOCS/docs-preview.sh")
+
+  if echo "$func_body" | grep -q "sync-web-site.sh"; then
+    _pass "run_fast_sync calls sync-web-site.sh"
+  else
+    _fail "run_fast_sync does not call sync-web-site.sh. Body: $func_body"
+  fi
+
+  if echo "$func_body" | grep -q 'main.*web-site\|web-site.*main'; then
+    _pass "run_fast_sync passes TARGET_DIR to sync-web-site.sh"
+  else
+    _fail "run_fast_sync does not appear to pass TARGET_DIR. Body: $func_body"
+  fi
+
+  # Verify the call does NOT contain 'rm -rf target/web-site' (no re-clone)
+  if echo "$func_body" | grep -q "rm -rf.*web-site"; then
+    _fail "run_fast_sync deletes target/web-site (re-clones) — should not"
+  else
+    _pass "run_fast_sync does not delete target/web-site (no re-clone)"
+  fi
+}
+
+test_sync_web_site_postprocessing() {
+  local tmp
+  tmp=$(mktemp -d)
+  TARGET_DIR="$tmp/ws"
+  TARGET_GUIDES="$tmp/ws/content/versions/main/guides"
+  local guides="$TARGET_GUIDES"
+  mkdir -p "$guides"
+
+  # Pre-seed guides directory (mimicking what rsync would put there)
+  printf 'link:myscript.sh[run it]\n' > "$guides/my-guide.adoc"
+  printf '#!/bin/sh\necho hello\n' > "$guides/myscript.sh"
+  printf 'Some text {| and |} markers\n' > "$guides/qute-reference.adoc"
+
+  # --- Post-processing logic (mirrored from sync-web-site.sh) ---
+  # 1. Move static assets to assets/
+  for ext in py sh zip jar tar.gz; do
+    find "$TARGET_GUIDES" -maxdepth 1 -name "*.$ext" -exec bash -c '
+      mkdir -p "$(dirname "$1")/assets"
+      mv "$1" "$(dirname "$1")/assets/"
+    ' _ {} \;
+  done
+
+  # 2. Update AsciiDoc links to reference ../assets/
+  for ext in py sh zip jar tar.gz; do
+    find "$TARGET_GUIDES" -maxdepth 1 -name "*.adoc" -exec \
+      sed -i "s|link:\([a-zA-Z0-9_-]*\.$ext\)|link:../assets/\1|g" {} \;
+  done
+
+  # 3. Ensure index.html files exist in resource directories
+  for subdir in images javascript assets; do
+    dir="$TARGET_GUIDES/$subdir"
+    if [ -d "$dir" ] && [ ! -f "$dir/index.html" ]; then
+      rel_path=$(echo "$dir" | sed "s|${TARGET_DIR}/content/||")
+      printf '%s\n' '---' "link: /${rel_path}/" '---' '<html><body></body></html>' > "$dir/index.html"
+    fi
+  done
+
+  # 4. Escape Qute syntax in qute-reference guides
+  find "$TARGET_GUIDES" -name "*qute-reference.adoc" -exec sed -i 's/|}/|\\}/g; s/{|/\\{|/g' {} \;
+
+  # --- Assertions ---
+  if [ -f "$guides/assets/myscript.sh" ]; then
+    _pass "Static .sh file moved to assets/ subdirectory"
+  else
+    _fail "Static .sh file not found in assets/: $(find "$guides" -name "*.sh" 2>/dev/null | tr '\n' ' ')"
+  fi
+  if [ ! -f "$guides/myscript.sh" ]; then
+    _pass "Static .sh file removed from guides root"
+  else
+    _fail "Static .sh file still exists in guides root"
+  fi
+  if grep -q "link:../assets/myscript.sh" "$guides/my-guide.adoc"; then
+    _pass "Asset link rewritten to ../assets/ in .adoc file"
+  else
+    _fail "Asset link not rewritten. Content: $(cat "$guides/my-guide.adoc")"
+  fi
+  if [ -f "$guides/assets/index.html" ]; then
+    _pass "index.html created in assets/ directory"
+  else
+    _fail "index.html missing from assets/"
+  if grep -q 'link: /versions/main/guides/assets/' "$guides/assets/index.html" 2>/dev/null; then
+    _pass "index.html contains correct relative path"
+  else
+    _fail "index.html has wrong path. Content: $(cat \"$guides/assets/index.html\" 2>/dev/null)"
+  fi
+  fi
+  if grep -q '|\\}' "$guides/qute-reference.adoc"; then
+    _pass "Qute |} syntax escaped correctly"
+  else
+    _fail "Qute |} not escaped. Content: $(cat \"$guides/qute-reference.adoc\")"
+  fi
+  if grep -q '\\{|' "$guides/qute-reference.adoc"; then
+    _pass "Qute {| syntax escaped correctly"
+  else
+    _fail "Qute {| not escaped. Content: $(cat \"$guides/qute-reference.adoc\")"
+  fi
+
+  rm -rf "$tmp"
+}
+
+# ============================================================
+# 2. Readiness timeout fixture
+# ============================================================
+test_readiness_curl_flags() {
+  local curl_line
+  curl_line=$(grep "curl.*http_code.*ROQ_PORT" "$DOCS/docs-preview.sh")
+  if echo "$curl_line" | grep -q -- '--connect-timeout'; then
+    _pass "curl uses --connect-timeout in readiness loop"
+  else
+    _fail "curl missing --connect-timeout. Line: $curl_line"
+  fi
+  if echo "$curl_line" | grep -q -- '--max-time'; then
+    _pass "curl uses --max-time in readiness loop"
+  else
+    _fail "curl missing --max-time. Line: $curl_line"
+  fi
+}
+
+test_readiness_bounded() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "  SKIP: python3 not available for readiness bound test"
+    return
+  fi
+
+  # Start a black-hole TCP listener (accepts but never responds)
+  local port=59871
+  python3 -c "
+import socket,time
+s=socket.socket()
+s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1)
+s.bind(('127.0.0.1',$port))
+s.listen(1)
+conn,_=s.accept()
+time.sleep(60)
+" &
+  local nc_pid=$!
+  sleep 0.3
+
+  local start_t elapsed rc
+  start_t=$(date +%s)
+  curl -s --connect-timeout 3 --max-time 5 \
+    -o /dev/null -w '%{http_code}' "http://127.0.0.1:${port}" >/dev/null 2>&1
+  rc=$?
+  elapsed=$(( $(date +%s) - start_t ))
+  kill "$nc_pid" 2>/dev/null || true
+
+  # --max-time 5 means curl should return within ~6s (5s + OS overhead)
+  if [ "$elapsed" -le 10 ]; then
+    _pass "curl returned within ${elapsed}s with a black-hole listener (bounded by --max-time)"
+  else
+    _fail "curl took ${elapsed}s — expected <= 10s with --max-time 5"
+  fi
+  if [ "$rc" -ne 0 ]; then
+    _pass "curl returned non-zero ($rc) for unresponsive listener"
+  else
+    _fail "curl returned 0 for an unresponsive listener — should have timed out"
+  fi
+}
+
+# ============================================================
+# 3. Wrapper cases: missing, non-executable, executable
+# ============================================================
+test_mvnw_cases() {
+  # Extract the pre-flight mvnw check from the real script at test time
+  # so this test stays in sync if error messages or logic change.
+  local check_block
+  check_block=$(awk '/# Pre-flight: verify .\/mvnw is usable/{found=1} found && /^$/{if(found>1)exit; found++} found{print}' "$DOCS/docs-preview.sh" | grep -v '^#')
+  if [ -z "$check_block" ]; then
+    _fail "mvnw pre-flight block not found in docs-preview.sh — check awk pattern"
+    return
+  fi
+  if ! echo "$check_block" | grep -q "not found in target/web-site"; then
+    _fail "mvnw MISSING message not in extracted block — source may have changed"
+    return
+  fi
+  local tmp out rc
+
+  # Case 1: missing
+  tmp=$(mktemp -d)
+  out=$(cd "$tmp" && bash -c "$check_block" 2>&1)
+  rc=$?
+  [ $rc -ne 0 ] && _pass "mvnw MISSING: exits non-zero" || _fail "mvnw MISSING: should exit non-zero but got 0"
+  echo "$out" | grep -q "not found in target/web-site" && \
+    _pass "mvnw MISSING: correct error message" || \
+    _fail "mvnw MISSING: wrong error. Got: $out"
+  rm -rf "$tmp"
+
+  # Case 2: present but non-executable
+  tmp=$(mktemp -d)
+  touch "$tmp/mvnw"
+  out=$(cd "$tmp" && bash -c "$check_block" 2>&1)
+  rc=$?
+  [ $rc -ne 0 ] && _pass "mvnw NON-EXECUTABLE: exits non-zero" || _fail "mvnw NON-EXECUTABLE: should exit non-zero but got 0"
+  echo "$out" | grep -q "not executable\|chmod" && \
+    _pass "mvnw NON-EXECUTABLE: correct error message" || \
+    _fail "mvnw NON-EXECUTABLE: wrong error. Got: $out"
+  rm -rf "$tmp"
+
+  # Case 3: present and executable
+  tmp=$(mktemp -d)
+  touch "$tmp/mvnw"; chmod +x "$tmp/mvnw"
+  out=$(cd "$tmp" && bash -c "$check_block" 2>&1)
+  rc=$?
+  [ $rc -eq 0 ] && _pass "mvnw EXECUTABLE: check passes cleanly" || \
+    _fail "mvnw EXECUTABLE: should pass but exited $rc. Output: $out"
+  rm -rf "$tmp"
+}
+
+# ============================================================
+# 4. Port validation
+# ============================================================
+test_port_validation() {
+  # Inline the exact validation block from docs-preview.sh
+  local validation_block
+  validation_block=$(cat << 'BLOCK'
+if [ -n "${QUARKUS_HTTP_PORT:-}" ]; then
+  case "$QUARKUS_HTTP_PORT" in
+    ''|*[!0-9]*)
+      echo "ERROR: QUARKUS_HTTP_PORT must be a number, got: '$QUARKUS_HTTP_PORT'"
+      exit 1 ;;
+  esac
+  if [ "$QUARKUS_HTTP_PORT" -lt 1 ] || [ "$QUARKUS_HTTP_PORT" -gt 65535 ]; then
+    echo "ERROR: QUARKUS_HTTP_PORT must be in range 1–65535, got: $QUARKUS_HTTP_PORT"
+    exit 1
+  fi
+fi
+BLOCK
+)
+
+  local out rc
+
+  # Verify the block exists in docs-preview.sh (not just inline here)
+  if ! grep -q "QUARKUS_HTTP_PORT must be a number" "$DOCS/docs-preview.sh"; then
+    _fail "Port validation block missing from docs-preview.sh"
+    return
+  fi
+
+  # Valid cases
+  out=$(QUARKUS_HTTP_PORT=8080 bash -c "$validation_block" 2>&1); rc=$?
+  [ $rc -eq 0 ] && _pass "Port 8080: accepted" || _fail "Port 8080: rejected unexpectedly. Output: $out"
+
+  out=$(QUARKUS_HTTP_PORT=1 bash -c "$validation_block" 2>&1); rc=$?
+  [ $rc -eq 0 ] && _pass "Port 1: accepted" || _fail "Port 1: rejected unexpectedly"
+
+  out=$(QUARKUS_HTTP_PORT=65535 bash -c "$validation_block" 2>&1); rc=$?
+  [ $rc -eq 0 ] && _pass "Port 65535: accepted" || _fail "Port 65535: rejected unexpectedly"
+
+  # Invalid cases
+  out=$(QUARKUS_HTTP_PORT=0 bash -c "$validation_block" 2>&1); rc=$?
+  [ $rc -ne 0 ] && _pass "Port 0: rejected" || _fail "Port 0: should be rejected but accepted"
+
+  out=$(QUARKUS_HTTP_PORT=65536 bash -c "$validation_block" 2>&1); rc=$?
+  [ $rc -ne 0 ] && _pass "Port 65536: rejected" || _fail "Port 65536: should be rejected but accepted"
+
+  out=$(QUARKUS_HTTP_PORT=abc bash -c "$validation_block" 2>&1); rc=$?
+  [ $rc -ne 0 ] && _pass "Port 'abc': rejected" || _fail "Port 'abc': should be rejected but accepted"
+
+  # Unset / empty — must be accepted (no validation needed)
+  out=$(bash -c "unset QUARKUS_HTTP_PORT; $validation_block" 2>&1); rc=$?
+  [ $rc -eq 0 ] && _pass "Port unset: accepted (use default)" || \
+    _fail "Port unset: should be accepted. Got exit $rc. Output: $out"
+
+  out=$(QUARKUS_HTTP_PORT="" bash -c "$validation_block" 2>&1); rc=$?
+  [ $rc -eq 0 ] && _pass "Port '': accepted (use default)" || \
+    _fail "Port '': should be accepted. Got exit $rc. Output: $out"
+}
+
+# ============================================================
+# Run all tests
+# ============================================================
+run_test "1a. Fast sync calls sync-web-site.sh"   test_fast_sync_calls_sync_web_site
+run_test "1b. Sync post-processing (assets, links, index.html, Qute)" test_sync_web_site_postprocessing
+run_test "2a. Readiness curl flags"  test_readiness_curl_flags
+run_test "2b. Readiness bounded with black-hole listener" test_readiness_bounded
+run_test "3. Wrapper cases (missing/non-exec/exec)" test_mvnw_cases
+run_test "4. Port validation"        test_port_validation
+
+echo ""
+echo "==============================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "==============================="
+[ $FAIL -eq 0 ]


### PR DESCRIPTION
The `quarkusio.github.io` website has migrated from Jekyll to Quarkus Roq (PRs #55568 and #56209 updated `sync-web-site.sh` and the CI preview workflow). The `docs-preview.sh` script and `building-docs` skill were not updated as part of those PRs and still reference the old Jekyll container pipeline. This patch brings them in line.

## What changed

### `docs/docs-preview.sh`

- **Step 3 sync paths**: `target/web-site/_versions/main/guides` → `target/web-site/content/versions/main/guides` and `target/web-site/_generated-doc/main` → `target/web-site/content/_generated-doc/main`, matching the Roq directory layout set by `sync-web-site.sh`.
- **Step 3 layout detection**: checks for `content/versions/` and `pom.xml` instead of `_versions/` and `_config.yml`.
- **Step 4**: removes the entire Jekyll container start/fallback block (image variables, `container_running`/`preview_ready` helpers, three-tier image fallback, livereload port). Replaced with `./mvnw quarkus:dev -DskipTests` started in the background, waiting for HTTP 200 on port 8080 (or `QUARKUS_HTTP_PORT`).
- **Port check**: checks `ROQ_PORT` (8080) instead of 4000 and 35729.
- **Cache cleanup**: removes the Podman-specific `podman unshare` branch — no longer needed without a container.
- **Step 5 post detection**: path updated from `target/web-site/_posts` to `target/web-site/content/posts`.
- **All preview URLs**: use `ROQ_PORT` variable instead of hardcoded 4000.
- **Stop hint**: prints the actual Roq server PID instead of a container stop command.

### `.agents/skills/building-docs/SKILL.md`

- Description, prerequisites, Step 0 env vars, Step 3 rsync paths, Step 4 (rewritten for `./mvnw quarkus:dev`), Step 5 table, iteration loop note, and all troubleshooting entries updated for Roq. All Jekyll/container content removed.

### `.justfile`

- Comment on the `docs-preview` target updated from "serve with Jekyll" to "serve with Roq".