### PR TITLE
OTel: Wrap the shared executor so that OTel shutdown does not take an extra 5 seconds to terminate

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/AutoConfiguredOpenTelemetrySdkBuilderCustomizer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/AutoConfiguredOpenTelemetrySdkBuilderCustomizer.java
@@ -344,7 +344,10 @@ public interface AutoConfiguredOpenTelemetrySdkBuilderCustomizer {
                             if (metricReader instanceof PeriodicMetricReader && managedExecutor.isResolvable()) {
                                 return PeriodicMetricReader.builder(metricExporterRef.get())
                                         .setInterval(oTelRuntimeConfig.metric().exportInterval())
-                                        .setExecutor(managedExecutor.get())
+                                        // wrap the shared managed executor: the reader assumes it owns its
+                                        // executor and shuts it down (with a 5s awaitTermination) on shutdown,
+                                        // which must not touch or block on the container-managed pool
+                                        .setExecutor(new NonShutdownableScheduledExecutorService(managedExecutor.get()))
                                         .build();
                             }
                             return metricReader;

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/NonShutdownableScheduledExecutorService.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/NonShutdownableScheduledExecutorService.java
@@ -1,0 +1,64 @@
+package io.quarkus.opentelemetry.runtime;
+
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import io.quarkus.runtime.util.ForwardingScheduledExecutorService;
+
+/**
+ * A {@link ScheduledExecutorService} view over a shared, container-managed executor whose lifecycle is
+ * <em>not</em> owned by the caller. Scheduling and execution are forwarded to the delegate, but the
+ * lifecycle methods are neutralized: {@link #shutdown()}/{@link #shutdownNow()} are no-ops and
+ * {@link #awaitTermination(long, TimeUnit)} returns immediately.
+ * <p>
+ * This is handed to OpenTelemetry's {@code PeriodicMetricReader}. That reader assumes it owns its executor
+ * and, on shutdown, calls {@code shutdown()} followed by {@code awaitTermination(5s)}. Forwarding those to
+ * the shared executor would (a) attempt to shut down an executor managed elsewhere and (b) block for the
+ * full timeout waiting for a termination that never happens. Neutralizing them avoids both.
+ * <p>
+ * Note: this is a pragmatic stub. It makes the reader believe its tasks have terminated without actually
+ * draining only the reader's own tasks; a more precise solution would give the reader a task-tracking
+ * <em>view</em> of the shared pool (e.g. a scheduled variant of {@code org.jboss.threads.ViewExecutor}) so
+ * that {@code shutdown()}/{@code awaitTermination()} drain exactly the reader's outstanding tasks.
+ */
+final class NonShutdownableScheduledExecutorService extends ForwardingScheduledExecutorService {
+
+    private final ScheduledExecutorService delegate;
+    private volatile boolean shutdown;
+
+    NonShutdownableScheduledExecutorService(ScheduledExecutorService delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    protected ScheduledExecutorService delegate() {
+        return delegate;
+    }
+
+    @Override
+    public void shutdown() {
+        shutdown = true;
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        shutdown = true;
+        return List.of();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return shutdown;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return shutdown;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+        return true;
+    }
+}


### PR DESCRIPTION
In my branch, I noticed that some tests were adding 5 seconds to shutdown. The cause is related to how we set up the exector for OTel. In `AutoConfiguredOpenTelemetrySdkBuilderCustomizer`, we configure OTel with our shared executor in order to avoid having redundant thread pools. But, even if you configure a shared executor, on shutdown, the framework tries to terminate the thread pool and then await for its termination. This never succeeds, since the await is happening on one of the executor threads (among other problems).

The fix is to wrap the injected scheduled executor with one that ignores shutdown requests and returns immediately from awaiting.

I think we may want to revisit how we wrap executors though: there's no reason why each service which consumes an executor *and* expects to manage it couldn't have a proper view which tracks the tasks submitted from that particular view, and manages its shutdown "nicely" in a way that the service expects. But, that's a future enhancement.