### PR TITLE
Check Keycloak token type on the OIDC server-less verification path

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -801,6 +801,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
         try {
             TokenVerificationResult result = resolvedContext.provider().verifyJwtToken(request.getToken().getToken(),
                     resolvedContext.oidcConfig().token().subjectRequired(), false, null);
+            OidcUtils.validatePrimaryJwtTokenType(resolvedContext.oidcConfig().token(), result.localVerificationResult());
             StepUpAuthenticationPolicy stepUpAuthPolicy = StepUpAuthenticationPolicy.getFromRequest(request);
             if (stepUpAuthPolicy != null) {
                 stepUpAuthPolicy.accept(result);

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -651,6 +651,39 @@ public class BearerTokenAuthorizationTest {
     }
 
     @Test
+    public void testKeycloakTokenTypeCheckedWithoutOidcServer() {
+        // An access token issued by Keycloak in a JWT format has a `typ` claim set to `Bearer`.
+        // It must be accepted when the token is verified locally without contacting the OIDC server.
+        String bearerToken = Jwt.preferredUserName("alice")
+                .groups(Set.of("user"))
+                .issuer("https://server.example.com")
+                .audience("https://service.example.com")
+                .claim("typ", "Bearer")
+                .sign();
+
+        RestAssured.given().auth().oauth2(bearerToken).when()
+                .get("/api/users/me/bearer")
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("alice"));
+
+        // A refresh token issued by Keycloak in a JWT format has a `typ` claim set to `Refresh`.
+        // It must be rejected even when the token is verified locally without contacting the OIDC server.
+        String refreshToken = Jwt.preferredUserName("alice")
+                .groups(Set.of("user"))
+                .issuer("https://server.example.com")
+                .audience("https://service.example.com")
+                .claim("typ", "Refresh")
+                .sign();
+
+        RestAssured.given().auth().oauth2(refreshToken).when()
+                .get("/api/users/me/bearer")
+                .then()
+                .statusCode(401)
+                .header("WWW-Authenticate", equalTo("Bearer"));
+    }
+
+    @Test
     public void testBearerTokenWrongIssuer() {
         String token = getAccessTokenWrongIssuer("alice", Set.of("user"));
 

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/AbstractBearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/AbstractBearerTokenAuthorizationTest.java
@@ -2,6 +2,7 @@ package io.quarkus.it.keycloak;
 
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -116,8 +117,22 @@ public abstract class AbstractBearerTokenAuthorizationTest {
     }
 
     @Test
-    public void testAccessAdminResourceWithRefreshToken() {
-        RestAssured.given().auth().oauth2(client.getRefreshToken("admin"))
+    public void testAccessAdminResourceWithAccessAndRefreshToken() {
+        // A real access token issued by Keycloak in a JWT format has a `typ` claim set to `Bearer`.
+        // It must be accepted on the bearer token verification path.
+        String accessToken = getAccessToken("admin");
+        assertEquals("Bearer", OidcUtils.decodeJwtContent(accessToken).getString("typ"));
+        RestAssured.given().auth().oauth2(accessToken)
+                .when().get("/api/admin")
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("granted:admin"));
+
+        // A real refresh token issued by Keycloak in a JWT format has a `typ` claim set to `Refresh`.
+        // It must be rejected on the bearer token verification path
+        String refreshToken = client.getRefreshToken("admin");
+        assertEquals("Refresh", OidcUtils.decodeJwtContent(refreshToken).getString("typ"));
+        RestAssured.given().auth().oauth2(refreshToken)
                 .when().get("/api/admin")
                 .then()
                 .statusCode(401);


### PR DESCRIPTION
Keycloak tokens that may be in JWT format have a type claim that we use to check to prevent Keycloak refresh tokens sent as bearer tokens. This is the best effort only - we can't prevent it if some other provider sends a RT in JWT format that is verifiable by the same key.

However this check is not performed on the OIDC server-less verification path such as when an inlined public key is used to verify the token, and it must be fixed.

Thanks to @Michael-JRead for noticing it