### PR TITLE
Keep WithFormRead request filter order when moving them after the body handler

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/WithFormReadFilterPriorityTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/WithFormReadFilterPriorityTest.java
@@ -1,0 +1,77 @@
+package io.quarkus.resteasy.reactive.server.test.customproviders;
+
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.core.HttpHeaders;
+
+import org.hamcrest.Matchers;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.server.ServerRequestFilter;
+import org.jboss.resteasy.reactive.server.WithFormRead;
+import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveContainerRequestContext;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+public class WithFormReadFilterPriorityTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(HelloResource.class, Filters.class);
+                }
+            });
+
+    @Test
+    public void testFormReadFiltersRunInPriorityOrder() {
+        RestAssured.with()
+                .formParam("name", "Quarkus")
+                .post("/hello")
+                .then().body(Matchers.equalTo("hello Quarkus first/second/third"));
+    }
+
+    @Path("hello")
+    public static class HelloResource {
+
+        @POST
+        public String helloPost(@RestForm String name, HttpHeaders headers) {
+            return "hello " + name + " " + headers.getHeaderString("order");
+        }
+    }
+
+    public static class Filters {
+
+        @WithFormRead
+        @ServerRequestFilter(readBody = true, priority = Priorities.USER + 100)
+        public void first(ResteasyReactiveContainerRequestContext context) {
+            append(context, "first");
+        }
+
+        @WithFormRead
+        @ServerRequestFilter(readBody = true, priority = Priorities.USER + 200)
+        public void second(ResteasyReactiveContainerRequestContext context) {
+            append(context, "second");
+        }
+
+        @WithFormRead
+        @ServerRequestFilter(readBody = true, priority = Priorities.USER + 300)
+        public void third(ResteasyReactiveContainerRequestContext context) {
+            append(context, "third");
+        }
+
+        private static void append(ResteasyReactiveContainerRequestContext context, String name) {
+            String current = context.getHeaders().getFirst("order");
+            context.getHeaders().putSingle("order", current == null ? name : current + "/" + name);
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -298,13 +298,15 @@ public class RuntimeResourceDeployment {
             }
         }
         if (checkWithFormReadRequestFilters && hasWithFormReadRequestFilters) {
-            // we need to remove the corresponding filters from the handlers list and add them to its end in the same order
+            // we need to remove the corresponding filters from the handlers list and add them to its end in the same order.
+            // the list is walked backwards because we remove by index as we go, so each match is inserted at the
+            // front to keep the relative order the handlers were already in
             List<ServerRestHandler> readBodyRequestFilters = new ArrayList<>(1);
             for (int i = handlers.size() - 2; i >= 0; i--) {
                 var serverRestHandler = handlers.get(i);
                 if (serverRestHandler instanceof ResourceRequestFilterHandler resourceRequestFilterHandler) {
                     if (resourceRequestFilterHandler.isWithFormRead()) {
-                        readBodyRequestFilters.add(handlers.remove(i));
+                        readBodyRequestFilters.add(0, handlers.remove(i));
                     }
                 }
             }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -299,17 +299,18 @@ public class RuntimeResourceDeployment {
         }
         if (checkWithFormReadRequestFilters && hasWithFormReadRequestFilters) {
             // we need to remove the corresponding filters from the handlers list and add them to its end in the same order.
-            // the list is walked backwards because we remove by index as we go, so each match is inserted at the
-            // front to keep the relative order the handlers were already in
+            // the list is walked backwards because we remove by index as we go, so the matches come out reversed and
+            // have to be flipped back before they are appended
             List<ServerRestHandler> readBodyRequestFilters = new ArrayList<>(1);
             for (int i = handlers.size() - 2; i >= 0; i--) {
                 var serverRestHandler = handlers.get(i);
                 if (serverRestHandler instanceof ResourceRequestFilterHandler resourceRequestFilterHandler) {
                     if (resourceRequestFilterHandler.isWithFormRead()) {
-                        readBodyRequestFilters.add(0, handlers.remove(i));
+                        readBodyRequestFilters.add(handlers.remove(i));
                     }
                 }
             }
+            Collections.reverse(readBodyRequestFilters);
             handlers.addAll(readBodyRequestFilters);
         }
 


### PR DESCRIPTION
`RuntimeResourceDeployment` moves `@WithFormRead` request filters to the end of the handler list once the body handler is in place. It walks the list backwards, because it removes by index as it goes, but it then appended the collected filters in that same backwards order, so the filters ended up reversed and priorities were applied in reverse.

The fix inserts each match at the front of the collected list instead, which keeps the order the handlers were already in. That is what the comment on the block already said should happen.

Added a test with three `@WithFormRead` filters at `USER + 100`, `USER + 200` and `USER + 300` that each append their name to a header, in the style of the existing `ReadBodyRequestFilterTest`. With the fix it gets `first/second/third`; without it the same test gets `third/second/first`.

`ReadBodyRequestFilterTest`, `ImpliedReadBodyRequestFilterTest`, `WithFormBodyTest` and `AnotherValidNonBlockingFiltersTest` still pass, 13 tests in total.

- Fixes: #54947