### PR TITLE
Upgrade RESTEasy to 7.0.4.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -28,7 +28,7 @@
         <parsson.version>1.1.9</parsson.version>
         <resteasy-microprofile.version>3.0.1.Final</resteasy-microprofile.version>
         <resteasy-spring-web.version>3.2.0.Final</resteasy-spring-web.version>
-        <resteasy.version>7.0.2.Final</resteasy.version>
+        <resteasy.version>7.0.4.Final</resteasy.version>
         <opentelemetry-instrumentation.version>2.28.1-alpha</opentelemetry-instrumentation.version> <!-- OTel SDk 1.62.0-->
         <opentelemetry-semconv.version>1.40.0-alpha</opentelemetry-semconv.version>
         <quarkus-http.version>6.0.0.Alpha4</quarkus-http.version>


### PR DESCRIPTION
### 7.0.4.Final Release Info

Full release notes: https://resteasy.dev/2026/09/01/releases/
Includes a fix for [CVE-2026-17615](https://github.com/resteasy/resteasy/security/advisories/GHSA-339g-695r-wx4w)
Tag: https://github.com/resteasy/resteasy/releases/tag/v7.0.4.Final

### 7.0.3.Final Release Info

Full release notes: https://resteasy.dev/2026/08/03/releases/
Tag: https://github.com/resteasy/resteasy/releases/tag/v7.0.3.Final
