### PR TITLE
[3.33] Upgrade RESTEasy to 6.2.18.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -28,7 +28,7 @@
         <parsson.version>1.1.7</parsson.version>
         <resteasy-microprofile.version>3.0.1.Final</resteasy-microprofile.version>
         <resteasy-spring-web.version>3.2.0.Final</resteasy-spring-web.version>
-        <resteasy.version>6.2.16.Final</resteasy.version>
+        <resteasy.version>6.2.18.Final</resteasy.version>
         <opentelemetry-instrumentation.version>2.23.0-alpha</opentelemetry-instrumentation.version> <!-- OTel SDk 1.55.0-->
         <opentelemetry-semconv.version>1.37.0-alpha</opentelemetry-semconv.version>
         <quarkus-http.version>5.5.0</quarkus-http.version>


### PR DESCRIPTION
### 6.2.18.Final Release Info

Full release notes: https://resteasy.dev/2026/09/01/releases/
Includes a fix for [CVE-2026-17615](https://github.com/resteasy/resteasy/security/advisories/GHSA-339g-695r-wx4w)
Tag: https://github.com/resteasy/resteasy/releases/tag/v6.2.18.Final

Full diff: https://github.com/resteasy/resteasy/compare/v6.2.16.Final...v6.2.18.Final

Upstream PR: #56361
