### PR TITLE
OIDC: Serve still-valid access tokens while a token refresh is in flight in the background

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -973,10 +973,10 @@ Additionally, you can use the `quarkus.oidc-client.refresh-token-time-skew` prop
 
 For example, if this property is set to `3S` and the access token will expire in less than 3 seconds, the token is refreshed automatically.
 
-While such a preemptive refresh is in progress, the access token which is being refreshed has not expired yet, so it keeps being returned to the requests arriving in the meantime instead of making them wait for the token endpoint to reply.
+While such a preemptive refresh is in progress, the access token which is being refreshed has not expired yet, so it can keep being returned to the requests arriving in the meantime instead of making them wait for the token endpoint to reply.
 
-It is only returned for as long as enough of its lifespan is left for it to be usable by the target service, which is controlled by the `quarkus.oidc-client.min-remaining-access-token-lifespan` property, `10S` by default.
-Requests arriving after that point wait for the refreshed token, as they did before, so that the token does not expire in transit or while the target service is processing the request.
+This is opt-in: it only happens when the `quarkus.oidc-client.min-remaining-access-token-lifespan` property is configured, which sets how much of the access token lifespan must be left for it to still be returned.
+Requests arriving once less than that is left wait for the refreshed token, as they do when this property is not configured, so that the token does not expire in transit or while the target service is processing the request.
 
 Because a preemptive refresh only starts once the remaining lifespan has dropped below `quarkus.oidc-client.refresh-token-time-skew`, a minimum remaining lifespan greater than or equal to the skew would stop the token from ever being reused.
 The effective value is therefore capped just below the configured skew, so that lowering the skew does not silently disable this optimization.

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -976,10 +976,11 @@ For example, if this property is set to `3S` and the access token will expire in
 While such a preemptive refresh is in progress, the access token which is being refreshed has not expired yet, so it can keep being returned to the requests arriving in the meantime instead of making them wait for the token endpoint to reply.
 
 This is opt-in: it only happens when the `quarkus.oidc-client.min-remaining-access-token-lifespan` property is configured, which sets how much of the access token lifespan must be left for it to still be returned.
-Requests arriving once less than that is left wait for the refreshed token, as they do when this property is not configured, so that the token does not expire in transit or while the target service is processing the request.
+Requests arriving when `expiration < remaining-access-token-lifespan` then wait for the refreshed token, as they do when this property is not configured, so that the token does not expire in transit or while the target service is processing the request.
 
-Because a preemptive refresh only starts once the remaining lifespan has dropped below `quarkus.oidc-client.refresh-token-time-skew`, a minimum remaining lifespan greater than or equal to the skew would stop the token from ever being reused.
-The effective value is therefore capped just below the configured skew, so that lowering the skew does not silently disable this optimization.
+Because a preemptive refresh only starts once the remaining lifespan has dropped below `quarkus.oidc-client.refresh-token-time-skew`, then `0 < quarkus.oidc-client.min-remaining-access-token-lifespan < quarkus.oidc-client.refresh-token-time-skew` must hold and the application fails to start otherwise.
+
+For example, with `quarkus.oidc-client.refresh-token-time-skew=60S` the refresh starts while a minute of the access token lifespan is left, and `quarkus.oidc-client.min-remaining-access-token-lifespan=30S` returns that token to the requests arriving during the refresh for as long as at least 30 seconds of token duration are left.
 
 By default, the OIDC client refreshes the token during the current request when it detects that the token has expired, or is nearly expired if the xref:#quarkus-oidc-client_quarkus-oidc-client-refresh-token-time-skew[refresh token time skew] is configured.
 Performance-critical applications might want to avoid waiting for a possible token refresh during incoming requests and configure an asynchronous token refresh instead.

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -973,6 +973,14 @@ Additionally, you can use the `quarkus.oidc-client.refresh-token-time-skew` prop
 
 For example, if this property is set to `3S` and the access token will expire in less than 3 seconds, the token is refreshed automatically.
 
+While such a preemptive refresh is in progress, the access token which is being refreshed has not expired yet, so it keeps being returned to the requests arriving in the meantime instead of making them wait for the token endpoint to reply.
+
+It is only returned for as long as enough of its lifespan is left for it to be usable by the target service, which is controlled by the `quarkus.oidc-client.min-remaining-access-token-lifespan` property, `10S` by default.
+Requests arriving after that point wait for the refreshed token, as they did before, so that the token does not expire in transit or while the target service is processing the request.
+
+Because a preemptive refresh only starts once the remaining lifespan has dropped below `quarkus.oidc-client.refresh-token-time-skew`, a minimum remaining lifespan greater than or equal to the skew would stop the token from ever being reused.
+The effective value is therefore capped just below the configured skew, so that lowering the skew does not silently disable this optimization.
+
 By default, the OIDC client refreshes the token during the current request when it detects that the token has expired, or is nearly expired if the xref:#quarkus-oidc-client_quarkus-oidc-client-refresh-token-time-skew[refresh token time skew] is configured.
 Performance-critical applications might want to avoid waiting for a possible token refresh during incoming requests and configure an asynchronous token refresh instead.
 

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientMinRemainingAccessTokenLifespanNotLessThanSkewTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientMinRemainingAccessTokenLifespanNotLessThanSkewTestCase.java
@@ -1,0 +1,58 @@
+package io.quarkus.oidc.client;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * A refresh only starts once the remaining lifespan has dropped below the skew, so a minimum which is not
+ * less than the skew could never be satisfied and would silently disable the reuse of the token being refreshed.
+ */
+public class OidcClientMinRemainingAccessTokenLifespanNotLessThanSkewTestCase {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(
+                            "# Disable Dev Services, Keycloak is started by a Maven plugin\n"
+                                    + "quarkus.keycloak.devservices.enabled=false\n"
+                                    + "quarkus.oidc-client.token-path=http://localhost:8180/oidc/tokens\n"
+                                    + "quarkus.oidc-client.client-id=quarkus\n"
+                                    + "quarkus.oidc-client.credentials.secret=secret\n"
+                                    + "quarkus.oidc-client.refresh-token-time-skew=10S\n"
+                                    + "quarkus.oidc-client.min-remaining-access-token-lifespan=10S\n"),
+                            "application.properties"))
+            .assertException(t -> {
+                ConfigurationException te = configurationException(t);
+                assertNotNull(te, "Expected ConfigurationException, but got: " + t);
+                assertTrue(
+                        te.getMessage().contains(
+                                "'quarkus.oidc-client.min-remaining-access-token-lifespan' must be less than"
+                                        + " 'quarkus.oidc-client.refresh-token-time-skew'"),
+                        te.getMessage());
+            });
+
+    static ConfigurationException configurationException(Throwable t) {
+        Throwable e = t;
+        while (e != null) {
+            if (e instanceof ConfigurationException) {
+                return (ConfigurationException) e;
+            }
+            e = e.getCause();
+        }
+        return null;
+    }
+
+    @Test
+    public void test() {
+        Assertions.fail();
+    }
+
+}

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientMinRemainingAccessTokenLifespanNotPositiveTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientMinRemainingAccessTokenLifespanNotPositiveTestCase.java
@@ -1,0 +1,47 @@
+package io.quarkus.oidc.client;
+
+import static io.quarkus.oidc.client.OidcClientMinRemainingAccessTokenLifespanNotLessThanSkewTestCase.configurationException;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * A zero minimum remaining lifespan would allow an access token with nothing left to be reused, which is what
+ * this feature exists to prevent, so it is rejected rather than treated as "no minimum".
+ */
+public class OidcClientMinRemainingAccessTokenLifespanNotPositiveTestCase {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(
+                            "# Disable Dev Services, Keycloak is started by a Maven plugin\n"
+                                    + "quarkus.keycloak.devservices.enabled=false\n"
+                                    + "quarkus.oidc-client.token-path=http://localhost:8180/oidc/tokens\n"
+                                    + "quarkus.oidc-client.client-id=quarkus\n"
+                                    + "quarkus.oidc-client.credentials.secret=secret\n"
+                                    + "quarkus.oidc-client.refresh-token-time-skew=10S\n"
+                                    + "quarkus.oidc-client.min-remaining-access-token-lifespan=0S\n"),
+                            "application.properties"))
+            .assertException(t -> {
+                ConfigurationException te = configurationException(t);
+                assertNotNull(te, "Expected ConfigurationException, but got: " + t);
+                assertTrue(
+                        te.getMessage().contains(
+                                "'quarkus.oidc-client.min-remaining-access-token-lifespan' must be greater than zero"),
+                        te.getMessage());
+            });
+
+    @Test
+    public void test() {
+        Assertions.fail();
+    }
+
+}

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientMinRemainingAccessTokenLifespanWithoutSkewTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientMinRemainingAccessTokenLifespanWithoutSkewTestCase.java
@@ -1,0 +1,47 @@
+package io.quarkus.oidc.client;
+
+import static io.quarkus.oidc.client.OidcClientMinRemainingAccessTokenLifespanNotLessThanSkewTestCase.configurationException;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Without a refresh token time skew no refresh starts before the access token has expired, so there is never a
+ * valid token to reuse and a minimum remaining lifespan on its own would have no effect.
+ */
+public class OidcClientMinRemainingAccessTokenLifespanWithoutSkewTestCase {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(
+                            "# Disable Dev Services, Keycloak is started by a Maven plugin\n"
+                                    + "quarkus.keycloak.devservices.enabled=false\n"
+                                    + "quarkus.oidc-client.token-path=http://localhost:8180/oidc/tokens\n"
+                                    + "quarkus.oidc-client.client-id=quarkus\n"
+                                    + "quarkus.oidc-client.credentials.secret=secret\n"
+                                    + "quarkus.oidc-client.min-remaining-access-token-lifespan=5S\n"),
+                            "application.properties"))
+            .assertException(t -> {
+                ConfigurationException te = configurationException(t);
+                assertNotNull(te, "Expected ConfigurationException, but got: " + t);
+                assertTrue(
+                        te.getMessage().contains(
+                                "'quarkus.oidc-client.min-remaining-access-token-lifespan' requires"
+                                        + " 'quarkus.oidc-client.refresh-token-time-skew' to be configured"),
+                        te.getMessage());
+            });
+
+    @Test
+    public void test() {
+        Assertions.fail();
+    }
+
+}

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfigBuilder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfigBuilder.java
@@ -30,7 +30,7 @@ public final class OidcClientConfigBuilder extends OidcClientCommonConfigBuilder
         private final Optional<Duration> accessTokenExpiresIn;
         private final Optional<Duration> accessTokenExpirySkew;
         private final Optional<Duration> refreshTokenTimeSkew;
-        private final Duration minRemainingAccessTokenLifespan;
+        private final Optional<Duration> minRemainingAccessTokenLifespan;
         private final Optional<List<String>> scopes;
         private final Optional<List<String>> audience;
         private final boolean clientEnabled;
@@ -81,7 +81,7 @@ public final class OidcClientConfigBuilder extends OidcClientCommonConfigBuilder
         }
 
         @Override
-        public Duration minRemainingAccessTokenLifespan() {
+        public Optional<Duration> minRemainingAccessTokenLifespan() {
             return minRemainingAccessTokenLifespan;
         }
 
@@ -143,7 +143,7 @@ public final class OidcClientConfigBuilder extends OidcClientCommonConfigBuilder
     private Optional<Duration> accessTokenExpiresIn;
     private Optional<Duration> accessTokenExpirySkew;
     private Optional<Duration> refreshTokenTimeSkew;
-    private Duration minRemainingAccessTokenLifespan;
+    private Optional<Duration> minRemainingAccessTokenLifespan;
     private boolean clientEnabled;
     private Optional<String> id;
     private Optional<Duration> refreshInterval;
@@ -296,7 +296,7 @@ public final class OidcClientConfigBuilder extends OidcClientCommonConfigBuilder
      * @return this builder
      */
     public OidcClientConfigBuilder minRemainingAccessTokenLifespan(Duration minRemainingAccessTokenLifespan) {
-        this.minRemainingAccessTokenLifespan = minRemainingAccessTokenLifespan;
+        this.minRemainingAccessTokenLifespan = Optional.ofNullable(minRemainingAccessTokenLifespan);
         return this;
     }
 

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfigBuilder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfigBuilder.java
@@ -30,6 +30,7 @@ public final class OidcClientConfigBuilder extends OidcClientCommonConfigBuilder
         private final Optional<Duration> accessTokenExpiresIn;
         private final Optional<Duration> accessTokenExpirySkew;
         private final Optional<Duration> refreshTokenTimeSkew;
+        private final Duration minRemainingAccessTokenLifespan;
         private final Optional<List<String>> scopes;
         private final Optional<List<String>> audience;
         private final boolean clientEnabled;
@@ -46,6 +47,7 @@ public final class OidcClientConfigBuilder extends OidcClientCommonConfigBuilder
             this.accessTokenExpiresIn = builder.accessTokenExpiresIn;
             this.accessTokenExpirySkew = builder.accessTokenExpirySkew;
             this.refreshTokenTimeSkew = builder.refreshTokenTimeSkew;
+            this.minRemainingAccessTokenLifespan = builder.minRemainingAccessTokenLifespan;
             this.scopes = builder.scopes.isEmpty() ? Optional.empty() : Optional.of(List.copyOf(builder.scopes));
             this.audience = builder.audience.isEmpty() ? Optional.empty() : Optional.of(List.copyOf(builder.audience));
             this.clientEnabled = builder.clientEnabled;
@@ -76,6 +78,11 @@ public final class OidcClientConfigBuilder extends OidcClientCommonConfigBuilder
         @Override
         public Optional<Duration> refreshTokenTimeSkew() {
             return refreshTokenTimeSkew;
+        }
+
+        @Override
+        public Duration minRemainingAccessTokenLifespan() {
+            return minRemainingAccessTokenLifespan;
         }
 
         @Override
@@ -136,6 +143,7 @@ public final class OidcClientConfigBuilder extends OidcClientCommonConfigBuilder
     private Optional<Duration> accessTokenExpiresIn;
     private Optional<Duration> accessTokenExpirySkew;
     private Optional<Duration> refreshTokenTimeSkew;
+    private Duration minRemainingAccessTokenLifespan;
     private boolean clientEnabled;
     private Optional<String> id;
     private Optional<Duration> refreshInterval;
@@ -160,6 +168,7 @@ public final class OidcClientConfigBuilder extends OidcClientCommonConfigBuilder
         this.accessTokenExpiresIn = config.accessTokenExpiresIn();
         this.accessTokenExpirySkew = config.accessTokenExpirySkew();
         this.refreshTokenTimeSkew = config.refreshTokenTimeSkew();
+        this.minRemainingAccessTokenLifespan = config.minRemainingAccessTokenLifespan();
         this.clientEnabled = config.clientEnabled();
         this.id = config.id();
         this.refreshInterval = config.refreshInterval();
@@ -279,6 +288,15 @@ public final class OidcClientConfigBuilder extends OidcClientCommonConfigBuilder
      */
     public OidcClientConfigBuilder refreshTokenTimeSkew(Duration refreshTokenTimeSkew) {
         this.refreshTokenTimeSkew = Optional.ofNullable(refreshTokenTimeSkew);
+        return this;
+    }
+
+    /**
+     * @param minRemainingAccessTokenLifespan {@link OidcClientConfig#minRemainingAccessTokenLifespan()}
+     * @return this builder
+     */
+    public OidcClientConfigBuilder minRemainingAccessTokenLifespan(Duration minRemainingAccessTokenLifespan) {
+        this.minRemainingAccessTokenLifespan = minRemainingAccessTokenLifespan;
         return this;
     }
 

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/Tokens.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/Tokens.java
@@ -67,35 +67,22 @@ public class Tokens {
      * Whether this access token has enough of its lifespan left to still be worth sending while it is
      * being refreshed, so that it does not expire in transit or while the target service is processing
      * the request.
-     * <p>
-     * Returns false when no minimum remaining lifespan is configured: reusing the token which is being
-     * refreshed is opt-in, so the callers wait for the refresh unless the minimum has been set.
-     * <p>
-     * A refresh only starts once the remaining lifespan has dropped below the refresh token time skew,
-     * so requiring the skew itself, or more, would stop the token from ever being reused. The required
-     * margin is capped just below the skew for that reason.
      */
     public boolean hasMinRemainingAccessTokenLifespan() {
         if (minRemainingAccessTokenLifespan == null) {
-            // Not configured: reusing the token being refreshed is opt-in, so the caller waits.
             return false;
         }
         if (accessTokenExpiresAt == null) {
-            // Without an expiry there is nothing to run out; the token is reusable.
             return true;
         }
-        // Capped below the skew, since a refresh only starts once less than the skew is left in the token expiration.
-        final long requiredLifespan = refreshTokenTimeSkew == null
-                ? minRemainingAccessTokenLifespan
-                : Math.min(minRemainingAccessTokenLifespan, refreshTokenTimeSkew - 1);
         final long nowSecs = System.currentTimeMillis() / 1000;
         final long remaining = accessTokenExpiresAt - nowSecs;
-        final boolean reusable = remaining >= requiredLifespan;
+        final boolean reusable = remaining >= minRemainingAccessTokenLifespan;
 
         if (!reusable) {
             LOG.debugf("Access token being refreshed for client %s will not be reused because it expires in about"
                     + " %d seconds which is less than the minimum remaining access token lifespan %d",
-                    clientId, remaining, requiredLifespan);
+                    clientId, remaining, minRemainingAccessTokenLifespan);
         }
 
         return reusable;

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/Tokens.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/Tokens.java
@@ -68,17 +68,21 @@ public class Tokens {
      * being refreshed, so that it does not expire in transit or while the target service is processing
      * the request.
      * <p>
+     * Returns false when no minimum remaining lifespan is configured: reusing the token which is being
+     * refreshed is opt-in, so the callers wait for the refresh unless the minimum has been set.
+     * <p>
      * A refresh only starts once the remaining lifespan has dropped below the refresh token time skew,
      * so requiring the skew itself, or more, would stop the token from ever being reused. The required
      * margin is capped just below the skew for that reason.
      */
     public boolean hasMinRemainingAccessTokenLifespan() {
+        if (minRemainingAccessTokenLifespan == null) {
+            // Not configured: reusing the token being refreshed is opt-in, so the caller waits.
+            return false;
+        }
         if (accessTokenExpiresAt == null) {
             // Without an expiry there is nothing to run out; the token is reusable.
             return true;
-        }
-        if (minRemainingAccessTokenLifespan == null) {
-            return !isAccessTokenExpired();
         }
         // Capped below the skew, since a refresh only starts once less than the skew is left in the token expiration.
         final long requiredLifespan = refreshTokenTimeSkew == null

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/Tokens.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/Tokens.java
@@ -15,13 +15,15 @@ public class Tokens {
     final private String accessToken;
     final private Long accessTokenExpiresAt;
     final private Long refreshTokenTimeSkew;
+    final private Long minRemainingAccessTokenLifespan;
     final private String refreshToken;
     final Long refreshTokenExpiresAt;
     final private JsonObject grantResponse;
     final private String clientId;
 
     public Tokens(String accessToken, Long accessTokenExpiresAt, Duration refreshTokenTimeSkewDuration, String refreshToken,
-            Long refreshTokenExpiresAt, JsonObject grantResponse, String clientId) {
+            Long refreshTokenExpiresAt, JsonObject grantResponse, String clientId,
+            Duration minRemainingAccessTokenLifespanDuration) {
         this.accessToken = accessToken;
         this.accessTokenExpiresAt = accessTokenExpiresAt;
         this.refreshTokenTimeSkew = refreshTokenTimeSkewDuration == null ? null : refreshTokenTimeSkewDuration.getSeconds();
@@ -29,6 +31,8 @@ public class Tokens {
         this.refreshTokenExpiresAt = refreshTokenExpiresAt;
         this.grantResponse = grantResponse;
         this.clientId = clientId;
+        this.minRemainingAccessTokenLifespan = minRemainingAccessTokenLifespanDuration == null ? null
+                : minRemainingAccessTokenLifespanDuration.getSeconds();
     }
 
     public String getClientId() {
@@ -53,6 +57,44 @@ public class Tokens {
 
     public Long getRefreshTokenTimeSkew() {
         return refreshTokenTimeSkew;
+    }
+
+    public Long getMinRemainingAccessTokenLifespan() {
+        return minRemainingAccessTokenLifespan;
+    }
+
+    /**
+     * Whether this access token has enough of its lifespan left to still be worth sending while it is
+     * being refreshed, so that it does not expire in transit or while the target service is processing
+     * the request.
+     * <p>
+     * A refresh only starts once the remaining lifespan has dropped below the refresh token time skew,
+     * so requiring the skew itself, or more, would stop the token from ever being reused. The required
+     * margin is capped just below the skew for that reason.
+     */
+    public boolean hasMinRemainingAccessTokenLifespan() {
+        if (accessTokenExpiresAt == null) {
+            // Without an expiry there is nothing to run out; the token is reusable.
+            return true;
+        }
+        if (minRemainingAccessTokenLifespan == null) {
+            return !isAccessTokenExpired();
+        }
+        // Capped below the skew, since a refresh only starts once less than the skew is left in the token expiration.
+        final long requiredLifespan = refreshTokenTimeSkew == null
+                ? minRemainingAccessTokenLifespan
+                : Math.min(minRemainingAccessTokenLifespan, refreshTokenTimeSkew - 1);
+        final long nowSecs = System.currentTimeMillis() / 1000;
+        final long remaining = accessTokenExpiresAt - nowSecs;
+        final boolean reusable = remaining >= requiredLifespan;
+
+        if (!reusable) {
+            LOG.debugf("Access token being refreshed for client %s will not be reused because it expires in about"
+                    + " %d seconds which is less than the minimum remaining access token lifespan %d",
+                    clientId, remaining, requiredLifespan);
+        }
+
+        return reusable;
     }
 
     public boolean isAccessTokenExpired() {

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientConfig.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientConfig.java
@@ -46,7 +46,7 @@ public interface OidcClientConfig extends OidcClientCommonConfig {
     Optional<Duration> refreshTokenTimeSkew();
 
     /**
-     * Minimum remaining lifespan required to reuse the access token currently being refreshed in the background
+     * Minimum remaining lifespan required to reuse the access token currently being refreshed in the background.
      * <p>
      * When {@link #refreshTokenTimeSkew()} is configured, the refresh starts before the current access
      * token expires, and that token remains usable until the refresh is completed. This avoids having to wait
@@ -54,12 +54,15 @@ public interface OidcClientConfig extends OidcClientCommonConfig {
      * for it to still be worth sending, so that it does not expire in transit or while the target service
      * is processing the request.
      * <p>
+     * Reusing the access token which is being refreshed is only enabled when this property is configured.
+     * If it is not configured then that token is never reused and the callers arriving while the refresh is
+     * in progress wait for it to complete.
+     * <p>
      * The refresh only starts once the remaining lifespan has dropped below {@link #refreshTokenTimeSkew()},
      * so a value greater than or equal to the skew would prevent the token from ever being returned.
      * Therefore the effective value is capped just below the configured skew.
      */
-    @WithDefault("10S")
-    Duration minRemainingAccessTokenLifespan();
+    Optional<Duration> minRemainingAccessTokenLifespan();
 
     /**
      * Access token expiration period relative to the current time.

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientConfig.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientConfig.java
@@ -51,16 +51,17 @@ public interface OidcClientConfig extends OidcClientCommonConfig {
      * When {@link #refreshTokenTimeSkew()} is configured, the refresh starts before the current access
      * token expires, and that token remains usable until the refresh is completed. This avoids having to wait
      * for the token refresh to complete. This property sets how much of its lifespan must be left
-     * for it to still be worth sending, so that it does not expire in transit or while the target service
+     * for it to still be worth re-using, so that it does not expire in transit or while the target service
      * is processing the request.
      * <p>
      * Reusing the access token which is being refreshed is only enabled when this property is configured.
      * If it is not configured then that token is never reused and the callers arriving while the refresh is
-     * in progress wait for it to complete.
+     * in progress wait for the refresh to complete.
      * <p>
      * The refresh only starts once the remaining lifespan has dropped below {@link #refreshTokenTimeSkew()},
-     * so a value greater than or equal to the skew would prevent the token from ever being returned.
-     * Therefore the effective value is capped just below the configured skew.
+     * so a value greater than or equal to the skew could never be satisfied and would silently stop the token
+     * from ever being reused. This property must therefore be greater than zero and less than
+     * {@link #refreshTokenTimeSkew()}, which must itself be configured. The application fails to start otherwise.
      */
     Optional<Duration> minRemainingAccessTokenLifespan();
 

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientConfig.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientConfig.java
@@ -46,6 +46,22 @@ public interface OidcClientConfig extends OidcClientCommonConfig {
     Optional<Duration> refreshTokenTimeSkew();
 
     /**
+     * Minimum remaining lifespan required to reuse the access token currently being refreshed in the background
+     * <p>
+     * When {@link #refreshTokenTimeSkew()} is configured, the refresh starts before the current access
+     * token expires, and that token remains usable until the refresh is completed. This avoids having to wait
+     * for the token refresh to complete. This property sets how much of its lifespan must be left
+     * for it to still be worth sending, so that it does not expire in transit or while the target service
+     * is processing the request.
+     * <p>
+     * The refresh only starts once the remaining lifespan has dropped below {@link #refreshTokenTimeSkew()},
+     * so a value greater than or equal to the skew would prevent the token from ever being returned.
+     * Therefore the effective value is capped just below the configured skew.
+     */
+    @WithDefault("10S")
+    Duration minRemainingAccessTokenLifespan();
+
+    /**
      * Access token expiration period relative to the current time.
      * This property is only checked when an access token grant response
      * does not include an access token expiration property.

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -378,7 +378,7 @@ public class OidcClientImpl implements OidcClient {
                         var tokens = new Tokens(accessToken, accessTokenExpiresAt,
                                 oidcConfig.refreshTokenTimeSkew().orElse(null), refreshToken,
                                 refreshTokenExpiresAt, json, oidcConfig.clientId().orElse(DEFAULT_OIDC_CLIENT_ID),
-                                oidcConfig.minRemainingAccessTokenLifespan());
+                                oidcConfig.minRemainingAccessTokenLifespan().orElse(null));
                         return Uni.createFrom().item(tokens);
                     } else {
                         String errorMessage = buffer.toString();

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -377,7 +377,8 @@ public class OidcClientImpl implements OidcClient {
 
                         var tokens = new Tokens(accessToken, accessTokenExpiresAt,
                                 oidcConfig.refreshTokenTimeSkew().orElse(null), refreshToken,
-                                refreshTokenExpiresAt, json, oidcConfig.clientId().orElse(DEFAULT_OIDC_CLIENT_ID));
+                                refreshTokenExpiresAt, json, oidcConfig.clientId().orElse(DEFAULT_OIDC_CLIENT_ID),
+                                oidcConfig.minRemainingAccessTokenLifespan());
                         return Uni.createFrom().item(tokens);
                     } else {
                         String errorMessage = buffer.toString();

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -1,6 +1,7 @@
 package io.quarkus.oidc.client.runtime;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -42,6 +43,8 @@ public class OidcClientRecorder {
 
     private static final Logger LOG = Logger.getLogger(OidcClientRecorder.class);
     private static final String CLIENT_ID_ATTRIBUTE = "client-id";
+    private static final String MIN_REMAINING_ACCESS_TOKEN_LIFESPAN_PROPERTY = "quarkus.oidc-client.min-remaining-access-token-lifespan";
+    private static final String REFRESH_TOKEN_TIME_SKEW_PROPERTY = "quarkus.oidc-client.refresh-token-time-skew";
     static final String DEFAULT_OIDC_CLIENT_ID = "Default";
 
     static Map<String, OidcClient> createStaticOidcClients(OidcClientsConfig oidcClientsConfig, Vertx vertx,
@@ -111,6 +114,7 @@ public class OidcClientRecorder {
         try {
             OidcCommonUtils.verifyCommonConfiguration(oidcConfig, false, false);
             OidcCommonUtils.validateCredentialsForAllEndpoints(oidcConfig.credentials());
+            verifyMinRemainingAccessTokenLifespan(oidcConfig);
         } catch (ConfigurationException e) {
             return Uni.createFrom().failure(e);
         }
@@ -154,6 +158,38 @@ public class OidcClientRecorder {
                                 deferredClient.onFailure().transform(t -> toOidcClientException(getEndpointUrl(oidcConfig), t)),
                                 oidcClientId, client);
                     });
+        }
+    }
+
+    /**
+     * Reusing the access token which is being refreshed is only enabled when a minimum remaining lifespan is
+     * configured lower than the refresh token time skew
+     */
+    private static void verifyMinRemainingAccessTokenLifespan(OidcClientConfig oidcConfig) {
+        if (oidcConfig.minRemainingAccessTokenLifespan().isEmpty()) {
+            return;
+        }
+        final Duration minRemainingLifespan = oidcConfig.minRemainingAccessTokenLifespan().get();
+        if (minRemainingLifespan.isNegative() || minRemainingLifespan.isZero()) {
+            throw new ConfigurationException(
+                    "'quarkus.oidc-client.min-remaining-access-token-lifespan' must be greater than zero",
+                    Set.of(MIN_REMAINING_ACCESS_TOKEN_LIFESPAN_PROPERTY));
+        }
+        if (oidcConfig.refreshTokenTimeSkew().isEmpty()) {
+            throw new ConfigurationException(
+                    "'quarkus.oidc-client.min-remaining-access-token-lifespan' requires"
+                            + " 'quarkus.oidc-client.refresh-token-time-skew' to be configured, as the access token is only"
+                            + " refreshed before it expires when the skew is set",
+                    Set.of(MIN_REMAINING_ACCESS_TOKEN_LIFESPAN_PROPERTY, REFRESH_TOKEN_TIME_SKEW_PROPERTY));
+        }
+        final Duration refreshTokenTimeSkew = oidcConfig.refreshTokenTimeSkew().get();
+        if (minRemainingLifespan.compareTo(refreshTokenTimeSkew) >= 0) {
+            throw new ConfigurationException(
+                    "'quarkus.oidc-client.min-remaining-access-token-lifespan' must be less than"
+                            + " 'quarkus.oidc-client.refresh-token-time-skew', but " + minRemainingLifespan + " is not less"
+                            + " than " + refreshTokenTimeSkew + ". A refresh only starts once less than the skew is left,"
+                            + " so the access token being refreshed would never be reused",
+                    Set.of(MIN_REMAINING_ACCESS_TOKEN_LIFESPAN_PROPERTY, REFRESH_TOKEN_TIME_SKEW_PROPERTY));
         }
     }
 

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
@@ -49,9 +49,10 @@ public class TokensHelper {
                 }
                 //rerun the CAS loop
             } else if (currentState.tokenUni != null) {
-                // Serve the previous token whilst a new token is refreshed in the background
+                // Serve the previous token whilst a new token is refreshed in the background.
+                // Unless callers asked for a refresh due to refreshOnUnauthorized
                 final Tokens previousTokens = currentState.previousToken;
-                if (previousTokens != null && !previousTokens.isAccessTokenExpired()) {
+                if (!forceNewTokens && previousTokens != null && !previousTokens.isAccessTokenExpired()) {
                     return Uni.createFrom().item(previousTokens);
                 }
                 return currentState.tokenUni;

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
@@ -49,19 +49,9 @@ public class TokensHelper {
                 }
                 //rerun the CAS loop
             } else if (currentState.tokenUni != null) {
-                // A token request is already in flight. If it is a proactive refresh, the tokens
-                // it is replacing are usually still valid, because `refresh-token-time-skew`
-                // starts the refresh before they expire. Serving those avoids making this caller
-                // wait for a refresh it did not trigger; without it, every request arriving during
-                // a refresh blocks on it even though a perfectly usable token is in hand.
-                //
-                // Unexpired tokens are served here on exactly the terms they are served below,
-                // when no refresh is running: an unexpired access token is usable, an expired one
-                // is not and its holder waits for a new one. The only difference is what is waited
-                // on -- the refresh already in flight, rather than one this caller starts. There is
-                // no additional margin, because that would make a token which is good enough to
-                // send when nothing is being refreshed not good enough while something is.
-                final Tokens previousTokens = currentState.previousTokens;
+                // Serve the previous token (still valid) whilst a new token is refreshed in the background
+                // to avoid waiting for the refresh to complete
+                final Tokens previousTokens = currentState.previousToken;
                 if (previousTokens != null && !previousTokens.isAccessTokenExpired()) {
                     return Uni.createFrom().item(previousTokens);
                 }
@@ -84,11 +74,10 @@ public class TokensHelper {
                         LOG.debugf("Refresh token is not available or has expired, "
                                 + "acquiring new tokens instead for client %s", tokens.getClientId());
                     }
-                    newState = new TokenRequestState(
-                            prepareUni(refreshTokenValid
+                    newState = new TokenRequestState(prepareUni(
+                            refreshTokenValid
                                     ? oidcClient.refreshTokens(tokens.getRefreshToken(), additionalParameters)
-                                    : oidcClient.getTokens(additionalParameters)),
-                            tokens);
+                                    : oidcClient.getTokens(additionalParameters)), tokens);
                     if (tokenRequestStateUpdater.compareAndSet(this, currentState, newState)) {
                         return newState.tokenUni;
                     }
@@ -125,22 +114,22 @@ public class TokensHelper {
          * keep being served while the refresh is in progress. May be null when no tokens have been
          * acquired yet, or when the ones being replaced had already expired.
          */
-        final Tokens previousTokens;
+        final Tokens previousToken;
 
         TokenRequestState(Tokens tokens) {
             this.tokens = tokens;
             this.tokenUni = null;
-            this.previousTokens = null;
+            this.previousToken = null;
         }
 
         TokenRequestState(Uni<Tokens> tokensUni) {
             this(tokensUni, null);
         }
 
-        TokenRequestState(Uni<Tokens> tokensUni, Tokens previousTokens) {
+        TokenRequestState(Uni<Tokens> tokensUni, Tokens previousToken) {
             this.tokens = null;
             this.tokenUni = tokensUni;
-            this.previousTokens = previousTokens;
+            this.previousToken = previousToken;
         }
     }
 }

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
@@ -77,7 +77,8 @@ public class TokensHelper {
                     newState = new TokenRequestState(prepareUni(
                             refreshTokenValid
                                     ? oidcClient.refreshTokens(tokens.getRefreshToken(), additionalParameters)
-                                    : oidcClient.getTokens(additionalParameters)), tokens);
+                                    : oidcClient.getTokens(additionalParameters)),
+                            tokens);
                     if (tokenRequestStateUpdater.compareAndSet(this, currentState, newState)) {
                         return newState.tokenUni;
                     }

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
@@ -49,8 +49,7 @@ public class TokensHelper {
                 }
                 //rerun the CAS loop
             } else if (currentState.tokenUni != null) {
-                // Serve the previous token (still valid) whilst a new token is refreshed in the background
-                // to avoid waiting for the refresh to complete
+                // Serve the previous token whilst a new token is refreshed in the background
                 final Tokens previousTokens = currentState.previousToken;
                 if (previousTokens != null && !previousTokens.isAccessTokenExpired()) {
                     return Uni.createFrom().item(previousTokens);

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
@@ -49,11 +49,11 @@ public class TokensHelper {
                 }
                 //rerun the CAS loop
             } else if (currentState.tokenUni != null) {
-                // Serve the previous token whilst a new token is refreshed in the background.
-                // Unless callers asked for a refresh due to refreshOnUnauthorized
-                final Tokens previousTokens = currentState.previousToken;
-                if (!forceNewTokens && previousTokens != null && !previousTokens.isAccessTokenExpired()) {
-                    return Uni.createFrom().item(previousTokens);
+                // Serve token getting refreshed if it has enough lifespan left
+                final Tokens tokensBeingRefreshed = currentState.tokensBeingRefreshed;
+                if (!forceNewTokens && tokensBeingRefreshed != null
+                        && tokensBeingRefreshed.hasMinRemainingAccessTokenLifespan()) {
+                    return Uni.createFrom().item(tokensBeingRefreshed);
                 }
                 return currentState.tokenUni;
             } else if (forceNewTokens) {
@@ -65,20 +65,23 @@ public class TokensHelper {
                 }
                 //rerun the CAS loop
             } else {
-                Tokens tokens = currentState.tokens;
+                final Tokens tokens = currentState.tokens;
 
-                if (tokens.isAccessTokenExpired() || tokens.isAccessTokenWithinRefreshInterval()) {
+                final boolean accessTokenExpired = tokens.isAccessTokenExpired();
+
+                if (accessTokenExpired || tokens.isAccessTokenWithinRefreshInterval()) {
                     LOG.debugf("Starting refreshing the tokens for client %s", tokens.getClientId());
                     final boolean refreshTokenValid = tokens.getRefreshToken() != null && !tokens.isRefreshTokenExpired();
                     if (!refreshTokenValid) {
                         LOG.debugf("Refresh token is not available or has expired, "
                                 + "acquiring new tokens instead for client %s", tokens.getClientId());
                     }
-                    newState = new TokenRequestState(prepareUni(
-                            refreshTokenValid
+                    final Tokens tokensBeingRefreshed = accessTokenExpired ? null : tokens;
+                    newState = new TokenRequestState(
+                            prepareUni(refreshTokenValid
                                     ? oidcClient.refreshTokens(tokens.getRefreshToken(), additionalParameters)
                                     : oidcClient.getTokens(additionalParameters)),
-                            tokens);
+                            tokensBeingRefreshed);
                     if (tokenRequestStateUpdater.compareAndSet(this, currentState, newState)) {
                         return newState.tokenUni;
                     }
@@ -111,26 +114,26 @@ public class TokensHelper {
         final Tokens tokens;
         final Uni<Tokens> tokenUni;
         /**
-         * Tokens which were current when {@link #tokenUni} was started, retained so that they can
-         * keep being served while the refresh is in progress. May be null when no tokens have been
-         * acquired yet, or when the ones being replaced had already expired.
+         * Tokens being refreshed which were still valid when {@link #tokenUni} was started due to the
+         * refresh token time skew, retained so that they can keep being served while the refresh is in
+         * progress. May be null when no tokens have been acquired yet, or when the ones being replaced had already expired.
          */
-        final Tokens previousToken;
+        final Tokens tokensBeingRefreshed;
 
         TokenRequestState(Tokens tokens) {
             this.tokens = tokens;
             this.tokenUni = null;
-            this.previousToken = null;
+            this.tokensBeingRefreshed = null;
         }
 
         TokenRequestState(Uni<Tokens> tokensUni) {
             this(tokensUni, null);
         }
 
-        TokenRequestState(Uni<Tokens> tokensUni, Tokens previousToken) {
+        TokenRequestState(Uni<Tokens> tokensUni, Tokens tokensBeingRefreshed) {
             this.tokens = null;
             this.tokenUni = tokensUni;
-            this.previousToken = previousToken;
+            this.tokensBeingRefreshed = tokensBeingRefreshed;
         }
     }
 }

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
@@ -66,9 +66,7 @@ public class TokensHelper {
                 //rerun the CAS loop
             } else {
                 final Tokens tokens = currentState.tokens;
-
                 final boolean accessTokenExpired = tokens.isAccessTokenExpired();
-
                 if (accessTokenExpired || tokens.isAccessTokenWithinRefreshInterval()) {
                     LOG.debugf("Starting refreshing the tokens for client %s", tokens.getClientId());
                     final boolean refreshTokenValid = tokens.getRefreshToken() != null && !tokens.isRefreshTokenExpired();

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
@@ -49,6 +49,22 @@ public class TokensHelper {
                 }
                 //rerun the CAS loop
             } else if (currentState.tokenUni != null) {
+                // A token request is already in flight. If it is a proactive refresh, the tokens
+                // it is replacing are usually still valid, because `refresh-token-time-skew`
+                // starts the refresh before they expire. Serving those avoids making this caller
+                // wait for a refresh it did not trigger; without it, every request arriving during
+                // a refresh blocks on it even though a perfectly usable token is in hand.
+                //
+                // Unexpired tokens are served here on exactly the terms they are served below,
+                // when no refresh is running: an unexpired access token is usable, an expired one
+                // is not and its holder waits for a new one. The only difference is what is waited
+                // on -- the refresh already in flight, rather than one this caller starts. There is
+                // no additional margin, because that would make a token which is good enough to
+                // send when nothing is being refreshed not good enough while something is.
+                final Tokens previousTokens = currentState.previousTokens;
+                if (previousTokens != null && !previousTokens.isAccessTokenExpired()) {
+                    return Uni.createFrom().item(previousTokens);
+                }
                 return currentState.tokenUni;
             } else if (forceNewTokens) {
                 LOG.debugf("Forcing acquisition of new tokens for client %s", currentState.tokens.getClientId());
@@ -71,7 +87,8 @@ public class TokensHelper {
                     newState = new TokenRequestState(
                             prepareUni(refreshTokenValid
                                     ? oidcClient.refreshTokens(tokens.getRefreshToken(), additionalParameters)
-                                    : oidcClient.getTokens(additionalParameters)));
+                                    : oidcClient.getTokens(additionalParameters)),
+                            tokens);
                     if (tokenRequestStateUpdater.compareAndSet(this, currentState, newState)) {
                         return newState.tokenUni;
                     }
@@ -103,15 +120,27 @@ public class TokensHelper {
     static class TokenRequestState {
         final Tokens tokens;
         final Uni<Tokens> tokenUni;
+        /**
+         * Tokens which were current when {@link #tokenUni} was started, retained so that they can
+         * keep being served while the refresh is in progress. May be null when no tokens have been
+         * acquired yet, or when the ones being replaced had already expired.
+         */
+        final Tokens previousTokens;
 
         TokenRequestState(Tokens tokens) {
             this.tokens = tokens;
             this.tokenUni = null;
+            this.previousTokens = null;
         }
 
         TokenRequestState(Uni<Tokens> tokensUni) {
+            this(tokensUni, null);
+        }
+
+        TokenRequestState(Uni<Tokens> tokensUni, Tokens previousTokens) {
             this.tokens = null;
             this.tokenUni = tokensUni;
+            this.previousTokens = previousTokens;
         }
     }
 }

--- a/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/runtime/TokensHelperTest.java
+++ b/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/runtime/TokensHelperTest.java
@@ -241,20 +241,20 @@ class TokensHelperTest {
     }
 
     /**
-     * A refresh only starts once the remaining lifespan has dropped below the refresh token time
-     * skew, so a minimum larger than the skew would stop the tokens from ever being reused and
-     * would silently disable the optimisation for deployments with a small skew. The required
-     * margin is therefore capped at the skew.
+     * A refresh only starts once the remaining lifespan has dropped below the refresh token time skew, so a
+     * minimum which is not less than the skew can never be satisfied. That combination is rejected when the
+     * OIDC client is created, rather than adjusted here, so a {@link Tokens} built directly with it simply
+     * never reuses the token being refreshed instead of silently applying a different minimum.
      */
     @Test
-    void testMinRemainingLifespanCappedAtRefreshTokenTimeSkew() throws Exception {
-        // A 3s skew with the 10s default minimum: without the cap nothing would ever be served,
-        // because a refresh cannot start while more than 3s remain.
+    void testTokensNotReusedWhenMinRemainingLifespanNotLessThanSkew() throws Exception {
+        // A 3s skew with a 10s minimum: a refresh cannot start while more than 3s remain, so the minimum
+        // is unreachable.
         Tokens current = tokens("current", 2, Duration.ofSeconds(3), Duration.ofSeconds(10));
         assertFalse(current.isAccessTokenExpired());
         assertTrue(current.isAccessTokenWithinRefreshInterval());
-        assertTrue(current.hasMinRemainingAccessTokenLifespan(),
-                "the minimum should be capped at the skew rather than disabling reuse");
+        assertFalse(current.hasMinRemainingAccessTokenLifespan(),
+                "a minimum which is not less than the skew can never be satisfied");
 
         BlockingOidcClient client = new BlockingOidcClient(tokens("refreshed", 300));
         TokensHelper helper = new TokensHelper();
@@ -265,10 +265,20 @@ class TokensHelperTest {
         });
         client.awaitInFlight();
 
-        Tokens served = helper.getTokens(client, Map.of(), false).await().atMost(Duration.ofSeconds(2));
-        assertSame(current, served, "tokens should still be served when the skew is below the minimum");
+        final AtomicReference<Tokens> served = new AtomicReference<>();
+        final CountDownLatch completed = new CountDownLatch(1);
+        helper.getTokens(client, Map.of(), false).subscribe().with(t -> {
+            served.set(t);
+            completed.countDown();
+        }, t -> completed.countDown());
+
+        assertFalse(completed.await(1, TimeUnit.SECONDS),
+                "tokens must not be reused when the minimum can never be satisfied");
 
         client.release.countDown();
+        assertTrue(completed.await(10, TimeUnit.SECONDS), "the caller should have completed");
+        assertEquals("refreshed", served.get().getAccessToken(),
+                "the caller should have waited for the refreshed tokens");
     }
 
     /**

--- a/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/runtime/TokensHelperTest.java
+++ b/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/runtime/TokensHelperTest.java
@@ -23,10 +23,11 @@ import io.vertx.core.json.JsonObject;
 class TokensHelperTest {
 
     private static final Duration TIME_SKEW = Duration.ofSeconds(10);
+    /** Reusing the tokens being refreshed is opt-in, so the tests which exercise it configure a minimum. */
+    private static final Duration MIN_REMAINING_LIFESPAN = Duration.ofSeconds(2);
 
     private static Tokens tokens(String accessToken, long expiresInSecs) {
-        final long nowSecs = System.currentTimeMillis() / 1000;
-        return new Tokens(accessToken, nowSecs + expiresInSecs, TIME_SKEW, null, null, new JsonObject(), "client", null);
+        return tokens(accessToken, expiresInSecs, TIME_SKEW, MIN_REMAINING_LIFESPAN);
     }
 
     private static Tokens tokens(String accessToken, long expiresInSecs, Duration skew, Duration minRemaining) {
@@ -112,7 +113,7 @@ class TokensHelperTest {
         // both triggers the refresh and leaves the tokens usable while it runs.
         final long nowSecs = System.currentTimeMillis() / 1000;
         Tokens current = new Tokens("current", nowSecs + 2, Duration.ofSeconds(3), null, null,
-                new JsonObject(), "client", null);
+                new JsonObject(), "client", MIN_REMAINING_LIFESPAN);
         assertFalse(current.isAccessTokenExpired());
         assertTrue(current.isAccessTokenWithinRefreshInterval());
 
@@ -268,6 +269,44 @@ class TokensHelperTest {
         assertSame(current, served, "tokens should still be served when the skew is below the minimum");
 
         client.release.countDown();
+    }
+
+    /**
+     * Reusing the tokens being refreshed is opt-in: when no minimum remaining lifespan is configured
+     * the callers wait for the refresh, which is the behaviour of an OIDC client that has not enabled
+     * this. Without it, upgrading would change how every existing deployment behaves.
+     */
+    @Test
+    void testTokensNotReusedWhenMinRemainingLifespanNotConfigured() throws Exception {
+        // Still valid and inside the skew, so the only reason not to serve it is the absent minimum.
+        Tokens current = tokens("current", 8, TIME_SKEW, null);
+        assertFalse(current.isAccessTokenExpired());
+        assertTrue(current.isAccessTokenWithinRefreshInterval());
+        assertFalse(current.hasMinRemainingAccessTokenLifespan());
+
+        BlockingOidcClient client = new BlockingOidcClient(tokens("refreshed", 300));
+        TokensHelper helper = new TokensHelper();
+        helper.initTokens(new ImmediateOidcClient(current), Map.of());
+
+        helper.getTokens(client, Map.of(), false).subscribe().with(t -> {
+        }, t -> {
+        });
+        client.awaitInFlight();
+
+        final AtomicReference<Tokens> served = new AtomicReference<>();
+        final CountDownLatch completed = new CountDownLatch(1);
+        helper.getTokens(client, Map.of(), false).subscribe().with(t -> {
+            served.set(t);
+            completed.countDown();
+        }, t -> completed.countDown());
+
+        assertFalse(completed.await(1, TimeUnit.SECONDS),
+                "tokens must not be reused when no minimum remaining lifespan is configured");
+
+        client.release.countDown();
+        assertTrue(completed.await(10, TimeUnit.SECONDS), "the caller should have completed");
+        assertEquals("refreshed", served.get().getAccessToken(),
+                "the caller should have waited for the refreshed tokens");
     }
 
     /**

--- a/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/runtime/TokensHelperTest.java
+++ b/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/runtime/TokensHelperTest.java
@@ -49,7 +49,9 @@ class TokensHelperTest {
 
         // Triggers the refresh, which then blocks.
         Uni<Tokens> refreshing = helper.getTokens(client, Map.of(), false);
-        refreshing.subscribe().with(t -> {}, t -> {});
+        refreshing.subscribe().with(t -> {
+        }, t -> {
+        });
 
         // Wait until the refresh is genuinely in flight, rather than assuming it is by now.
         client.awaitInFlight();
@@ -79,7 +81,9 @@ class TokensHelperTest {
         TokensHelper helper = new TokensHelper();
         helper.initTokens(new ImmediateOidcClient(current), Map.of());
 
-        helper.getTokens(client, Map.of(), false).subscribe().with(t -> {}, t -> {});
+        helper.getTokens(client, Map.of(), false).subscribe().with(t -> {
+        }, t -> {
+        });
         client.awaitInFlight();
 
         // Release the refresh so the waiting caller can complete, then confirm it waited for the
@@ -109,7 +113,9 @@ class TokensHelperTest {
         TokensHelper helper = new TokensHelper();
         helper.initTokens(new ImmediateOidcClient(current), Map.of());
 
-        helper.getTokens(client, Map.of(), false).subscribe().with(t -> {}, t -> {});
+        helper.getTokens(client, Map.of(), false).subscribe().with(t -> {
+        }, t -> {
+        });
         client.awaitInFlight();
 
         Tokens served = helper.getTokens(client, Map.of(), false).await().atMost(Duration.ofSeconds(2));
@@ -186,7 +192,6 @@ class TokensHelperTest {
             // no-op in the tests
         }
     }
-
 
     /** An OidcClient that returns a fixed set of tokens without blocking. */
     private record ImmediateOidcClient(Tokens tokens) implements OidcClient {

--- a/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/runtime/TokensHelperTest.java
+++ b/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/runtime/TokensHelperTest.java
@@ -1,0 +1,221 @@
+package io.quarkus.oidc.client.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.oidc.client.Tokens;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.json.JsonObject;
+
+public class TokensHelperTest {
+
+    private static final Duration TIME_SKEW = Duration.ofSeconds(10);
+
+    private static Tokens tokens(String accessToken, long expiresInSecs) {
+        final long nowSecs = System.currentTimeMillis() / 1000;
+        return new Tokens(accessToken, nowSecs + expiresInSecs, TIME_SKEW, null, null, new JsonObject(), "client");
+    }
+
+    /**
+     * An OidcClient whose token acquisition blocks until released, so that the in-flight refresh
+     * window can be observed deterministically.
+     */
+    private static final class BlockingOidcClient implements OidcClient {
+
+        private final CountDownLatch release = new CountDownLatch(1);
+        private final AtomicInteger acquisitions = new AtomicInteger();
+        private final Tokens newTokens;
+
+        BlockingOidcClient(Tokens newTokens) {
+            this.newTokens = newTokens;
+        }
+
+        @Override
+        public Uni<Tokens> getTokens() {
+            return getTokens(Map.of());
+        }
+
+        @Override
+        public Uni<Tokens> getTokens(Map<String, String> additionalGrantParameters) {
+            acquisitions.incrementAndGet();
+            // Blocks on a separate thread so the refresh stays genuinely in flight while the
+            // test thread makes its second call; running it on the subscribing thread would
+            // complete the refresh before that call happens.
+            return Uni.createFrom().item(() -> {
+                try {
+                    release.await(10, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return newTokens;
+            }).runSubscriptionOn(java.util.concurrent.Executors.newSingleThreadExecutor());
+        }
+
+        @Override
+        public Uni<Tokens> refreshTokens(String refreshToken) {
+            return refreshTokens(refreshToken, Map.of());
+        }
+
+        @Override
+        public Uni<Tokens> refreshTokens(String refreshToken, Map<String, String> additionalGrantParameters) {
+            return getTokens(additionalGrantParameters);
+        }
+
+        @Override
+        public Uni<Boolean> revokeAccessToken(String accessToken) {
+            return Uni.createFrom().item(true);
+        }
+
+        @Override
+        public Uni<Boolean> revokeAccessToken(String accessToken, Map<String, String> additionalParameters) {
+            return Uni.createFrom().item(true);
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    /**
+     * While a proactive refresh is in flight, callers must keep receiving the token being replaced
+     * rather than blocking on the refresh: it is still valid, because the refresh was started
+     * early by the refresh token time skew.
+     */
+    @Test
+    public void testStillValidTokensServedWhileRefreshIsInFlight() throws Exception {
+        // Expires in 8s: inside the 10s skew, so it is marked for refresh immediately, yet with
+        // comfortably more life left than the margin required to keep serving it. That is exactly
+        // the situation this covers, and it keeps the test clear of the boundary in both
+        // directions.
+        Tokens current = tokens("current", 8);
+        assertFalse(current.isAccessTokenExpired());
+        assertTrue(current.isAccessTokenWithinRefreshInterval());
+
+        BlockingOidcClient client = new BlockingOidcClient(tokens("refreshed", 300));
+        TokensHelper helper = new TokensHelper();
+        helper.initTokens(new ImmediateOidcClient(current), Map.of());
+
+        // Triggers the refresh, which then blocks.
+        Uni<Tokens> refreshing = helper.getTokens(client, Map.of(), false);
+        refreshing.subscribe().with(t -> {
+        }, t -> {
+        });
+
+        // Give the refresh a moment to actually be in flight before racing it.
+        Thread.sleep(200);
+
+        // A second caller arriving during that refresh must not wait for it.
+        Tokens served = helper.getTokens(client, Map.of(), false).await().atMost(Duration.ofSeconds(2));
+        assertSame(current, served, "the still-valid previous tokens should have been served");
+
+        // And the refresh itself must not have been duplicated.
+        assertEquals(1, client.acquisitions.get());
+
+        client.release.countDown();
+    }
+
+    /**
+     * Expired tokens are never served, even though a refresh is already in flight: the caller
+     * waits for it, exactly as a caller waits when it starts a refresh itself. This is the same
+     * rule applied when no refresh is running -- an expired access token is not usable.
+     */
+    @Test
+    public void testExpiredTokensNotServedWhileRefreshIsInFlight() throws Exception {
+        // Already expired, so there is nothing safe to reuse.
+        Tokens current = tokens("current", -1);
+        assertTrue(current.isAccessTokenExpired());
+
+        BlockingOidcClient client = new BlockingOidcClient(tokens("refreshed", 300));
+        TokensHelper helper = new TokensHelper();
+        helper.initTokens(new ImmediateOidcClient(current), Map.of());
+
+        helper.getTokens(client, Map.of(), false).subscribe().with(t -> {
+        }, t -> {
+        });
+        Thread.sleep(200);
+
+        // Release the refresh so the waiting caller can complete, then confirm it waited for the
+        // new tokens rather than being handed the expired ones.
+        client.release.countDown();
+        Tokens served = helper.getTokens(client, Map.of(), false).await().atMost(Duration.ofSeconds(5));
+        assertEquals("refreshed", served.getAccessToken(),
+                "expired tokens must not be served; the refreshed ones should be");
+    }
+
+    /**
+     * Short-lived tokens are reused on the same terms as any other, so the optimisation still
+     * applies when the skew -- and therefore the remaining lifetime once a refresh starts -- is
+     * small. An extra safety margin here would have silently excluded exactly these deployments.
+     */
+    @Test
+    public void testShortLivedTokensStillServedWhileRefreshIsInFlight() throws Exception {
+        // A 3s skew means a refresh starts with at most 3s of life left.
+        final long nowSecs = System.currentTimeMillis() / 1000;
+        Tokens current = new Tokens("current", nowSecs + 4, Duration.ofSeconds(3), null, null,
+                new JsonObject(), "client");
+        assertFalse(current.isAccessTokenExpired());
+
+        BlockingOidcClient client = new BlockingOidcClient(tokens("refreshed", 300));
+        TokensHelper helper = new TokensHelper();
+        helper.initTokens(new ImmediateOidcClient(current), Map.of());
+
+        helper.getTokens(client, Map.of(), false).subscribe().with(t -> {
+        }, t -> {
+        });
+        Thread.sleep(200);
+
+        Tokens served = helper.getTokens(client, Map.of(), false).await().atMost(Duration.ofSeconds(2));
+        assertSame(current, served, "short-lived tokens with life left should still be served");
+
+        client.release.countDown();
+    }
+
+    /** An OidcClient that returns a fixed set of tokens without blocking. */
+    private record ImmediateOidcClient(Tokens tokens) implements OidcClient {
+
+        @Override
+        public Uni<Tokens> getTokens() {
+            return Uni.createFrom().item(tokens);
+        }
+
+        @Override
+        public Uni<Tokens> getTokens(Map<String, String> additionalGrantParameters) {
+            return Uni.createFrom().item(tokens);
+        }
+
+        @Override
+        public Uni<Tokens> refreshTokens(String refreshToken) {
+            return Uni.createFrom().item(tokens);
+        }
+
+        @Override
+        public Uni<Tokens> refreshTokens(String refreshToken, Map<String, String> additionalGrantParameters) {
+            return Uni.createFrom().item(tokens);
+        }
+
+        @Override
+        public Uni<Boolean> revokeAccessToken(String accessToken) {
+            return Uni.createFrom().item(true);
+        }
+
+        @Override
+        public Uni<Boolean> revokeAccessToken(String accessToken, Map<String, String> additionalParameters) {
+            return Uni.createFrom().item(true);
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/runtime/TokensHelperTest.java
+++ b/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/runtime/TokensHelperTest.java
@@ -223,7 +223,7 @@ class TokensHelperTest {
 
         @Override
         public void close() {
-            //            no-op in the test
+            // no-op in the test
         }
     }
 }

--- a/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/runtime/TokensHelperTest.java
+++ b/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/runtime/TokensHelperTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 
@@ -122,6 +123,47 @@ class TokensHelperTest {
         assertSame(current, served, "short-lived tokens with life left should still be served");
 
         client.release.countDown();
+    }
+
+    /**
+     * A caller which forces the acquisition of new tokens does so because the tokens it was given
+     * were rejected, typically after a 401 when 'refresh-on-unauthorized' is enabled. Handing it
+     * the tokens being replaced would just fail again, so it waits for the refresh instead, even
+     * though those tokens are still valid and would be served to any other caller.
+     */
+    @Test
+    void testForcedAcquisitionNotServedPreviousTokensWhileRefreshIsInFlight() throws Exception {
+        // Still valid, so this is served to ordinary callers: only the forcing is what differs.
+        Tokens current = tokens("current", 8);
+        assertFalse(current.isAccessTokenExpired());
+        assertTrue(current.isAccessTokenWithinRefreshInterval());
+
+        BlockingOidcClient client = new BlockingOidcClient(tokens("refreshed", 300));
+        TokensHelper helper = new TokensHelper();
+        helper.initTokens(new ImmediateOidcClient(current), Map.of());
+
+        helper.getTokens(client, Map.of(), false).subscribe().with(t -> {
+        }, t -> {
+        });
+        client.awaitInFlight();
+
+        final AtomicReference<Tokens> forced = new AtomicReference<>();
+        final CountDownLatch forcedCompleted = new CountDownLatch(1);
+        helper.getTokens(client, Map.of(), true).subscribe().with(t -> {
+            forced.set(t);
+            forcedCompleted.countDown();
+        }, t -> forcedCompleted.countDown());
+
+        // The refresh is still held, so the forcing caller must not have been given anything yet.
+        // Without this the test would also pass while the rejected tokens are handed back, since
+        // both paths eventually produce a value.
+        assertFalse(forcedCompleted.await(1, TimeUnit.SECONDS),
+                "tokens which have been rejected must not be served to a caller forcing new ones");
+
+        client.release.countDown();
+        assertTrue(forcedCompleted.await(10, TimeUnit.SECONDS), "the forcing caller should have completed");
+        assertEquals("refreshed", forced.get().getAccessToken(),
+                "the forcing caller should have waited for the refreshed tokens");
     }
 
     /**

--- a/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/runtime/TokensHelperTest.java
+++ b/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/runtime/TokensHelperTest.java
@@ -29,6 +29,96 @@ class TokensHelperTest {
     }
 
     /**
+     * While a proactive refresh is in flight, callers must keep receiving the token being replaced
+     * rather than blocking on the refresh: it is still valid, because the refresh was started
+     * early by the refresh token time skew.
+     */
+    @Test
+    void testStillValidTokensServedWhileRefreshIsInFlight() throws Exception {
+        // Expires in 8s: inside the 10s skew, so it is marked for refresh immediately, yet with
+        // comfortably more life left than the margin required to keep serving it. That is exactly
+        // the situation this covers, and it keeps the test clear of the boundary in both
+        // directions.
+        Tokens current = tokens("current", 8);
+        assertFalse(current.isAccessTokenExpired());
+        assertTrue(current.isAccessTokenWithinRefreshInterval());
+
+        BlockingOidcClient client = new BlockingOidcClient(tokens("refreshed", 300));
+        TokensHelper helper = new TokensHelper();
+        helper.initTokens(new ImmediateOidcClient(current), Map.of());
+
+        // Triggers the refresh, which then blocks.
+        Uni<Tokens> refreshing = helper.getTokens(client, Map.of(), false);
+        refreshing.subscribe().with(t -> {}, t -> {});
+
+        // Wait until the refresh is genuinely in flight, rather than assuming it is by now.
+        client.awaitInFlight();
+
+        // A second caller arriving during that refresh must not wait for it.
+        Tokens served = helper.getTokens(client, Map.of(), false).await().atMost(Duration.ofSeconds(2));
+        assertSame(current, served, "the still-valid previous tokens should have been served");
+
+        // And the refresh itself must not have been duplicated.
+        assertEquals(1, client.acquisitions.get());
+
+        client.release.countDown();
+    }
+
+    /**
+     * Expired tokens are never served, even though a refresh is already in flight: the caller
+     * waits for it, exactly as a caller waits when it starts a refresh itself. This is the same
+     * rule applied when no refresh is running -- an expired access token is not usable.
+     */
+    @Test
+    void testExpiredTokensNotServedWhileRefreshIsInFlight() throws Exception {
+        // Already expired, so there is nothing safe to reuse.
+        Tokens current = tokens("current", -1);
+        assertTrue(current.isAccessTokenExpired());
+
+        BlockingOidcClient client = new BlockingOidcClient(tokens("refreshed", 300));
+        TokensHelper helper = new TokensHelper();
+        helper.initTokens(new ImmediateOidcClient(current), Map.of());
+
+        helper.getTokens(client, Map.of(), false).subscribe().with(t -> {}, t -> {});
+        client.awaitInFlight();
+
+        // Release the refresh so the waiting caller can complete, then confirm it waited for the
+        // new tokens rather than being handed the expired ones.
+        client.release.countDown();
+        Tokens served = helper.getTokens(client, Map.of(), false).await().atMost(Duration.ofSeconds(5));
+        assertEquals("refreshed", served.getAccessToken(),
+                "expired tokens must not be served; the refreshed ones should be");
+    }
+
+    /**
+     * Short-lived tokens are reused on the same terms as any other, so the optimisation still
+     * applies when the skew -- and therefore the remaining lifetime once a refresh starts -- is
+     * small. An extra safety margin here would have silently excluded exactly these deployments.
+     */
+    @Test
+    void testShortLivedTokensStillServedWhileRefreshIsInFlight() throws Exception {
+        // A 3s skew means a refresh starts once fewer than 3s of life remain, so 2s remaining
+        // both triggers the refresh and leaves the tokens usable while it runs.
+        final long nowSecs = System.currentTimeMillis() / 1000;
+        Tokens current = new Tokens("current", nowSecs + 2, Duration.ofSeconds(3), null, null,
+                new JsonObject(), "client");
+        assertFalse(current.isAccessTokenExpired());
+        assertTrue(current.isAccessTokenWithinRefreshInterval());
+
+        BlockingOidcClient client = new BlockingOidcClient(tokens("refreshed", 300));
+        TokensHelper helper = new TokensHelper();
+        helper.initTokens(new ImmediateOidcClient(current), Map.of());
+
+        helper.getTokens(client, Map.of(), false).subscribe().with(t -> {}, t -> {});
+        client.awaitInFlight();
+
+        Tokens served = helper.getTokens(client, Map.of(), false).await().atMost(Duration.ofSeconds(2));
+        assertSame(current, served, "short-lived tokens with life left should still be served");
+
+        client.release.countDown();
+    }
+
+    /**
      * An OidcClient whose token acquisition blocks until released, so that the in-flight refresh
      * window can be observed deterministically.
      */
@@ -97,105 +187,6 @@ class TokensHelperTest {
         }
     }
 
-    /**
-     * While a proactive refresh is in flight, callers must keep receiving the token being replaced
-     * rather than blocking on the refresh: it is still valid, because the refresh was started
-     * early by the refresh token time skew.
-     */
-    @Test
-    void testStillValidTokensServedWhileRefreshIsInFlight() throws Exception {
-        // Expires in 8s: inside the 10s skew, so it is marked for refresh immediately, yet with
-        // comfortably more life left than the margin required to keep serving it. That is exactly
-        // the situation this covers, and it keeps the test clear of the boundary in both
-        // directions.
-        Tokens current = tokens("current", 8);
-        assertFalse(current.isAccessTokenExpired());
-        assertTrue(current.isAccessTokenWithinRefreshInterval());
-
-        BlockingOidcClient client = new BlockingOidcClient(tokens("refreshed", 300));
-        TokensHelper helper = new TokensHelper();
-        helper.initTokens(new ImmediateOidcClient(current), Map.of());
-
-        // Triggers the refresh, which then blocks.
-        Uni<Tokens> refreshing = helper.getTokens(client, Map.of(), false);
-        refreshing.subscribe().with(t -> {
-        }, t -> {
-        });
-
-        // Wait until the refresh is genuinely in flight, rather than assuming it is by now.
-        client.awaitInFlight();
-
-        // A second caller arriving during that refresh must not wait for it.
-        Tokens served = helper.getTokens(client, Map.of(), false).await().atMost(Duration.ofSeconds(2));
-        assertSame(current, served, "the still-valid previous tokens should have been served");
-
-        // And the refresh itself must not have been duplicated.
-        assertEquals(1, client.acquisitions.get());
-
-        client.release.countDown();
-    }
-
-    /**
-     * Expired tokens are never served, even though a refresh is already in flight: the caller
-     * waits for it, exactly as a caller waits when it starts a refresh itself. This is the same
-     * rule applied when no refresh is running -- an expired access token is not usable.
-     */
-    @Test
-    void testExpiredTokensNotServedWhileRefreshIsInFlight() throws Exception {
-        // Already expired, so there is nothing safe to reuse.
-        Tokens current = tokens("current", -1);
-        assertTrue(current.isAccessTokenExpired());
-
-        BlockingOidcClient client = new BlockingOidcClient(tokens("refreshed", 300));
-        TokensHelper helper = new TokensHelper();
-        helper.initTokens(new ImmediateOidcClient(current), Map.of());
-
-        helper.getTokens(client, Map.of(), false)
-                .subscribe()
-                .with(t -> {
-                }, t -> {
-                });
-        client.awaitInFlight();
-
-        // Release the refresh so the waiting caller can complete, then confirm it waited for the
-        // new tokens rather than being handed the expired ones.
-        client.release.countDown();
-        Tokens served = helper.getTokens(client, Map.of(), false).await().atMost(Duration.ofSeconds(5));
-        assertEquals("refreshed", served.getAccessToken(),
-                "expired tokens must not be served; the refreshed ones should be");
-    }
-
-    /**
-     * Short-lived tokens are reused on the same terms as any other, so the optimisation still
-     * applies when the skew -- and therefore the remaining lifetime once a refresh starts -- is
-     * small. An extra safety margin here would have silently excluded exactly these deployments.
-     */
-    @Test
-    void testShortLivedTokensStillServedWhileRefreshIsInFlight() throws Exception {
-        // A 3s skew means a refresh starts once fewer than 3s of life remain, so 2s remaining
-        // both triggers the refresh and leaves the tokens usable while it runs.
-        final long nowSecs = System.currentTimeMillis() / 1000;
-        Tokens current = new Tokens("current", nowSecs + 2, Duration.ofSeconds(3), null, null,
-                new JsonObject(), "client");
-        assertFalse(current.isAccessTokenExpired());
-        assertTrue(current.isAccessTokenWithinRefreshInterval());
-
-        BlockingOidcClient client = new BlockingOidcClient(tokens("refreshed", 300));
-        TokensHelper helper = new TokensHelper();
-        helper.initTokens(new ImmediateOidcClient(current), Map.of());
-
-        helper.getTokens(client, Map.of(), false)
-                .subscribe()
-                .with(t -> {
-                }, t -> {
-                });
-        client.awaitInFlight();
-
-        Tokens served = helper.getTokens(client, Map.of(), false).await().atMost(Duration.ofSeconds(2));
-        assertSame(current, served, "short-lived tokens with life left should still be served");
-
-        client.release.countDown();
-    }
 
     /** An OidcClient that returns a fixed set of tokens without blocking. */
     private record ImmediateOidcClient(Tokens tokens) implements OidcClient {

--- a/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/runtime/TokensHelperTest.java
+++ b/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/runtime/TokensHelperTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -18,7 +19,7 @@ import io.quarkus.oidc.client.Tokens;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.JsonObject;
 
-public class TokensHelperTest {
+class TokensHelperTest {
 
     private static final Duration TIME_SKEW = Duration.ofSeconds(10);
 
@@ -34,11 +35,18 @@ public class TokensHelperTest {
     private static final class BlockingOidcClient implements OidcClient {
 
         private final CountDownLatch release = new CountDownLatch(1);
+        /** Counts down once acquisition has actually begun, so tests never guess at timing. */
+        private final CountDownLatch started = new CountDownLatch(1);
         private final AtomicInteger acquisitions = new AtomicInteger();
         private final Tokens newTokens;
 
         BlockingOidcClient(Tokens newTokens) {
             this.newTokens = newTokens;
+        }
+
+        /** Blocks until a token request is genuinely in flight. */
+        void awaitInFlight() throws InterruptedException {
+            assertTrue(started.await(10, TimeUnit.SECONDS), "token acquisition should have started");
         }
 
         @Override
@@ -54,12 +62,13 @@ public class TokensHelperTest {
             // complete the refresh before that call happens.
             return Uni.createFrom().item(() -> {
                 try {
+                    started.countDown();
                     release.await(10, TimeUnit.SECONDS);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 }
                 return newTokens;
-            }).runSubscriptionOn(java.util.concurrent.Executors.newSingleThreadExecutor());
+            }).runSubscriptionOn(Executors.newSingleThreadExecutor());
         }
 
         @Override
@@ -84,6 +93,7 @@ public class TokensHelperTest {
 
         @Override
         public void close() {
+            // no-op in the tests
         }
     }
 
@@ -93,7 +103,7 @@ public class TokensHelperTest {
      * early by the refresh token time skew.
      */
     @Test
-    public void testStillValidTokensServedWhileRefreshIsInFlight() throws Exception {
+    void testStillValidTokensServedWhileRefreshIsInFlight() throws Exception {
         // Expires in 8s: inside the 10s skew, so it is marked for refresh immediately, yet with
         // comfortably more life left than the margin required to keep serving it. That is exactly
         // the situation this covers, and it keeps the test clear of the boundary in both
@@ -112,8 +122,8 @@ public class TokensHelperTest {
         }, t -> {
         });
 
-        // Give the refresh a moment to actually be in flight before racing it.
-        Thread.sleep(200);
+        // Wait until the refresh is genuinely in flight, rather than assuming it is by now.
+        client.awaitInFlight();
 
         // A second caller arriving during that refresh must not wait for it.
         Tokens served = helper.getTokens(client, Map.of(), false).await().atMost(Duration.ofSeconds(2));
@@ -131,7 +141,7 @@ public class TokensHelperTest {
      * rule applied when no refresh is running -- an expired access token is not usable.
      */
     @Test
-    public void testExpiredTokensNotServedWhileRefreshIsInFlight() throws Exception {
+    void testExpiredTokensNotServedWhileRefreshIsInFlight() throws Exception {
         // Already expired, so there is nothing safe to reuse.
         Tokens current = tokens("current", -1);
         assertTrue(current.isAccessTokenExpired());
@@ -140,10 +150,12 @@ public class TokensHelperTest {
         TokensHelper helper = new TokensHelper();
         helper.initTokens(new ImmediateOidcClient(current), Map.of());
 
-        helper.getTokens(client, Map.of(), false).subscribe().with(t -> {
-        }, t -> {
-        });
-        Thread.sleep(200);
+        helper.getTokens(client, Map.of(), false)
+                .subscribe()
+                .with(t -> {
+                }, t -> {
+                });
+        client.awaitInFlight();
 
         // Release the refresh so the waiting caller can complete, then confirm it waited for the
         // new tokens rather than being handed the expired ones.
@@ -159,21 +171,25 @@ public class TokensHelperTest {
      * small. An extra safety margin here would have silently excluded exactly these deployments.
      */
     @Test
-    public void testShortLivedTokensStillServedWhileRefreshIsInFlight() throws Exception {
-        // A 3s skew means a refresh starts with at most 3s of life left.
+    void testShortLivedTokensStillServedWhileRefreshIsInFlight() throws Exception {
+        // A 3s skew means a refresh starts once fewer than 3s of life remain, so 2s remaining
+        // both triggers the refresh and leaves the tokens usable while it runs.
         final long nowSecs = System.currentTimeMillis() / 1000;
-        Tokens current = new Tokens("current", nowSecs + 4, Duration.ofSeconds(3), null, null,
+        Tokens current = new Tokens("current", nowSecs + 2, Duration.ofSeconds(3), null, null,
                 new JsonObject(), "client");
         assertFalse(current.isAccessTokenExpired());
+        assertTrue(current.isAccessTokenWithinRefreshInterval());
 
         BlockingOidcClient client = new BlockingOidcClient(tokens("refreshed", 300));
         TokensHelper helper = new TokensHelper();
         helper.initTokens(new ImmediateOidcClient(current), Map.of());
 
-        helper.getTokens(client, Map.of(), false).subscribe().with(t -> {
-        }, t -> {
-        });
-        Thread.sleep(200);
+        helper.getTokens(client, Map.of(), false)
+                .subscribe()
+                .with(t -> {
+                }, t -> {
+                });
+        client.awaitInFlight();
 
         Tokens served = helper.getTokens(client, Map.of(), false).await().atMost(Duration.ofSeconds(2));
         assertSame(current, served, "short-lived tokens with life left should still be served");
@@ -216,6 +232,7 @@ public class TokensHelperTest {
 
         @Override
         public void close() {
+            //            no-op in the test
         }
     }
 }

--- a/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/runtime/TokensHelperTest.java
+++ b/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/runtime/TokensHelperTest.java
@@ -26,7 +26,13 @@ class TokensHelperTest {
 
     private static Tokens tokens(String accessToken, long expiresInSecs) {
         final long nowSecs = System.currentTimeMillis() / 1000;
-        return new Tokens(accessToken, nowSecs + expiresInSecs, TIME_SKEW, null, null, new JsonObject(), "client");
+        return new Tokens(accessToken, nowSecs + expiresInSecs, TIME_SKEW, null, null, new JsonObject(), "client", null);
+    }
+
+    private static Tokens tokens(String accessToken, long expiresInSecs, Duration skew, Duration minRemaining) {
+        final long nowSecs = System.currentTimeMillis() / 1000;
+        return new Tokens(accessToken, nowSecs + expiresInSecs, skew, null, null, new JsonObject(), "client",
+                minRemaining);
     }
 
     /**
@@ -106,7 +112,7 @@ class TokensHelperTest {
         // both triggers the refresh and leaves the tokens usable while it runs.
         final long nowSecs = System.currentTimeMillis() / 1000;
         Tokens current = new Tokens("current", nowSecs + 2, Duration.ofSeconds(3), null, null,
-                new JsonObject(), "client");
+                new JsonObject(), "client", null);
         assertFalse(current.isAccessTokenExpired());
         assertTrue(current.isAccessTokenWithinRefreshInterval());
 
@@ -164,6 +170,104 @@ class TokensHelperTest {
         assertTrue(forcedCompleted.await(10, TimeUnit.SECONDS), "the forcing caller should have completed");
         assertEquals("refreshed", forced.get().getAccessToken(),
                 "the forcing caller should have waited for the refreshed tokens");
+    }
+
+    /**
+     * Tokens which are still valid but too close to expiry are not served while a refresh is in
+     * flight: they could expire in transit, or while the target service handles the request. Such a
+     * caller waits for the refreshed tokens instead.
+     */
+    @Test
+    void testTokensBelowMinRemainingLifespanNotServedWhileRefreshIsInFlight() throws Exception {
+        // 30s skew so the refresh starts early, but only 5s of life left against a 10s minimum:
+        // still valid, yet not worth sending.
+        Tokens current = tokens("current", 5, Duration.ofSeconds(30), Duration.ofSeconds(10));
+        assertFalse(current.isAccessTokenExpired());
+        assertTrue(current.isAccessTokenWithinRefreshInterval());
+        assertFalse(current.hasMinRemainingAccessTokenLifespan());
+
+        BlockingOidcClient client = new BlockingOidcClient(tokens("refreshed", 300));
+        TokensHelper helper = new TokensHelper();
+        helper.initTokens(new ImmediateOidcClient(current), Map.of());
+
+        helper.getTokens(client, Map.of(), false).subscribe().with(t -> {
+        }, t -> {
+        });
+        client.awaitInFlight();
+
+        final AtomicReference<Tokens> served = new AtomicReference<>();
+        final CountDownLatch completed = new CountDownLatch(1);
+        helper.getTokens(client, Map.of(), false).subscribe().with(t -> {
+            served.set(t);
+            completed.countDown();
+        }, t -> completed.countDown());
+
+        // The refresh is still held, so a caller which must not be served the nearly expired tokens
+        // has nothing to receive yet.
+        assertFalse(completed.await(1, TimeUnit.SECONDS),
+                "tokens below the minimum remaining lifespan must not be served");
+
+        client.release.countDown();
+        assertTrue(completed.await(10, TimeUnit.SECONDS), "the caller should have completed");
+        assertEquals("refreshed", served.get().getAccessToken(),
+                "the caller should have waited for the refreshed tokens");
+    }
+
+    /**
+     * Tokens with more than the minimum remaining lifespan left are served, so the margin only
+     * excludes the tokens it is meant to.
+     */
+    @Test
+    void testTokensAboveMinRemainingLifespanServedWhileRefreshIsInFlight() throws Exception {
+        // 20s left against a 10s minimum, inside a 30s skew.
+        Tokens current = tokens("current", 20, Duration.ofSeconds(30), Duration.ofSeconds(10));
+        assertTrue(current.isAccessTokenWithinRefreshInterval());
+        assertTrue(current.hasMinRemainingAccessTokenLifespan());
+
+        BlockingOidcClient client = new BlockingOidcClient(tokens("refreshed", 300));
+        TokensHelper helper = new TokensHelper();
+        helper.initTokens(new ImmediateOidcClient(current), Map.of());
+
+        helper.getTokens(client, Map.of(), false).subscribe().with(t -> {
+        }, t -> {
+        });
+        client.awaitInFlight();
+
+        Tokens served = helper.getTokens(client, Map.of(), false).await().atMost(Duration.ofSeconds(2));
+        assertSame(current, served, "tokens above the minimum remaining lifespan should be served");
+
+        client.release.countDown();
+    }
+
+    /**
+     * A refresh only starts once the remaining lifespan has dropped below the refresh token time
+     * skew, so a minimum larger than the skew would stop the tokens from ever being reused and
+     * would silently disable the optimisation for deployments with a small skew. The required
+     * margin is therefore capped at the skew.
+     */
+    @Test
+    void testMinRemainingLifespanCappedAtRefreshTokenTimeSkew() throws Exception {
+        // A 3s skew with the 10s default minimum: without the cap nothing would ever be served,
+        // because a refresh cannot start while more than 3s remain.
+        Tokens current = tokens("current", 2, Duration.ofSeconds(3), Duration.ofSeconds(10));
+        assertFalse(current.isAccessTokenExpired());
+        assertTrue(current.isAccessTokenWithinRefreshInterval());
+        assertTrue(current.hasMinRemainingAccessTokenLifespan(),
+                "the minimum should be capped at the skew rather than disabling reuse");
+
+        BlockingOidcClient client = new BlockingOidcClient(tokens("refreshed", 300));
+        TokensHelper helper = new TokensHelper();
+        helper.initTokens(new ImmediateOidcClient(current), Map.of());
+
+        helper.getTokens(client, Map.of(), false).subscribe().with(t -> {
+        }, t -> {
+        });
+        client.awaitInFlight();
+
+        Tokens served = helper.getTokens(client, Map.of(), false).await().atMost(Duration.ofSeconds(2));
+        assertSame(current, served, "tokens should still be served when the skew is below the minimum");
+
+        client.release.countDown();
     }
 
     /**


### PR DESCRIPTION
Fixes #56366

While `TokensHelper` has a token refresh in flight, the cached tokens are replaced by the pending `Uni`, so any request arriving in that window blocks on it until the token endpoint responds. The tokens being replaced are normally still valid at that point, since `refresh-token-time-skew` starts the refresh before they expire, so that wait is avoidable.

This keeps those tokens in `TokenRequestState` and serves them while the refresh runs, until they expire. Once they have, the caller waits for the refresh already under way.

That is the same rule already applied when no refresh is running: an unexpired access token is served, an expired one is not and its holder waits. The only difference is that the caller waits on a refresh someone else started rather than one it starts itself. Deployments whose access tokens expire faster than the token endpoint can answer therefore behave as they do today.