### PR TITLE
[3.27] Manage projectreactor in the bom, update to 3.8.7

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -222,6 +222,7 @@
         <importmap.version>1.0.11</importmap.version>
         <webauthn4j.version>0.28.0.RELEASE</webauthn4j.version>
         <jsoup.version>1.23.1</jsoup.version> <!-- JSoup is used by Camel and LangChain4J so be careful when updating -->
+        <reactor.version>3.8.7</reactor.version>
     </properties>
 
     <pluginRepositories>
@@ -6585,6 +6586,11 @@
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
                 <version>${jsoup.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.projectreactor</groupId>
+                <artifactId>reactor-core</artifactId>
+                <version>${reactor.version}</version>
             </dependency>
 
             <!-- Picocli -->


### PR DESCRIPTION
backport of https://github.com/quarkusio/quarkus/pull/56346 to 3.27