### PR TITLE
Upgrade Oracle JDBC driver to latest version 23.26.3.0.0

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -1846,8 +1846,8 @@ jobs:
           TESTPILOT_CLIENT_ID: ""
           TESTPILOT_TOKEN: ""
           # Needed for TFO (TCP fast open)
-          LD_PRELOAD: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.2.0.0/libtfojdbc1.so
-          LD_LIBRARY_PATH: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.2.0.0
+          LD_PRELOAD: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.3.0.0/libtfojdbc1.so
+          LD_LIBRARY_PATH: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.3.0.0
           # End OTP setup
           TEST_MODULES: ${{matrix.test-modules}}
           CAPTURE_BUILD_SCAN: true
@@ -1967,8 +1967,8 @@ jobs:
           TESTPILOT_TOKEN: ""
           # Needed for TFO (TCP fast open)
           # TODO: enable after fixing https://github.com/quarkusio/quarkus/issues/54479
-          #LD_PRELOAD: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.2.0.0/libtfojdbc1.so
-          #LD_LIBRARY_PATH: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.2.0.0
+          #LD_PRELOAD: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.3.0.0/libtfojdbc1.so
+          #LD_LIBRARY_PATH: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.3.0.0
           #  -Dquarkus.native.additional-build-args='-ELD_PRELOAD,-ELD_LIBRARY_PATH' \
           # End OTP setup
           TEST_MODULES: ${{matrix.test-modules}}

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -129,7 +129,7 @@
         <mysql-jdbc.version>26.7.0</mysql-jdbc.version>
         <mssql-jdbc.version>13.4.0.jre11</mssql-jdbc.version>
         <adal4j.version>1.6.7</adal4j.version>
-        <oracle-jdbc.version>23.26.2.0.0</oracle-jdbc.version> <!-- Keep in synch. with Oracle Test Pilot CI workflow: ci-actions-incremental.yml -->
+        <oracle-jdbc.version>23.26.3.0.0</oracle-jdbc.version> <!-- Keep in synch. with Oracle Test Pilot CI workflow: ci-actions-incremental.yml -->
         <db2-jdbc.version>12.1.5.0</db2-jdbc.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
         <hamcrest.version>2.2</hamcrest.version><!-- The version needs to be compatible with both REST Assured and Awaitility -->

--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
@@ -124,6 +124,12 @@ public final class OracleMetadataOverrides {
         runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.driver.T4CXAConnection"));
         runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.security.o5logon.O5Logon"));
 
+        // These two classes, new in driver version 23.26.3.0.0, hold a static field of type
+        // SSLContext, eagerly initialized in a static initializer; such an object cannot be
+        // initialized at build time.
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.net.aso.TLSHandshakeHandler"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.net.nt.EZTLSKeyVerifier"));
+
         //These were missing in the original driver, and apparently in its automatic feature definitions as well;
         //the need was spotted by running the native build: GraalVM will complain about these types having initialized fields
         //referring to various other types which aren't allowed in a captured heap.


### PR DESCRIPTION
This PR upgrades the Oracle JDBC version to the latest available one: 23.26.3.0.0.

* Fixes #56356 
