### PR TITLE
Fix TOCTOU race in setChunked() causing flaky SSE TCK closeTest

### DIFF
--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
@@ -474,7 +474,21 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
 
     @Override
     public ServerHttpResponse setChunked(boolean chunked) {
-        response.setChunked(chunked);
+        if (!response.headWritten()) {
+            try {
+                response.setChunked(chunked);
+            } catch (IllegalStateException e) {
+                // TOCTOU: head was concurrently written between our check and setChunked();
+                // verify the already-sent value matches what we wanted to set
+                if (response.isChunked() != chunked) {
+                    throw e;
+                }
+            }
+        } else if (response.isChunked() != chunked) {
+            throw new IllegalStateException(
+                    "Response head already sent with chunked=" + response.isChunked()
+                            + ", cannot change to chunked=" + chunked);
+        }
         return this;
     }
 


### PR DESCRIPTION
Hopefully this fixes a flaky Jakarta REST TCK test that appears to be related to calling chunk around the same time as closing.

`VertxResteasyReactiveRequestContext.setChunked()` is forwarded directly to the Vert.x response, which throws `IllegalStateException` when the head has already been written. 
In SSE endpoints, `sendInitialResponse()` writes the head on the event loop, but Vert.x's `headWritten` field is not volatile — so a background thread calling `SseEventSink.send()` can read a stale false from `headWritten()`, pass the guard in `SseUtil.setHeaders()`, and hit the ISE from `setChunked()`. The uncaught exception kills the thread, leaving the TCK's static fields unset and failing the test.

Guard `setChunked()` with a `headWritten()` check (matching setStatusCode), catch the remaining TOCTOU window, and verify the already-sent value matches the requested one — propagating a real mismatch as an error.

