### PR TITLE
Update docs preview tooling for Roq-based website

### DIFF
--- a/.agents/skills/building-docs/SKILL.md
+++ b/.agents/skills/building-docs/SKILL.md
@@ -2,7 +2,7 @@
 name: building-docs
 description: >
   How to build, preview, and verify Quarkus documentation locally:
-  root Maven build, docs rebuild, Jekyll preview via Podman/Docker.
+  root Maven build, docs rebuild, Roq (Quarkus dev mode) preview.
 ---
 
 # Building Documentation
@@ -11,6 +11,10 @@ description: >
 
 This workflow is supported on Linux, macOS, and Windows through WSL2.
 Native Windows shells (PowerShell, CMD, Git Bash) are not supported.
+
+No container runtime is required — the website is a Quarkus application
+(built with [Roq](https://docs.quarkiverse.io/quarkus-roq/dev/index.html))
+served directly via `mvnw quarkus:dev`. Java 21+ is required for that step.
 
 ## Quick Start
 
@@ -32,6 +36,8 @@ The script uses local marker files to keep the preview workflow fast:
   Used to decide whether Step 2 can be skipped.
 * `docs/.docs-preview-last-run` — last preview run.
   Used to detect recently changed files and open the right preview URL.
+* `docs/.docs-preview-server.pid` — PID of the backgrounded `quarkus:dev`
+  process. Used to detect and reuse an already-running preview server.
 * `docs/.docs-preview-times` — cached execution times for progress estimates.
 
 All marker files are gitignored. Delete them to force a full rebuild.
@@ -44,15 +50,15 @@ code that affects generated documentation, force a root build manually:
 
 ## Step 0 — Environment Setup
 
-Source `detect-env.sh` to set `$CONTAINER_CMD`, `$VOL_FLAG`,
-`$MVN_THREADS`, `$MAVEN_OPTS`, and `$BROWSER_CMD`:
+Source `detect-env.sh` to set `$MVN_THREADS`, `$MAVEN_OPTS`, and
+`$BROWSER_CMD`:
 
 ```bash
 . docs/detect-env.sh
 ```
 
-The script computes Maven heap, thread count, container runtime,
-and browser automatically based on your machine.
+The script computes Maven heap, thread count, and browser command
+automatically based on your machine.
 
 ## Step 1 — Root Build (from repo root)
 
@@ -91,21 +97,40 @@ or attribute warnings that are harmless for local preview).
 
 First time: `./sync-web-site.sh`
 
+This clones `quarkusio.github.io` into `target/web-site/` and copies the
+built guides into its Roq content tree (`target/web-site/content/versions/main/guides`),
+plus generated docs and index data, then runs Roq-specific post-processing
+(moving static assets under `assets/`, rewriting asset links, adding
+placeholder `index.html` files, and escaping Qute syntax in
+`*qute-reference.adoc`).
+
 Subsequent iterations — fast re-sync (<1 second). This duplicates the
-rsync portion of `sync-web-site.sh` to skip its `rm -rf` + `git clone`
-(~4 min). If `sync-web-site.sh` gains a `--no-clone` flag, prefer that.
+rsync and post-processing portions of `sync-web-site.sh` to skip its
+`rm -rf` + `git clone` (~4 min). If `sync-web-site.sh` gains a
+`--no-clone` flag, prefer that.
 
 ```bash
+TARGET_GUIDES=target/web-site/content/versions/main/guides
+
 rsync -rt --delete \
     --exclude='**/*.html' --exclude='**/index.adoc' \
     --exclude='**/_attributes-local.adoc' --exclude='**/guides.md' \
     --exclude='**/_templates' \
-    target/asciidoc/sources/ target/web-site/_versions/main/guides
+    target/asciidoc/sources/ "$TARGET_GUIDES"
+
+# Roq post-processing (see sync-web-site.sh for the full, current version)
+for ext in py sh zip jar tar.gz; do
+    find "$TARGET_GUIDES" -maxdepth 1 -name "*.$ext" -exec bash -c \
+        'mkdir -p "$(dirname "$1")/assets"; mv "$1" "$(dirname "$1")/assets/"' _ {} \;
+    find "$TARGET_GUIDES" -maxdepth 1 -name "*.adoc" \
+        -exec sed -i "s|link:\([a-zA-Z0-9_-]*\.$ext\)|link:../assets/\1|g" {} \;
+done
+find "$TARGET_GUIDES" -name "*qute-reference.adoc" -exec sed -i 's/|}/|\\}/g; s/{|/\\{|/g' {} \;
 
 [ -d target/quarkus-generated-doc/ ] && rsync -rt --delete \
     --exclude='**/*.html' --exclude='**/index.adoc' \
     --exclude='**/_attributes.adoc' \
-    target/quarkus-generated-doc/ target/web-site/_generated-doc/main
+    target/quarkus-generated-doc/ target/web-site/content/_generated-doc/main
 
 if [ -f target/indexByType.yaml ]; then
     mkdir -p target/web-site/_data/versioned/main/index
@@ -122,55 +147,36 @@ fi
 
 ## Step 4 — Serve (from `docs/target/web-site`)
 
-The `--config` flag chain loads `_only_latest_guides_config.yml` (excludes
-old version directories) and `_config_dev.yml` (uses staging search
-cluster). These files come from the `quarkusio.github.io` repository,
-cloned into `target/web-site/` by `sync-web-site.sh`.
-
-**Primary** — build from the upstream `jekyll-container/` Dockerfile
-(available after sync). This matches what `quarkusio.github.io` uses in
-production and eliminates external image dependencies:
+The website is a Quarkus Roq site. It ships its own `serve-only-latest-guides.sh`,
+which runs `mvnw quarkus:dev` with the `only-latest-guides` profile
+(`config/application-only-latest-guides.properties`, which excludes old
+version directories so dev-mode startup stays fast). This comes from the
+`quarkusio.github.io` repository, cloned into `target/web-site/` by
+`sync-web-site.sh`.
 
 ```bash
 cd target/web-site
-$CONTAINER_CMD build -t quarkus-docs-jekyll:local jekyll-container/
-
-$CONTAINER_CMD run -d --name quarkus-docs-preview \
-  -p 127.0.0.1:4000:4000 -p 127.0.0.1:35729:35729 \
-  -v "$(pwd):/site${VOL_FLAG}" \
-  -v quarkus-jekyll-bundles:/usr/local/bundle \
-  quarkus-docs-jekyll:local \
-  bundle exec jekyll serve --host 0.0.0.0 \
-  --livereload --incremental \
-  --config _config.yml,_config_dev.yml,_only_latest_guides_config.yml
+QUARKUS_HTTP_PORT=8042 ./serve-only-latest-guides.sh
 ```
 
-Stop: `$CONTAINER_CMD rm -f quarkus-docs-preview`
+Quarkus dev mode watches the content tree and live-reloads the browser on
+change — there is no separate build-then-restart step and no livereload
+port to manage. `QUARKUS_HTTP_PORT` (or any `quarkus.*` property, via its
+env-var form) can be set to change the port; it defaults to `8042`
+(`config/application.properties`).
 
-**Fallback** — pre-built images (pinned by digest) if the local build
-is not available (e.g., first run before sync completes):
+To background it and reuse it across `docs-preview.sh` runs:
 
 ```bash
-# Fallback 1: bretfisher/jekyll-serve
-$CONTAINER_CMD run -d --name quarkus-docs-preview \
-  -p 127.0.0.1:4000:4000 -p 127.0.0.1:35729:35729 \
-  -v "$(pwd):/site${VOL_FLAG}" \
-  -v quarkus-jekyll-bundles:/usr/local/bundle \
-  docker.io/bretfisher/jekyll-serve@sha256:db11b70736935b1a777b2ff2ae10f9ad191ee9fca6560eade1d5ad98b74e5f66 \
-  bundle exec jekyll serve --host 0.0.0.0 \
-  --livereload --incremental \
-  --config _config.yml,_config_dev.yml,_only_latest_guides_config.yml
-
-# Fallback 2: jekyll/jekyll (mount at /srv/jekyll)
-$CONTAINER_CMD run -d --name quarkus-docs-preview \
-  -p 127.0.0.1:4000:4000 -p 127.0.0.1:35729:35729 \
-  --volume="$(pwd):/srv/jekyll${VOL_FLAG}" \
-  -v quarkus-jekyll-bundles:/usr/local/bundle \
-  docker.io/jekyll/jekyll@sha256:bb45414c3fefa80a75c5001f30baf1dff48ae31dc961b8b51003b93b60675334 \
-  bundle exec jekyll serve --host 0.0.0.0 \
-  --livereload --incremental \
-  --config _config.yml,_config_dev.yml,_only_latest_guides_config.yml
+nohup ./serve-only-latest-guides.sh > server.log 2>&1 &
+echo $! > .server.pid
 ```
+
+Stop: `kill $(cat .server.pid)`
+
+Other profiles available in that repo (see `.agents/skills/building-blog/SKILL.md`
+there for the blog-focused equivalent): `./serve.sh` (full site, all guide
+versions) and `./serve-noguides.sh` (fastest, no guides at all).
 
 ## Step 5 — Verify
 
@@ -178,11 +184,11 @@ The script auto-detects what you were working on and opens the right page:
 
 | Content type | How detected | Preview URL |
 |---|---|---|
-| 1 guide | Recently modified `.adoc` in `docs/src/main/asciidoc/` | `/version/main/guides/<name>.html` (direct) |
+| 1 guide | Recently modified `.adoc` in `docs/src/main/asciidoc/` | `/version/main/guides/<name>/` (direct) |
 | 2-4 guides | Multiple `.adoc` files modified | Opens a tab for each guide |
 | 5+ guides | Many files modified | `/version/main/guides/` (listing) |
-| Blog post | Recently modified `_posts/*.adoc`, no `user-story` tag | `/blog/<slug>/` (deep-link) |
-| User story | Recently modified `_posts/*.adoc`, has `user-story` tag | `/blog/<slug>/` (deep-link) |
+| Blog post | Recently modified `content/posts/*.adoc`, no `user-story` tag | `/blog/<slug>/` (deep-link) |
+| User story | Recently modified `content/posts/*.adoc`, has `user-story` tag | `/blog/<slug>/` (deep-link) |
 | No changes | No recent `.adoc` changes found | `/` (homepage) |
 
 ## Iteration Loop
@@ -191,8 +197,10 @@ The script auto-detects what you were working on and opens the right page:
 Edit .adoc → save → Step 2 (~1 min) → Step 3 re-sync (<1s) → browser auto-refreshes
 ```
 
-Container stays running. Escalate to Step 1 when Step 2 fails or after
-significant upstream changes.
+The dev server stays running (backgrounded, tracked via
+`docs/.docs-preview-server.pid`). Re-running `just docs-preview` reuses it
+if it's still up and just re-syncs + re-opens the browser. Escalate to
+Step 1 when Step 2 fails or after significant upstream changes.
 
 ## When to escalate to a root build
 
@@ -206,24 +214,21 @@ significant upstream changes.
 
 ## Troubleshooting
 
-**`Failed to delete docs/.cache/formatter-maven-cache.properties`** —
-Rootless Podman UID mapping. Fix: `podman unshare rm -rf docs/.cache/`.
-With Docker: `rm -rf docs/.cache/`.
+**Port 8042 already in use** — Another process (possibly a stale dev server
+from a previous run) is occupying the port. `docs-preview.sh` detects and
+stops a stale server tracked via `docs/.docs-preview-server.pid`
+automatically; for anything else, free the port or set `QUARKUS_HTTP_PORT`
+to a different value.
 
-**Volume mount errors on macOS/Ubuntu** — SELinux `:z` flag applied on
-a system without SELinux. Source `detect-env.sh` to set `$VOL_FLAG`
-correctly.
+**Preview shows partial or stale content** — Stop the dev server
+(`kill $(cat docs/.docs-preview-server.pid)`) and run `just docs-preview`
+again. If that doesn't help, delete `docs/target/web-site` to force a full
+re-clone and re-sync.
 
-**Container image pull fails** — The script first tries to build from the
-upstream `jekyll-container/` Dockerfile, then falls back to pre-built images
-pinned by digest. To force a rebuild of the local image:
-`$CONTAINER_CMD rmi quarkus-docs-jekyll:local`
-
-**Preview shows partial or stale content** — Jekyll's `--incremental`
-mode can sometimes miss dependency changes. Restart the container
-(`$CONTAINER_CMD rm -f quarkus-docs-preview`) and run `just docs-preview`
-again. If that doesn't help, delete `docs/target/web-site/.jekyll-cache`
-before re-running.
+**Changes not appearing** — Quarkus dev mode watches the content tree
+under `target/web-site/`. If a change is not picked up, press `s` in the
+terminal running the dev server to force a restart (or kill and restart it
+via `docs-preview.sh`).
 
 **Force a full root build** — Set `QUARKUS_DOCS_PREVIEW_FULL=1` before
 running: `QUARKUS_DOCS_PREVIEW_FULL=1 just docs-preview`

--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,6 @@ docs/.docs-preview-root-build-head
 docs/.docs-preview-docs-build-last-run
 docs/.docs-preview-times
 docs/.docs-preview.lock/
+docs/.docs-preview-server.pid
 hostkey.ser
 java_pid*.hprof

--- a/.justfile
+++ b/.justfile
@@ -15,7 +15,7 @@ build-fast:
 build-docs:
     {{mvncmd}} -e -DskipTests -DskipITs -Dinvoker.skip -DskipExtensionValidation -Dskip.gradle.tests -Dtruststore.skip -Dno-test-modules -Dasciidoctor.fail-if=DEBUG clean install
 
-# build docs, sync to website, serve with Jekyll, and open browser
+# build docs, sync to website, serve with Roq (Quarkus dev mode), and open browser
 docs-preview:
     bash docs/docs-preview.sh
 

--- a/docs/detect-env.sh
+++ b/docs/detect-env.sh
@@ -4,16 +4,6 @@
 # Only MAVEN_OPTS is exported; other variables are set in the caller's
 # shell context when sourced.
 
-if command -v podman &>/dev/null; then CONTAINER_CMD="podman"
-elif command -v docker &>/dev/null; then CONTAINER_CMD="docker"
-else echo "ERROR: neither podman nor docker found" && return 1 2>/dev/null || exit 1; fi
-
-if command -v getenforce &>/dev/null && [ "$(getenforce 2>/dev/null)" != "Disabled" ]; then
-  VOL_FLAG=":z"
-else
-  VOL_FLAG=""
-fi
-
 if command -v nproc &>/dev/null; then
   CORES=$(nproc)
 elif command -v sysctl &>/dev/null; then
@@ -58,8 +48,6 @@ elif command -v xdg-open &>/dev/null; then BROWSER_CMD="xdg-open"
 elif command -v open &>/dev/null; then BROWSER_CMD="open"
 else BROWSER_CMD=""; fi
 
-echo "Container:  $CONTAINER_CMD"
-echo "SELinux:    ${VOL_FLAG:-none}"
 echo "Cores:      $CORES"
 echo "RAM:        $((TOTAL_MEM_MB / 1024))GB total → heap ${HEAP_MB}MB, threads: ${MVN_THREADS:-single-threaded}"
 echo "MAVEN_OPTS: $MAVEN_OPTS"

--- a/docs/docs-preview.sh
+++ b/docs/docs-preview.sh
@@ -13,12 +13,12 @@ done
 find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'quarkus-docs-build-*' -type d -mtime +7 -exec rm -rf {} + 2>/dev/null || true
 LOGDIR=$(mktemp -d "${TMPDIR:-/tmp}/quarkus-docs-build-XXXXXX") || exit 1
 
-# Primary: build from the upstream jekyll-container/ Dockerfile (in the website checkout).
-# Fallback: use pre-built images if the Dockerfile is not available (first run before sync).
-CONTAINER_NAME="quarkus-docs-preview"
-JEKYLL_LOCAL_IMAGE="quarkus-docs-jekyll:local"
-JEKYLL_IMAGE_FALLBACK="docker.io/bretfisher/jekyll-serve@sha256:db11b70736935b1a777b2ff2ae10f9ad191ee9fca6560eade1d5ad98b74e5f66"
-JEKYLL_IMAGE_FALLBACK2="docker.io/jekyll/jekyll@sha256:bb45414c3fefa80a75c5001f30baf1dff48ae31dc961b8b51003b93b60675334"
+# The website (quarkusio.github.io) is a Quarkus Roq site. Preview is served
+# by its own `serve-only-latest-guides.sh`, which runs `mvnw quarkus:dev` —
+# no container runtime is required.
+DOCS_PREVIEW_PORT="${QUARKUS_HTTP_PORT:-8042}"
+SERVER_PID_FILE="$SCRIPTDIR/docs/.docs-preview-server.pid"
+BASE_URL="http://127.0.0.1:${DOCS_PREVIEW_PORT}"
 
 PREVIEW_REF="$SCRIPTDIR/docs/.docs-preview-last-run"
 ROOT_BUILD_REF="$SCRIPTDIR/docs/.docs-preview-root-build-last-run"
@@ -79,7 +79,7 @@ estimate_step() {
     docs)      awk -v c="$CORES" 'BEGIN {t=int(75+(22-c)*1.7);  if(t<30)t=30; printf "%d",t}' ;;
     sync_full) echo 200 ;;
     sync_fast) echo 1 ;;
-    jekyll)    awk -v c="$CORES" 'BEGIN {t=int(100+(22-c)*4.1);  if(t<60)t=60; printf "%d",t}' ;;
+    serve)     awk -v c="$CORES" 'BEGIN {t=int(60+(22-c)*2.5);  if(t<20)t=20; printf "%d",t}' ;;
     *)         echo 120 ;;
   esac
 }
@@ -169,14 +169,17 @@ root_build_needed() {
   return 1
 }
 
-# --- Container reuse ---
+# --- Server reuse ---
 
-container_running() {
-  [ "$($CONTAINER_CMD inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null)" = "true" ]
+server_running() {
+  [ -f "$SERVER_PID_FILE" ] || return 1
+  local pid
+  pid=$(cat "$SERVER_PID_FILE" 2>/dev/null)
+  [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null
 }
 
 preview_ready() {
-  [ "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:4000 2>/dev/null)" = "200" ]
+  [ "$(curl -s -o /dev/null -w '%{http_code}' "$BASE_URL" 2>/dev/null)" = "200" ]
 }
 
 # --- Step 0: Environment ---
@@ -196,17 +199,17 @@ fi
 
 EST_ROOT=$(estimate_step root)
 EST_DOCS=$(estimate_step docs)
-EST_JEKYLL=$(estimate_step jekyll)
+EST_SERVE=$(estimate_step serve)
 
 PREVIEW_ALREADY_RUNNING=false
-if container_running && preview_ready; then
+if server_running && preview_ready; then
   PREVIEW_ALREADY_RUNNING=true
 fi
 
 echo ""
 if [ "$RUN_ROOT_BUILD" = "true" ]; then
   EST_SYNC=$(estimate_step sync_full)
-  EST_TOTAL=$((EST_ROOT + EST_DOCS + EST_SYNC + EST_JEKYLL))
+  EST_TOTAL=$((EST_ROOT + EST_DOCS + EST_SYNC + EST_SERVE))
   echo "Full root build needed."
   echo "Estimated time: ~$((EST_TOTAL / 60)) minutes on this machine."
   echo "After this completes, later docs updates take about 1 minute."
@@ -218,7 +221,7 @@ fi
 echo "Logs: $LOGDIR"
 echo ""
 
-# Pre-flight: port check (skip if reusing container)
+# Pre-flight: port check (skip if reusing the running dev server)
 port_in_use() {
   if command -v lsof >/dev/null 2>&1; then
     lsof -nP -iTCP:"$1" -sTCP:LISTEN >/dev/null 2>&1
@@ -232,32 +235,24 @@ port_in_use() {
 }
 
 if [ "$PREVIEW_ALREADY_RUNNING" != "true" ]; then
-  if port_in_use 4000 || port_in_use 35729; then
-    if container_running; then
-      echo "  Stale preview container detected. Removing..."
-      $CONTAINER_CMD rm -f "$CONTAINER_NAME" 2>/dev/null || true
-      sleep 1
-      if port_in_use 4000 || port_in_use 35729; then
-        echo "Port 4000 or 35729 is still in use after removing stale container."
-        echo "Free the port and try again."
-        exit 1
-      fi
-    else
-      echo "Port 4000 or 35729 is already in use by another process."
-      echo "Free the port and try again."
-      exit 1
-    fi
+  if [ -f "$SERVER_PID_FILE" ]; then
+    echo "  Stale preview server detected. Stopping it..."
+    STALE_PID=$(cat "$SERVER_PID_FILE" 2>/dev/null)
+    [ -n "$STALE_PID" ] && kill "$STALE_PID" 2>/dev/null
+    rm -f "$SERVER_PID_FILE"
+    sleep 1
+  fi
+  if port_in_use "$DOCS_PREVIEW_PORT"; then
+    echo "Port $DOCS_PREVIEW_PORT is already in use by another process."
+    echo "Free the port, or set QUARKUS_HTTP_PORT to a different one, and try again."
+    exit 1
   fi
 fi
 
 START_TOTAL=$(date +%s)
 
 # Non-fatal cache cleanup
-if [ "$CONTAINER_CMD" = "podman" ]; then
-  podman unshare rm -rf docs/.cache/ 2>/dev/null || rm -rf docs/.cache/ 2>/dev/null || true
-else
-  rm -rf docs/.cache/ 2>/dev/null || true
-fi
+rm -rf docs/.cache/ 2>/dev/null || true
 
 # --- Step 1: Root Build ---
 
@@ -367,16 +362,38 @@ echo "=== Step 3: Sync ==="
 STEP3_START=$(date +%s)
 
 run_fast_sync() {
+  local target_guides=target/web-site/content/versions/main/guides
   rsync -rt --delete \
       --exclude='**/*.html' --exclude='**/index.adoc' \
       --exclude='**/_attributes-local.adoc' --exclude='**/guides.md' \
       --exclude='**/_templates' \
-      target/asciidoc/sources/ target/web-site/_versions/main/guides || return 1
+      target/asciidoc/sources/ "$target_guides" || return 1
+
+  # Mirror sync-web-site.sh's Roq post-processing so the fast path stays
+  # equivalent to a full sync.
+  for ext in py sh zip jar tar.gz; do
+    find "$target_guides" -maxdepth 1 -name "*.$ext" -exec bash -c '
+      mkdir -p "$(dirname "$1")/assets"
+      mv "$1" "$(dirname "$1")/assets/"
+    ' _ {} \; || return 1
+    find "$target_guides" -maxdepth 1 -name "*.adoc" \
+      -exec sed -i "s|link:\([a-zA-Z0-9_-]*\.$ext\)|link:../assets/\1|g" {} \; || return 1
+  done
+  for subdir in images javascript assets; do
+    local dir="$target_guides/$subdir"
+    if [ -d "$dir" ] && [ ! -f "$dir/index.html" ]; then
+      local rel_path
+      rel_path=$(echo "$dir" | sed 's|target/web-site/content/||')
+      printf '%s\n' '---' "link: /${rel_path}/" '---' '<html><body></body></html>' > "$dir/index.html" || return 1
+    fi
+  done
+  find "$target_guides" -name "*qute-reference.adoc" -exec sed -i 's/|}/|\\}/g; s/{|/\\{|/g' {} \; || return 1
+
   if [ -d target/quarkus-generated-doc/ ]; then
     rsync -rt --delete \
         --exclude='**/*.html' --exclude='**/index.adoc' \
         --exclude='**/_attributes.adoc' \
-        target/quarkus-generated-doc/ target/web-site/_generated-doc/main || return 1
+        target/quarkus-generated-doc/ target/web-site/content/_generated-doc/main || return 1
   fi
   if [ -f target/indexByType.yaml ]; then
     mkdir -p target/web-site/_data/versioned/main/index || return 1
@@ -396,11 +413,11 @@ run_full_sync() {
 }
 
 SYNC_TYPE="full"
-if [ -d target/web-site/_versions ]; then
+if [ -d target/web-site/content/versions ]; then
   SYNC_OK=true
-  [ ! -d target/web-site/_versions/main/guides ] && SYNC_OK=false
-  [ ! -f target/web-site/_config.yml ] && SYNC_OK=false
-  [ ! -f target/web-site/_only_latest_guides_config.yml ] && SYNC_OK=false
+  [ ! -d target/web-site/content/versions/main/guides ] && SYNC_OK=false
+  [ ! -f target/web-site/config/application.properties ] && SYNC_OK=false
+  [ ! -f target/web-site/config/application-only-latest-guides.properties ] && SYNC_OK=false
 
   if [ "$SYNC_OK" = "true" ]; then
     SYNC_TYPE="fast"
@@ -436,7 +453,8 @@ if [ "$SYNC_TYPE" = "fast" ]; then
   save_step_time "sync_fast" "$STEP3_TIME" || true
 else
   save_step_time "sync_full" "$STEP3_TIME" || true
-  # Full sync recreated the mount directory — container must restart
+  # Full sync recreated the checkout — the dev server must restart to pick
+  # up the (re-)cloned site sources.
   PREVIEW_ALREADY_RUNNING=false
 fi
 
@@ -446,7 +464,7 @@ echo ""
 echo "=== Step 4: Preview server ==="
 
 if [ "$PREVIEW_ALREADY_RUNNING" = "true" ]; then
-  if container_running && preview_ready; then
+  if server_running && preview_ready; then
     echo "  Preview server is already running. Reusing it."
   else
     echo "  Previously running preview server is no longer ready. Restarting."
@@ -455,119 +473,55 @@ if [ "$PREVIEW_ALREADY_RUNNING" = "true" ]; then
 fi
 
 if [ "$PREVIEW_ALREADY_RUNNING" != "true" ]; then
-  $CONTAINER_CMD rm -f "$CONTAINER_NAME" 2>/dev/null || true
+  if [ -f "$SERVER_PID_FILE" ]; then
+    OLD_PID=$(cat "$SERVER_PID_FILE" 2>/dev/null)
+    [ -n "$OLD_PID" ] && kill "$OLD_PID" 2>/dev/null
+    rm -f "$SERVER_PID_FILE"
+  fi
   cd target/web-site || exit 1
   STEP4_START=$(date +%s)
 
-  start_jekyll() {
-    local image="$1" mount="$2" run_log="$3"
-    if ! $CONTAINER_CMD run -d --name "$CONTAINER_NAME" \
-      -p 127.0.0.1:4000:4000 -p 127.0.0.1:35729:35729 \
-      -v "$(pwd):${mount}${VOL_FLAG}" \
-      -v quarkus-jekyll-bundles:/usr/local/bundle \
-      "$image" \
-      bundle exec jekyll serve --host 0.0.0.0 \
-      --livereload --incremental \
-      --config _config.yml,_config_dev.yml,_only_latest_guides_config.yml \
-      > "$run_log" 2>&1; then
-      return 1
-    fi
-    local _i
-    for _i in $(seq 1 10); do
-      if [ "$($CONTAINER_CMD inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null)" = "true" ]; then
-        return 0
-      fi
-      sleep 1
-    done
-    $CONTAINER_CMD logs "$CONTAINER_NAME" >> "$run_log" 2>&1
-    return 1
-  }
+  # Roq's own serve-only-latest-guides.sh runs `mvnw quarkus:dev` with the
+  # only-latest-guides profile — no container image, no port for a separate
+  # livereload channel (Quarkus dev mode reloads over the same HTTP port).
+  QUARKUS_HTTP_PORT="$DOCS_PREVIEW_PORT" \
+    nohup ./serve-only-latest-guides.sh > "$LOGDIR/step4-serve.log" 2>&1 &
+  SERVER_PID=$!
+  disown "$SERVER_PID" 2>/dev/null || true
+  echo "$SERVER_PID" > "$SERVER_PID_FILE"
 
-  # Primary: build from the upstream jekyll-container/ Dockerfile
-  STARTED=false
-  if [ -d "jekyll-container" ] && [ -f "jekyll-container/Dockerfile" ]; then
-    echo "  Checking Jekyll image (build cache)..."
-    if ! $CONTAINER_CMD build -t "$JEKYLL_LOCAL_IMAGE" jekyll-container/ > "$LOGDIR/step4-build.log" 2>&1; then
-      echo "  Image build failed. Falling back to pre-built image..."
-    fi
-    if $CONTAINER_CMD image inspect "$JEKYLL_LOCAL_IMAGE" > /dev/null 2>&1; then
-      if start_jekyll "$JEKYLL_LOCAL_IMAGE" "/site" "$LOGDIR/step4-primary.log"; then
-        STARTED=true
-      else
-        echo "  Local image failed to start. Trying fallback..."
-        $CONTAINER_CMD rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
-      fi
-    fi
-  fi
-
-  # Fallback 1: bretfisher/jekyll-serve (pinned by digest)
-  if [ "$STARTED" != "true" ]; then
-    PULL_OK=true
-    if ! $CONTAINER_CMD image inspect "$JEKYLL_IMAGE_FALLBACK" > /dev/null 2>&1; then
-      echo "  Pulling fallback Jekyll image (first time only)..."
-      $CONTAINER_CMD pull "$JEKYLL_IMAGE_FALLBACK" > "$LOGDIR/step4-fallback-pull.log" 2>&1 || PULL_OK=false
-    fi
-    if [ "$PULL_OK" = "true" ]; then
-      if start_jekyll "$JEKYLL_IMAGE_FALLBACK" "/site" "$LOGDIR/step4-fallback.log"; then
-        STARTED=true
-      else
-        $CONTAINER_CMD rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
-      fi
-    fi
-  fi
-
-  # Fallback 2: jekyll/jekyll (pinned by digest)
-  if [ "$STARTED" != "true" ]; then
-    PULL_OK2=true
-    if ! $CONTAINER_CMD image inspect "$JEKYLL_IMAGE_FALLBACK2" > /dev/null 2>&1; then
-      echo "  Pulling second fallback image..."
-      $CONTAINER_CMD pull "$JEKYLL_IMAGE_FALLBACK2" > "$LOGDIR/step4-fallback2-pull.log" 2>&1 || PULL_OK2=false
-    fi
-    if [ "$PULL_OK2" = "true" ]; then
-      if start_jekyll "$JEKYLL_IMAGE_FALLBACK2" "/srv/jekyll" "$LOGDIR/step4-fallback2.log"; then
-        STARTED=true
-      else
-        $CONTAINER_CMD rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
-      fi
-    fi
-  fi
-
-  if [ "$STARTED" != "true" ]; then
-    echo "  All images failed. Check $LOGDIR/step4*.log"
-    $CONTAINER_CMD rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
-    exit 1
-  fi
-
-  echo "  Waiting for Jekyll to generate the site..."
+  echo "  Waiting for the Roq dev server to start..."
   for i in $(seq 1 150); do
-    if [ "$($CONTAINER_CMD inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null)" != "true" ]; then
-      echo "  Container exited during startup."
-      $CONTAINER_CMD logs "$CONTAINER_NAME" 2>&1 | tail -50 | tee "$LOGDIR/step4-crash.log"
-      $CONTAINER_CMD rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+      echo "  Server process exited during startup."
+      tail -50 "$LOGDIR/step4-serve.log" | tee "$LOGDIR/step4-crash.log"
+      rm -f "$SERVER_PID_FILE"
       exit 1
     fi
-    if [ "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:4000 2>/dev/null)" = "200" ]; then
+    if preview_ready; then
       STEP4_TIME=$(( $(date +%s) - STEP4_START ))
       printf '  Preview server ✓ %ds\n' "$STEP4_TIME"
-      save_step_time "jekyll" "$STEP4_TIME" || true
+      save_step_time "serve" "$STEP4_TIME" || true
       break
     fi
     if [ "$i" -eq 150 ]; then
       echo "  Timeout after 300s."
-      $CONTAINER_CMD logs "$CONTAINER_NAME" 2>&1 | tail -50 | tee "$LOGDIR/step4-timeout.log"
-      $CONTAINER_CMD rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+      tail -50 "$LOGDIR/step4-serve.log" | tee "$LOGDIR/step4-timeout.log"
+      kill "$SERVER_PID" 2>/dev/null
+      rm -f "$SERVER_PID_FILE"
       exit 1
     fi
     local_elapsed=$(( $(date +%s) - STEP4_START ))
-    local_pct=$(( local_elapsed * 100 / (EST_JEKYLL > 0 ? EST_JEKYLL : 120) ))
+    local_pct=$(( local_elapsed * 100 / (EST_SERVE > 0 ? EST_SERVE : 60) ))
     [ "$local_pct" -gt 99 ] && local_pct=99
     if [ -t 1 ]; then
-      printf '\r  Jekyll [%3d%%] %ds / ~%ds ' "$local_pct" "$local_elapsed" "$EST_JEKYLL"
+      printf '\r  Roq dev server [%3d%%] %ds / ~%ds ' "$local_pct" "$local_elapsed" "$EST_SERVE"
     else
-      printf '  Jekyll: %ds / ~%ds\n' "$local_elapsed" "$EST_JEKYLL"
+      printf '  Roq dev server: %ds / ~%ds\n' "$local_elapsed" "$EST_SERVE"
     fi
     sleep 2
   done
+  cd "$SCRIPTDIR/docs" || exit 1
 fi
 
 # --- Step 5: Detect and open ---
@@ -607,13 +561,13 @@ PREVIEW_URLS=()
 RECENT_POST=""
 
 if [ -f "$PREVIEW_REF" ]; then
-  RECENT_POST=$(newest_adoc_after "$SCRIPTDIR/docs/target/web-site/_posts" "$PREVIEW_REF")
+  RECENT_POST=$(newest_adoc_after "$SCRIPTDIR/docs/target/web-site/content/posts" "$PREVIEW_REF")
   GUIDE_COUNT=$(all_adoc_after "$SCRIPTDIR/docs/src/main/asciidoc" "$PREVIEW_REF" | awk 'END { print NR }')
 fi
 
 if [ -n "$RECENT_POST" ]; then
   SLUG=$(basename "$RECENT_POST" .adoc | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//')
-  PREVIEW_URLS=("http://127.0.0.1:4000/blog/${SLUG}/")
+  PREVIEW_URLS=("${BASE_URL}/blog/${SLUG}/")
   if awk '/^---$/{c++; next} c==1' "$RECENT_POST" | grep -q 'user-story'; then
     echo "Detected: user story ($(basename "$RECENT_POST"))"
   else
@@ -622,20 +576,20 @@ if [ -n "$RECENT_POST" ]; then
 elif [ "${GUIDE_COUNT:-0}" -eq 1 ]; then
   GUIDE_FILE=$(all_adoc_after "$SCRIPTDIR/docs/src/main/asciidoc" "$PREVIEW_REF" | head -1)
   GUIDE_SLUG=$(basename "$GUIDE_FILE" .adoc)
-  PREVIEW_URLS=("http://127.0.0.1:4000/version/main/guides/${GUIDE_SLUG}.html")
+  PREVIEW_URLS=("${BASE_URL}/version/main/guides/${GUIDE_SLUG}/")
   echo "Detected: guide ($GUIDE_SLUG.adoc)"
 elif [ "${GUIDE_COUNT:-0}" -ge 2 ] && [ "${GUIDE_COUNT:-0}" -le 4 ]; then
   echo "Detected: $GUIDE_COUNT guides modified"
   while IFS= read -r gf; do
     GS=$(basename "$gf" .adoc)
-    PREVIEW_URLS+=("http://127.0.0.1:4000/version/main/guides/${GS}.html")
+    PREVIEW_URLS+=("${BASE_URL}/version/main/guides/${GS}/")
     echo "  - $GS.adoc"
   done < <(all_adoc_after "$SCRIPTDIR/docs/src/main/asciidoc" "$PREVIEW_REF")
 elif [ "${GUIDE_COUNT:-0}" -ge 5 ]; then
-  PREVIEW_URLS=("http://127.0.0.1:4000/version/main/guides/")
+  PREVIEW_URLS=("${BASE_URL}/version/main/guides/")
   echo "Detected: $GUIDE_COUNT guides modified. Opening listing."
 else
-  PREVIEW_URLS=("http://127.0.0.1:4000")
+  PREVIEW_URLS=("${BASE_URL}")
   echo "No recent changes detected. Opening homepage."
 fi
 
@@ -656,6 +610,6 @@ else
 fi
 echo ""
 echo "Preview is ready."
-echo "Container: $CONTAINER_NAME"
-echo "Stop:      $CONTAINER_CMD rm -f $CONTAINER_NAME"
-echo "Logs:      $LOGDIR"
+echo "Server PID: $(cat "$SERVER_PID_FILE" 2>/dev/null || echo unknown)"
+echo "Stop:       kill \$(cat $SERVER_PID_FILE)"
+echo "Logs:       $LOGDIR"


### PR DESCRIPTION
@lucamolteni spotted that the docs preview scripts on the quarkus side still assume Jekyll. I've updated things so that the scriptno longer needs a container runtime: it now starts the site's own `serve-only-latest-guides.sh` directly and tracks it via a PID file instead of a named container. Sync paths, guide URLs, and the building-docs skill are updated to match Roq's content/ layout.
