### PR TITLE
Do not use attributes in guide title to work around Roq/Yupiik limitation

### DIFF
--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -92,7 +92,6 @@
 :vault-datasource-guide: https://docs.quarkiverse.io/quarkus-vault/dev/vault-datasource.html
 :micrometer-registry-guide: https://docs.quarkiverse.io/quarkus-micrometer-registry/dev/index.html
 :quarkus-migration-guide: https://github.com/quarkusio/quarkus/wiki/Migration-Guides[Migration Guides]
-:quarkus-tls-registry-reference-guide: TLS registry reference
 // .
 :create-app-group-id: org.acme
 :create-cli-group-id: {create-app-group-id}

--- a/docs/src/main/asciidoc/tls-registry-reference.adoc
+++ b/docs/src/main/asciidoc/tls-registry-reference.adoc
@@ -4,7 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id="tls-registry-reference"]
-= {quarkus-tls-registry-reference-guide}
+= TLS registry reference
 include::_attributes.adoc[]
 :summary: TLS registry configuration and usage
 :numbered:


### PR DESCRIPTION
@michalvavrik pointed out one of our guides has a stupid title after the Roq migration: 

<img width="1107" height="236" alt="image" src="https://github.com/user-attachments/assets/fe1e3763-996d-4119-938e-649b829854d6" />

It's the only guide that used an attribute in its title. In principle, this should work, but making it work needs a Yupiik fix or a Roq workaround. I'll raise those issues, but in the interim, I think there's little harm in just updating the guide to look better. I think the value of using an attribute for the title is pretty low in this case.