### PR TITLE
Fix numbered callout lists in documentation examples

### DIFF
--- a/docs/src/main/asciidoc/funqy-gcp-functions.adoc
+++ b/docs/src/main/asciidoc/funqy-gcp-functions.adoc
@@ -115,16 +115,15 @@ public class GreetingFunctions {
     }
 }
 ----
+<1> Injection works inside your function.
+<2> This is a background function that takes as parameter a `io.quarkus.funqy.gcp.functions.event.PubsubMessage`,
+this is a convenient class to deserialize a PubSub message.
+<3> This is a background function that takes as parameter a `io.quarkus.funqy.gcp.functions.event.StorageEvent`,
+this is a convenient class to deserialize a Google Storage event.
+<4> This is a cloud events function, that takes as parameter a `io.cloudevents.CloudEvent`,
+inside it the `getData()` method will return the event content, a storage event in this case.
 
 NOTE: Function return type can also be Mutiny reactive types.
-
-1. Injection works inside your function.
-2. This is a background function that takes as parameter a `io.quarkus.funqy.gcp.functions.event.PubsubMessage`,
-this is a convenient class to deserialize a PubSub message.
-3. This is a background function that takes as parameter a `io.quarkus.funqy.gcp.functions.event.StorageEvent`,
-this is a convenient class to deserialize a Google Storage event.
-4. This is a cloud events function, that takes as parameter a `io.cloudevents.CloudEvent`,
-inside it the `getData()` method will return the event content, a storage event in this case.
 
 NOTE: we provide convenience class to deserialize common Google Cloud events inside the `io.quarkus.funqy.gcp.functions.event` package.
 They are not mandatory to use, you can use any object you want.
@@ -412,10 +411,9 @@ class GreetingFunctionsPubsubTest {
 }
 
 ----
-
-1. This is a standard Quarkus test that must be annotated by `@QuarkusTest`.
-2. `@WithFunction(FunctionType.FUNQY_BACKGROUND)` indicates to launch the function as a Funqy background function. If multiple functions exist in the same application, the `functionName` attribute must be used to denote which one should be launched.
-3. REST-assured is used to test the function, `{"data":"world"}` will be sent to it via the invoker.
+<1> This is a standard Quarkus test that must be annotated by `@QuarkusTest`.
+<2> `@WithFunction(FunctionType.FUNQY_BACKGROUND)` indicates to launch the function as a Funqy background function. If multiple functions exist in the same application, the `functionName` attribute must be used to denote which one should be launched.
+<3> REST-assured is used to test the function, `{"data":"world"}` will be sent to it via the invoker.
 
 === Background Functions - Cloud Storage
 
@@ -435,7 +433,7 @@ class GreetingFunctionsStorageTest {
     @Test
     public void test() {
         given()
-                .body("{\"data\":{\"name\":\"hello.txt\"}}") // <2>
+                .body("{\"data\":{\"name\":\"hello.txt\"}}") // <3>
                 .when()
                 .post()
                 .then()
@@ -443,10 +441,9 @@ class GreetingFunctionsStorageTest {
     }
 }
 ----
-
-1. This is a standard Quarkus test that must be annotated by `@QuarkusTest`.
-2. `@WithFunction(FunctionType.FUNQY_BACKGROUND)` indicates to launch the function as a Funqy background function. If multiple functions exist in the same application, the `functionName` attribute must be used to denote which one should be launched.
-3. REST-assured is used to test the function, `{"name":"hello.txt"}` will be sent to it via the invoker.
+<1> This is a standard Quarkus test that must be annotated by `@QuarkusTest`.
+<2> `@WithFunction(FunctionType.FUNQY_BACKGROUND)` indicates to launch the function as a Funqy background function. If multiple functions exist in the same application, the `functionName` attribute must be used to denote which one should be launched.
+<3> REST-assured is used to test the function, `{"name":"hello.txt"}` will be sent to it via the invoker.
 
 === Cloud Events Functions - Cloud Storage
 
@@ -492,11 +489,10 @@ class GreetingFunctionsCloudEventTest {
     }
 }
 ----
-
-1. This is a standard Quarkus test that must be annotated by `@QuarkusTest`.
-2. `@WithFunction(FunctionType.FUNQY_CLOUD_EVENTS)` indicates to launch the function as a Funqy cloud events function. If multiple functions exist in the same application, the `functionName` attribute must be used to denote which one should be launched.
-3. REST-assured is used to test the function, this payload that describe a storage event will be sent to it via the invoker.
-4. The cloud events headers must be sent via HTTP headers.
+<1> This is a standard Quarkus test that must be annotated by `@QuarkusTest`.
+<2> `@WithFunction(FunctionType.FUNQY_CLOUD_EVENTS)` indicates to launch the function as a Funqy cloud events function. If multiple functions exist in the same application, the `functionName` attribute must be used to denote which one should be launched.
+<3> REST-assured is used to test the function, this payload that describe a storage event will be sent to it via the invoker.
+<4> The cloud events headers must be sent via HTTP headers.
 
 
 == What's next?

--- a/docs/src/main/asciidoc/gcp-functions.adoc
+++ b/docs/src/main/asciidoc/gcp-functions.adoc
@@ -514,10 +514,9 @@ class HttpFunctionTestCase {
     }
 }
 ----
-
-1. This is a standard Quarkus test that must be annotated by `@QuarkusTest`.
-2. `@WithFunction(FunctionType.HTTP)` indicates to launch the function as an HTTP function. If multiple functions exist in the same application, the `functionName` attribute must be used to denote which one should be launched.
-3. REST-assured is used to test the function, `Hello World!` will be sent to it via the invoker.
+<1> This is a standard Quarkus test that must be annotated by `@QuarkusTest`.
+<2> `@WithFunction(FunctionType.HTTP)` indicates to launch the function as an HTTP function. If multiple functions exist in the same application, the `functionName` attribute must be used to denote which one should be launched.
+<3> REST-assured is used to test the function, `Hello World!` will be sent to it via the invoker.
 
 === The BackgroundFunction
 
@@ -545,10 +544,9 @@ class BackgroundFunctionStorageTestCase {
     }
 }
 ----
-
-1. This is a standard Quarkus test that must be annotated by `@QuarkusTest`.
-2. `@WithFunction(FunctionType.BACKGROUND)` indicates to launch the function as a background function. If multiple functions exist in the same application, the `functionName` attribute must be used to denote which one should be launched.
-3. REST-assured is used to test the function, `{"name":"hello.txt"}` will be sent to it via the invoker.
+<1> This is a standard Quarkus test that must be annotated by `@QuarkusTest`.
+<2> `@WithFunction(FunctionType.BACKGROUND)` indicates to launch the function as a background function. If multiple functions exist in the same application, the `functionName` attribute must be used to denote which one should be launched.
+<3> REST-assured is used to test the function, `{"name":"hello.txt"}` will be sent to it via the invoker.
 
 === The RawBackgroundFunction
 
@@ -576,10 +574,9 @@ class RawBackgroundFunctionPubSubTestCase {
     }
 }
 ----
-
-1. This is a standard Quarkus test that must be annotated by `@QuarkusTest`.
-2. `@WithFunction(FunctionType.RAW_BACKGROUND)` indicates to launch the function as a raw background function. If multiple functions exist in the same application, the `functionName` attribute must be used to denote which one should be launched.
-3. REST-assured is used to test the function, `{"name":"hello.txt"}` will be sent to it via the invoker.
+<1> This is a standard Quarkus test that must be annotated by `@QuarkusTest`.
+<2> `@WithFunction(FunctionType.RAW_BACKGROUND)` indicates to launch the function as a raw background function. If multiple functions exist in the same application, the `functionName` attribute must be used to denote which one should be launched.
+<3> REST-assured is used to test the function, `{"name":"hello.txt"}` will be sent to it via the invoker.
 
 === The CloudEventsFunction
 
@@ -625,11 +622,10 @@ class CloudEventStorageTestCase {
     }
 }
 ----
-
-1. This is a standard Quarkus test that must be annotated by `@QuarkusTest`.
-2. `@WithFunction(FunctionType.CLOUD_EVENTS)` indicates to launch the function as a cloud events function. If multiple functions exist in the same application, the `functionName` attribute must be used to denote which one should be launched.
-3. REST-assured is used to test the function, this payload that describe a storage event will be sent to it via the invoker.
-4. The cloud events headers must be sent via HTTP headers.
+<1> This is a standard Quarkus test that must be annotated by `@QuarkusTest`.
+<2> `@WithFunction(FunctionType.CLOUD_EVENTS)` indicates to launch the function as a cloud events function. If multiple functions exist in the same application, the `functionName` attribute must be used to denote which one should be launched.
+<3> REST-assured is used to test the function, this payload that describe a storage event will be sent to it via the invoker.
+<4> The cloud events headers must be sent via HTTP headers.
 
 == What's next?
 

--- a/docs/src/main/asciidoc/proxy-registry.adoc
+++ b/docs/src/main/asciidoc/proxy-registry.adoc
@@ -65,10 +65,9 @@ quarkus.proxy.host=localhost <1>
 quarkus.proxy.port=8443 <2>
 quarkus.proxy.type=HTTP <3>
 ----
-
-1. The proxy host
-2. The proxy port
-3. The proxy type.
+<1> The proxy host
+<2> The proxy port
+<3> The proxy type.
 Possible values are `HTTP` (default), `SOCKS4`, and `SOCKS5`.
 
 Extensions that are aware of the Proxy Registry use the default proxy.
@@ -91,8 +90,7 @@ quarkus.proxy.my-proxy.port=8443
 quarkus.proxy.my-proxy.type=HTTP
 quarkus.proxy.my-proxy.non-proxy-hosts=proxy.mycompany.com,proxy.org.acme <1>
 ----
-
-1. Hostnames or IP addresses that should bypass the proxy
+<1> Hostnames or IP addresses that should bypass the proxy
 
 In this example, two named proxies are configured.
 The proxies are named `local` and `my-proxy`.

--- a/docs/src/main/asciidoc/pulsar.adoc
+++ b/docs/src/main/asciidoc/pulsar.adoc
@@ -134,9 +134,8 @@ Configure your application to receive Pulsar messages on the `prices` channel as
 mp.messaging.incoming.prices.serviceUrl=pulsar://pulsar:6650 # <1>
 mp.messaging.incoming.prices.subscriptionInitialPosition=Earliest # <2>
 ----
-
-1.  Configure the Pulsar broker service url.
-2.  Make sure consumer subscription starts receiving messages from the `Earliest` position.
+<1> Configure the Pulsar broker service url.
+<2> Make sure consumer subscription starts receiving messages from the `Earliest` position.
 
 [NOTE]
 ====
@@ -465,8 +464,7 @@ Configure your application to write the messages from the `prices` channel into 
 ----
 mp.messaging.outgoing.prices.serviceUrl=pulsar://pulsar:6650 # <1>
 ----
-
-1.  Configure the Pulsar broker service url.
+<1> Configure the Pulsar broker service url.
 
 [NOTE]
 ====

--- a/docs/src/main/asciidoc/websockets-next-reference.adoc
+++ b/docs/src/main/asciidoc/websockets-next-reference.adoc
@@ -536,7 +536,7 @@ Item find(Item item) {
         //....
 }
 ----
-1. Specify the codec to use for both the deserialization and serialization of the message
+<1> Specify the codec to use for both the deserialization and serialization of the message
 
 When the serialization and deserialization must use a different codec, you can specify the codec to use for the serialization and deserialization separately:
 
@@ -549,8 +549,8 @@ Item find(Item item) {
         //....
 }
 ----
-1. Specify the codec to use for the deserialization of the incoming message
-2. Specify the codec to use for the serialization of the outgoing message
+<1> Specify the codec to use for the deserialization of the incoming message
+<2> Specify the codec to use for the serialization of the outgoing message
 
 === Ping/Pong messages
 


### PR DESCRIPTION
Related to #56386.

The Funqy/GCP Functions, Proxy Registry, Pulsar, and WebSockets Next guides explain code markers with ordinary numbered lists, so those explanations do not render as callouts. Use adjacent callout lists for these 14 examples and correct the duplicated marker in the Funqy Storage test example. This addresses the numbered-list portion of the issue; detached and orphaned callouts elsewhere remain separate work.

Rendered the affected excerpts with Asciidoctor 2.0.26 and checked that all 37 explanations match their source markers. The local Maven docs command could not resolve the `999-SNAPSHOT` BOM in a fresh checkout. The upstream [documentation build and CI sanity check](https://github.com/quarkusio/quarkus/actions/runs/33656735994) have since passed, and the documentation preview was deployed successfully.
