### PR TITLE
Fix Redis connection leak on cancellation

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveRedisDataSourceImpl.java
@@ -35,6 +35,8 @@ import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSo
 import io.quarkus.redis.datasource.transactions.TransactionResult;
 import io.quarkus.redis.datasource.value.ReactiveValueCommands;
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.subscription.Cancellable;
+import io.smallrye.mutiny.subscription.UniEmitter;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.redis.client.Redis;
 import io.vertx.mutiny.redis.client.RedisAPI;
@@ -243,12 +245,68 @@ public class ReactiveRedisDataSourceImpl implements ReactiveRedisDataSource, Red
             // We are already on a connection, keep this one
             return function.apply(this);
         }
-        return redis.connect()
-                .onItem().transformToUni(connection -> {
-                    ReactiveRedisDataSourceImpl singleConnectionDS = new ReactiveRedisDataSourceImpl(vertx, redis, connection);
-                    return function.apply(singleConnectionDS)
-                            .onTermination().call(connection::close);
-                });
+        return Uni.createFrom().emitter(emitter -> {
+            ConnectionExecution<Void> execution = new ConnectionExecution<>(emitter,
+                    connection -> {
+                        ReactiveRedisDataSourceImpl singleConnectionDS = new ReactiveRedisDataSourceImpl(vertx, redis,
+                                connection);
+                        return function.apply(singleConnectionDS);
+                    });
+            emitter.onTermination(execution::cancel);
+            redis.connect().subscribe().with(emitter.context(), execution::connected, execution::fail);
+        });
+    }
+
+    private static final class ConnectionExecution<T> {
+
+        private final UniEmitter<? super T> emitter;
+        private final Function<RedisConnection, Uni<T>> function;
+        private boolean terminated;
+        private Cancellable action;
+
+        private ConnectionExecution(UniEmitter<? super T> emitter, Function<RedisConnection, Uni<T>> function) {
+            this.emitter = emitter;
+            this.function = function;
+        }
+
+        private synchronized void connected(RedisConnection connection) {
+            if (terminated) {
+                connection.closeAndForget();
+                return;
+            }
+
+            Uni<T> result;
+            try {
+                result = nonNull(function.apply(connection), "The function must not return null");
+            } catch (Throwable failure) {
+                result = Uni.createFrom().failure(failure);
+            }
+            action = result.onTermination().call(connection::close)
+                    .subscribe().with(emitter.context(), this::complete, this::fail);
+        }
+
+        private synchronized void complete(T result) {
+            if (!terminated) {
+                terminated = true;
+                emitter.complete(result);
+            }
+        }
+
+        private synchronized void fail(Throwable failure) {
+            if (!terminated) {
+                terminated = true;
+                emitter.fail(failure);
+            }
+        }
+
+        private synchronized void cancel() {
+            if (!terminated) {
+                terminated = true;
+                if (action != null) {
+                    action.cancel();
+                }
+            }
+        }
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ConnectionRecyclingTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ConnectionRecyclingTest.java
@@ -3,12 +3,19 @@ package io.quarkus.redis.datasource;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.subscription.Cancellable;
+import io.vertx.mutiny.redis.client.Redis;
+import io.vertx.mutiny.redis.client.RedisAPI;
+import io.vertx.mutiny.redis.client.RedisConnection;
+import io.vertx.redis.client.RedisOptions;
 
 public class ConnectionRecyclingTest extends DatasourceTestBase {
 
@@ -40,5 +47,37 @@ public class ConnectionRecyclingTest extends DatasourceTestBase {
         }
 
         assertThat(rds.value(String.class, Integer.class).get(k).await().indefinitely()).isEqualTo(1000);
+    }
+
+    @Test
+    void verifyThatConnectionsAreClosedWhenAcquisitionIsCancelled() {
+        Redis limitedRedis = Redis.createClient(vertx, new RedisOptions()
+                .setConnectionString(
+                        "redis://" + RedisServerExtension.getHost() + ":" + RedisServerExtension.getFirstMappedPort())
+                .setMaxPoolSize(1)
+                .setMaxPoolWaiting(2));
+        RedisConnection occupiedConnection = limitedRedis.connect().await().indefinitely();
+        AtomicBoolean functionInvoked = new AtomicBoolean();
+
+        try {
+            ReactiveRedisDataSource limitedDataSource = new ReactiveRedisDataSourceImpl(vertx, limitedRedis,
+                    RedisAPI.api(limitedRedis));
+            Cancellable cancellable = limitedDataSource.withConnection(connection -> {
+                functionInvoked.set(true);
+                return Uni.createFrom().voidItem();
+            }).subscribe().with(ignored -> {
+            });
+
+            cancellable.cancel();
+            occupiedConnection.closeAndAwait();
+
+            RedisConnection recycledConnection = limitedRedis.connect()
+                    .ifNoItem().after(Duration.ofSeconds(5)).fail()
+                    .await().indefinitely();
+            recycledConnection.closeAndAwait();
+            assertThat(functionInvoked).isFalse();
+        } finally {
+            limitedRedis.closeAndAwait();
+        }
     }
 }


### PR DESCRIPTION
Prevent `ReactiveRedisDataSource.withConnection(...)` from leaking a pooled connection when its subscription is cancelled before connection acquisition completes. Connections delivered after cancellation are now released, while cancellation is propagated normally once the supplied operation has started.

Adds regression coverage using a constrained connection pool to verify that cancelled acquisitions do not exhaust the pool.

* Fixes #56393