### PR TITLE
Suppress PeriodicMetricReader exporter warnings

### DIFF
--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterProcessor.java
@@ -114,6 +114,7 @@ public class OtlpExporterProcessor {
         // Reduce the log level of the exporters because it's too much, and we do log important things ourselves.
         log.produce(new LogCategoryBuildItem("io.opentelemetry.exporter.internal.grpc.GrpcExporter", Level.OFF));
         log.produce(new LogCategoryBuildItem("io.opentelemetry.exporter.internal.http.HttpExporter", Level.OFF));
+        log.produce(new LogCategoryBuildItem("io.opentelemetry.sdk.metrics.export.PeriodicMetricReader", Level.OFF));
     }
 
     @BuildStep

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/PeriodicMetricReaderLogTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/PeriodicMetricReaderLogTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.opentelemetry.deployment.exporter.otlp;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryMetricExporter;
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryMetricExporterProvider;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class PeriodicMetricReaderLogTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar
+                    .addClasses(InMemoryMetricExporter.class, InMemoryMetricExporterProvider.class)
+                    .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
+                            "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider"))
+            .overrideConfigKey("quarkus.otel.traces.enabled", "false")
+            .overrideConfigKey("quarkus.otel.metrics.exporter", "in-memory")
+            .overrideConfigKey("quarkus.otel.logs.enabled", "false")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false")
+            .setLogRecordPredicate(record -> PeriodicMetricReader.class.getName().equals(record.getLoggerName())
+                    && "Exporter failed".equals(record.getMessage()))
+            .assertLogRecords(logRecords -> assertThat(logRecords).isEmpty());
+
+    @Inject
+    OpenTelemetry openTelemetry;
+
+    @Inject
+    Meter meter;
+
+    @Inject
+    InMemoryMetricExporter metricExporter;
+
+    @Test
+    void exporterFailureWarningIsSuppressed() {
+        CompletableResultCode shutdownResult = metricExporter.shutdown();
+        shutdownResult.join(10, SECONDS);
+        assertThat(shutdownResult.isSuccess()).isTrue();
+
+        meter.counterBuilder("test.counter").build().add(1);
+
+        CompletableResultCode flushResult = ((OpenTelemetrySdk) openTelemetry).getSdkMeterProvider().forceFlush();
+        flushResult.join(10, SECONDS);
+    }
+}


### PR DESCRIPTION
OpenTelemetry metrics are enabled by default, and failed metric exports can produce a generic `PeriodicMetricReader` warning in addition to the relevant exporter diagnostics. 

Suppressing this redundant warning avoids unnecessary log noise while preserving the actionable exporter messages.

Fixes #56374