### PR TITLE
Bump the time-out to 4 minutes for NativeImageBundleIT

### DIFF
--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/NativeImageBundleIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/NativeImageBundleIT.java
@@ -34,7 +34,7 @@ public class NativeImageBundleIT extends MojoTestBase {
 
         try {
             final MavenProcessInvocationResult result = running.execute(mvnArgs, Collections.emptyMap());
-            await().atMost(3, TimeUnit.MINUTES).until(() -> result.getProcess() != null && !result.getProcess().isAlive());
+            await().atMost(4, TimeUnit.MINUTES).until(() -> result.getProcess() != null && !result.getProcess().isAlive());
 
             // Check the build was successful with dry run and actual build executed
             final String processLog = running.log();


### PR DESCRIPTION
We see the occasional timeout being reached in our Mandrel CI which tests graal/master builds (GraalVM CE Innovation builds). What's more the CI runs on free GHA runners, with 4 CPU cores and 14GB of memory. Those builds received features which increase build time.

For example:

- Priority inliner (approx. 30-40% longer build times) https://github.com/oracle/graal/pull/14138

Some successful builds take around up to 2 minutes 50-ish seconds to complete for the said native IT test. We only see failures of the test after this upstream PR merged. This seems in-line with the build time increase.  Note that older builds of graal/master from July 2026 took about 2 minutes and 30 seconds at most.

Overall, the goal for us is to stabilize this native IT test with GraalVM CE innovation releases.

Thoughts?