### PR TITLE
[3.33] Manage httpclient5 and httpcore5 in the bom

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -111,8 +111,8 @@
         <jboss-marshalling.version>2.3.0</jboss-marshalling.version>
         <jboss-threads.version>3.9.2</jboss-threads.version>
         <vertx.version>4.5.32</vertx.version>
-        <httpclient5.version>5.6.1</httpclient5.version>
-        <httpcore5.version>5.4.3</httpcore5.version>
+        <httpclient5.version>5.5.2</httpclient5.version>
+        <httpcore5.version>5.3.6</httpcore5.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>
@@ -4507,6 +4507,36 @@
                 <groupId>org.apache.qpid</groupId>
                 <artifactId>proton-j</artifactId>
                 <version>${proton-j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5-cache</artifactId>
+                <version>${httpclient5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5-fluent</artifactId>
+                <version>${httpclient5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>${httpclient5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5-h2</artifactId>
+                <version>${httpcore5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5-reactive</artifactId>
+                <version>${httpcore5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5</artifactId>
+                <version>${httpcore5.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Turns out that the `httpclient5.version` and `httpcore5.version` are UNUSED and the real version isn't managed in the Quarkus bom in 3.33 at all. They were added by accident during a backport that bumped them: this is the borked backport: https://github.com/quarkusio/quarkus/commit/938cbd414c98cda0eb6457d1673a3bdcdf1cf1eb (it adds the properties but not the entry in `dependencyManagement`).

So, here I'm adding the proper dependency management entries and aligining them with what Camel Quarkus brings in.
The product `3.33.3.SP1` contains httpclient5 `5.5.2.redhat-00002` and httpcore5 `5.3.6.redhat-00002` so I aligned this PR with that, minus the custom CVE cherry-picks of course.

I'm leaving 3.27 out of this because the support phase will end soon and it's probably not worth bothering. The 3.27.6 product will be built with the CVE cherry-picks just like 3.27.5.SP1.