### PR TITLE
Fix health-check URL handling in Stork automatic service registration

### DIFF
--- a/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/StorkConfigUtil.java
+++ b/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/StorkConfigUtil.java
@@ -77,11 +77,9 @@ public class StorkConfigUtil {
     public static ServiceConfiguration buildRegistrarOnlyConfiguration(String serviceRegistrarType, String healthCheckPath) {
         requireRegistrarTypeNotBlank(serviceRegistrarType);
         Map<String, String> parameters = new HashMap<>();
-        Config quarkusConfig = ConfigProvider.getConfig();
         if (healthCheckPath != null && !healthCheckPath.isBlank()) {
-            healthCheckPath = HTTPS + getOrDefaultHost(parameters, quarkusConfig) + ":"
-                    + getOrDefaultPort(parameters, quarkusConfig) + healthCheckPath;
-            parameters.put("health-check-url", healthCheckPath);
+            Config quarkusConfig = ConfigProvider.getConfig();
+            parameters.put("health-check-url", resolveHealthCheckUrl(healthCheckPath, parameters, quarkusConfig));
         }
         StorkServiceRegistrarConfiguration registrar = buildServiceRegistrarConfiguration(serviceRegistrarType, true,
                 parameters);
@@ -108,12 +106,14 @@ public class StorkConfigUtil {
      * and optional health check URL added if the registrar type is not already set.
      * <p>
      * If the registrar is already present, its configuration is reused and only the missing
-     * health check URL may be appended. The registrar is marked as enabled by default unless
-     * specified otherwise.
+     * health check URL may be appended. A {@code health-check-url} already present in the
+     * existing registrar parameters takes precedence over the auto-derived {@code healthCheckUrl}.
+     * The registrar is marked as enabled by default unless specified otherwise.
      *
      * @param serviceRegistrarType the registrar type to set if missing (e.g., "consul"); must not be blank
      * @param serviceConfiguration the existing service configuration to update
-     * @param healthCheckUrl optional full health check URL to add to the parameters
+     * @param healthCheckUrl fallback health check URL, used only when the existing parameters
+     *        do not already contain a {@code health-check-url} entry
      * @return an updated {@link ServiceConfiguration} with type and health check URL as needed
      * @throws IllegalArgumentException if {@code serviceRegistrarType} is null or blank
      */
@@ -125,8 +125,12 @@ public class StorkConfigUtil {
         Map<String, String> parameters = storkServiceRegistrarConfiguration
                 .map(StorkServiceRegistrarConfiguration::parameters)
                 .orElse(new HashMap<>());
+        // Preserve a user-configured health-check-url; only fall back to the auto-derived path
         if (healthCheckUrl != null && !healthCheckUrl.isBlank()) {
-            parameters.put("health-check-url", healthCheckUrl);
+            if (!parameters.containsKey("health-check-url")) {
+                Config quarkusConfig = ConfigProvider.getConfig();
+                parameters.put("health-check-url", resolveHealthCheckUrl(healthCheckUrl, parameters, quarkusConfig));
+            }
         }
         boolean enabled = storkServiceRegistrarConfiguration.map(StorkServiceRegistrarConfiguration::enabled).orElse(true);
         StorkServiceRegistrarConfiguration registrar = buildServiceRegistrarConfiguration(serviceRegistrarType, enabled,
@@ -278,6 +282,22 @@ public class StorkConfigUtil {
         }
 
         return null;
+    }
+
+    /**
+     * Builds a full health-check URL from a relative path, using the management host and port
+     * when the management interface is enabled, or the service registration host and port otherwise.
+     */
+    private static String resolveHealthCheckUrl(String healthCheckPath, Map<String, String> registrarParameters,
+            Config quarkusConfig) {
+        String host = getOrDefaultHost(registrarParameters, quarkusConfig);
+        int port;
+        if (quarkusConfig.getOptionalValue("quarkus.management.enabled", Boolean.class).orElse(false)) {
+            port = quarkusConfig.getOptionalValue("quarkus.management.port", Integer.class).orElse(9000);
+        } else {
+            port = getOrDefaultPort(registrarParameters, quarkusConfig);
+        }
+        return HTTPS + host + ":" + port + healthCheckPath;
     }
 
     public static void requireRegistrarTypeNotBlank(String type) {

--- a/extensions/smallrye-stork/runtime/src/test/java/io/quarkus/stork/StorkConfigUtilTest.java
+++ b/extensions/smallrye-stork/runtime/src/test/java/io/quarkus/stork/StorkConfigUtilTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -120,7 +121,9 @@ public class StorkConfigUtilTest {
 
         assertThat(registrar.type()).isPresent();
         assertThat("consul").isEqualTo(registrar.type().get());
-        assertThat("/custom").isEqualTo(registrar.parameters().get("health-check-url"));
+        String healthCheckUrl = registrar.parameters().get("health-check-url");
+        assertThat(healthCheckUrl).startsWith("https://");
+        assertThat(healthCheckUrl).endsWith("/custom");
     }
 
     @Test
@@ -133,7 +136,9 @@ public class StorkConfigUtilTest {
 
         assertThat(updated.serviceRegistrar()).isPresent();
         assertThat(updated.serviceRegistrar().get().type()).hasValue("consul");
-        assertThat(updated.serviceRegistrar().get().parameters()).containsEntry("health-check-url", "/health");
+        String healthCheckUrl = updated.serviceRegistrar().get().parameters().get("health-check-url");
+        assertThat(healthCheckUrl).startsWith("https://");
+        assertThat(healthCheckUrl).endsWith("/health");
 
         assertThat(updated.serviceDiscovery()).isPresent();
         assertThat(updated.serviceDiscovery().get().type()).isEqualTo("consul");
@@ -316,6 +321,91 @@ public class StorkConfigUtilTest {
         assertThat(svc.loadBalancer()).isNull();
         assertThat(svc.serviceRegistrar()).isNotNull();
         assertThat(svc.serviceRegistrar().type()).isEqualTo("consul");
+    }
+
+    @Test
+    public void shouldResolveRelativeHealthCheckPathToFullUrl() {
+        ServiceConfiguration original = buildServiceConfig(null, null,
+                buildRegistrarConfig("consul", Map.of()));
+
+        ServiceConfiguration updated = StorkConfigUtil.addRegistrarTypeIfAbsent("consul", original, "/q/health/live");
+
+        assertThat(updated.serviceRegistrar()).isPresent();
+        String healthCheckUrl = updated.serviceRegistrar().get().parameters().get("health-check-url");
+        assertThat(healthCheckUrl).startsWith("http");
+        assertThat(healthCheckUrl).contains("/q/health/live");
+    }
+
+    @Test
+    public void shouldUseManagementPortForHealthCheckWhenManagementEnabled() {
+        Map<String, String> mgmtConfigMap = new HashMap<>();
+        mgmtConfigMap.put("quarkus.http.host", "localhost");
+        mgmtConfigMap.put("quarkus.http.port", "8080");
+        mgmtConfigMap.put("quarkus.management.enabled", "true");
+        mgmtConfigMap.put("quarkus.management.host", "0.0.0.0");
+        mgmtConfigMap.put("quarkus.management.port", "9000");
+
+        Config mgmtConfig = new SmallRyeConfigBuilder()
+                .withSources(new MapBackedConfigSource("test-management", mgmtConfigMap) {
+                })
+                .build();
+        ConfigProviderResolver resolver = ConfigProviderResolver.instance();
+        resolver.releaseConfig(ConfigProvider.getConfig());
+        resolver.registerConfig(mgmtConfig, Thread.currentThread().getContextClassLoader());
+        try {
+            ServiceConfiguration original = buildServiceConfig(null, null,
+                    buildRegistrarConfig("consul", Map.of()));
+
+            ServiceConfiguration updated = StorkConfigUtil.addRegistrarTypeIfAbsent("consul", original, "/q/health/live");
+
+            assertThat(updated.serviceRegistrar()).isPresent();
+            String healthCheckUrl = updated.serviceRegistrar().get().parameters().get("health-check-url");
+            assertThat(healthCheckUrl).contains(":9000");
+            assertThat(healthCheckUrl).doesNotContain(":8080");
+        } finally {
+            resolver.releaseConfig(mgmtConfig);
+        }
+    }
+
+    @Test
+    public void shouldUseManagementPortInBuildRegistrarOnlyWhenManagementEnabled() {
+        Map<String, String> mgmtConfigMap = new HashMap<>();
+        mgmtConfigMap.put("quarkus.http.host", "localhost");
+        mgmtConfigMap.put("quarkus.http.port", "8080");
+        mgmtConfigMap.put("quarkus.management.enabled", "true");
+        mgmtConfigMap.put("quarkus.management.host", "0.0.0.0");
+        mgmtConfigMap.put("quarkus.management.port", "9000");
+
+        Config mgmtConfig = new SmallRyeConfigBuilder()
+                .withSources(new MapBackedConfigSource("test-management", mgmtConfigMap) {
+                })
+                .build();
+        ConfigProviderResolver resolver = ConfigProviderResolver.instance();
+        resolver.releaseConfig(ConfigProvider.getConfig());
+        resolver.registerConfig(mgmtConfig, Thread.currentThread().getContextClassLoader());
+        try {
+            ServiceConfiguration result = StorkConfigUtil.buildRegistrarOnlyConfiguration("consul", "/q/health/live");
+
+            assertThat(result.serviceRegistrar()).isPresent();
+            String healthCheckUrl = result.serviceRegistrar().get().parameters().get("health-check-url");
+            assertThat(healthCheckUrl).contains(":9000");
+            assertThat(healthCheckUrl).doesNotContain(":8080");
+        } finally {
+            resolver.releaseConfig(mgmtConfig);
+        }
+    }
+
+    @Test
+    public void shouldPreserveExplicitHealthCheckUrlWhenAddingRegistrarType() {
+        String userConfiguredUrl = "http://host.containers.internal:8152/q/health/live";
+        ServiceConfiguration original = buildServiceConfig(null, null,
+                buildRegistrarConfig("consul", Map.of("health-check-url", userConfiguredUrl)));
+
+        ServiceConfiguration updated = StorkConfigUtil.addRegistrarTypeIfAbsent("consul", original, "/q/health/live");
+
+        assertThat(updated.serviceRegistrar()).isPresent();
+        assertThat(updated.serviceRegistrar().get().parameters())
+                .containsEntry("health-check-url", userConfiguredUrl);
     }
 
     // --- Helper methods to build test configurations ---


### PR DESCRIPTION

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
and the AI/LLM usage policy at https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md
-->

- Preserve user-configured health-check-url instead of overwriting it                                                                                                             
- Resolve auto-derived health-check path to a full URL                                                                                                                            
- Use management port for health-check URL when management interface is enabled 

Fixes #56412

cc @cescoffier 

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

