### PR TITLE
Further Netty startup optimizations

### DIFF
--- a/extensions/netty/deployment/pom.xml
+++ b/extensions/netty/deployment/pom.xml
@@ -25,10 +25,27 @@
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- this is important as we have two tests depending on each other and we need them to be ordered -->
+                    <runOrder>alphabetical</runOrder>
+                </configuration>
+            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <executions>

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -725,6 +725,9 @@ class NettyProcessor {
                                     m.returnVoid();
                                 }
 
+                                // --- readBitsMaxDirectMemory() -> reads Bits.MAX_MEMORY via reflection ---
+                                generateReadBitsMaxDirectMemory(transformer, className);
+
                                 // --- Java 25+ specific transforms ---
                                 if (isJava25OrHigher) {
                                     replaceWithReturnTrue(transformer, className, "hasMemorySegmentAddressOfBuffer");
@@ -1826,25 +1829,56 @@ class NettyProcessor {
     }
 
     /**
-     * Creates an ASM {@link ClassVisitor} that intercepts the {@code <clinit>} method and patches
-     * version-gated MethodHandle lookup blocks. For each block matching the pattern:
-     *
-     * <pre>
-     * invokestatic javaVersion()I
-     * bipush/sipush N
-     * if_icmplt/if_icmple ELSE_LABEL
-     * ... MethodHandle lookup via AccessController.doPrivileged ...
-     * putstatic FIELD
-     * goto END_LABEL
-     * ELSE_LABEL:
-     * aconst_null
-     * putstatic FIELD
-     * </pre>
-     *
-     * If {@code FIELD} is in {@code fieldsToSkip}, the version check is replaced with a
-     * {@code GOTO ELSE_LABEL}, forcing the null assignment and skipping the expensive
-     * MethodHandle lookup.
+     * Generates a private static helper method {@code readBitsMaxDirectMemory()} that reads
+     * {@code java.nio.Bits.MAX_MEMORY} via reflection. This is used by the clinit patcher to
+     * replace the {@code BITS_MAX_DIRECT_MEMORY = -1} assignment in the {@code unsafe == null}
+     * branch, so that the value is available even without Unsafe. This avoids the expensive
+     * {@code ManagementFactory.getRuntimeMXBean()} fallback in
+     * {@code PlatformDependent.estimateMaxDirectMemory()}.
      */
+    private static void generateReadBitsMaxDirectMemory(ClassTransformer transformer, String className) {
+        MethodDescriptor md = MethodDescriptor.ofMethod(className, "readBitsMaxDirectMemory", long.class);
+        MethodCreator m = transformer.addMethod(md).setModifiers(Modifier.STATIC | Modifier.PRIVATE);
+
+        AssignableResultHandle result = m.createVariable(long.class);
+        m.assign(result, m.load(-1L));
+
+        TryBlock tryBlock = m.tryBlock();
+
+        ResultHandle bitsClass = tryBlock.invokeStaticMethod(
+                MethodDescriptor.ofMethod(Class.class, "forName", Class.class,
+                        String.class, boolean.class, ClassLoader.class),
+                tryBlock.load("java.nio.Bits"),
+                tryBlock.load(false),
+                tryBlock.invokeStaticMethod(
+                        MethodDescriptor.ofMethod(ClassLoader.class, "getSystemClassLoader", ClassLoader.class)));
+
+        ResultHandle field = tryBlock.invokeVirtualMethod(
+                MethodDescriptor.ofMethod(Class.class, "getDeclaredField",
+                        java.lang.reflect.Field.class, String.class),
+                bitsClass, tryBlock.load("MAX_MEMORY"));
+
+        tryBlock.invokeVirtualMethod(
+                MethodDescriptor.ofMethod(java.lang.reflect.Field.class, "setAccessible",
+                        void.class, boolean.class),
+                field, tryBlock.load(true));
+
+        ResultHandle value = tryBlock.invokeVirtualMethod(
+                MethodDescriptor.ofMethod(java.lang.reflect.Field.class, "get",
+                        Object.class, Object.class),
+                field, tryBlock.loadNull());
+
+        ResultHandle longValue = tryBlock.invokeVirtualMethod(
+                MethodDescriptor.ofMethod(Long.class, "longValue", long.class),
+                value);
+
+        tryBlock.assign(result, longValue);
+
+        tryBlock.addCatch(Throwable.class);
+
+        m.returnValue(result);
+    }
+
     private static void generateDirectBufferAddress(ClassTransformer transformer, String className) {
         MethodDescriptor md = MethodDescriptor.ofMethod(className, "directBufferAddress",
                 long.class, ByteBuffer.class);
@@ -1885,6 +1919,29 @@ class NettyProcessor {
         m.returnValue(result);
     }
 
+    /**
+     * Creates an ASM {@link ClassVisitor} that intercepts the {@code <clinit>} method and patches
+     * version-gated MethodHandle lookup blocks. For each block matching the pattern:
+     *
+     * <pre>
+     * invokestatic javaVersion()I
+     * bipush/sipush N
+     * if_icmplt/if_icmple ELSE_LABEL
+     * ... MethodHandle lookup via AccessController.doPrivileged ...
+     * putstatic FIELD
+     * goto END_LABEL
+     * ELSE_LABEL:
+     * aconst_null
+     * putstatic FIELD
+     * </pre>
+     *
+     * If {@code FIELD} is in {@code fieldsToSkip}, the version check is replaced with a
+     * {@code GOTO ELSE_LABEL}, forcing the null assignment and skipping the expensive
+     * MethodHandle lookup.
+     * <p>
+     * Also patches the {@code BITS_MAX_DIRECT_MEMORY = -1} assignment in the {@code unsafe == null}
+     * branch to call {@code readBitsMaxDirectMemory()} instead, reading the value via reflection.
+     */
     private static ClassVisitor createClinitPatcher(ClassVisitor downstream, Set<String> fieldsToSkip,
             Set<String> knownUnhandledFields) {
         return new ClassVisitor(Gizmo.ASM_API_VERSION, downstream) {
@@ -1990,6 +2047,39 @@ class NettyProcessor {
             throw new IllegalStateException(
                     "Failed to patch all expected version-gated MethodHandle lookup blocks in "
                             + "PlatformDependent0.<clinit>. Missing fields: " + missing + ". "
+                            + "The bytecode pattern may have changed in a Netty update.");
+        }
+
+        // Patch the BITS_MAX_DIRECT_MEMORY = -1 assignment in the unsafe == null branch.
+        // Replace: ldc2_w -1L; putstatic BITS_MAX_DIRECT_MEMORY
+        // With:    invokestatic readBitsMaxDirectMemory(); putstatic BITS_MAX_DIRECT_MEMORY
+        // This reads java.nio.Bits.MAX_MEMORY via reflection so the value is available
+        // even without Unsafe, avoiding the expensive ManagementFactory fallback in
+        // PlatformDependent.estimateMaxDirectMemory().
+        boolean patchedBitsMaxDirectMemory = false;
+        for (AbstractInsnNode n = instructions.getFirst(); n != null; n = n.getNext()) {
+            if (n instanceof org.objectweb.asm.tree.LdcInsnNode ldcInsn
+                    && ldcInsn.cst instanceof Long longVal
+                    && longVal == -1L) {
+                AbstractInsnNode nextInsn = nextRealInsn(n);
+                if (nextInsn instanceof FieldInsnNode fieldInsn
+                        && fieldInsn.getOpcode() == Opcodes.PUTSTATIC
+                        && "BITS_MAX_DIRECT_MEMORY".equals(fieldInsn.name)) {
+                    instructions.set(n, new MethodInsnNode(
+                            Opcodes.INVOKESTATIC,
+                            "io/netty/util/internal/PlatformDependent0",
+                            "readBitsMaxDirectMemory",
+                            "()J",
+                            false));
+                    patchedBitsMaxDirectMemory = true;
+                    break;
+                }
+            }
+        }
+        if (!patchedBitsMaxDirectMemory) {
+            throw new IllegalStateException(
+                    "Could not find BITS_MAX_DIRECT_MEMORY = -1 assignment in "
+                            + "PlatformDependent0.<clinit>. "
                             + "The bytecode pattern may have changed in a Netty update.");
         }
     }

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.netty.deployment;
 
+import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
@@ -47,6 +48,7 @@ import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildI
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedPackageBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.UnsafeAccessedFieldBuildItem;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
+import io.quarkus.deployment.pkg.builditem.CompiledJavaVersionBuildItem;
 import io.quarkus.gizmo.AssignableResultHandle;
 import io.quarkus.gizmo.BranchResult;
 import io.quarkus.gizmo.BytecodeCreator;
@@ -785,6 +787,662 @@ class NettyProcessor {
                             return transformer.applyTo(updateBytecodeVersion);
                         })
                         .build());
+    }
+
+    /**
+     * Rewrites {@code CleanerJava24Linker}'s static initializer and
+     * {@code CleanableDirectBufferImpl}'s constructor to avoid the expensive reflection-based
+     * FFM API lookups via {@code Class.forName} and {@code MethodHandles} chains. When building
+     * on Java 25+, the Foreign Function &amp; Memory API is stable and can be called directly,
+     * eliminating ~20 reflective lookups and MethodHandle chain constructions.
+     * <p>
+     * {@code INVOKE_MALLOC} and {@code INVOKE_FREE} must remain {@code MethodHandle}s because
+     * FFM's {@code Linker.downcallHandle()} always returns a {@code MethodHandle} to bridge
+     * Java to native code. But {@code INVOKE_CREATE_BYTEBUFFER} wraps plain Java methods
+     * ({@code MemorySegment.ofAddress/reinterpret/asByteBuffer}) and can be replaced with
+     * direct calls in the inner class constructor.
+     * <p>
+     * We replace the static initializer with:
+     *
+     * <pre>{@code
+     * static {
+     *     logger = InternalLoggerFactory.getInstance(CleanerJava24Linker.class);
+     *     MethodHandle mallocMethod = null;
+     *     MethodHandle freeMethod = null;
+     *     Throwable error = null;
+     *     try {
+     *         if (!CleanerJava24Linker.class.getModule().isNativeAccessEnabled()) {
+     *             throw new UnsupportedOperationException(
+     *                     "Native access (restricted methods) is not enabled for the io.netty.common module.");
+     *         }
+     *         if (ValueLayout.ADDRESS.byteSize() != Long.BYTES) {
+     *             throw new UnsupportedOperationException(
+     *                     "Linking to malloc and free is only supported on 64-bit platforms.");
+     *         }
+     *         Linker linker = Linker.nativeLinker();
+     *         SymbolLookup defaultLookup = linker.defaultLookup();
+     *         ValueLayout.OfLong javaLong = ValueLayout.JAVA_LONG;
+     *         MemoryLayout[] layouts = new MemoryLayout[] { javaLong };
+     *         Linker.Option[] emptyOptions = new Linker.Option[0];
+     *         MemorySegment mallocPtr = defaultLookup.findOrThrow("malloc");
+     *         mallocMethod = linker.downcallHandle(mallocPtr,
+     *                 FunctionDescriptor.of(javaLong, layouts), emptyOptions);
+     *         MemorySegment freePtr = defaultLookup.findOrThrow("free");
+     *         freeMethod = linker.downcallHandle(freePtr,
+     *                 FunctionDescriptor.ofVoid(layouts), emptyOptions);
+     *     } catch (Throwable throwable) {
+     *         mallocMethod = null;
+     *         freeMethod = null;
+     *         error = throwable;
+     *     }
+     *     if (error == null) {
+     *         logger.debug("java.nio.ByteBuffer.cleaner(): available");
+     *     } else {
+     *         logger.debug("java.nio.ByteBuffer.cleaner(): unavailable", error);
+     *     }
+     *     INVOKE_MALLOC = mallocMethod;
+     *     INVOKE_CREATE_BYTEBUFFER = null;
+     *     INVOKE_FREE = freeMethod;
+     * }
+     * }</pre>
+     *
+     * And we replace the {@code INVOKE_CREATE_BYTEBUFFER.invokeExact(addr, (long) capacity)}
+     * call in {@code CleanableDirectBufferImpl}'s constructor with:
+     *
+     * <pre>{@code
+     * buffer = MemorySegment.ofAddress(addr).reinterpret((long) capacity).asByteBuffer();
+     * }</pre>
+     */
+    @BuildStep
+    void transformCleanerJava24Linker(CompiledJavaVersionBuildItem compiledJavaVersion,
+            BuildProducer<BytecodeTransformerBuildItem> producer) {
+        if (compiledJavaVersion.getJavaVersion()
+                .isJava25OrHigher() != CompiledJavaVersionBuildItem.JavaVersion.Status.TRUE) {
+            return;
+        }
+
+        String className = "io.netty.util.internal.CleanerJava24Linker";
+        String innerClassName = className + "$CleanableDirectBufferImpl";
+
+        // Transform the clinit of CleanerJava24Linker
+        producer.produce(new BytecodeTransformerBuildItem.Builder()
+                .setClassToTransform(className)
+                .setCacheable(true)
+                .setVisitorFunction(new BiFunction<>() {
+                    @Override
+                    public ClassVisitor apply(String s, ClassVisitor classVisitor) {
+                        ClassVisitor updateBytecodeVersion = new ClassVisitor(Gizmo.ASM_API_VERSION, classVisitor) {
+                            @Override
+                            public void visit(int version, int access, String name, String signature,
+                                    String superName, String[] interfaces) {
+                                super.visit(Math.max(version, 69), access, name, signature, superName, interfaces);
+                            }
+                        };
+
+                        ClassTransformer transformer = new ClassTransformer(className);
+
+                        MethodDescriptor clinitDescriptor = MethodDescriptor.ofMethod(
+                                className, "<clinit>", void.class);
+                        transformer.removeMethod(clinitDescriptor);
+
+                        MethodCreator clinit = transformer.addMethod(clinitDescriptor)
+                                .setModifiers(Modifier.STATIC);
+
+                        generateCleanerJava24LinkerClinit(clinit, className);
+
+                        return transformer.applyTo(updateBytecodeVersion);
+                    }
+                })
+                .build());
+
+        // Transform the constructor of CleanableDirectBufferImpl to replace
+        // INVOKE_CREATE_BYTEBUFFER.invokeExact(addr, (long) capacity)
+        // with MemorySegment.ofAddress(addr).reinterpret((long) capacity).asByteBuffer()
+        producer.produce(new BytecodeTransformerBuildItem.Builder()
+                .setClassToTransform(innerClassName)
+                .setCacheable(true)
+                .setVisitorFunction(new BiFunction<>() {
+                    @Override
+                    public ClassVisitor apply(String s, ClassVisitor classVisitor) {
+                        ClassVisitor updateBytecodeVersion = new ClassVisitor(Gizmo.ASM_API_VERSION, classVisitor) {
+                            @Override
+                            public void visit(int version, int access, String name, String signature,
+                                    String superName, String[] interfaces) {
+                                super.visit(Math.max(version, 69), access, name, signature, superName, interfaces);
+                            }
+                        };
+
+                        ClassTransformer transformer = new ClassTransformer(innerClassName);
+
+                        MethodDescriptor ctorDescriptor = MethodDescriptor.ofConstructor(
+                                innerClassName, int.class);
+                        transformer.removeMethod(ctorDescriptor);
+
+                        MethodCreator ctor = transformer.addMethod(ctorDescriptor)
+                                .setModifiers(Modifier.PRIVATE);
+
+                        generateCleanableDirectBufferImplCtor(ctor, className, innerClassName);
+
+                        return transformer.applyTo(updateBytecodeVersion);
+                    }
+                })
+                .build());
+    }
+
+    private static void generateCleanerJava24LinkerClinit(MethodCreator clinit, String className) {
+        // Field descriptors for the static fields we need to initialize
+        FieldDescriptor loggerField = FieldDescriptor.of(className, "logger",
+                "io.netty.util.internal.logging.InternalLogger");
+        FieldDescriptor mallocField = FieldDescriptor.of(className, "INVOKE_MALLOC",
+                MethodHandle.class);
+        FieldDescriptor wrapField = FieldDescriptor.of(className, "INVOKE_CREATE_BYTEBUFFER",
+                MethodHandle.class);
+        FieldDescriptor freeField = FieldDescriptor.of(className, "INVOKE_FREE",
+                MethodHandle.class);
+
+        // logger = InternalLoggerFactory.getInstance(CleanerJava24Linker.class)
+        ResultHandle clazz = clinit.loadClassFromTCCL(className);
+        ResultHandle loggerValue = clinit.invokeStaticMethod(
+                MethodDescriptor.ofMethod("io.netty.util.internal.logging.InternalLoggerFactory",
+                        "getInstance", "io.netty.util.internal.logging.InternalLogger", Class.class),
+                clazz);
+        clinit.writeStaticField(loggerField, loggerValue);
+
+        // Local variables for the MethodHandle fields and error tracking
+        AssignableResultHandle mallocVar = clinit.createVariable(MethodHandle.class);
+        AssignableResultHandle freeVar = clinit.createVariable(MethodHandle.class);
+        AssignableResultHandle errorVar = clinit.createVariable(Throwable.class);
+        clinit.assign(mallocVar, clinit.loadNull());
+        clinit.assign(freeVar, clinit.loadNull());
+        clinit.assign(errorVar, clinit.loadNull());
+
+        TryBlock tryBlock = clinit.tryBlock();
+
+        // Check native access: CleanerJava24Linker.class.getModule().isNativeAccessEnabled()
+        ResultHandle classRef = tryBlock.loadClassFromTCCL(className);
+        ResultHandle module = tryBlock.invokeVirtualMethod(
+                MethodDescriptor.ofMethod(Class.class, "getModule", Module.class), classRef);
+        ResultHandle isNativeAccess = tryBlock.invokeVirtualMethod(
+                MethodDescriptor.ofMethod(Module.class, "isNativeAccessEnabled", boolean.class), module);
+
+        BranchResult nativeCheck = tryBlock.ifNonZero(isNativeAccess);
+
+        // No native access: throw UnsupportedOperationException
+        BytecodeCreator noNative = nativeCheck.falseBranch();
+        noNative.throwException(noNative.newInstance(
+                MethodDescriptor.ofConstructor(UnsupportedOperationException.class, String.class),
+                noNative.load(
+                        "Native access (restricted methods) is not enabled for the io.netty.common module.")));
+
+        // Has native access: check 64-bit platform
+        BytecodeCreator hasNative = nativeCheck.trueBranch();
+
+        // ValueLayout.ADDRESS.byteSize() != Long.BYTES
+        ResultHandle addressLayout = hasNative.readStaticField(
+                FieldDescriptor.of("java.lang.foreign.ValueLayout", "ADDRESS",
+                        "java.lang.foreign.AddressLayout"));
+        ResultHandle addressSize = hasNative.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.MemoryLayout", "byteSize", long.class),
+                addressLayout);
+        ResultHandle cmp = hasNative.invokeStaticMethod(
+                MethodDescriptor.ofMethod(Long.class, "compare", int.class, long.class, long.class),
+                addressSize, hasNative.load(8L));
+        BranchResult sizeCheck = hasNative.ifNonZero(cmp);
+
+        // Not 64-bit: throw
+        BytecodeCreator not64bit = sizeCheck.trueBranch();
+        not64bit.throwException(not64bit.newInstance(
+                MethodDescriptor.ofConstructor(UnsupportedOperationException.class, String.class),
+                not64bit.load("Linking to malloc and free is only supported on 64-bit platforms.")));
+
+        // 64-bit: create the downcall MethodHandles for malloc and free
+        BytecodeCreator bc = sizeCheck.falseBranch();
+
+        // Linker linker = Linker.nativeLinker()
+        ResultHandle linker = bc.invokeStaticInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.Linker", "nativeLinker",
+                        "java.lang.foreign.Linker"));
+
+        // SymbolLookup defaultLookup = linker.defaultLookup()
+        ResultHandle defaultLookup = bc.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.Linker", "defaultLookup",
+                        "java.lang.foreign.SymbolLookup"),
+                linker);
+
+        // ValueLayout.OfLong javaLong = ValueLayout.JAVA_LONG
+        ResultHandle javaLong = bc.readStaticField(
+                FieldDescriptor.of("java.lang.foreign.ValueLayout", "JAVA_LONG",
+                        "java.lang.foreign.ValueLayout$OfLong"));
+
+        // MemoryLayout[] layouts = new MemoryLayout[] { javaLong }
+        ResultHandle layoutArray = bc.newArray("java.lang.foreign.MemoryLayout", 1);
+        bc.writeArrayValue(layoutArray, 0, javaLong);
+
+        // Linker.Option[] emptyOptions = new Linker.Option[0]
+        ResultHandle emptyOptions = bc.newArray("java.lang.foreign.Linker$Option", 0);
+
+        // --- malloc ---
+        ResultHandle mallocPtr = bc.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.SymbolLookup", "findOrThrow",
+                        "java.lang.foreign.MemorySegment", String.class),
+                defaultLookup, bc.load("malloc"));
+        ResultHandle mallocDesc = bc.invokeStaticInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.FunctionDescriptor", "of",
+                        "java.lang.foreign.FunctionDescriptor",
+                        "java.lang.foreign.MemoryLayout", "[Ljava.lang.foreign.MemoryLayout;"),
+                javaLong, layoutArray);
+        ResultHandle mallocHandle = bc.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.Linker", "downcallHandle",
+                        MethodHandle.class,
+                        "java.lang.foreign.MemorySegment", "java.lang.foreign.FunctionDescriptor",
+                        "[Ljava.lang.foreign.Linker$Option;"),
+                linker, mallocPtr, mallocDesc, emptyOptions);
+        bc.assign(mallocVar, mallocHandle);
+
+        // --- free ---
+        ResultHandle freePtr = bc.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.SymbolLookup", "findOrThrow",
+                        "java.lang.foreign.MemorySegment", String.class),
+                defaultLookup, bc.load("free"));
+        ResultHandle freeDesc = bc.invokeStaticInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.FunctionDescriptor", "ofVoid",
+                        "java.lang.foreign.FunctionDescriptor",
+                        "[Ljava.lang.foreign.MemoryLayout;"),
+                layoutArray);
+        ResultHandle freeHandle = bc.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.Linker", "downcallHandle",
+                        MethodHandle.class,
+                        "java.lang.foreign.MemorySegment", "java.lang.foreign.FunctionDescriptor",
+                        "[Ljava.lang.foreign.Linker$Option;"),
+                linker, freePtr, freeDesc, emptyOptions);
+        bc.assign(freeVar, freeHandle);
+
+        // Catch block: null out everything and save error
+        CatchBlockCreator catchBlock = tryBlock.addCatch(Throwable.class);
+        catchBlock.assign(mallocVar, catchBlock.loadNull());
+        catchBlock.assign(freeVar, catchBlock.loadNull());
+        catchBlock.assign(errorVar, catchBlock.getCaughtException());
+
+        // After try-catch: log result and assign to static fields
+        ResultHandle loggerRef = clinit.readStaticField(loggerField);
+        BranchResult errorCheck = clinit.ifNull(errorVar);
+
+        // No error: logger.debug("java.nio.ByteBuffer.cleaner(): available")
+        BytecodeCreator noError = errorCheck.trueBranch();
+        noError.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod("io.netty.util.internal.logging.InternalLogger",
+                        "debug", void.class, String.class),
+                loggerRef, noError.load("java.nio.ByteBuffer.cleaner(): available"));
+
+        // Has error: logger.debug("java.nio.ByteBuffer.cleaner(): unavailable", error)
+        BytecodeCreator hasError = errorCheck.falseBranch();
+        hasError.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod("io.netty.util.internal.logging.InternalLogger",
+                        "debug", void.class, String.class, Throwable.class),
+                loggerRef, hasError.load("java.nio.ByteBuffer.cleaner(): unavailable"), errorVar);
+
+        // Assign to static final fields
+        clinit.writeStaticField(mallocField, mallocVar);
+        // INVOKE_CREATE_BYTEBUFFER is no longer used - direct calls in CleanableDirectBufferImpl
+        clinit.writeStaticField(wrapField, clinit.loadNull());
+        clinit.writeStaticField(freeField, freeVar);
+
+        clinit.returnVoid();
+    }
+
+    /**
+     * Generates the constructor for {@code CleanableDirectBufferImpl} that replaces
+     * {@code INVOKE_CREATE_BYTEBUFFER.invokeExact(addr, (long) capacity)} with direct
+     * FFM calls.
+     * <p>
+     * The original constructor:
+     *
+     * <pre>{@code
+     * private CleanableDirectBufferImpl(int capacity) {
+     *     PlatformDependent.incrementMemoryCounter(capacity);
+     *     long addr;
+     *     try {
+     *         addr = malloc(capacity);
+     *     } catch (Throwable e) {
+     *         PlatformDependent.decrementMemoryCounter(capacity);
+     *         throw e;
+     *     }
+     *     try {
+     *         memoryAddress = addr;
+     *         buffer = (ByteBuffer) INVOKE_CREATE_BYTEBUFFER.invokeExact(addr, (long) capacity);
+     *     } catch (Throwable throwable) {
+     *         PlatformDependent.decrementMemoryCounter(capacity);
+     *         Error error = new Error(throwable);
+     *         try {
+     *             free(addr);
+     *         } catch (Throwable e) {
+     *             error.addSuppressed(e);
+     *         }
+     *         throw error;
+     *     }
+     * }
+     * }</pre>
+     *
+     * We replace the buffer assignment with:
+     *
+     * <pre>{@code
+     * buffer = MemorySegment.ofAddress(addr).reinterpret((long) capacity).asByteBuffer();
+     * }</pre>
+     */
+    private static void generateCleanableDirectBufferImplCtor(MethodCreator ctor,
+            String outerClassName, String innerClassName) {
+        FieldDescriptor bufferField = FieldDescriptor.of(innerClassName, "buffer",
+                "java.nio.ByteBuffer");
+        FieldDescriptor memoryAddressField = FieldDescriptor.of(innerClassName, "memoryAddress",
+                long.class);
+
+        ResultHandle self = ctor.getThis();
+        ResultHandle capacity = ctor.getMethodParam(0);
+
+        // super()
+        ctor.invokeSpecialMethod(
+                MethodDescriptor.ofConstructor(Object.class), self);
+
+        // PlatformDependent.incrementMemoryCounter(capacity)
+        ctor.invokeStaticMethod(
+                MethodDescriptor.ofMethod("io.netty.util.internal.PlatformDependent",
+                        "incrementMemoryCounter", void.class, int.class),
+                capacity);
+
+        // First try: addr = malloc(capacity)
+        AssignableResultHandle addrVar = ctor.createVariable(long.class);
+        TryBlock tryMalloc = ctor.tryBlock();
+        ResultHandle addr = tryMalloc.invokeStaticMethod(
+                MethodDescriptor.ofMethod(outerClassName, "malloc", long.class, int.class),
+                capacity);
+        tryMalloc.assign(addrVar, addr);
+
+        CatchBlockCreator catchMalloc = tryMalloc.addCatch(Throwable.class);
+        catchMalloc.invokeStaticMethod(
+                MethodDescriptor.ofMethod("io.netty.util.internal.PlatformDependent",
+                        "decrementMemoryCounter", void.class, int.class),
+                capacity);
+        catchMalloc.throwException(catchMalloc.getCaughtException());
+
+        // Second try: set fields and create ByteBuffer
+        TryBlock tryWrap = ctor.tryBlock();
+
+        // memoryAddress = addr
+        tryWrap.writeInstanceField(memoryAddressField, self, addrVar);
+
+        // buffer = MemorySegment.ofAddress(addr).reinterpret((long) capacity).asByteBuffer()
+        ResultHandle segment = tryWrap.invokeStaticInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.MemorySegment", "ofAddress",
+                        "java.lang.foreign.MemorySegment", long.class),
+                addrVar);
+        ResultHandle capacityLong = tryWrap.convertPrimitive(capacity, long.class);
+        ResultHandle reinterpreted = tryWrap.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.MemorySegment", "reinterpret",
+                        "java.lang.foreign.MemorySegment", long.class),
+                segment, capacityLong);
+        ResultHandle byteBuffer = tryWrap.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.MemorySegment", "asByteBuffer",
+                        "java.nio.ByteBuffer"),
+                reinterpreted);
+        tryWrap.writeInstanceField(bufferField, self, byteBuffer);
+
+        // Catch block for the wrap try
+        CatchBlockCreator catchWrap = tryWrap.addCatch(Throwable.class);
+        catchWrap.invokeStaticMethod(
+                MethodDescriptor.ofMethod("io.netty.util.internal.PlatformDependent",
+                        "decrementMemoryCounter", void.class, int.class),
+                capacity);
+        ResultHandle error = catchWrap.newInstance(
+                MethodDescriptor.ofConstructor(Error.class, Throwable.class),
+                catchWrap.getCaughtException());
+
+        // Inner try: free(addr) with suppressed exception handling
+        TryBlock tryFree = catchWrap.tryBlock();
+        tryFree.invokeStaticMethod(
+                MethodDescriptor.ofMethod(outerClassName, "free", void.class, long.class),
+                addrVar);
+        CatchBlockCreator catchFree = tryFree.addCatch(Throwable.class);
+        catchFree.invokeVirtualMethod(
+                MethodDescriptor.ofMethod(Throwable.class, "addSuppressed", void.class, Throwable.class),
+                error, catchFree.getCaughtException());
+
+        catchWrap.throwException(error);
+
+        ctor.returnVoid();
+    }
+
+    /**
+     * Rewrites {@code CleanerJava25}'s static initializer and {@code allocate(int)} method
+     * to avoid the expensive reflection-based FFM API lookups via {@code Class.forName} and
+     * complex {@code MethodHandles} composition chains (~10 MethodHandle operations). When
+     * building on Java 25+, the Foreign Function &amp; Memory API is stable and can be called
+     * directly.
+     * <p>
+     * The original clinit constructs a single {@code INVOKE_ALLOCATOR} MethodHandle that
+     * chains Arena.ofShared(), allocate(), asByteBuffer(), address(), and the
+     * CleanableDirectBufferImpl constructor into one composite handle. We replace all of that
+     * with a simple Arena.ofShared() availability check.
+     * <p>
+     * We replace the static initializer with:
+     *
+     * <pre>{@code
+     * static {
+     *     logger = InternalLoggerFactory.getInstance(CleanerJava25.class);
+     *     MethodHandle method = null;
+     *     Throwable error = null;
+     *     try {
+     *         Arena arena = Arena.ofShared();
+     *         arena.close();
+     *         method = MethodHandles.identity(int.class);
+     *     } catch (Throwable throwable) {
+     *         error = throwable;
+     *     }
+     *     if (error == null) {
+     *         logger.debug("java.nio.ByteBuffer.cleaner(): available");
+     *     } else {
+     *         logger.debug("java.nio.ByteBuffer.cleaner(): unavailable", error);
+     *     }
+     *     INVOKE_ALLOCATOR = method;
+     * }
+     * }</pre>
+     *
+     * And we replace the {@code allocate(int)} method with direct FFM calls:
+     *
+     * <pre>{@code
+     * public CleanableDirectBuffer allocate(int capacity) {
+     *     PlatformDependent.incrementMemoryCounter(capacity);
+     *     try {
+     *         Arena arena = Arena.ofShared();
+     *         MemorySegment segment = arena.allocate((long) capacity);
+     *         return new CleanableDirectBufferImpl(
+     *                 (AutoCloseable) arena, segment.asByteBuffer(), segment.address());
+     *     } catch (RuntimeException e) {
+     *         PlatformDependent.decrementMemoryCounter(capacity);
+     *         throw e;
+     *     } catch (Throwable e) {
+     *         PlatformDependent.decrementMemoryCounter(capacity);
+     *         throw new IllegalStateException("Unexpected allocation exception", e);
+     *     }
+     * }
+     * }</pre>
+     */
+    @BuildStep
+    void transformCleanerJava25(CompiledJavaVersionBuildItem compiledJavaVersion,
+            BuildProducer<BytecodeTransformerBuildItem> producer) {
+        if (compiledJavaVersion.getJavaVersion()
+                .isJava25OrHigher() != CompiledJavaVersionBuildItem.JavaVersion.Status.TRUE) {
+            return;
+        }
+
+        String className = "io.netty.util.internal.CleanerJava25";
+        String innerClassName = className + "$CleanableDirectBufferImpl";
+
+        // Transform the clinit of CleanerJava25
+        producer.produce(new BytecodeTransformerBuildItem.Builder()
+                .setClassToTransform(className)
+                .setCacheable(true)
+                .setVisitorFunction(new BiFunction<>() {
+                    @Override
+                    public ClassVisitor apply(String s, ClassVisitor classVisitor) {
+                        ClassVisitor updateBytecodeVersion = new ClassVisitor(Gizmo.ASM_API_VERSION, classVisitor) {
+                            @Override
+                            public void visit(int version, int access, String name, String signature,
+                                    String superName, String[] interfaces) {
+                                super.visit(Math.max(version, 69), access, name, signature, superName, interfaces);
+                            }
+                        };
+
+                        ClassTransformer transformer = new ClassTransformer(className);
+
+                        // Replace <clinit>
+                        MethodDescriptor clinitDescriptor = MethodDescriptor.ofMethod(
+                                className, "<clinit>", void.class);
+                        transformer.removeMethod(clinitDescriptor);
+                        MethodCreator clinit = transformer.addMethod(clinitDescriptor)
+                                .setModifiers(Modifier.STATIC);
+                        generateCleanerJava25Clinit(clinit, className);
+
+                        // Replace allocate(int)
+                        MethodDescriptor allocateDescriptor = MethodDescriptor.ofMethod(
+                                className, "allocate",
+                                "io.netty.util.internal.CleanableDirectBuffer", int.class);
+                        transformer.removeMethod(allocateDescriptor);
+                        MethodCreator allocate = transformer.addMethod(allocateDescriptor)
+                                .setModifiers(Modifier.PUBLIC);
+                        generateCleanerJava25Allocate(allocate, className, innerClassName);
+
+                        return transformer.applyTo(updateBytecodeVersion);
+                    }
+                })
+                .build());
+    }
+
+    private static void generateCleanerJava25Clinit(MethodCreator clinit, String className) {
+        FieldDescriptor loggerField = FieldDescriptor.of(className, "logger",
+                "io.netty.util.internal.logging.InternalLogger");
+        FieldDescriptor allocatorField = FieldDescriptor.of(className, "INVOKE_ALLOCATOR",
+                MethodHandle.class);
+
+        // logger = InternalLoggerFactory.getInstance(CleanerJava25.class)
+        ResultHandle clazz = clinit.loadClassFromTCCL(className);
+        ResultHandle loggerValue = clinit.invokeStaticMethod(
+                MethodDescriptor.ofMethod("io.netty.util.internal.logging.InternalLoggerFactory",
+                        "getInstance", "io.netty.util.internal.logging.InternalLogger", Class.class),
+                clazz);
+        clinit.writeStaticField(loggerField, loggerValue);
+
+        AssignableResultHandle methodVar = clinit.createVariable(MethodHandle.class);
+        AssignableResultHandle errorVar = clinit.createVariable(Throwable.class);
+        clinit.assign(methodVar, clinit.loadNull());
+        clinit.assign(errorVar, clinit.loadNull());
+
+        TryBlock tryBlock = clinit.tryBlock();
+
+        // Arena arena = Arena.ofShared()
+        ResultHandle arena = tryBlock.invokeStaticInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.Arena", "ofShared",
+                        "java.lang.foreign.Arena"));
+
+        // arena.close() - verify it works (can fail on GraalVM 25.0.0)
+        tryBlock.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.Arena", "close", void.class),
+                arena);
+
+        // Set to non-null marker for isSupported() check
+        // method = MethodHandles.identity(int.class)
+        ResultHandle intClass = tryBlock.readStaticField(
+                FieldDescriptor.of(Integer.class, "TYPE", Class.class));
+        ResultHandle marker = tryBlock.invokeStaticMethod(
+                MethodDescriptor.ofMethod("java.lang.invoke.MethodHandles", "identity",
+                        MethodHandle.class, Class.class),
+                intClass);
+        tryBlock.assign(methodVar, marker);
+
+        // Catch block
+        CatchBlockCreator catchBlock = tryBlock.addCatch(Throwable.class);
+        catchBlock.assign(errorVar, catchBlock.getCaughtException());
+
+        // Log result
+        ResultHandle loggerRef = clinit.readStaticField(loggerField);
+        BranchResult errorCheck = clinit.ifNull(errorVar);
+
+        BytecodeCreator noError = errorCheck.trueBranch();
+        noError.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod("io.netty.util.internal.logging.InternalLogger",
+                        "debug", void.class, String.class),
+                loggerRef, noError.load("java.nio.ByteBuffer.cleaner(): available"));
+
+        BytecodeCreator hasError = errorCheck.falseBranch();
+        hasError.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod("io.netty.util.internal.logging.InternalLogger",
+                        "debug", void.class, String.class, Throwable.class),
+                loggerRef, hasError.load("java.nio.ByteBuffer.cleaner(): unavailable"), errorVar);
+
+        clinit.writeStaticField(allocatorField, methodVar);
+        clinit.returnVoid();
+    }
+
+    private static void generateCleanerJava25Allocate(MethodCreator method,
+            String className, String innerClassName) {
+        ResultHandle capacity = method.getMethodParam(0);
+
+        // PlatformDependent.incrementMemoryCounter(capacity)
+        method.invokeStaticMethod(
+                MethodDescriptor.ofMethod("io.netty.util.internal.PlatformDependent",
+                        "incrementMemoryCounter", void.class, int.class),
+                capacity);
+
+        TryBlock tryBlock = method.tryBlock();
+
+        // Arena arena = Arena.ofShared()
+        ResultHandle arena = tryBlock.invokeStaticInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.Arena", "ofShared",
+                        "java.lang.foreign.Arena"));
+
+        // MemorySegment segment = arena.allocate((long) capacity)
+        ResultHandle capacityLong = tryBlock.convertPrimitive(capacity, long.class);
+        ResultHandle segment = tryBlock.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.Arena", "allocate",
+                        "java.lang.foreign.MemorySegment", long.class),
+                arena, capacityLong);
+
+        // segment.asByteBuffer()
+        ResultHandle byteBuffer = tryBlock.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.MemorySegment", "asByteBuffer",
+                        "java.nio.ByteBuffer"),
+                segment);
+
+        // segment.address()
+        ResultHandle address = tryBlock.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.MemorySegment", "address",
+                        long.class),
+                segment);
+
+        // return new CleanableDirectBufferImpl(arena, byteBuffer, address)
+        ResultHandle result = tryBlock.newInstance(
+                MethodDescriptor.ofConstructor(innerClassName,
+                        AutoCloseable.class, "java.nio.ByteBuffer", long.class),
+                arena, byteBuffer, address);
+        tryBlock.returnValue(result);
+
+        // catch (RuntimeException e) { decrementMemoryCounter(capacity); throw e; }
+        CatchBlockCreator catchRE = tryBlock.addCatch(RuntimeException.class);
+        catchRE.invokeStaticMethod(
+                MethodDescriptor.ofMethod("io.netty.util.internal.PlatformDependent",
+                        "decrementMemoryCounter", void.class, int.class),
+                capacity);
+        catchRE.throwException(catchRE.getCaughtException());
+
+        // catch (Throwable e) { decrementMemoryCounter(capacity); throw new IllegalStateException(..., e); }
+        CatchBlockCreator catchT = tryBlock.addCatch(Throwable.class);
+        catchT.invokeStaticMethod(
+                MethodDescriptor.ofMethod("io.netty.util.internal.PlatformDependent",
+                        "decrementMemoryCounter", void.class, int.class),
+                capacity);
+        ResultHandle ise = catchT.newInstance(
+                MethodDescriptor.ofConstructor(IllegalStateException.class, String.class, Throwable.class),
+                catchT.load("Unexpected allocation exception"), catchT.getCaughtException());
+        catchT.throwException(ise);
     }
 
     @BuildStep

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -752,6 +752,151 @@ class NettyProcessor {
     }
 
     /**
+     * Rewrites {@code PlatformDependent#estimateMaxDirectMemory()} to replace the
+     * reflection-based VM argument lookup with direct calls. The original code uses
+     * {@code Class.forName} + {@code MethodHandles.publicLookup().findStatic/findVirtual}
+     * to call {@code ManagementFactory.getRuntimeMXBean().getInputArguments()} because
+     * "Android doesn't have these classes". Since we target JDK 17+, these are always available.
+     * <p>
+     * Using ASM's tree API, we surgically replace the instruction sequence that performs
+     * the reflection with a direct invocation, preserving all surrounding code (the loop,
+     * the regex matching, the switch, the logging).
+     */
+    @BuildStep
+    void transformPlatformDependentEstimateMaxDirectMemory(BuildProducer<BytecodeTransformerBuildItem> producer) {
+        String className = PlatformDependent.class.getName();
+
+        producer.produce(new BytecodeTransformerBuildItem.Builder()
+                .setClassToTransform(className)
+                .setCacheable(true)
+                .setClassReaderOptions(ClassReader.EXPAND_FRAMES)
+                .setVisitorFunction(new BiFunction<>() {
+                    @Override
+                    public ClassVisitor apply(String s, ClassVisitor classVisitor) {
+                        return new ClassVisitor(Gizmo.ASM_API_VERSION, classVisitor) {
+                            @Override
+                            public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                    String signature, String[] exceptions) {
+                                MethodVisitor mv = super.visitMethod(access, name, descriptor,
+                                        signature, exceptions);
+                                if ("estimateMaxDirectMemory".equals(name) && "()J".equals(descriptor)) {
+                                    MethodVisitor target = mv;
+                                    return new MethodNode(Gizmo.ASM_API_VERSION, access, name, descriptor,
+                                            signature, exceptions) {
+                                        @Override
+                                        public void visitEnd() {
+                                            super.visitEnd();
+                                            patchEstimateMaxDirectMemory(this.instructions);
+                                            this.accept(target);
+                                        }
+                                    };
+                                }
+                                return mv;
+                            }
+                        };
+                    }
+                })
+                .build());
+    }
+
+    /**
+     * Replaces the reflection-based sequence in {@code estimateMaxDirectMemory} with direct calls.
+     * <p>
+     * Finds and replaces:
+     *
+     * <pre>
+     * invokestatic getSystemClassLoader -> astore X
+     * ldc "java.lang.management.ManagementFactory"
+     * ... Class.forName ...
+     * ... Class.forName ...
+     * ... MethodHandles.publicLookup ...
+     * ... lookup.findStatic ...
+     * ... lookup.findVirtual ...
+     * ... getInputArguments.invoke(getRuntime.invoke()) ...
+     * checkcast List -> astore Y (vmArgs)
+     * </pre>
+     *
+     * with:
+     *
+     * <pre>
+     * invokestatic ManagementFactory.getRuntimeMXBean()
+     * invokeinterface RuntimeMXBean.getInputArguments()
+     * astore Y (vmArgs)
+     * </pre>
+     *
+     * The approach: find the {@code invokestatic getSystemClassLoader} that starts the block
+     * and the {@code checkcast java/util/List} that ends it, remove everything in between,
+     * and insert the direct calls before the checkcast (which becomes a no-op but is harmless).
+     */
+    private static void patchEstimateMaxDirectMemory(org.objectweb.asm.tree.InsnList instructions) {
+        // Find the invokestatic getSystemClassLoader call that starts the reflection block
+        AbstractInsnNode startNode = null;
+        for (AbstractInsnNode node = instructions.getFirst(); node != null; node = node.getNext()) {
+            if (node instanceof MethodInsnNode methodInsn
+                    && methodInsn.getOpcode() == Opcodes.INVOKESTATIC
+                    && "getSystemClassLoader".equals(methodInsn.name)) {
+                startNode = node;
+                break;
+            }
+        }
+        if (startNode == null) {
+            throw new IllegalStateException(
+                    "Could not find getSystemClassLoader call in PlatformDependent.estimateMaxDirectMemory. "
+                            + "The bytecode pattern may have changed in a Netty update.");
+        }
+
+        // Find the last MethodHandle.invoke call that ends the reflection block.
+        // The sequence ends with: invokevirtual MethodHandle.invoke -> astore (vmArgs).
+        // We keep the astore and replace everything before it.
+        AbstractInsnNode lastInvoke = null;
+        for (AbstractInsnNode node = startNode.getNext(); node != null; node = node.getNext()) {
+            if (node instanceof MethodInsnNode methodInsn
+                    && "invoke".equals(methodInsn.name)
+                    && "java/lang/invoke/MethodHandle".equals(methodInsn.owner)) {
+                lastInvoke = node;
+            }
+            // Stop scanning once we pass the reflection block (next invokestatic is
+            // getMaxDirectMemorySizeArgPattern)
+            if (node instanceof MethodInsnNode methodInsn
+                    && "getMaxDirectMemorySizeArgPattern".equals(methodInsn.name)) {
+                break;
+            }
+        }
+        if (lastInvoke == null) {
+            throw new IllegalStateException(
+                    "Could not find MethodHandle.invoke in PlatformDependent.estimateMaxDirectMemory. "
+                            + "The bytecode pattern may have changed in a Netty update.");
+        }
+
+        // The astore after the last invoke stores vmArgs - we keep it
+        AbstractInsnNode astoreNode = nextRealInsn(lastInvoke);
+
+        // Remove everything from startNode through lastInvoke (inclusive)
+        AbstractInsnNode current = startNode;
+        while (current != astoreNode) {
+            AbstractInsnNode next = current.getNext();
+            instructions.remove(current);
+            current = next;
+        }
+
+        // Insert direct calls before the astore:
+        // invokestatic ManagementFactory.getRuntimeMXBean() -> RuntimeMXBean
+        // invokeinterface RuntimeMXBean.getInputArguments() -> List
+        instructions.insertBefore(astoreNode, new MethodInsnNode(
+                Opcodes.INVOKESTATIC,
+                "java/lang/management/ManagementFactory",
+                "getRuntimeMXBean",
+                "()Ljava/lang/management/RuntimeMXBean;",
+                false));
+        instructions.insertBefore(astoreNode, new MethodInsnNode(
+                Opcodes.INVOKEINTERFACE,
+                "java/lang/management/RuntimeMXBean",
+                "getInputArguments",
+                "()Ljava/util/List;",
+                true));
+    }
+
+    /**
      * Rewrites {@code DefaultChannelId#processHandlePid(ClassLoader)} to avoid reflection as we target Java 21+.
      * <p>
      * The upstream Netty 4.2.x code uses reflection:

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -2,10 +2,13 @@ package io.quarkus.netty.deployment;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Modifier;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
+import java.util.SplittableRandom;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
@@ -15,7 +18,16 @@ import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.IndexView;
 import org.jboss.logging.Logger;
 import org.jboss.logmanager.Level;
+import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.IntInsnNode;
+import org.objectweb.asm.tree.JumpInsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.DefaultChannelId;
@@ -543,62 +555,64 @@ class NettyProcessor {
     }
 
     /**
-     * Rewrites {@code PlatformDependent0} to avoid the {@code MethodHandle} lookup used by Netty for virtual thread
-     * detection (which has a noticeable impact on startup). Since we target Java 21+, {@code Thread.isVirtual()} is
-     * always available and can be called directly.
+     * Rewrites {@code PlatformDependent0} to eliminate expensive {@code MethodHandle} lookups
+     * from its static initializer and replace {@code MethodHandle.invokeExact} dispatch with
+     * direct method calls. Since we target Java 17+, the following APIs are always available:
+     * <ul>
+     * <li>{@code Thread.isVirtual()} (Java 21+, but Quarkus minimum is 21)</li>
+     * <li>{@code ByteBuffer.alignedSlice(int)} (Java 9+)</li>
+     * <li>{@code ByteBuffer.slice(int, int)} (Java 13+)</li>
+     * <li>{@code ByteBuffer.put(int, ByteBuffer, int, int)} (Java 16+)</li>
+     * <li>{@code ByteBuffer.put(int, byte[], int, int)} (Java 13+)</li>
+     * <li>{@code SplittableRandom.nextBytes(byte[])} (Java 17+)</li>
+     * </ul>
      * <p>
-     * The upstream Netty 4.2.x code initializes a {@code MethodHandle} at class load time:
-     *
-     * <pre>{@code
-     * static final MethodHandle IS_VIRTUAL_THREAD_METHOD_HANDLE = getIsVirtualThreadMethodHandle();
-     *
-     * private static MethodHandle getIsVirtualThreadMethodHandle() {
-     *     try {
-     *         MethodHandle methodHandle = MethodHandles.publicLookup().findVirtual(Thread.class, "isVirtual",
-     *                 methodType(boolean.class));
-     *         boolean isVirtual = (boolean) methodHandle.invokeExact(Thread.currentThread());
-     *         return methodHandle;
-     *     } catch (Throwable e) {
-     *         ...
-     *         return null;
-     *     }
-     * }
-     * }</pre>
-     *
-     * and then uses it in:
-     *
-     * <pre>{@code
-     * static boolean isVirtualThread(Thread thread) {
-     *     if (thread == null || IS_VIRTUAL_THREAD_METHOD_HANDLE == null) {
-     *         return false;
-     *     }
-     *     try {
-     *         return (boolean) IS_VIRTUAL_THREAD_METHOD_HANDLE.invokeExact(thread);
-     *     } catch (Throwable t) {
-     *         ...
-     *     }
-     * }
-     * }</pre>
-     *
-     * We replace {@code getIsVirtualThreadMethodHandle()} to return {@code null} (skipping the lookup)
-     * and {@code isVirtualThread(Thread)} with a direct call:
-     *
-     * <pre>{@code
-     * static boolean isVirtualThread(Thread thread) {
-     *     return thread != null && thread.isVirtual();
-     * }
-     * }</pre>
+     * For each field, we apply three atomic changes:
+     * <ol>
+     * <li>Patch the static initializer (via ASM tree API) to skip the
+     * {@code AccessController.doPrivileged} + {@code MethodHandles.publicLookup().findVirtual()}
+     * lookup, forcing the field to {@code null}.</li>
+     * <li>Replace the {@code has*Method()} guard to return {@code true} unconditionally.</li>
+     * <li>Replace the accessor method to call the target method directly instead of going
+     * through {@code MethodHandle.invokeExact}.</li>
+     * </ol>
      */
     @BuildStep
-    void transformPlatformDependent0(BuildProducer<BytecodeTransformerBuildItem> producer) {
+    void transformPlatformDependent0(CompiledJavaVersionBuildItem compiledJavaVersion,
+            BuildProducer<BytecodeTransformerBuildItem> producer) {
         String className = "io.netty.util.internal.PlatformDependent0";
+
+        boolean isJava25OrHigher = compiledJavaVersion.getJavaVersion()
+                .isJava25OrHigher() == CompiledJavaVersionBuildItem.JavaVersion.Status.TRUE;
+
+        Set<String> fieldsToSkip;
+        Set<String> knownUnhandledFields;
+        if (isJava25OrHigher) {
+            fieldsToSkip = Set.of(
+                    "ALIGN_SLICE", "OFFSET_SLICE", "ABSOLUTE_PUT_BUFFER",
+                    "ABSOLUTE_PUT_ARRAY", "SPLITTABLE_RANDOM_NEXT_BYTES",
+                    "MEMORY_SEGMENT_ADDRESS_OF_BUFFER");
+            knownUnhandledFields = Set.of(
+                    "DIRECT_BUFFER_CONSTRUCTOR", "ALLOCATE_ARRAY_METHOD");
+        } else {
+            fieldsToSkip = Set.of(
+                    "ALIGN_SLICE", "OFFSET_SLICE", "ABSOLUTE_PUT_BUFFER",
+                    "ABSOLUTE_PUT_ARRAY", "SPLITTABLE_RANDOM_NEXT_BYTES");
+            knownUnhandledFields = Set.of(
+                    "DIRECT_BUFFER_CONSTRUCTOR", "ALLOCATE_ARRAY_METHOD",
+                    "MEMORY_SEGMENT_ADDRESS_OF_BUFFER");
+        }
+
         producer.produce(new BytecodeTransformerBuildItem.Builder().setClassToTransform(className)
-                .setCacheable(true).setVisitorFunction(
+                .setCacheable(true)
+                .setClassReaderOptions(ClassReader.EXPAND_FRAMES)
+                .setVisitorFunction(
                         new BiFunction<>() {
                             @Override
                             public ClassVisitor apply(String s, ClassVisitor classVisitor) {
                                 ClassTransformer transformer = new ClassTransformer(className);
 
+                                // --- getIsVirtualThreadMethodHandle -> return null ---
                                 {
                                     MethodDescriptor methodDescriptor = MethodDescriptor.ofMethod(className,
                                             "getIsVirtualThreadMethodHandle",
@@ -609,6 +623,7 @@ class NettyProcessor {
                                     method.returnValue(method.loadNull());
                                 }
 
+                                // --- isVirtualThread(Thread) -> thread != null && thread.isVirtual() ---
                                 {
                                     MethodDescriptor methodDescriptor = MethodDescriptor.ofMethod(className, "isVirtualThread",
                                             boolean.class, Thread.class);
@@ -617,16 +632,12 @@ class NettyProcessor {
                                     MethodCreator isVirtualThreadMethod = transformer.addMethod(methodDescriptor)
                                             .setModifiers(Modifier.STATIC);
 
-                                    // Get the thread parameter
                                     ResultHandle threadParam = isVirtualThreadMethod.getMethodParam(0);
 
-                                    // Check if thread is null
                                     BranchResult nullCheck = isVirtualThreadMethod.ifNull(threadParam);
 
-                                    // If null, return false
                                     nullCheck.trueBranch().returnValue(nullCheck.trueBranch().load(false));
 
-                                    // If not null, call thread.isVirtual()
                                     MethodDescriptor isVirtualMethod = MethodDescriptor.ofMethod(
                                             Thread.class,
                                             "isVirtual",
@@ -635,11 +646,106 @@ class NettyProcessor {
                                             isVirtualMethod,
                                             threadParam);
 
-                                    // Return the result
                                     nullCheck.falseBranch().returnValue(isVirtualResult);
                                 }
 
-                                return transformer.applyTo(classVisitor);
+                                // --- has* methods -> return true ---
+                                replaceWithReturnTrue(transformer, className, "hasAlignSliceMethod");
+                                replaceWithReturnTrue(transformer, className, "hasOffsetSliceMethod");
+                                replaceWithReturnTrue(transformer, className, "hasAbsolutePutBufferMethod");
+                                replaceWithReturnTrue(transformer, className, "hasAbsolutePutArrayMethod");
+
+                                // --- alignSlice(ByteBuffer, int) -> buffer.alignedSlice(alignment) ---
+                                {
+                                    MethodDescriptor md = MethodDescriptor.ofMethod(className, "alignSlice",
+                                            ByteBuffer.class, ByteBuffer.class, int.class);
+                                    transformer.removeMethod(md);
+                                    MethodCreator m = transformer.addMethod(md).setModifiers(Modifier.STATIC);
+                                    ResultHandle result = m.invokeVirtualMethod(
+                                            MethodDescriptor.ofMethod(ByteBuffer.class, "alignedSlice",
+                                                    ByteBuffer.class, int.class),
+                                            m.getMethodParam(0), m.getMethodParam(1));
+                                    m.returnValue(result);
+                                }
+
+                                // --- offsetSlice(ByteBuffer, int, int) -> buffer.slice(index, length) ---
+                                {
+                                    MethodDescriptor md = MethodDescriptor.ofMethod(className, "offsetSlice",
+                                            ByteBuffer.class, ByteBuffer.class, int.class, int.class);
+                                    transformer.removeMethod(md);
+                                    MethodCreator m = transformer.addMethod(md).setModifiers(Modifier.STATIC);
+                                    ResultHandle result = m.invokeVirtualMethod(
+                                            MethodDescriptor.ofMethod(ByteBuffer.class, "slice",
+                                                    ByteBuffer.class, int.class, int.class),
+                                            m.getMethodParam(0), m.getMethodParam(1), m.getMethodParam(2));
+                                    m.returnValue(result);
+                                }
+
+                                // --- absolutePut(ByteBuffer, int, ByteBuffer, int, int) -> dst.put(...) ---
+                                {
+                                    MethodDescriptor md = MethodDescriptor.ofMethod(className, "absolutePut",
+                                            ByteBuffer.class, ByteBuffer.class, int.class,
+                                            ByteBuffer.class, int.class, int.class);
+                                    transformer.removeMethod(md);
+                                    MethodCreator m = transformer.addMethod(md).setModifiers(Modifier.STATIC);
+                                    ResultHandle result = m.invokeVirtualMethod(
+                                            MethodDescriptor.ofMethod(ByteBuffer.class, "put",
+                                                    ByteBuffer.class, int.class, ByteBuffer.class, int.class, int.class),
+                                            m.getMethodParam(0), m.getMethodParam(1), m.getMethodParam(2),
+                                            m.getMethodParam(3), m.getMethodParam(4));
+                                    m.returnValue(result);
+                                }
+
+                                // --- absolutePut(ByteBuffer, int, byte[], int, int) -> dst.put(...) ---
+                                {
+                                    MethodDescriptor md = MethodDescriptor.ofMethod(className, "absolutePut",
+                                            ByteBuffer.class, ByteBuffer.class, int.class,
+                                            byte[].class, int.class, int.class);
+                                    transformer.removeMethod(md);
+                                    MethodCreator m = transformer.addMethod(md).setModifiers(Modifier.STATIC);
+                                    ResultHandle result = m.invokeVirtualMethod(
+                                            MethodDescriptor.ofMethod(ByteBuffer.class, "put",
+                                                    ByteBuffer.class, int.class, byte[].class, int.class, int.class),
+                                            m.getMethodParam(0), m.getMethodParam(1), m.getMethodParam(2),
+                                            m.getMethodParam(3), m.getMethodParam(4));
+                                    m.returnValue(result);
+                                }
+
+                                // --- splittableRandomNextBytes(SplittableRandom, byte[]) -> rng.nextBytes(data) ---
+                                {
+                                    MethodDescriptor md = MethodDescriptor.ofMethod(className,
+                                            "splittableRandomNextBytes",
+                                            void.class, SplittableRandom.class, byte[].class);
+                                    transformer.removeMethod(md);
+                                    MethodCreator m = transformer.addMethod(md).setModifiers(Modifier.STATIC);
+                                    m.invokeVirtualMethod(
+                                            MethodDescriptor.ofMethod(SplittableRandom.class, "nextBytes",
+                                                    void.class, byte[].class),
+                                            m.getMethodParam(0), m.getMethodParam(1));
+                                    m.returnVoid();
+                                }
+
+                                // --- Java 25+ specific transforms ---
+                                if (isJava25OrHigher) {
+                                    replaceWithReturnTrue(transformer, className, "hasMemorySegmentAddressOfBuffer");
+                                    generateDirectBufferAddress(transformer, className);
+                                }
+
+                                ClassVisitor downstream = classVisitor;
+                                if (isJava25OrHigher) {
+                                    downstream = new ClassVisitor(Gizmo.ASM_API_VERSION, downstream) {
+                                        @Override
+                                        public void visit(int version, int access, String name, String signature,
+                                                String superName, String[] interfaces) {
+                                            super.visit(Math.max(version, 69), access, name, signature,
+                                                    superName, interfaces);
+                                        }
+                                    };
+                                }
+
+                                ClassVisitor gizmoVisitor = transformer.applyTo(downstream);
+                                return createClinitPatcher(gizmoVisitor, fieldsToSkip,
+                                        knownUnhandledFields);
                             }
                         })
                 .build());
@@ -1565,6 +1671,195 @@ class NettyProcessor {
                     }
                 }).build());
 
+    }
+
+    private static void replaceWithReturnTrue(ClassTransformer transformer, String className, String methodName) {
+        MethodDescriptor md = MethodDescriptor.ofMethod(className, methodName, boolean.class);
+        transformer.removeMethod(md);
+        MethodCreator m = transformer.addMethod(md).setModifiers(Modifier.STATIC);
+        m.returnValue(m.load(true));
+    }
+
+    /**
+     * Creates an ASM {@link ClassVisitor} that intercepts the {@code <clinit>} method and patches
+     * version-gated MethodHandle lookup blocks. For each block matching the pattern:
+     *
+     * <pre>
+     * invokestatic javaVersion()I
+     * bipush/sipush N
+     * if_icmplt/if_icmple ELSE_LABEL
+     * ... MethodHandle lookup via AccessController.doPrivileged ...
+     * putstatic FIELD
+     * goto END_LABEL
+     * ELSE_LABEL:
+     * aconst_null
+     * putstatic FIELD
+     * </pre>
+     *
+     * If {@code FIELD} is in {@code fieldsToSkip}, the version check is replaced with a
+     * {@code GOTO ELSE_LABEL}, forcing the null assignment and skipping the expensive
+     * MethodHandle lookup.
+     */
+    private static void generateDirectBufferAddress(ClassTransformer transformer, String className) {
+        MethodDescriptor md = MethodDescriptor.ofMethod(className, "directBufferAddress",
+                long.class, ByteBuffer.class);
+        transformer.removeMethod(md);
+        MethodCreator m = transformer.addMethod(md).setModifiers(Modifier.STATIC);
+
+        ResultHandle buffer = m.getMethodParam(0);
+
+        // if (hasUnsafe()) return getLong(buffer, ADDRESS_FIELD_OFFSET);
+        ResultHandle hasUnsafe = m.invokeStaticMethod(
+                MethodDescriptor.ofMethod(className, "hasUnsafe", boolean.class));
+        BranchResult unsafeCheck = m.ifNonZero(hasUnsafe);
+
+        BytecodeCreator unsafeBranch = unsafeCheck.trueBranch();
+        ResultHandle addressFieldOffset = unsafeBranch.readStaticField(
+                FieldDescriptor.of(className, "ADDRESS_FIELD_OFFSET", long.class));
+        ResultHandle addr = unsafeBranch.invokeStaticMethod(
+                MethodDescriptor.ofMethod(className, "getLong",
+                        long.class, Object.class, long.class),
+                buffer, addressFieldOffset);
+        unsafeBranch.returnValue(addr);
+
+        // return MemorySegment.ofBuffer((Buffer) buffer).address() - buffer.position();
+        ResultHandle segment = m.invokeStaticInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.MemorySegment", "ofBuffer",
+                        "java.lang.foreign.MemorySegment",
+                        "java.nio.Buffer"),
+                buffer);
+        ResultHandle segAddr = m.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod("java.lang.foreign.MemorySegment", "address",
+                        long.class),
+                segment);
+        ResultHandle position = m.invokeVirtualMethod(
+                MethodDescriptor.ofMethod(ByteBuffer.class, "position", int.class),
+                buffer);
+        ResultHandle positionLong = m.convertPrimitive(position, long.class);
+        ResultHandle result = m.subtract(segAddr, positionLong);
+        m.returnValue(result);
+    }
+
+    private static ClassVisitor createClinitPatcher(ClassVisitor downstream, Set<String> fieldsToSkip,
+            Set<String> knownUnhandledFields) {
+        return new ClassVisitor(Gizmo.ASM_API_VERSION, downstream) {
+            @Override
+            public MethodVisitor visitMethod(int access, String name, String descriptor,
+                    String signature, String[] exceptions) {
+                MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
+                if ("<clinit>".equals(name)) {
+                    MethodVisitor target = mv;
+                    return new MethodNode(Gizmo.ASM_API_VERSION, access, name, descriptor,
+                            signature, exceptions) {
+                        @Override
+                        public void visitEnd() {
+                            super.visitEnd();
+                            patchClinitVersionChecks(this.instructions, fieldsToSkip,
+                                    knownUnhandledFields);
+                            this.accept(target);
+                        }
+                    };
+                }
+                return mv;
+            }
+        };
+    }
+
+    private static void patchClinitVersionChecks(
+            org.objectweb.asm.tree.InsnList instructions, Set<String> fieldsToSkip,
+            Set<String> knownUnhandledFields) {
+        Set<String> patchedFields = new java.util.HashSet<>();
+        AbstractInsnNode node = instructions.getFirst();
+        while (node != null) {
+            if (node instanceof MethodInsnNode methodInsn
+                    && methodInsn.getOpcode() == Opcodes.INVOKESTATIC
+                    && "javaVersion".equals(methodInsn.name)
+                    && "io/netty/util/internal/PlatformDependent0".equals(methodInsn.owner)) {
+
+                AbstractInsnNode pushNode = nextRealInsn(methodInsn);
+                if (pushNode == null || !(pushNode instanceof IntInsnNode)) {
+                    node = node.getNext();
+                    continue;
+                }
+
+                AbstractInsnNode jumpNode = nextRealInsn(pushNode);
+                if (jumpNode == null || !(jumpNode instanceof JumpInsnNode jumpInsn)) {
+                    node = node.getNext();
+                    continue;
+                }
+
+                int opcode = jumpInsn.getOpcode();
+                if (opcode != Opcodes.IF_ICMPLT && opcode != Opcodes.IF_ICMPLE) {
+                    node = node.getNext();
+                    continue;
+                }
+
+                // Walk from the jump target to find the null-assignment and identify the field
+                AbstractInsnNode nullInsn = nextRealInsn(jumpInsn.label);
+                if (nullInsn == null || nullInsn.getOpcode() != Opcodes.ACONST_NULL) {
+                    node = node.getNext();
+                    continue;
+                }
+
+                AbstractInsnNode putStaticInsn = nextRealInsn(nullInsn);
+                if (!(putStaticInsn instanceof FieldInsnNode fieldInsn)
+                        || fieldInsn.getOpcode() != Opcodes.PUTSTATIC) {
+                    node = node.getNext();
+                    continue;
+                }
+
+                String fieldName = fieldInsn.name;
+
+                if (!fieldsToSkip.contains(fieldName)) {
+                    if (!knownUnhandledFields.contains(fieldName)) {
+                        throw new IllegalStateException(
+                                "PlatformDependent0.<clinit> contains an unhandled version-gated MethodHandle "
+                                        + "lookup block for field '" + fieldName + "'. "
+                                        + "This likely means Netty added a new version-gated block. "
+                                        + "Either add it to fieldsToSkip (and replace the accessor method) "
+                                        + "or add it to KNOWN_UNHANDLED_CLINIT_FIELDS.");
+                    }
+                    node = node.getNext();
+                    continue;
+                }
+
+                // Advance past the nodes we're about to remove BEFORE removing them
+                AbstractInsnNode nextNode = jumpInsn.getNext();
+
+                // Patch: remove invokestatic + push constant, change conditional to GOTO
+                instructions.remove(methodInsn);
+                instructions.remove(pushNode);
+                jumpInsn.setOpcode(Opcodes.GOTO);
+                patchedFields.add(fieldName);
+
+                node = nextNode;
+                continue;
+            }
+            node = node.getNext();
+        }
+
+        // Verify that all expected fields were found and patched
+        if (!patchedFields.equals(fieldsToSkip)) {
+            Set<String> missing = new java.util.HashSet<>(fieldsToSkip);
+            missing.removeAll(patchedFields);
+            throw new IllegalStateException(
+                    "Failed to patch all expected version-gated MethodHandle lookup blocks in "
+                            + "PlatformDependent0.<clinit>. Missing fields: " + missing + ". "
+                            + "The bytecode pattern may have changed in a Netty update.");
+        }
+    }
+
+    private static AbstractInsnNode nextRealInsn(AbstractInsnNode node) {
+        node = node.getNext();
+        while (node != null) {
+            int type = node.getType();
+            if (type != AbstractInsnNode.LABEL && type != AbstractInsnNode.FRAME
+                    && type != AbstractInsnNode.LINE) {
+                return node;
+            }
+            node = node.getNext();
+        }
+        return null;
     }
 
     private static class AddSharableVisitorFunction implements BiFunction<String, ClassVisitor, ClassVisitor> {

--- a/extensions/netty/deployment/src/test/java/io/quarkus/netty/deployment/NettyOriginalBehaviorDumpTest.java
+++ b/extensions/netty/deployment/src/test/java/io/quarkus/netty/deployment/NettyOriginalBehaviorDumpTest.java
@@ -1,0 +1,187 @@
+package io.quarkus.netty.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.SplittableRandom;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Plain JUnit test (no Quarkus) that runs against the ORIGINAL (untransformed) Netty classes.
+ * It captures method results to a file so that {@link NettyTransformVerificationTest} can compare
+ * them against the bytecode-transformed versions.
+ * <p>
+ * This test must run before {@link NettyTransformVerificationTest}.
+ * Maven Surefire runs tests alphabetically by default, and since this class name sorts before
+ * "NettyTransformVerification", the ordering is naturally correct.
+ */
+public class NettyOriginalBehaviorDumpTest {
+
+    static final Path DUMP_FILE = Path.of("target", "netty-original-behavior.properties");
+
+    private static final String PD0 = "io.netty.util.internal.PlatformDependent0";
+
+    @Test
+    void dumpOriginalBehavior() throws Exception {
+        Map<String, String> results = new LinkedHashMap<>();
+
+        Class<?> pd0Class = Class.forName(PD0);
+
+        dumpIsVirtualThread(pd0Class, results);
+        dumpHasMethods(pd0Class, results);
+        dumpAlignSlice(pd0Class, results);
+        dumpOffsetSlice(pd0Class, results);
+        dumpAbsolutePutBuffer(pd0Class, results);
+        dumpAbsolutePutArray(pd0Class, results);
+        dumpSplittableRandomNextBytes(pd0Class, results);
+        dumpMaxDirectMemory(results);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("# Original Netty behavior captured by NettyOriginalBehaviorDumpTest\n");
+        for (Map.Entry<String, String> entry : results.entrySet()) {
+            sb.append(entry.getKey()).append("=").append(entry.getValue()).append("\n");
+        }
+        Files.writeString(DUMP_FILE, sb.toString());
+
+        assertThat(DUMP_FILE).exists();
+        assertThat(results).isNotEmpty();
+    }
+
+    private void dumpIsVirtualThread(Class<?> pd0Class, Map<String, String> results) throws Exception {
+        Method isVirtualThread = pd0Class.getDeclaredMethod("isVirtualThread", Thread.class);
+        isVirtualThread.setAccessible(true);
+
+        boolean platformResult = (boolean) isVirtualThread.invoke(null, Thread.currentThread());
+        results.put("isVirtualThread.platform", String.valueOf(platformResult));
+
+        Thread.ofVirtual().start(() -> {
+            try {
+                boolean virtualResult = (boolean) isVirtualThread.invoke(null, Thread.currentThread());
+                results.put("isVirtualThread.virtual", String.valueOf(virtualResult));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }).join();
+
+        boolean nullResult = (boolean) isVirtualThread.invoke(null, (Thread) null);
+        results.put("isVirtualThread.null", String.valueOf(nullResult));
+    }
+
+    private void dumpHasMethods(Class<?> pd0Class, Map<String, String> results) throws Exception {
+        for (String methodName : new String[] {
+                "hasAlignSliceMethod", "hasOffsetSliceMethod",
+                "hasAbsolutePutBufferMethod", "hasAbsolutePutArrayMethod" }) {
+            Method method = pd0Class.getDeclaredMethod(methodName);
+            method.setAccessible(true);
+            results.put(methodName, String.valueOf(method.invoke(null)));
+        }
+    }
+
+    private void dumpAlignSlice(Class<?> pd0Class, Map<String, String> results) throws Exception {
+        Method alignSlice = pd0Class.getDeclaredMethod("alignSlice", ByteBuffer.class, int.class);
+        alignSlice.setAccessible(true);
+
+        ByteBuffer buffer = ByteBuffer.allocateDirect(64);
+        ByteBuffer sliced = (ByteBuffer) alignSlice.invoke(null, buffer, 8);
+        results.put("alignSlice.capacity", String.valueOf(sliced.capacity()));
+        results.put("alignSlice.position", String.valueOf(sliced.position()));
+        results.put("alignSlice.limit", String.valueOf(sliced.limit()));
+    }
+
+    private void dumpOffsetSlice(Class<?> pd0Class, Map<String, String> results) throws Exception {
+        Method offsetSlice = pd0Class.getDeclaredMethod("offsetSlice", ByteBuffer.class, int.class, int.class);
+        offsetSlice.setAccessible(true);
+
+        ByteBuffer buffer = ByteBuffer.allocateDirect(64);
+        for (int i = 0; i < 64; i++) {
+            buffer.put(i, (byte) i);
+        }
+        ByteBuffer sliced = (ByteBuffer) offsetSlice.invoke(null, buffer, 10, 20);
+        results.put("offsetSlice.capacity", String.valueOf(sliced.capacity()));
+        results.put("offsetSlice.position", String.valueOf(sliced.position()));
+        results.put("offsetSlice.limit", String.valueOf(sliced.limit()));
+        results.put("offsetSlice.byte0", String.valueOf(sliced.get(0)));
+        results.put("offsetSlice.byte19", String.valueOf(sliced.get(19)));
+    }
+
+    private void dumpAbsolutePutBuffer(Class<?> pd0Class, Map<String, String> results) throws Exception {
+        Method absolutePut = pd0Class.getDeclaredMethod("absolutePut",
+                ByteBuffer.class, int.class, ByteBuffer.class, int.class, int.class);
+        absolutePut.setAccessible(true);
+
+        ByteBuffer dst = ByteBuffer.allocateDirect(32);
+        ByteBuffer src = ByteBuffer.allocateDirect(16);
+        for (int i = 0; i < 16; i++) {
+            src.put(i, (byte) (100 + i));
+        }
+        ByteBuffer returnedDst = (ByteBuffer) absolutePut.invoke(null, dst, 4, src, 2, 8);
+        byte[] dstBytes = new byte[8];
+        for (int i = 0; i < 8; i++) {
+            dstBytes[i] = returnedDst.get(4 + i);
+        }
+        results.put("absolutePutBuffer.bytes", bytesToString(dstBytes));
+    }
+
+    private void dumpAbsolutePutArray(Class<?> pd0Class, Map<String, String> results) throws Exception {
+        Method absolutePut = pd0Class.getDeclaredMethod("absolutePut",
+                ByteBuffer.class, int.class, byte[].class, int.class, int.class);
+        absolutePut.setAccessible(true);
+
+        ByteBuffer dst = ByteBuffer.allocateDirect(32);
+        byte[] src = new byte[16];
+        for (int i = 0; i < 16; i++) {
+            src[i] = (byte) (50 + i);
+        }
+        ByteBuffer returnedDst = (ByteBuffer) absolutePut.invoke(null, dst, 2, src, 3, 10);
+        byte[] dstBytes = new byte[10];
+        for (int i = 0; i < 10; i++) {
+            dstBytes[i] = returnedDst.get(2 + i);
+        }
+        results.put("absolutePutArray.bytes", bytesToString(dstBytes));
+    }
+
+    private void dumpSplittableRandomNextBytes(Class<?> pd0Class, Map<String, String> results) throws Exception {
+        Method splittableRandomNextBytes = pd0Class.getDeclaredMethod("splittableRandomNextBytes",
+                SplittableRandom.class, byte[].class);
+        splittableRandomNextBytes.setAccessible(true);
+
+        SplittableRandom rng = new SplittableRandom(42);
+        byte[] data = new byte[16];
+        splittableRandomNextBytes.invoke(null, rng, data);
+        results.put("splittableRandomNextBytes.bytes", bytesToString(data));
+    }
+
+    private void dumpMaxDirectMemory(Map<String, String> results) throws Exception {
+        Class<?> pdClass = Class.forName("io.netty.util.internal.PlatformDependent");
+        Method maxDirectMemory = pdClass.getDeclaredMethod("maxDirectMemory");
+        maxDirectMemory.setAccessible(true);
+        long value = (long) maxDirectMemory.invoke(null);
+        results.put("maxDirectMemory", String.valueOf(value));
+    }
+
+    static String bytesToString(byte[] bytes) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < bytes.length; i++) {
+            if (i > 0) {
+                sb.append(",");
+            }
+            sb.append(bytes[i]);
+        }
+        return sb.toString();
+    }
+
+    static byte[] bytesFromString(String str) {
+        String[] parts = str.split(",");
+        byte[] result = new byte[parts.length];
+        for (int i = 0; i < parts.length; i++) {
+            result[i] = Byte.parseByte(parts[i].trim());
+        }
+        return result;
+    }
+}

--- a/extensions/netty/deployment/src/test/java/io/quarkus/netty/deployment/NettyTransformVerificationTest.java
+++ b/extensions/netty/deployment/src/test/java/io/quarkus/netty/deployment/NettyTransformVerificationTest.java
@@ -1,0 +1,248 @@
+package io.quarkus.netty.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SplittableRandom;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Runs inside Quarkus (bytecode transforms applied) and compares the behavior of the
+ * transformed Netty classes against the reference data captured by {@link NettyOriginalBehaviorDumpTest}.
+ * <p>
+ * This test verifies that our bytecode rewrites produce the same observable behavior as the
+ * original MethodHandle-based code. It checks both the method return values AND the internal
+ * state (MethodHandle fields should be null, has* guards should be true) to ensure the optimized
+ * code path is actually taken.
+ */
+public class NettyTransformVerificationTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withEmptyApplication();
+
+    private static final String PD0 = "io.netty.util.internal.PlatformDependent0";
+    private static final Path DUMP_FILE = Path.of("target", "netty-original-behavior.properties");
+
+    private static Map<String, String> originalBehavior;
+
+    @BeforeAll
+    static void loadOriginalBehavior() throws Exception {
+        assumeTrue(Files.exists(DUMP_FILE),
+                "Reference data file from NettyOriginalBehaviorDumpTest not found at " + DUMP_FILE
+                        + ". This test must run after NettyOriginalBehaviorDumpTest.");
+
+        originalBehavior = new HashMap<>();
+        for (String line : Files.readAllLines(DUMP_FILE)) {
+            if (line.startsWith("#") || line.isBlank()) {
+                continue;
+            }
+            int eq = line.indexOf('=');
+            if (eq > 0) {
+                originalBehavior.put(line.substring(0, eq), line.substring(eq + 1));
+            }
+        }
+    }
+
+    @Test
+    void methodHandleFieldsAreNull() throws Exception {
+        Class<?> pd0Class = Class.forName(PD0);
+
+        for (String fieldName : new String[] {
+                "ALIGN_SLICE", "OFFSET_SLICE", "ABSOLUTE_PUT_BUFFER",
+                "ABSOLUTE_PUT_ARRAY", "SPLITTABLE_RANDOM_NEXT_BYTES" }) {
+            Field field = pd0Class.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            assertThat(field.get(null))
+                    .as("MethodHandle field %s should be null (clinit patch should have skipped the lookup)", fieldName)
+                    .isNull();
+        }
+
+        Field isVirtualField = pd0Class.getDeclaredField("IS_VIRTUAL_THREAD_METHOD_HANDLE");
+        isVirtualField.setAccessible(true);
+        assertThat(isVirtualField.get(null))
+                .as("IS_VIRTUAL_THREAD_METHOD_HANDLE should be null (getIsVirtualThreadMethodHandle returns null)")
+                .isNull();
+    }
+
+    @Test
+    void hasMethodsReturnTrue() throws Exception {
+        Class<?> pd0Class = Class.forName(PD0);
+
+        for (String methodName : new String[] {
+                "hasAlignSliceMethod", "hasOffsetSliceMethod",
+                "hasAbsolutePutBufferMethod", "hasAbsolutePutArrayMethod" }) {
+            Method method = pd0Class.getDeclaredMethod(methodName);
+            method.setAccessible(true);
+            boolean result = (boolean) method.invoke(null);
+            assertThat(result)
+                    .as("%s must return true so the optimized path is used", methodName)
+                    .isTrue();
+            assertThat(String.valueOf(result))
+                    .as("%s should match original behavior", methodName)
+                    .isEqualTo(originalBehavior.get(methodName));
+        }
+    }
+
+    @Test
+    void isVirtualThread() throws Exception {
+        Class<?> pd0Class = Class.forName(PD0);
+        Method isVirtualThread = pd0Class.getDeclaredMethod("isVirtualThread", Thread.class);
+        isVirtualThread.setAccessible(true);
+
+        boolean platformResult = (boolean) isVirtualThread.invoke(null, Thread.currentThread());
+        assertThat(String.valueOf(platformResult))
+                .isEqualTo(originalBehavior.get("isVirtualThread.platform"));
+
+        Thread.ofVirtual().start(() -> {
+            try {
+                boolean virtualResult = (boolean) isVirtualThread.invoke(null, Thread.currentThread());
+                assertThat(String.valueOf(virtualResult))
+                        .isEqualTo(originalBehavior.get("isVirtualThread.virtual"));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }).join();
+
+        boolean nullResult = (boolean) isVirtualThread.invoke(null, (Thread) null);
+        assertThat(String.valueOf(nullResult))
+                .isEqualTo(originalBehavior.get("isVirtualThread.null"));
+    }
+
+    @Test
+    void alignSlice() throws Exception {
+        Class<?> pd0Class = Class.forName(PD0);
+        Method alignSlice = pd0Class.getDeclaredMethod("alignSlice", ByteBuffer.class, int.class);
+        alignSlice.setAccessible(true);
+
+        ByteBuffer buffer = ByteBuffer.allocateDirect(64);
+        ByteBuffer sliced = (ByteBuffer) alignSlice.invoke(null, buffer, 8);
+
+        assertThat(String.valueOf(sliced.capacity()))
+                .isEqualTo(originalBehavior.get("alignSlice.capacity"));
+        assertThat(String.valueOf(sliced.position()))
+                .isEqualTo(originalBehavior.get("alignSlice.position"));
+        assertThat(String.valueOf(sliced.limit()))
+                .isEqualTo(originalBehavior.get("alignSlice.limit"));
+    }
+
+    @Test
+    void offsetSlice() throws Exception {
+        Class<?> pd0Class = Class.forName(PD0);
+        Method offsetSlice = pd0Class.getDeclaredMethod("offsetSlice", ByteBuffer.class, int.class, int.class);
+        offsetSlice.setAccessible(true);
+
+        ByteBuffer buffer = ByteBuffer.allocateDirect(64);
+        for (int i = 0; i < 64; i++) {
+            buffer.put(i, (byte) i);
+        }
+        ByteBuffer sliced = (ByteBuffer) offsetSlice.invoke(null, buffer, 10, 20);
+
+        assertThat(String.valueOf(sliced.capacity()))
+                .isEqualTo(originalBehavior.get("offsetSlice.capacity"));
+        assertThat(String.valueOf(sliced.position()))
+                .isEqualTo(originalBehavior.get("offsetSlice.position"));
+        assertThat(String.valueOf(sliced.limit()))
+                .isEqualTo(originalBehavior.get("offsetSlice.limit"));
+        assertThat(String.valueOf(sliced.get(0)))
+                .isEqualTo(originalBehavior.get("offsetSlice.byte0"));
+        assertThat(String.valueOf(sliced.get(19)))
+                .isEqualTo(originalBehavior.get("offsetSlice.byte19"));
+    }
+
+    @Test
+    void absolutePutBuffer() throws Exception {
+        Class<?> pd0Class = Class.forName(PD0);
+        Method absolutePut = pd0Class.getDeclaredMethod("absolutePut",
+                ByteBuffer.class, int.class, ByteBuffer.class, int.class, int.class);
+        absolutePut.setAccessible(true);
+
+        ByteBuffer dst = ByteBuffer.allocateDirect(32);
+        ByteBuffer src = ByteBuffer.allocateDirect(16);
+        for (int i = 0; i < 16; i++) {
+            src.put(i, (byte) (100 + i));
+        }
+        ByteBuffer returnedDst = (ByteBuffer) absolutePut.invoke(null, dst, 4, src, 2, 8);
+        byte[] dstBytes = new byte[8];
+        for (int i = 0; i < 8; i++) {
+            dstBytes[i] = returnedDst.get(4 + i);
+        }
+
+        assertThat(bytesToString(dstBytes))
+                .isEqualTo(originalBehavior.get("absolutePutBuffer.bytes"));
+    }
+
+    @Test
+    void absolutePutArray() throws Exception {
+        Class<?> pd0Class = Class.forName(PD0);
+        Method absolutePut = pd0Class.getDeclaredMethod("absolutePut",
+                ByteBuffer.class, int.class, byte[].class, int.class, int.class);
+        absolutePut.setAccessible(true);
+
+        ByteBuffer dst = ByteBuffer.allocateDirect(32);
+        byte[] src = new byte[16];
+        for (int i = 0; i < 16; i++) {
+            src[i] = (byte) (50 + i);
+        }
+        ByteBuffer returnedDst = (ByteBuffer) absolutePut.invoke(null, dst, 2, src, 3, 10);
+        byte[] dstBytes = new byte[10];
+        for (int i = 0; i < 10; i++) {
+            dstBytes[i] = returnedDst.get(2 + i);
+        }
+
+        assertThat(bytesToString(dstBytes))
+                .isEqualTo(originalBehavior.get("absolutePutArray.bytes"));
+    }
+
+    @Test
+    void splittableRandomNextBytes() throws Exception {
+        Class<?> pd0Class = Class.forName(PD0);
+        Method splittableRandomNextBytes = pd0Class.getDeclaredMethod("splittableRandomNextBytes",
+                SplittableRandom.class, byte[].class);
+        splittableRandomNextBytes.setAccessible(true);
+
+        SplittableRandom rng = new SplittableRandom(42);
+        byte[] data = new byte[16];
+        splittableRandomNextBytes.invoke(null, rng, data);
+
+        assertThat(bytesToString(data))
+                .isEqualTo(originalBehavior.get("splittableRandomNextBytes.bytes"));
+    }
+
+    @Test
+    void maxDirectMemory() throws Exception {
+        Class<?> pdClass = Class.forName("io.netty.util.internal.PlatformDependent");
+        Method maxDirectMemory = pdClass.getDeclaredMethod("maxDirectMemory");
+        maxDirectMemory.setAccessible(true);
+        long value = (long) maxDirectMemory.invoke(null);
+
+        assertThat(value)
+                .as("maxDirectMemory should be positive")
+                .isGreaterThan(0);
+        assertThat(String.valueOf(value))
+                .isEqualTo(originalBehavior.get("maxDirectMemory"));
+    }
+
+    private static String bytesToString(byte[] bytes) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < bytes.length; i++) {
+            if (i > 0) {
+                sb.append(",");
+            }
+            sb.append(bytes[i]);
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
This is a follow-up of the work we did to optimize Netty startup time by avoiding `MethodHandle` initialization.

It started with making the new `CleanerJava24Linker` and `CleanerJava25` lighter but then I also tackled the `PlatformDependent` `<clinit>` content itself which had been a problem for quite some time.

I tried to add some checks so that the bytecode changes are not too brittle.

With this work, we go from 21,5% of CPU time to 1.15% for the `PlatformDependent` `<clinit>`.

Before:

<img width="3326" height="1680" alt="Screenshot From 2026-09-03 11-36-35" src="https://github.com/user-attachments/assets/129ac112-fbe3-4ab9-88d8-f6ad59b283bd" />

After:

<img width="3326" height="1373" alt="Screenshot From 2026-09-03 11-37-24" src="https://github.com/user-attachments/assets/44b5aa59-8bd9-40a3-b9c5-4ac122df60f7" />

Commits are semantic.

Fixes #56347
