### PR TITLE
OTel exporter coexistence. 

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -417,6 +417,36 @@ Currently, are available the following exporters (may be outdated) for:
 
 Also on Quarkiverse, the https://docs.quarkiverse.io/quarkus-amazon-services/dev/opentelemetry.html[Quarkus AWS SDK has integration with OpenTelemetry].
 
+=== Coexistence with the default exporter
+
+By default, when an additional exporter is present for a signal (a `SpanExporter`, `MetricExporter` or
+`LogRecordExporter` CDI bean, or an exporter contributed by a Quarkiverse extension), the built-in
+Quarkus OTLP exporter is *not* created for that signal. The additional exporter replaces the default one.
+
+If you want the built-in OTLP exporter to keep exporting *in addition to* the other exporter, so the same
+telemetry is sent to both, set the following build time property:
+
+[source,properties]
+----
+quarkus.otel.exporter.otlp.experimental.default-enabled=true
+----
+
+This is a single switch that applies to all signals (traces, metrics and logs). Setting a signal
+`exporter` to `none` (for example `quarkus.otel.traces.exporter=none`) still disables the built-in
+exporter for that signal, regardless of this property.
+
+[WARNING]
+====
+For *metrics*, all coexisting exporters share a single metric reader, which registers one
+aggregation temporality. When several metric exporters coexist, the temporality of the first one is
+applied to all of them. If the built-in OTLP exporter and a custom exporter disagree on temporality
+(for example cumulative versus delta), the one that does not match will receive metrics in an
+unexpected temporality.
+
+Coexistence of metric exporters that disagree on temporality is therefore not
+supported. Traces and logs are unaffected.
+====
+
 === Logging exporter (for debugging)
 
 You can output all metrics to the console, for debugging/development purposes.

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.opentelemetry.deployment.exporter.otlp;
 
 import static io.quarkus.opentelemetry.runtime.config.build.ExporterType.Constants.CDI_VALUE;
+import static io.quarkus.opentelemetry.runtime.config.build.ExporterType.Constants.NONE_VALUE;
 import static io.quarkus.opentelemetry.runtime.config.build.ExporterType.Constants.OTLP_VALUE;
 
 import java.util.List;
@@ -52,7 +53,10 @@ public class OtlpExporterProcessor {
         public boolean getAsBoolean() {
             return otelBuildConfig.enabled() &&
                     otelBuildConfig.traces().enabled().orElse(Boolean.TRUE) &&
-                    otelBuildConfig.traces().exporter().contains(CDI_VALUE) &&
+                    !otelBuildConfig.traces().exporter().contains(NONE_VALUE) &&
+                    (otelBuildConfig.traces().exporter().contains(CDI_VALUE) ||
+                            exportBuildConfig.experimental().defaultEnabled())
+                    &&
                     exportBuildConfig.enabled();
         }
     }
@@ -64,7 +68,10 @@ public class OtlpExporterProcessor {
         public boolean getAsBoolean() {
             return otelBuildConfig.enabled() &&
                     otelBuildConfig.metrics().enabled().orElse(Boolean.TRUE) &&
-                    otelBuildConfig.metrics().exporter().contains(CDI_VALUE) &&
+                    !otelBuildConfig.metrics().exporter().contains(NONE_VALUE) &&
+                    (otelBuildConfig.metrics().exporter().contains(CDI_VALUE) ||
+                            exportBuildConfig.experimental().defaultEnabled())
+                    &&
                     exportBuildConfig.enabled();
         }
     }
@@ -76,7 +83,10 @@ public class OtlpExporterProcessor {
         public boolean getAsBoolean() {
             return otelBuildConfig.enabled() &&
                     otelBuildConfig.logs().enabled().orElse(Boolean.TRUE) &&
-                    otelBuildConfig.logs().exporter().contains(CDI_VALUE) &&
+                    !otelBuildConfig.logs().exporter().contains(NONE_VALUE) &&
+                    (otelBuildConfig.logs().exporter().contains(CDI_VALUE) ||
+                            exportBuildConfig.experimental().defaultEnabled())
+                    &&
                     exportBuildConfig.enabled();
         }
     }
@@ -145,19 +155,23 @@ public class OtlpExporterProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     @Consume(TlsRegistryBuildItem.class)
     void createSpanExporter(
+            OtlpExporterBuildConfig exportBuildConfig,
             BeanDiscoveryFinishedBuildItem beanDiscovery,
             OTelExporterRecorder recorder,
             CoreVertxBuildItem vertxBuildItem,
             List<ExternalOtelExporterBuildItem> externalOtelExporterBuildItem,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
-        if (!externalOtelExporterBuildItem.isEmpty()) {
-            // if there is an external exporter, we don't want to create the default one
+
+        // Another exporter may already be present as an external synthetic bean (which does not show
+        // in the BeanDiscoveryFinishedBuildItem) or as a discovered SpanExporter CDI bean.
+        boolean otherExporterExists = !externalOtelExporterBuildItem.isEmpty() ||
+                !beanDiscovery.beanStream().withBeanType(SPAN_EXPORTER).isEmpty();
+
+        // When another exporter exists we skip the built-in one, unless coexistence is explicitly enabled.
+        if (otherExporterExists && !exportBuildConfig.experimental().defaultEnabled()) {
             return;
         }
-        if (!beanDiscovery.beanStream().withBeanType(SPAN_EXPORTER).isEmpty()) {
-            // if there is a SpanExporter bean impl around, we don't want to create the default one
-            return;
-        }
+
         syntheticBeanBuildItemBuildProducer.produce(SyntheticBeanBuildItem
                 .configure(SpanExporter.class)
                 .types(SpanExporter.class)
@@ -173,20 +187,20 @@ public class OtlpExporterProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     @Consume(TlsRegistryBuildItem.class)
     void createMetricsExporterProcessor(
+            OtlpExporterBuildConfig exportBuildConfig,
             BeanDiscoveryFinishedBuildItem beanDiscovery,
             OTelExporterRecorder recorder,
             List<ExternalOtelExporterBuildItem> externalOtelExporterBuildItem,
             CoreVertxBuildItem vertxBuildItem,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
 
-        if (!externalOtelExporterBuildItem.isEmpty()) {
-            // if there is an external exporter, we don't want to create the default one.
-            // External exporter also use synthetic beans. However, synthetic beans don't show in the BeanDiscoveryFinishedBuildItem
-            return;
-        }
+        // Another exporter may already be present as an external synthetic bean (which does not show
+        // in the BeanDiscoveryFinishedBuildItem) or as a discovered MetricExporter CDI bean.
+        boolean otherExporterExists = !externalOtelExporterBuildItem.isEmpty() ||
+                !beanDiscovery.beanStream().withBeanType(METRIC_EXPORTER).isEmpty();
 
-        if (!beanDiscovery.beanStream().withBeanType(METRIC_EXPORTER).isEmpty()) {
-            // if there is a MetricExporter bean impl around, we don't want to create the default one
+        // When another exporter exists we skip the built-in one, unless coexistence is explicitly enabled.
+        if (otherExporterExists && !exportBuildConfig.experimental().defaultEnabled()) {
             return;
         }
 
@@ -207,20 +221,20 @@ public class OtlpExporterProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     @Consume(TlsRegistryBuildItem.class)
     void createLogRecordExporterProcessor(
+            OtlpExporterBuildConfig exportBuildConfig,
             BeanDiscoveryFinishedBuildItem beanDiscovery,
             OTelExporterRecorder recorder,
             List<ExternalOtelExporterBuildItem> externalOtelExporterBuildItem,
             CoreVertxBuildItem vertxBuildItem,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
 
-        if (!externalOtelExporterBuildItem.isEmpty()) {
-            // if there is an external exporter, we don't want to create the default one.
-            // External exporter also use synthetic beans. However, synthetic beans don't show in the BeanDiscoveryFinishedBuildItem
-            return;
-        }
+        // Another exporter may already be present as an external synthetic bean (which does not show
+        // in the BeanDiscoveryFinishedBuildItem) or as a discovered LogRecordExporter CDI bean.
+        boolean otherExporterExists = !externalOtelExporterBuildItem.isEmpty() ||
+                !beanDiscovery.beanStream().withBeanType(LOG_RECORD_EXPORTER).isEmpty();
 
-        if (!beanDiscovery.beanStream().withBeanType(LOG_RECORD_EXPORTER).isEmpty()) {
-            // if there is a MetricExporter bean impl around, we don't want to create the default one
+        // When another exporter exists we skip the built-in one, unless coexistence is explicitly enabled.
+        if (otherExporterExists && !exportBuildConfig.experimental().defaultEnabled()) {
             return;
         }
 

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterCoexistenceDisabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterCoexistenceDisabledTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.opentelemetry.deployment.exporter.otlp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.quarkus.opentelemetry.runtime.config.build.exporter.OtlpExporterBuildConfig;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * With coexistence disabled (the default), a custom CDI exporter suppresses the built-in OTLP
+ * exporter, so only the custom one is present.
+ */
+public class OtlpExporterCoexistenceDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClass(CustomSpanExporter.class));
+
+    @Inject
+    Instance<SpanExporter> spanExporters;
+
+    @Inject
+    OtlpExporterBuildConfig otlpExporterBuildConfig;
+
+    @Test
+    void onlyTheCustomExporterIsPresent() {
+        assertThat(otlpExporterBuildConfig.experimental().defaultEnabled()).isFalse();
+        assertThat(spanExporters.stream()).hasSize(1);
+        assertThat(spanExporters.get()).isInstanceOf(CustomSpanExporter.class);
+    }
+
+    @Singleton
+    public static class CustomSpanExporter implements SpanExporter {
+        @Override
+        public CompletableResultCode export(Collection<SpanData> spans) {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+        }
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterCoexistenceEnabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterCoexistenceEnabledTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.opentelemetry.deployment.exporter.otlp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.quarkus.opentelemetry.runtime.config.build.exporter.OtlpExporterBuildConfig;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * When coexistence is enabled, the built-in OTLP exporter is created in addition to a custom
+ * CDI exporter, so both are present for the same signal.
+ */
+public class OtlpExporterCoexistenceEnabledTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClass(CustomSpanExporter.class))
+            .overrideConfigKey("quarkus.otel.exporter.otlp.experimental.default-enabled", "true");
+
+    @Inject
+    Instance<SpanExporter> spanExporters;
+
+    @Inject
+    OtlpExporterBuildConfig otlpExporterBuildConfig;
+
+    @Test
+    void bothBuiltInAndCustomExportersArePresent() {
+        assertThat(otlpExporterBuildConfig.experimental().defaultEnabled()).isTrue();
+        assertThat(spanExporters.stream()).hasSizeGreaterThanOrEqualTo(2);
+        assertThat(spanExporters.stream()).anyMatch(CustomSpanExporter.class::isInstance);
+    }
+
+    @Singleton
+    public static class CustomSpanExporter implements SpanExporter {
+        @Override
+        public CompletableResultCode export(Collection<SpanData> spans) {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+        }
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterCoexistenceNoneWinsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterCoexistenceNoneWinsTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.opentelemetry.deployment.exporter.otlp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Setting a signal's exporter to {@code none} disables the built-in exporter for that signal even
+ * when coexistence is enabled.
+ */
+public class OtlpExporterCoexistenceNoneWinsTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.otel.traces.exporter", "none")
+            .overrideConfigKey("quarkus.otel.exporter.otlp.experimental.default-enabled", "true");
+
+    @Inject
+    Instance<SpanExporter> spanExporters;
+
+    @Test
+    void noneDisablesTheBuiltInExporterDespiteCoexistence() {
+        assertThat(spanExporters.isResolvable()).isFalse();
+        assertThat(spanExporters.stream()).isEmpty();
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpMultipleMetricExportersTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpMultipleMetricExportersTest.java
@@ -1,0 +1,72 @@
+package io.quarkus.opentelemetry.deployment.exporter.otlp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Two custom {@link MetricExporter} beans must not cause an {@code AmbiguousResolutionException}
+ * when the SDK asks the CDI provider for the metric exporter. The provider composites them, so the
+ * application boots and both remain resolvable.
+ */
+public class OtlpMultipleMetricExportersTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClasses(CustomMetricExporterA.class, CustomMetricExporterB.class))
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "true");
+
+    @Inject
+    Instance<MetricExporter> metricExporters;
+
+    @Test
+    void bothCustomMetricExportersBootAndResolve() {
+        assertThat(metricExporters.stream()).hasSizeGreaterThanOrEqualTo(2);
+        assertThat(metricExporters.stream()).anyMatch(CustomMetricExporterA.class::isInstance);
+        assertThat(metricExporters.stream()).anyMatch(CustomMetricExporterB.class::isInstance);
+    }
+
+    abstract static class AbstractCustomMetricExporter implements MetricExporter {
+        @Override
+        public CompletableResultCode export(Collection<MetricData> metrics) {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+            return AggregationTemporality.CUMULATIVE;
+        }
+    }
+
+    @Singleton
+    public static class CustomMetricExporterA extends AbstractCustomMetricExporter {
+    }
+
+    @Singleton
+    public static class CustomMetricExporterB extends AbstractCustomMetricExporter {
+    }
+}

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/AutoConfiguredOpenTelemetrySdkBuilderCustomizer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/AutoConfiguredOpenTelemetrySdkBuilderCustomizer.java
@@ -336,6 +336,8 @@ public interface AutoConfiguredOpenTelemetrySdkBuilderCustomizer {
                             return metricExporter;
                         }
                     })
+                    // TODO Support more than a meeter reader and get rif of the CompositeMetricExporter.
+                    //  See: https://github.com/open-telemetry/opentelemetry-java/issues/4553
                     .addMetricReaderCustomizer(new BiFunction<MetricReader, ConfigProperties, MetricReader>() {
                         @Override
                         public MetricReader apply(MetricReader metricReader, ConfigProperties configProperties) {

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/build/exporter/OtlpExporterBuildConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/build/exporter/OtlpExporterBuildConfig.java
@@ -13,4 +13,24 @@ public interface OtlpExporterBuildConfig {
      */
     @WithDefault("true")
     boolean enabled();
+
+    /**
+     * Experimental OTLP exporter options that may change or be removed in a future version.
+     */
+    Experimental experimental();
+
+    interface Experimental {
+        /**
+         * If `true`, the built-in OTLP exporter is created even when another exporter
+         * (a CDI bean or a Quarkiverse extension exporter) is already present for a signal, so both
+         * export the same telemetry. This applies to all signals (traces, metrics and logs).
+         * <p>
+         * Setting a signal `exporter` to `none` still disables the built-in exporter for that signal,
+         * regardless of this option.
+         * <p>
+         * This is a build time property. Defaults to `false`.
+         */
+        @WithDefault("false")
+        boolean defaultEnabled();
+    }
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/metrics/CompositeMetricExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/metrics/CompositeMetricExporter.java
@@ -1,0 +1,96 @@
+package io.quarkus.opentelemetry.runtime.exporter.otlp.metrics;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+
+/**
+ * A {@link MetricExporter} that fans out to several delegates, so the built-in OTLP exporter can
+ * coexist with additional exporters (CDI beans or Quarkiverse extension exporters).
+ * <p>
+ * Each delegate is invoked independently: a delegate that throws does not prevent the others from
+ * running, and its failure is folded into the aggregated result.
+ */
+public final class CompositeMetricExporter implements MetricExporter {
+
+    private static final Logger log = Logger.getLogger(CompositeMetricExporter.class);
+
+    private final List<MetricExporter> delegates;
+
+    private CompositeMetricExporter(List<MetricExporter> delegates) {
+        this.delegates = delegates;
+    }
+
+    /**
+     * Collapses the given exporters into a single {@link MetricExporter}: an empty collection returns
+     * the Noop exporter, a single element is returned as-is, and multiple elements are wrapped in a
+     * {@link CompositeMetricExporter}.
+     */
+    public static MetricExporter of(Collection<MetricExporter> exporters) {
+        List<MetricExporter> delegates = new ArrayList<>(exporters);
+        if (delegates.isEmpty()) {
+            return NoopMetricExporter.INSTANCE;
+        }
+        if (delegates.size() == 1) {
+            return delegates.get(0);
+        }
+        return new CompositeMetricExporter(delegates);
+    }
+
+    @Override
+    public CompletableResultCode export(Collection<MetricData> metrics) {
+        List<CompletableResultCode> results = new ArrayList<>(delegates.size());
+        for (MetricExporter delegate : delegates) {
+            try {
+                results.add(delegate.export(metrics));
+            } catch (RuntimeException e) {
+                log.debugf(e, "Exception thrown by metric exporter %s", delegate.getClass().getName());
+                results.add(CompletableResultCode.ofFailure());
+            }
+        }
+        return CompletableResultCode.ofAll(results);
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+        List<CompletableResultCode> results = new ArrayList<>(delegates.size());
+        for (MetricExporter delegate : delegates) {
+            try {
+                results.add(delegate.flush());
+            } catch (RuntimeException e) {
+                log.debugf(e, "Exception thrown while flushing metric exporter %s", delegate.getClass().getName());
+                results.add(CompletableResultCode.ofFailure());
+            }
+        }
+        return CompletableResultCode.ofAll(results);
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+        List<CompletableResultCode> results = new ArrayList<>(delegates.size());
+        for (MetricExporter delegate : delegates) {
+            try {
+                results.add(delegate.shutdown());
+            } catch (RuntimeException e) {
+                log.debugf(e, "Exception thrown while shutting down metric exporter %s", delegate.getClass().getName());
+                results.add(CompletableResultCode.ofFailure());
+            }
+        }
+        return CompletableResultCode.ofAll(results);
+    }
+
+    @Override
+    public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+        // A MeterProvider registers a single temporality per exporter, so we honor the first
+        // delegate's preference. Mixing exporters that disagree on temporality is not supported.
+        return delegates.get(0).getAggregationTemporality(instrumentType);
+    }
+}

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/spi/LogsExporterCDIProvider.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/spi/LogsExporterCDIProvider.java
@@ -29,8 +29,10 @@ public class LogsExporterCDIProvider implements ConfigurableLogRecordExporterPro
         if (exporters.isUnsatisfied()) {
             return NoopLogRecordExporter.INSTANCE;
         } else {
-            log.debugf("using exporter: %s", exporters.get().getClass().getName());
-            return exporters.get();
+            // Fan out to every exporter so the built-in OTLP exporter can coexist with additional
+            // exporters (CDI beans or Quarkiverse extension exporters). The SDK composite isolates
+            // per-delegate failures.
+            return LogRecordExporter.composite(exporters.stream().toList());
         }
     }
 

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/metrics/spi/MetricsExporterCDIProvider.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/metrics/spi/MetricsExporterCDIProvider.java
@@ -11,6 +11,7 @@ import org.jboss.logging.Logger;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.quarkus.opentelemetry.runtime.exporter.otlp.metrics.CompositeMetricExporter;
 import io.quarkus.opentelemetry.runtime.exporter.otlp.metrics.NoopMetricExporter;
 
 public class MetricsExporterCDIProvider implements ConfigurableMetricExporterProvider {
@@ -29,7 +30,7 @@ public class MetricsExporterCDIProvider implements ConfigurableMetricExporterPro
         if (exporters.isUnsatisfied()) {
             return NoopMetricExporter.INSTANCE;
         } else {
-            return exporters.get();
+            return CompositeMetricExporter.of(exporters.stream().toList());
         }
     }
 

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/metrics/CompositeMetricExporterTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/metrics/CompositeMetricExporterTest.java
@@ -1,0 +1,131 @@
+package io.quarkus.opentelemetry.runtime.exporter.otlp.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+
+class CompositeMetricExporterTest {
+
+    @Test
+    void ofEmptyReturnsNoop() {
+        assertThat(CompositeMetricExporter.of(List.of())).isSameAs(NoopMetricExporter.INSTANCE);
+    }
+
+    @Test
+    void ofSingleReturnsSameInstance() {
+        MetricExporter single = new RecordingMetricExporter(AggregationTemporality.CUMULATIVE);
+        assertThat(CompositeMetricExporter.of(List.of(single))).isSameAs(single);
+    }
+
+    @Test
+    void fansOutToAllDelegates() {
+        RecordingMetricExporter first = new RecordingMetricExporter(AggregationTemporality.CUMULATIVE);
+        RecordingMetricExporter second = new RecordingMetricExporter(AggregationTemporality.DELTA);
+
+        MetricExporter composite = CompositeMetricExporter.of(List.of(first, second));
+        assertThat(composite).isInstanceOf(CompositeMetricExporter.class);
+
+        assertThat(composite.export(List.of()).isSuccess()).isTrue();
+        assertThat(composite.flush().isSuccess()).isTrue();
+        assertThat(composite.shutdown().isSuccess()).isTrue();
+
+        assertThat(first.exportCount.get()).isEqualTo(1);
+        assertThat(second.exportCount.get()).isEqualTo(1);
+        assertThat(first.flushCount.get()).isEqualTo(1);
+        assertThat(second.flushCount.get()).isEqualTo(1);
+        assertThat(first.shutdownCount.get()).isEqualTo(1);
+        assertThat(second.shutdownCount.get()).isEqualTo(1);
+
+        // temporality follows the first delegate
+        assertThat(composite.getAggregationTemporality(InstrumentType.COUNTER))
+                .isEqualTo(AggregationTemporality.CUMULATIVE);
+    }
+
+    @Test
+    void oneThrowingDelegateDoesNotStopTheOthers() {
+        RecordingMetricExporter before = new RecordingMetricExporter(AggregationTemporality.CUMULATIVE);
+        ThrowingMetricExporter throwing = new ThrowingMetricExporter();
+        RecordingMetricExporter after = new RecordingMetricExporter(AggregationTemporality.CUMULATIVE);
+
+        MetricExporter composite = CompositeMetricExporter.of(List.of(before, throwing, after));
+
+        // The failure of one delegate is folded into the aggregated result...
+        assertThat(composite.export(List.of()).isSuccess()).isFalse();
+        assertThat(composite.flush().isSuccess()).isFalse();
+        assertThat(composite.shutdown().isSuccess()).isFalse();
+
+        // ...but the delegates surrounding the failing one still run.
+        assertThat(before.exportCount.get()).isEqualTo(1);
+        assertThat(after.exportCount.get()).isEqualTo(1);
+        assertThat(before.flushCount.get()).isEqualTo(1);
+        assertThat(after.flushCount.get()).isEqualTo(1);
+        assertThat(before.shutdownCount.get()).isEqualTo(1);
+        assertThat(after.shutdownCount.get()).isEqualTo(1);
+    }
+
+    private static final class ThrowingMetricExporter implements MetricExporter {
+        @Override
+        public CompletableResultCode export(Collection<MetricData> metrics) {
+            throw new RuntimeException("boom on export");
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            throw new RuntimeException("boom on flush");
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            throw new RuntimeException("boom on shutdown");
+        }
+
+        @Override
+        public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+            return AggregationTemporality.CUMULATIVE;
+        }
+    }
+
+    private static final class RecordingMetricExporter implements MetricExporter {
+        final AtomicInteger exportCount = new AtomicInteger();
+        final AtomicInteger flushCount = new AtomicInteger();
+        final AtomicInteger shutdownCount = new AtomicInteger();
+        final AggregationTemporality temporality;
+
+        RecordingMetricExporter(AggregationTemporality temporality) {
+            this.temporality = temporality;
+        }
+
+        @Override
+        public CompletableResultCode export(Collection<MetricData> metrics) {
+            exportCount.incrementAndGet();
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            flushCount.incrementAndGet();
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            shutdownCount.incrementAndGet();
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+            return temporality;
+        }
+    }
+}

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/coexistence/CoexistenceGrpcTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/coexistence/CoexistenceGrpcTest.java
@@ -1,0 +1,104 @@
+package io.quarkus.it.opentelemetry.vertx.exporter.coexistence;
+
+import static io.restassured.RestAssured.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.opentelemetry.proto.metrics.v1.Metric;
+import io.opentelemetry.proto.trace.v1.Span;
+import io.quarkus.it.opentelemetry.vertx.exporter.Logs;
+import io.quarkus.it.opentelemetry.vertx.exporter.Metrics;
+import io.quarkus.it.opentelemetry.vertx.exporter.OtelCollectorLifecycleManager;
+import io.quarkus.it.opentelemetry.vertx.exporter.Traces;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * End-to-end test proving coexistence: with the flag on, a single request produces telemetry that
+ * reaches both the built-in OTLP exporter (received by the collector) and a custom CDI exporter
+ * (captured in-application), for traces, metrics and logs.
+ */
+@QuarkusTest
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "protocol", value = "grpc"), restrictToAnnotatedClass = true)
+@TestProfile(CoexistenceProfile.class)
+public class CoexistenceGrpcTest {
+
+    // Injected by OtelCollectorLifecycleManager.
+    Traces traces;
+    Metrics metrics;
+    Logs logs;
+
+    @Inject
+    CoexistenceProfile.CapturedTelemetry captured;
+
+    @Test
+    void builtInAndCustomExportersBothReceiveTelemetry() {
+        when()
+                .get("/hello")
+                .then()
+                .statusCode(200);
+
+        // The built-in OTLP exporter still sends everything to the collector.
+        await().atMost(Duration.ofSeconds(30))
+                .untilAsserted(() -> assertThat(collectorSpanNames()).contains("GET /hello"));
+        await().atMost(Duration.ofSeconds(30))
+                .untilAsserted(() -> assertThat(collectorMetricNames()).contains("hello"));
+        await().atMost(Duration.ofSeconds(30))
+                .untilAsserted(() -> assertThat(collectorLogBodies()).contains("Hello World"));
+
+        // The custom CDI exporters receive the same telemetry.
+        await().atMost(Duration.ofSeconds(30))
+                .untilAsserted(() -> assertThat(captured.getSpanCount()).isGreaterThan(0));
+        await().atMost(Duration.ofSeconds(30))
+                .untilAsserted(() -> assertThat(captured.getMetricNames()).contains("hello"));
+        await().atMost(Duration.ofSeconds(30))
+                .untilAsserted(() -> assertThat(captured.getLogBodies()).contains("Hello World"));
+    }
+
+    private List<String> collectorSpanNames() {
+        return traces.getTraceRequests().stream()
+                .flatMap(req -> req.getResourceSpansList().stream())
+                .flatMap(resourceSpans -> resourceSpans.getScopeSpansList().stream())
+                .flatMap(scopeSpans -> scopeSpans.getSpansList().stream())
+                .map(Span::getName)
+                .toList();
+    }
+
+    private List<String> collectorMetricNames() {
+        return metrics.getMetricRequests().stream()
+                .flatMap(req -> req.getResourceMetricsList().stream())
+                .flatMap(resourceMetrics -> resourceMetrics.getScopeMetricsList().stream())
+                .flatMap(scopeMetrics -> scopeMetrics.getMetricsList().stream())
+                .map(Metric::getName)
+                .toList();
+    }
+
+    private List<String> collectorLogBodies() {
+        return logs.getLogsRequests().stream()
+                .flatMap(req -> req.getResourceLogsList().stream())
+                .flatMap(resourceLogs -> resourceLogs.getScopeLogsList().stream())
+                .flatMap(scopeLogs -> scopeLogs.getLogRecordsList().stream())
+                .map(logRecord -> logRecord.getBody().getStringValue())
+                .toList();
+    }
+
+    @BeforeEach
+    @AfterEach
+    void resetTelemetry() {
+        traces.reset();
+        metrics.reset();
+        logs.reset();
+        captured.reset();
+    }
+}

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/coexistence/CoexistenceProfile.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/coexistence/CoexistenceProfile.java
@@ -1,0 +1,174 @@
+package io.quarkus.it.opentelemetry.vertx.exporter.coexistence;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import io.opentelemetry.api.common.Value;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.quarkus.arc.Unremovable;
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+/**
+ * Enables coexistence so the built-in OTLP exporter is created alongside the custom capturing
+ * exporters. This is a build-time flag, so it must be set through a profile to get its own
+ * augmentation, keeping the other exporter tests unaffected.
+ * <p>
+ * The capturing exporters and their telemetry holder are declared as nested static beans: per
+ * {@link QuarkusTestProfile}, such beans are only active when this profile is used, so they do not
+ * leak into the other exporter tests. That is why no {@code @IfBuildProperty} gating is needed.
+ */
+public final class CoexistenceProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("quarkus.otel.exporter.otlp.experimental.default-enabled", "true");
+    }
+
+    /**
+     * In-application holder that records what the custom CDI exporters received, so a test can
+     * assert the built-in OTLP exporter and a custom exporter both got the same telemetry.
+     */
+    @ApplicationScoped
+    public static class CapturedTelemetry {
+
+        private final AtomicInteger spanCount = new AtomicInteger();
+        private final List<String> metricNames = new CopyOnWriteArrayList<>();
+        private final List<String> logBodies = new CopyOnWriteArrayList<>();
+
+        public void addSpans(int count) {
+            spanCount.addAndGet(count);
+        }
+
+        public void addMetricName(String name) {
+            metricNames.add(name);
+        }
+
+        public void addLogBody(String body) {
+            logBodies.add(body);
+        }
+
+        public int getSpanCount() {
+            return spanCount.get();
+        }
+
+        public List<String> getMetricNames() {
+            return metricNames;
+        }
+
+        public List<String> getLogBodies() {
+            return logBodies;
+        }
+
+        public void reset() {
+            spanCount.set(0);
+            metricNames.clear();
+            logBodies.clear();
+        }
+    }
+
+    /**
+     * Custom span exporter that records into {@link CapturedTelemetry}.
+     */
+    @Singleton
+    @Unremovable
+    public static class CapturingSpanExporter implements SpanExporter {
+
+        @Inject
+        CapturedTelemetry captured;
+
+        @Override
+        public CompletableResultCode export(Collection<SpanData> spans) {
+            captured.addSpans(spans.size());
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+        }
+    }
+
+    /**
+     * Custom metric exporter that records into {@link CapturedTelemetry}.
+     */
+    @Singleton
+    @Unremovable
+    public static class CapturingMetricExporter implements MetricExporter {
+
+        @Inject
+        CapturedTelemetry captured;
+
+        @Override
+        public CompletableResultCode export(Collection<MetricData> metrics) {
+            for (MetricData metric : metrics) {
+                captured.addMetricName(metric.getName());
+            }
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+            return AggregationTemporality.CUMULATIVE;
+        }
+    }
+
+    /**
+     * Custom log record exporter that records into {@link CapturedTelemetry}.
+     */
+    @Singleton
+    @Unremovable
+    public static class CapturingLogRecordExporter implements LogRecordExporter {
+
+        @Inject
+        CapturedTelemetry captured;
+
+        @Override
+        public CompletableResultCode export(Collection<LogRecordData> logs) {
+            for (LogRecordData log : logs) {
+                Value<?> body = log.getBodyValue();
+                captured.addLogBody(body == null ? "" : body.asString());
+            }
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+        }
+    }
+}


### PR DESCRIPTION
This PR allows the coexistence of many OTel exporters at the same time. 
The default is the current behavior, only one is allowed and if none is found, the quarkus default exporter is instantiated.  

This is another approach to https://github.com/quarkusio/quarkus/pull/53636, originally implemented by @amalsebs. He is listed as co-author of the current commit. 

There is a TODO in the code for later as we should overcome the limitations of using a `CompositeMetricExporter`, but that requires a rewire of the metrics exporter and readers. Out of scope for now and the `CompositeMetricExporter` is good enough for now. 

- Fixes: https://github.com/quarkusio/quarkus/issues/36500