### PR TITLE
Doc - place callout lists after source listings

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry-metrics.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-metrics.adoc
@@ -120,13 +120,12 @@ public class MetricResource {
     }
 }
 ----
-
-Quarkus is not currently producing metrics out of the box.
-Here we are creating a counter for the number of invocations of the `hello()` method.
-
 <1> Constructor injection of the `Meter` instance.
 <2> Create a `LongCounter` named `hello-metrics` with a description and unit.
 <3> Increment the counter by one for each invocation of the `hello()` method.
+
+Quarkus is not currently producing metrics out of the box.
+Here we are creating a counter for the number of invocations of the `hello()` method.
 
 === Create the configuration
 

--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -489,9 +489,6 @@ public class ExtensionsResource {
     }
 }
 ----
-
-There are two interesting parts in this listing:
-
 <1> the client stub is injected with the `@RestClient` annotation instead of the usual CDI `@Inject`
 <2> `org.jboss.resteasy.reactive.RestResponse` used as effective way of getting response properties via RestResponse directly from RestClient, 
 as described in <<Using RestResponse>>
@@ -1938,9 +1935,6 @@ public interface CRMService {
     }
 }
 ----
-
-The code uses the following pieces:
-
 <1>  `@ClientHeaderParam(name = "Content-Type", value = "{calculateContentType}")` which ensures that the `Content-Type` header is created by calling the interface's `calculateContentType` default method.
 <2> The aforementioned parameter needs to be annotated with `@NotBody` because it is only used to aid the construction of HTTP headers.
 <3> `context.methodParameters().get(1).value()` which allows the `calculateContentType` method to obtain the proper method parameter passed to the REST Client method.

--- a/docs/src/main/asciidoc/security-getting-started-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-getting-started-tutorial.adoc
@@ -281,9 +281,6 @@ public class User extends PanacheEntity {
     }
 }
 ----
-
-The `quarkus-security-jpa` extension only initializes if a single entity is annotated with `@UserDefinition`.
-
 <1> The `@UserDefinition` annotation must be present on a single entity, either a regular Hibernate ORM entity or a Hibernate ORM with Panache entity.
 <2> Indicates the field used for the username.
 <3> Indicates the field used for the password.
@@ -295,6 +292,8 @@ The `BcryptUtil.bcryptHash()` method:
 * Automatically generates a random salt for each password.
 * Hashes the password using bcrypt with 10 iterations (default).
 * Returns the hash in Modular Crypt Format (MCF), which includes the algorithm identifier, cost parameter, salt, and hash.
+
+The `quarkus-security-jpa` extension only initializes if a single entity is annotated with `@UserDefinition`.
 
 [TIP]
 ====

--- a/docs/src/main/asciidoc/security-jdbc.adoc
+++ b/docs/src/main/asciidoc/security-jdbc.adoc
@@ -211,12 +211,11 @@ quarkus.security.jdbc.principal-query.bcrypt-password-mapper.password-index=1
 quarkus.security.jdbc.principal-query.attribute-mappings.0.index=2 <3>
 quarkus.security.jdbc.principal-query.attribute-mappings.0.to=groups
 ----
-
-The `elytron-security-jdbc` extension requires at least one principal query to authenticate the user and its identity.
-
 <1> We define a parameterized SQL statement (with exactly 1 parameter) which should return the user's password plus any additional information you want to load.
 <2> The password mapper is configured with the position of the password field in the `SELECT` fields. The hash is stored in the Modular Crypt Format (MCF) because the salt and iteration count indexes are set to `-1` by default. You can override them in order to decompose each element into three separate columns.
 <3> We use `attribute-mappings` to bind the `SELECT` projection fields (i.e. `u.role` here) to the target Principal representation attributes.
+
+The `elytron-security-jdbc` extension requires at least one principal query to authenticate the user and its identity.
 
 [NOTE]
 ====

--- a/docs/src/main/asciidoc/security-jpa.adoc
+++ b/docs/src/main/asciidoc/security-jpa.adoc
@@ -76,9 +76,6 @@ public class User extends PanacheEntity {
 }
 
 ----
-
-The `quarkus-security-jpa` extension initializes only if a single entity is annotated with `@UserDefinition`.
-
 <1> Table name. Do not define it as `user`, which is a restricted keyword in most databases.
 <2> The `@UserDefinition` annotation must be present on a single entity, either a regular Hibernate ORM entity or a Hibernate ORM with Panache entity.
 <3> Indicates the field used for the username.
@@ -86,6 +83,8 @@ The `quarkus-security-jpa` extension initializes only if a single entity is anno
 By default, `quarkus-security-jpa` uses bcrypt-hashed passwords, or you can configure plain text or custom passwords instead.
 <5> This indicates the comma-separated list of roles added to the target principal representation attributes.
 <6> This method lets you add users while hashing passwords with the proper `bcrypt` hash.
+
+The `quarkus-security-jpa` extension initializes only if a single entity is annotated with `@UserDefinition`.
 
 
 == Jakarta Persistence entity as storage of roles

--- a/docs/src/main/asciidoc/stork-kubernetes.adoc
+++ b/docs/src/main/asciidoc/stork-kubernetes.adoc
@@ -283,9 +283,6 @@ spec:
             pathType: Prefix
 
 ----
-
-There are a few interesting parts in this listing:
-
 <1> The Kubernetes Service resource, `color-service`, that Stork will discover.
 <2> The Red and Blue service instances behind the `color-service` Kubernetes service.
 <3> A Kubernetes Ingress resource making the `color-service` accessible from the outside of the cluster at the `color-service.127.0.0.1.nip.io` url. Note that the Ingress is not needed for Stork however, it helps to check that the architecture is in place.

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -1143,6 +1143,11 @@ public class LoggingProcessor {
     LogConfiguration config; // <3>
 }
 ----
+<1> The `@ConfigMapping` annotation indicates that the interface is a configuration mapping, in this case one which
+corresponds to a `quarkus.log` segment.
+<2> The `@ConfigRoot` annotation indicated to which Config phase, the configuration applies to.
+<3> Here the `LoggingProcessor` injects a `LogConfiguration` instance automatically by detecting the `@ConfigRoot`
+annotation.
 
 A configuration property name can be split into segments. For example, a property name like
 `quarkus.log.file.enabled` can be split into the following segments:
@@ -1151,12 +1156,6 @@ A configuration property name can be split into segments. For example, a propert
 * `log` - a name segment which corresponds to the prefix set in the interface annotated with `@ConfigMapping`,
 * `file` - a name segment which corresponds to the `file` field in this class,
 * `enabled` - a name segment which corresponds to `enabled` field in `FileConfig`.
-
-<1> The `@ConfigMapping` annotation indicates that the interface is a configuration mapping, in this case one which
-corresponds to a `quarkus.log` segment.
-<2> The `@ConfigRoot` annotation indicated to which Config phase, the configuration applies to.
-<3> Here the `LoggingProcessor` injects a `LogConfiguration` instance automatically by detecting the `@ConfigRoot`
-annotation.
 
 A corresponding `application.properties` for the above example could be:
 


### PR DESCRIPTION
AsciiDoc callout lists cannot sit in the same paragraph as the listing that closed on the previous line. Several guides still had that pattern after #56391.

Move the remaining callout lists onto their own lines. Left `doc-contribute-docs-howto.adoc` alone because #56240 already covers it.

Fixes #56386
