### PR TITLE
Remove orphaned callout markers with missing explanations

### DIFF
--- a/docs/src/main/asciidoc/infinispan-client.adoc
+++ b/docs/src/main/asciidoc/infinispan-client.adoc
@@ -147,7 +147,7 @@ is explicitly added.
 [source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
 .build.gradle
 ----
-annotationProcessor 'org.infinispan.protostream:protostream-processor:{infinispan-protostream-version}' <1>
+annotationProcessor 'org.infinispan.protostream:protostream-processor:{infinispan-protostream-version}'
 ----
 ====
 

--- a/docs/src/main/asciidoc/quarkus-data-hibernate.adoc
+++ b/docs/src/main/asciidoc/quarkus-data-hibernate.adoc
@@ -685,7 +685,7 @@ mode: if you don't, a dev service will be provided for you):
 ----
 quarkus.datasource.username = quarkus_test
 quarkus.datasource.password = quarkus_test
-quarkus.datasource.reactive.url = vertx-reactive:postgresql://localhost/quarkus_test <1>
+quarkus.datasource.reactive.url = vertx-reactive:postgresql://localhost/quarkus_test
 ----
 
 Now, in your code, the only differences with a regular managed session entity are:

--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -1791,7 +1791,7 @@ This can be done by setting a special attribute via `TemplateInstance.setVariant
 class MyService {
 
     @Inject
-    Template items; <1>
+    Template items;
 
     @Inject
     ItemManager manager;

--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -1842,7 +1842,7 @@ In a similar fashion if the received server multipart request is known and looks
 
 [source, java]
 ----
-public class Request { // <1>
+public class Request {
 
   @RestForm("files")
   @PartType(MediaType.APPLICATION_OCTET_STREAM)

--- a/docs/src/main/asciidoc/rest.adoc
+++ b/docs/src/main/asciidoc/rest.adoc
@@ -2053,7 +2053,7 @@ public class RecordsResource {
     @Path("/search/{text}")
     @RestLink(rel = "search records by free text")
     @InjectRestLinks
-    public List<Record> search(@PathParam("text") String text) { <4>
+    public List<Record> search(@PathParam("text") String text) {
         // ...
     }
 

--- a/docs/src/main/asciidoc/websockets-next-reference.adoc
+++ b/docs/src/main/asciidoc/websockets-next-reference.adoc
@@ -94,7 +94,7 @@ package org.acme.websockets;
 import io.quarkus.websockets.next.WebSocket;
 import jakarta.inject.Inject;
 
-@WebSocket(path = "/chat/{username}") <1>
+@WebSocket(path = "/chat/{username}")
 public class ChatWebSocket {
 
 }
@@ -118,7 +118,7 @@ package org.acme.websockets;
 import io.quarkus.websockets.next.WebSocketClient;
 import jakarta.inject.Inject;
 
-@WebSocketClient(path = "/chat/{username}") <1>
+@WebSocketClient(path = "/chat/{username}")
 public class ChatWebSocket {
 
 }


### PR DESCRIPTION
Fixes part of #56386 (Section: "Orphaned callouts (no explanation list at all)")

### Description

Removes orphaned `<1>` and `<4>` callout markers in code listings that have no corresponding explanation list below, preventing broken/unlinked callout annotations from rendering in the documentation:

- `docs/src/main/asciidoc/infinispan-client.adoc:150` — removed dangling `<1>` on gradle annotationProcessor line.
- `docs/src/main/asciidoc/quarkus-data-hibernate.adoc:688` — removed dangling `<1>` on reactive url property line.
- `docs/src/main/asciidoc/rest.adoc:2056` — removed dangling `<4>` on search method line.
- `docs/src/main/asciidoc/rest-client.adoc:1845` — removed dangling `// <1>` on Request class line.
- `docs/src/main/asciidoc/qute-reference.adoc:1794` — removed dangling `<1>` on Template items line.
- `docs/src/main/asciidoc/websockets-next-reference.adoc:97, 121` — removed dangling `<1>` on `@WebSocket` and `@WebSocketClient` definitions.
