### PR TITLE
Signals: propagate OpenTelemetry trace context to receivers

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry-tracing.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-tracing.adoc
@@ -850,6 +850,7 @@ See the main xref:opentelemetry.adoc#exporters[OpenTelemetry Guide exporters] se
 * https://quarkus.io/guides/resteasy[`quarkus-resteasy`]
 * https://quarkus.io/guides/resteasy-client[`quarkus-resteasy-client`]
 * https://quarkus.io/guides/scheduler[`quarkus-scheduler`]
+* https://quarkus.io/guides/signals[`quarkus-signals`]
 * https://quarkus.io/guides/smallrye-graphql[`quarkus-smallrye-graphql`]
 * https://quarkus.io/extensions/io.quarkus/quarkus-mongodb-client[`quarkus-mongodb-client`]
 * https://quarkus.io/extensions/io.quarkus/quarkus-messaging[`quarkus-messaging`]

--- a/docs/src/main/asciidoc/signals.adoc
+++ b/docs/src/main/asciidoc/signals.adoc
@@ -520,6 +520,35 @@ NOTE: The Signals resolution model deviates from CDI observer resolution in two 
 * Use *CDI events* for simple publish/subscribe notifications between components, especially when you need synchronous delivery, transactional observers, or ordering of observers, or when you need to stay with the standard Jakarta EE API.
 * Use the *Vert.x EventBus* when you need to interact with the underlying Vert.x runtime directly or integrate with existing Vert.x components.
 
+== OpenTelemetry Tracing
+
+If the xref:opentelemetry.adoc[OpenTelemetry extension] is present, the active trace context is automatically propagated from the signal emission to the receiver invocations.
+
+Because receivers are executed asynchronously on a separate context, the trace context captured on the emitting thread would otherwise be lost.
+To bridge this gap, when the signal is emitted the active context is captured into the signal metadata under the `quarkus.tracing` key -- as a map of https://www.w3.org/TR/trace-context/[W3C Trace Context] headers (e.g. `traceparent`) -- and restored when a receiver is invoked.
+A new span is created for each receiver invocation.
+When the signal is emitted within an active trace, the span is a child of the emitter's span, so a `publish` emission that reaches multiple receivers results in one child span per receiver.
+Otherwise the span is started as a new root span (i.e. a new trace).
+Each span is named `receive <signal type>` (where `<signal type>` is the raw signal type name) and carries the following attributes:
+
+* `signals.signal.type` -- the signal type, including generic type arguments if any (unlike the span name, which uses the raw type name),
+* `signals.emission.type` -- the emission type (`PUBLISH`, `SEND` or `REQUEST`),
+* `signals.response.type` -- the expected response type; only present for request-reply emissions,
+* `signals.qualifiers` -- the emission qualifiers, excluding the built-in `@Default` and `@Any`; only present if there is at least one such qualifier,
+* `signals.receiver` -- a human-readable name of the receiver; only present if available,
+* `signals.receiver.wait_ms` -- the time in milliseconds elapsed between the emission and the start of the receiver invocation.
+
+If the receiver fails, the span status is set to error and the exception is recorded together with the `error.type` attribute.
+
+NOTE: If the signal metadata already contains a `quarkus.tracing` entry it is left untouched.
+
+This integration is enabled by default and can be disabled with the following configuration property:
+
+[source,properties]
+----
+quarkus.signals.telemetry.traces.enabled=false
+----
+
 == SPI
 
 The `io.quarkus.signals.spi` package provides extension points for integrators.

--- a/extensions/signals/deployment/pom.xml
+++ b/extensions/signals/deployment/pom.xml
@@ -40,6 +40,12 @@
             <artifactId>quarkus-security-test-utils</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Needed for InMemorySpanExporter to verify captured traces -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/extensions/signals/deployment/src/main/java/io/quarkus/signals/deployment/SignalsBuildTimeConfig.java
+++ b/extensions/signals/deployment/src/main/java/io/quarkus/signals/deployment/SignalsBuildTimeConfig.java
@@ -1,0 +1,30 @@
+package io.quarkus.signals.deployment;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
+
+@ConfigMapping(prefix = "quarkus.signals")
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public interface SignalsBuildTimeConfig {
+
+    /**
+     * Telemetry configuration.
+     */
+    Telemetry telemetry();
+
+    interface Telemetry {
+
+        /**
+         * If collection of signal traces is enabled. When enabled, the trace context is propagated from the signal
+         * emission to the receiver invocations, and a span is created for each receiver invocation.
+         * <p>
+         * Only applicable when the OpenTelemetry extension is present.
+         */
+        @WithName("traces.enabled")
+        @WithDefault("true")
+        boolean tracesEnabled();
+    }
+}

--- a/extensions/signals/deployment/src/main/java/io/quarkus/signals/deployment/SignalsProcessor.java
+++ b/extensions/signals/deployment/src/main/java/io/quarkus/signals/deployment/SignalsProcessor.java
@@ -278,7 +278,8 @@ class SignalsProcessor {
                         Expr receiveInfo = bc.new_(InvokerReceiverInfo.class,
                                 Const.of(receiver.getSignalParam().position()),
                                 Const.of(receiver.getSignalParam().type().name().equals(DotNames.SIGNAL_CONTEXT)),
-                                Const.of((short) receiver.getMethod().parametersCount()));
+                                Const.of((short) receiver.getMethod().parametersCount()),
+                                Const.of(receiver.getMethod().declaringClass().name() + "#" + receiver.getMethod().name()));
                         bc.invokeSpecial(ConstructorDesc.of(InvokerReceiver.class, Invoker.class, InvokerReceiverInfo.class),
                                 cc.this_(), invoker, receiveInfo);
 
@@ -359,6 +360,19 @@ class SignalsProcessor {
                 .creator(SignalBeanCreator.class)
                 .forceApplicationClass()
                 .done());
+    }
+
+    @BuildStep
+    void registerTracing(Capabilities capabilities, SignalsBuildTimeConfig config,
+            BuildProducer<AdditionalBeanBuildItem> beans) {
+        if (config.telemetry().tracesEnabled() && capabilities.isPresent(Capability.OPENTELEMETRY_TRACER)) {
+            // The classes are referenced by name so that OpenTelemetry types are not loaded when the capability is absent
+            beans.produce(AdditionalBeanBuildItem.builder()
+                    .addBeanClasses(
+                            "io.quarkus.signals.runtime.tracing.TracingSignalMetadataEnricher",
+                            "io.quarkus.signals.runtime.tracing.TracingReceiverInterceptor")
+                    .build());
+        }
     }
 
     @BuildStep

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/ResolveReceiversTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/ResolveReceiversTest.java
@@ -47,6 +47,7 @@ public class ResolveReceiversTest extends AbstractSignalTest {
         assertThat(infos).allMatch(i -> i.kind() == ReceiverKind.DECLARATIVE);
         assertThat(infos).allMatch(i -> i.signalType() == Event.class);
         assertThat(infos).allMatch(i -> i.responseType() == void.class);
+        assertThat(infos).allMatch(i -> i.name().endsWith("MyReceivers#onEvent"));
     }
 
     @Test
@@ -61,7 +62,24 @@ public class ResolveReceiversTest extends AbstractSignalTest {
             assertThat(infos).hasSize(2);
             assertThat(infos).anyMatch(i -> i.kind() == ReceiverKind.PROGRAMMATIC
                     && i.executionModel() == ExecutionModel.NON_BLOCKING
-                    && i.responseType() == String.class);
+                    && i.responseType() == String.class
+                    && i.name() == null);
+        } finally {
+            reg.unregister();
+        }
+    }
+
+    @Test
+    public void testProgrammaticReceiverName() {
+        Consumer<SignalContext<Event>> noop = ctx -> {
+        };
+        Receivers.Registration reg = receivers.newReceiver(Event.class)
+                .setName("my-event-receiver")
+                .notify(noop);
+        try {
+            List<ReceiverInfo> infos = receivers.resolveReceivers(Event.class);
+            assertThat(infos).anyMatch(i -> i.kind() == ReceiverKind.PROGRAMMATIC
+                    && "my-event-receiver".equals(i.name()));
         } finally {
             reg.unregister();
         }

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/tracing/InMemorySpanExporterProducer.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/tracing/InMemorySpanExporterProducer.java
@@ -1,0 +1,18 @@
+package io.quarkus.signals.deployment.test.tracing;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+
+@ApplicationScoped
+public class InMemorySpanExporterProducer {
+
+    @Produces
+    @Singleton
+    InMemorySpanExporter inMemorySpanExporter() {
+        return InMemorySpanExporter.create();
+    }
+
+}

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/tracing/OpenTelemetrySignalsTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/tracing/OpenTelemetrySignalsTest.java
@@ -1,0 +1,312 @@
+package io.quarkus.signals.deployment.test.tracing;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.time.Duration;
+import java.util.List;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Inject;
+import jakarta.inject.Qualifier;
+import jakarta.inject.Singleton;
+
+import org.awaitility.Awaitility;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.signals.Receivers;
+import io.quarkus.signals.Receivers.ExecutionModel;
+import io.quarkus.signals.Receives;
+import io.quarkus.signals.Signal;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Verifies that the OpenTelemetry trace context is propagated from a signal emission to the receiver invocations.
+ */
+public class OpenTelemetrySignalsTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(PingReceivers.class, Ping.class, Urgent.class, InMemorySpanExporterProducer.class)
+                    // always_on: record and export every span so the assertions can find them; the short batch
+                    // processor delays make exported spans show up quickly in the in-memory exporter
+                    .addAsResource(new StringAsset("""
+                            quarkus.otel.traces.sampler=always_on
+                            quarkus.otel.bsp.export.timeout=1s
+                            quarkus.otel.bsp.schedule.delay=50
+                            """), "application.properties"))
+            .setForcedDependencies(
+                    List.of(Dependency.of("io.quarkus", "quarkus-opentelemetry-deployment", Version.getVersion())));
+
+    private static final AttributeKey<String> SIGNAL_TYPE = AttributeKey.stringKey("signals.signal.type");
+    private static final AttributeKey<String> EMISSION_TYPE = AttributeKey.stringKey("signals.emission.type");
+    private static final AttributeKey<String> RESPONSE_TYPE = AttributeKey.stringKey("signals.response.type");
+    private static final AttributeKey<Long> WAIT_MS = AttributeKey.longKey("signals.receiver.wait_ms");
+    private static final AttributeKey<String> RECEIVER = AttributeKey.stringKey("signals.receiver");
+    private static final AttributeKey<List<String>> QUALIFIERS = AttributeKey.stringArrayKey("signals.qualifiers");
+    private static final AttributeKey<String> ERROR_TYPE = AttributeKey.stringKey("error.type");
+
+    @Inject
+    Signal<Ping> ping;
+
+    @Inject
+    Signal<Pong> pong;
+
+    @Inject
+    Receivers receivers;
+
+    @Inject
+    InMemorySpanExporter exporter;
+
+    @Inject
+    Tracer tracer;
+
+    @BeforeEach
+    void reset() {
+        exporter.reset();
+    }
+
+    @Test
+    public void testReceiverSpanIsChildOfEmitterSpan() {
+        // Setup: emit a request signal while the "test-parent" span is active on the emitting thread.
+        // Expected: exactly one receiver span, created as a child of the parent span (same trace, parent span id ==
+        // the parent's span id), of kind INTERNAL and carrying the signal/emission/response type, wait time and the
+        // declarative receiver name.
+        Span parent = tracer.spanBuilder("test-parent").startSpan();
+        SpanContext parentCtx = parent.getSpanContext();
+        String result;
+        try (Scope scope = parent.makeCurrent()) {
+            result = ping.reactive().request(new Ping("hello"), String.class)
+                    .ifNoItem().after(Duration.ofSeconds(5)).fail()
+                    .await().indefinitely();
+        } finally {
+            parent.end();
+        }
+        assertEquals("hello", result);
+
+        // Only the "ping" receiver returns a String, so the request resolves to a single receiver -> a single span
+        List<SpanData> spans = awaitReceiveSpans(1);
+        assertEquals(1, spans.size());
+        SpanData child = spans.get(0);
+        assertEquals("receive " + Ping.class.getTypeName(), child.getName());
+        assertEquals(SpanKind.INTERNAL, child.getKind());
+        // Same trace and direct parent-child link with the emitter span
+        assertEquals(parentCtx.getTraceId(), child.getTraceId());
+        assertEquals(parentCtx.getSpanId(), child.getParentSpanId());
+        assertTrue(child.getAttributes().get(SIGNAL_TYPE).endsWith("Ping"));
+        assertEquals("REQUEST", child.getAttributes().get(EMISSION_TYPE));
+        assertEquals(String.class.getTypeName(), child.getAttributes().get(RESPONSE_TYPE));
+        assertNotNull(child.getAttributes().get(WAIT_MS), "The emit-to-receive wait time should be recorded");
+        assertTrue(child.getAttributes().get(RECEIVER).endsWith("PingReceivers#ping"),
+                "The declarative receiver name should be recorded");
+    }
+
+    @Test
+    public void testQualifiersRecorded() {
+        // Setup: narrow the emission to the @Urgent qualifier via select(...); this reaches only the @Urgent-qualified
+        // "urgentPing" receiver (the plain "ping"/"observe" receivers do not match).
+        // Expected: the receiver span records the emission qualifiers, with the built-in @Default (added by select on
+        // top of the @Urgent qualifier) filtered out, leaving only @Urgent.
+        Span parent = tracer.spanBuilder("test-parent").startSpan();
+        String result;
+        try (Scope scope = parent.makeCurrent()) {
+            result = ping.select(Urgent.Literal.INSTANCE)
+                    .reactive().request(new Ping("urgent"), String.class)
+                    .ifNoItem().after(Duration.ofSeconds(5)).fail()
+                    .await().indefinitely();
+        } finally {
+            parent.end();
+        }
+        assertEquals("urgent", result);
+
+        List<SpanData> spans = awaitReceiveSpans(1);
+        assertEquals(1, spans.size());
+        SpanData child = spans.get(0);
+        List<String> qualifiers = child.getAttributes().get(QUALIFIERS);
+        assertNotNull(qualifiers, "The emission qualifiers should be recorded");
+        // Only the user-defined @Urgent qualifier remains; the built-in @Default/@Any are filtered out
+        assertEquals(List.of(Urgent.class.getName()), qualifiers);
+    }
+
+    @Test
+    public void testPublishCreatesSiblingSpans() {
+        // Setup: publish (multicast) a Ping while the "test-parent" span is active; both plain receivers
+        // ("ping" and "observe") match the unqualified emission.
+        // Expected: two sibling receiver spans, each a direct child of the same emitter span (same trace and parent
+        // span id) and tagged with the PUBLISH emission type.
+        Span parent = tracer.spanBuilder("test-parent").startSpan();
+        SpanContext parentCtx = parent.getSpanContext();
+        try (Scope scope = parent.makeCurrent()) {
+            ping.reactive().publish(new Ping("multi"))
+                    .ifNoItem().after(Duration.ofSeconds(5)).fail()
+                    .await().indefinitely();
+        } finally {
+            parent.end();
+        }
+
+        // The two matching receivers -> one span each, both siblings under the emitter span
+        List<SpanData> spans = awaitReceiveSpans(2);
+        assertEquals(2, spans.size());
+        for (SpanData child : spans) {
+            assertEquals(parentCtx.getTraceId(), child.getTraceId());
+            assertEquals(parentCtx.getSpanId(), child.getParentSpanId());
+            assertEquals("PUBLISH", child.getAttributes().get(EMISSION_TYPE));
+        }
+    }
+
+    @Test
+    public void testFailureRecordsErrorStatus() {
+        // Setup: the "ping" receiver throws IllegalStateException for the "boom" payload.
+        // Expected: the receiver span reflects the failure - ERROR status, the exception recorded as a span event, and
+        // the error.type attribute set to the exception class name.
+        Span parent = tracer.spanBuilder("test-parent").startSpan();
+        try (Scope scope = parent.makeCurrent()) {
+            assertThrows(RuntimeException.class, () -> ping.reactive().request(new Ping("boom"), String.class)
+                    .ifNoItem().after(Duration.ofSeconds(5)).fail()
+                    .await().indefinitely());
+        } finally {
+            parent.end();
+        }
+
+        List<SpanData> spans = awaitReceiveSpans(1);
+        SpanData child = spans.get(0);
+        assertEquals(StatusCode.ERROR, child.getStatus().getStatusCode());
+        assertEquals(1, child.getEvents().size(), "The exception should be recorded as a span event");
+        assertEquals(IllegalStateException.class.getName(), child.getAttributes().get(ERROR_TYPE));
+    }
+
+    @Test
+    public void testNoActiveTraceCreatesRootSpan() {
+        // Setup: emit a request with no active trace on the emitting thread (no parent span is made current), so no
+        // trace context is propagated to the receiver.
+        // Expected: the receiver still creates a span, but as a new root span (a brand new trace with no parent), and
+        // it still records the emit-to-receive wait time.
+        String result = ping.reactive().request(new Ping("hello"), String.class)
+                .ifNoItem().after(Duration.ofSeconds(5)).fail()
+                .await().indefinitely();
+        assertEquals("hello", result);
+
+        List<SpanData> spans = awaitReceiveSpans(1);
+        assertEquals(1, spans.size());
+        SpanData child = spans.get(0);
+        assertEquals("receive " + Ping.class.getTypeName(), child.getName());
+        // No propagated parent context -> the span is the root of a new trace
+        assertFalse(child.getParentSpanContext().isValid(), "The receiver span must be a root span (no parent)");
+        assertTrue(child.getAttributes().get(SIGNAL_TYPE).endsWith("Ping"));
+        assertNotNull(child.getAttributes().get(WAIT_MS), "The emit-to-receive wait time should be recorded");
+    }
+
+    @Test
+    public void testSpanIsCurrentOnVirtualThreadReceiver() {
+        // Setup: register a named programmatic receiver that runs on a virtual thread and captures, from inside the
+        // callback, whether it runs on a virtual thread and which span is current at that point.
+        // Expected: the callback runs on a virtual thread and sees the receiver span as the current span (so nested
+        // instrumentation would be correlated), and the span carries the programmatic receiver name.
+        String[] receiverSpanId = new String[1];
+        boolean[] onVirtualThread = new boolean[1];
+        var registration = receivers.newReceiver(Pong.class)
+                .setName("pong-receiver")
+                .setExecutionModel(ExecutionModel.VIRTUAL_THREAD)
+                .notify(ctx -> {
+                    onVirtualThread[0] = Thread.currentThread().isVirtual();
+                    receiverSpanId[0] = Span.current().getSpanContext().getSpanId();
+                });
+        try {
+            Span parent = tracer.spanBuilder("test-parent").startSpan();
+            try (Scope scope = parent.makeCurrent()) {
+                pong.reactive().send(new Pong("vt"))
+                        .ifNoItem().after(Duration.ofSeconds(5)).fail()
+                        .await().indefinitely();
+            } finally {
+                parent.end();
+            }
+
+            List<SpanData> spans = awaitReceiveSpans(1);
+            SpanData child = spans.get(0);
+            assertTrue(onVirtualThread[0], "Receiver should be executed on a virtual thread");
+            assertEquals(child.getSpanId(), receiverSpanId[0],
+                    "The receiver span must be the current span inside the virtual-thread receiver");
+            assertEquals("pong-receiver", child.getAttributes().get(RECEIVER),
+                    "The programmatic receiver name should be recorded");
+        } finally {
+            registration.unregister();
+        }
+    }
+
+    // Receiver spans are identified by the "signals.signal.type" attribute; this excludes the "test-parent" span and
+    // any other unrelated spans that the exporter may have collected
+    private List<SpanData> receiveSpans() {
+        return exporter.getFinishedSpanItems().stream()
+                .filter(s -> s.getAttributes().get(SIGNAL_TYPE) != null)
+                .toList();
+    }
+
+    // Spans are exported asynchronously by the batch span processor, so wait until at least the expected count is there
+    private List<SpanData> awaitReceiveSpans(int count) {
+        Awaitility.await().atMost(Duration.ofSeconds(10)).until(() -> receiveSpans().size() >= count);
+        return receiveSpans();
+    }
+
+    record Ping(String value) {
+    }
+
+    record Pong(String value) {
+    }
+
+    @Qualifier
+    @Target({ FIELD, METHOD, PARAMETER })
+    @Retention(RUNTIME)
+    public @interface Urgent {
+
+        final class Literal extends AnnotationLiteral<Urgent> implements Urgent {
+            public static final Literal INSTANCE = new Literal();
+            private static final long serialVersionUID = 1L;
+        }
+    }
+
+    @Singleton
+    public static class PingReceivers {
+
+        // The unqualified request receiver: returns a String (so request(..., String.class) resolves to it) and throws
+        // for the "boom" payload to exercise the failure path
+        String ping(@Receives Ping ping) {
+            if ("boom".equals(ping.value())) {
+                throw new IllegalStateException("boom");
+            }
+            return ping.value();
+        }
+
+        // A second unqualified receiver so that a publish (multicast) delivers to two receivers
+        void observe(@Receives Ping ping) {
+        }
+
+        // A @Urgent-qualified receiver, only reached when the emission is narrowed with select(@Urgent)
+        String urgentPing(@Receives @Urgent Ping ping) {
+            return ping.value();
+        }
+    }
+}

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/tracing/PipelineTracingTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/tracing/PipelineTracingTest.java
@@ -1,0 +1,180 @@
+package io.quarkus.signals.deployment.test.tracing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.awaitility.Awaitility;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.signals.Receives;
+import io.quarkus.signals.Signal;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Verifies that the OpenTelemetry trace context is propagated through a multi-stage signal pipeline (see the
+ * <em>Pipeline Pattern</em> in the guide), producing a single linear trace across all execution models:
+ * blocking -&gt; non-blocking -&gt; virtual thread.
+ */
+public class PipelineTracingTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(PlaceOrder.class, ValidatedOrder.class, EnrichedOrder.class, ShipmentConfirmation.class,
+                            ValidationStage.class, EnrichmentStage.class, ShipmentStage.class,
+                            InMemorySpanExporterProducer.class)
+                    .addAsResource(new StringAsset("""
+                            quarkus.otel.traces.sampler=always_on
+                            quarkus.otel.bsp.export.timeout=1s
+                            quarkus.otel.bsp.schedule.delay=50
+                            """), "application.properties"))
+            .setForcedDependencies(
+                    List.of(Dependency.of("io.quarkus", "quarkus-opentelemetry-deployment", Version.getVersion())));
+
+    private static final AttributeKey<String> SIGNAL_TYPE = AttributeKey.stringKey("signals.signal.type");
+
+    @Inject
+    Signal<PlaceOrder> placeOrder;
+
+    @Inject
+    InMemorySpanExporter exporter;
+
+    @Inject
+    Tracer tracer;
+
+    @BeforeEach
+    void reset() {
+        exporter.reset();
+    }
+
+    @Test
+    public void testTraceContextPropagatesThroughPipeline() {
+        // Setup: request PlaceOrder while the "test-parent" span is active. Each stage receiver emits the next signal
+        // from within its own receiver span, chaining across three execution models: blocking (ValidationStage) ->
+        // non-blocking (EnrichmentStage) -> virtual thread (ShipmentStage).
+        // Expected: three receiver spans, all in the same trace as the parent, forming a linear parent-child chain
+        // (parent -> PlaceOrder -> ValidatedOrder -> EnrichedOrder). This proves the context survives each hop and each
+        // execution-model switch.
+        Span parent = tracer.spanBuilder("test-parent").startSpan();
+        SpanContext parentCtx = parent.getSpanContext();
+        ShipmentConfirmation confirmation;
+        try (Scope scope = parent.makeCurrent()) {
+            confirmation = placeOrder.reactive()
+                    .request(new PlaceOrder("ORD-1", "Widget", 3), ShipmentConfirmation.class)
+                    .ifNoItem().after(Duration.ofSeconds(5)).fail()
+                    .await().indefinitely();
+        } finally {
+            parent.end();
+        }
+        assertEquals("ORD-1", confirmation.orderId());
+
+        List<SpanData> spans = awaitReceiveSpans(3);
+        SpanData stage1 = spanForType(spans, "PlaceOrder");
+        SpanData stage2 = spanForType(spans, "ValidatedOrder");
+        SpanData stage3 = spanForType(spans, "EnrichedOrder");
+
+        // A single trace spans all stages
+        assertEquals(parentCtx.getTraceId(), stage1.getTraceId());
+        assertEquals(parentCtx.getTraceId(), stage2.getTraceId());
+        assertEquals(parentCtx.getTraceId(), stage3.getTraceId());
+
+        // Linear parent-child chain: parent -> stage1 -> stage2 -> stage3
+        assertEquals(parentCtx.getSpanId(), stage1.getParentSpanId());
+        assertEquals(stage1.getSpanId(), stage2.getParentSpanId());
+        assertEquals(stage2.getSpanId(), stage3.getParentSpanId());
+    }
+
+    private static SpanData spanForType(List<SpanData> spans, String simpleTypeName) {
+        return spans.stream()
+                .filter(s -> {
+                    String type = s.getAttributes().get(SIGNAL_TYPE);
+                    return type != null && type.endsWith(simpleTypeName);
+                })
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No span for signal type " + simpleTypeName));
+    }
+
+    private List<SpanData> receiveSpans() {
+        return exporter.getFinishedSpanItems().stream()
+                .filter(s -> s.getAttributes().get(SIGNAL_TYPE) != null)
+                .toList();
+    }
+
+    private List<SpanData> awaitReceiveSpans(int count) {
+        Awaitility.await().atMost(Duration.ofSeconds(10)).until(() -> receiveSpans().size() >= count);
+        return receiveSpans();
+    }
+
+    // --- Signal types ---
+
+    record PlaceOrder(String orderId, String item, int quantity) {
+    }
+
+    record ValidatedOrder(String orderId, String item, int quantity) {
+    }
+
+    record EnrichedOrder(String orderId, String item, int quantity, int totalPrice) {
+    }
+
+    record ShipmentConfirmation(String orderId, String trackingId) {
+    }
+
+    // --- Stages ---
+
+    @Singleton
+    public static class ValidationStage {
+
+        @Inject
+        Signal<ValidatedOrder> validatedOrder;
+
+        // Blocking signature
+        ShipmentConfirmation onPlaceOrder(@Receives PlaceOrder order) {
+            return validatedOrder.request(
+                    new ValidatedOrder(order.orderId(), order.item(), order.quantity()),
+                    ShipmentConfirmation.class);
+        }
+    }
+
+    @Singleton
+    public static class EnrichmentStage {
+
+        @Inject
+        Signal<EnrichedOrder> enrichedOrder;
+
+        @NonBlocking
+        Uni<ShipmentConfirmation> onValidatedOrder(@Receives ValidatedOrder order) {
+            return enrichedOrder.reactive().request(
+                    new EnrichedOrder(order.orderId(), order.item(), order.quantity(), order.quantity() * 10),
+                    ShipmentConfirmation.class);
+        }
+    }
+
+    @Singleton
+    public static class ShipmentStage {
+
+        @RunOnVirtualThread
+        ShipmentConfirmation onEnrichedOrder(@Receives EnrichedOrder order) {
+            return new ShipmentConfirmation(order.orderId(), "SHIP-" + order.orderId());
+        }
+    }
+}

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/tracing/TracesDisabledSignalsTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/tracing/TracesDisabledSignalsTest.java
@@ -1,0 +1,95 @@
+package io.quarkus.signals.deployment.test.tracing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.signals.Receives;
+import io.quarkus.signals.Signal;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Verifies that no signal spans are created when tracing is disabled via configuration, even though the OpenTelemetry
+ * extension is present.
+ */
+public class TracesDisabledSignalsTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(PingReceiver.class, Ping.class, InMemorySpanExporterProducer.class)
+                    .addAsResource(new StringAsset("""
+                            quarkus.signals.telemetry.traces.enabled=false
+                            quarkus.otel.traces.sampler=always_on
+                            quarkus.otel.bsp.export.timeout=1s
+                            quarkus.otel.bsp.schedule.delay=50
+                            """), "application.properties"))
+            .setForcedDependencies(
+                    List.of(Dependency.of("io.quarkus", "quarkus-opentelemetry-deployment", Version.getVersion())));
+
+    @Inject
+    Signal<Ping> ping;
+
+    @Inject
+    InMemorySpanExporter exporter;
+
+    @Inject
+    Tracer tracer;
+
+    @Test
+    public void testNoSignalSpanWhenDisabled() {
+        // Setup: signals tracing is turned off via quarkus.signals.telemetry.traces.enabled=false, so the built-in
+        // tracing enricher/interceptor are not registered - even though the OpenTelemetry extension is present and an
+        // active "test-parent" span is set. The emission itself must still work normally.
+        // Expected: the request completes, but no receiver span is created (no span carries "signals.signal.type").
+        Span parent = tracer.spanBuilder("test-parent").startSpan();
+        String result;
+        try (Scope scope = parent.makeCurrent()) {
+            result = ping.reactive().request(new Ping("hello"), String.class)
+                    .ifNoItem().after(Duration.ofSeconds(5)).fail()
+                    .await().indefinitely();
+        } finally {
+            parent.end();
+        }
+        assertEquals("hello", result);
+
+        // Give any (unexpected) signal span a chance to be exported before asserting there is none
+        try {
+            Thread.sleep(200);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        List<SpanData> receiveSpans = exporter.getFinishedSpanItems().stream()
+                .filter(s -> s.getAttributes().get(AttributeKey.stringKey("signals.signal.type")) != null)
+                .toList();
+        assertTrue(receiveSpans.isEmpty(), "No receiver span must be created when tracing is disabled");
+    }
+
+    record Ping(String value) {
+    }
+
+    @Singleton
+    public static class PingReceiver {
+
+        String ping(@Receives Ping ping) {
+            return ping.value();
+        }
+    }
+}

--- a/extensions/signals/runtime-api/src/main/java/io/quarkus/signals/Receivers.java
+++ b/extensions/signals/runtime-api/src/main/java/io/quarkus/signals/Receivers.java
@@ -84,6 +84,12 @@ public interface Receivers {
     interface ReceiverInfo {
 
         /**
+         * @return a human-readable identifier ({@code declaringClassName#methodName} for a declarative receiver), or
+         *         {@code null} if not available (e.g. for a programmatic receiver)
+         */
+        String name();
+
+        /**
          * @return the received signal type
          */
         Type signalType();
@@ -117,6 +123,16 @@ public interface Receivers {
      * @see Receivers#newReceiver(Class)
      */
     interface ReceiverDefinition<SIGNAL> {
+
+        /**
+         * Sets a human-readable name of the built receiver, useful for logging and monitoring.
+         * By default, a programmatic receiver has no name.
+         *
+         * @param name the receiver name
+         * @return self
+         * @see ReceiverInfo#name()
+         */
+        ReceiverDefinition<SIGNAL> setName(String name);
 
         /**
          * Sets the qualifiers of the built receiver.

--- a/extensions/signals/runtime/pom.xml
+++ b/extensions/signals/runtime/pom.xml
@@ -25,6 +25,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/InvokerReceiver.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/InvokerReceiver.java
@@ -44,7 +44,12 @@ public abstract class InvokerReceiver<SIGNAL, RESPONSE> implements Receiver<SIGN
         }
     }
 
-    public record InvokerReceiverInfo(short signalArgPosition, boolean receiveContext, short totalParams) {
+    public record InvokerReceiverInfo(short signalArgPosition, boolean receiveContext, short totalParams, String name) {
+    }
+
+    @Override
+    public String name() {
+        return receiveInfo.name();
     }
 
     @Override

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/ReceiverDefinitionImpl.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/ReceiverDefinitionImpl.java
@@ -24,6 +24,7 @@ class ReceiverDefinitionImpl<SIGNAL, RESPONSE> implements Receivers.ReceiverDefi
     private final Function<CallbackReceiver<SIGNAL, RESPONSE>, Receivers.Registration> registerFun;
     private final BeanContainer beanContainer;
     private final Type signalType;
+    private String name;
     private Set<Annotation> qualifiers = Set.of();
     private ExecutionModel executionModel = ExecutionModel.BLOCKING;
 
@@ -32,6 +33,12 @@ class ReceiverDefinitionImpl<SIGNAL, RESPONSE> implements Receivers.ReceiverDefi
         this.signalType = signalType;
         this.beanContainer = beanContainer;
         this.registerFun = registerFun;
+    }
+
+    @Override
+    public Receivers.ReceiverDefinition<SIGNAL> setName(String name) {
+        this.name = name;
+        return this;
     }
 
     @Override
@@ -56,7 +63,7 @@ class ReceiverDefinitionImpl<SIGNAL, RESPONSE> implements Receivers.ReceiverDefi
         Objects.requireNonNull(callback);
         @SuppressWarnings("unchecked")
         CallbackReceiver<SIGNAL, RESPONSE> receiver = (CallbackReceiver<SIGNAL, RESPONSE>) new CallbackReceiver<>(
-                signalType, qualifiers, void.class, executionModel,
+                signalType, name, qualifiers, void.class, executionModel,
                 new Function<SignalContext<SIGNAL>, Uni<Void>>() {
                     @Override
                     public Uni<Void> apply(SignalContext<SIGNAL> ctx) {
@@ -77,7 +84,7 @@ class ReceiverDefinitionImpl<SIGNAL, RESPONSE> implements Receivers.ReceiverDefi
         Objects.requireNonNull(responseType);
         Objects.requireNonNull(callback);
         return registerFun.apply(
-                (CallbackReceiver<SIGNAL, RESPONSE>) new CallbackReceiver<>(signalType, qualifiers,
+                (CallbackReceiver<SIGNAL, RESPONSE>) new CallbackReceiver<>(signalType, name, qualifiers,
                         responseType, executionModel, callback));
     }
 
@@ -87,22 +94,24 @@ class ReceiverDefinitionImpl<SIGNAL, RESPONSE> implements Receivers.ReceiverDefi
         Objects.requireNonNull(responseType);
         Objects.requireNonNull(callback);
         return registerFun.apply(
-                (CallbackReceiver<SIGNAL, RESPONSE>) new CallbackReceiver<>(signalType, qualifiers,
+                (CallbackReceiver<SIGNAL, RESPONSE>) new CallbackReceiver<>(signalType, name, qualifiers,
                         responseType.getType(), executionModel, callback));
     }
 
     static class CallbackReceiver<SIGNAL, RESPONSE> implements Receiver<SIGNAL, RESPONSE> {
 
         private final String id;
+        private final String name;
         private final Type signalType;
         private final Type responseType;
         private final Set<Annotation> qualifiers;
         private final ExecutionModel executionModel;
         private final Function<SignalContext<SIGNAL>, Uni<RESPONSE>> callback;
 
-        CallbackReceiver(Type signalType, Set<Annotation> qualifiers, Type responseType, ExecutionModel executionModel,
-                Function<SignalContext<SIGNAL>, Uni<RESPONSE>> callback) {
+        CallbackReceiver(Type signalType, String name, Set<Annotation> qualifiers, Type responseType,
+                ExecutionModel executionModel, Function<SignalContext<SIGNAL>, Uni<RESPONSE>> callback) {
             this.id = UUID.randomUUID().toString();
+            this.name = name;
             this.signalType = signalType;
             this.responseType = responseType;
             this.qualifiers = qualifiers;
@@ -112,6 +121,11 @@ class ReceiverDefinitionImpl<SIGNAL, RESPONSE> implements Receivers.ReceiverDefi
 
         String id() {
             return id;
+        }
+
+        @Override
+        public String name() {
+            return name;
         }
 
         @Override
@@ -150,8 +164,8 @@ class ReceiverDefinitionImpl<SIGNAL, RESPONSE> implements Receivers.ReceiverDefi
 
         @Override
         public String toString() {
-            return "CallbackReceiver [signalType=" + signalType + ", responseType=" + responseType + ", qualifiers="
-                    + qualifiers + ", executionModel=" + executionModel + "]";
+            return "CallbackReceiver [name=" + name + ", signalType=" + signalType + ", responseType=" + responseType
+                    + ", qualifiers=" + qualifiers + ", executionModel=" + executionModel + "]";
         }
 
     }

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/ReceiverManager.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/ReceiverManager.java
@@ -233,6 +233,11 @@ public class ReceiverManager implements Receivers, Signals {
         }
 
         @Override
+        public String name() {
+            return delegate.name();
+        }
+
+        @Override
         public java.lang.reflect.Type signalType() {
             return delegate.signalType();
         }

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/tracing/TracingReceiverInterceptor.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/tracing/TracingReceiverInterceptor.java
@@ -1,0 +1,149 @@
+package io.quarkus.signals.runtime.tracing;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Default;
+import jakarta.inject.Singleton;
+
+import org.jboss.logging.Logger;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.quarkus.signals.SignalContext;
+import io.quarkus.signals.spi.ReceiverInterceptor;
+import io.quarkus.signals.spi.RelativeOrder;
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Built-in interceptor that creates a {@link SpanKind#INTERNAL} span for each receiver invocation. If the
+ * {@link TracingSignalMetadataEnricher} propagated a valid trace context, the span becomes a child of the emitter's
+ * span; otherwise a new root span is started.
+ * <p>
+ * The interceptor is ordered before {@link #ID_REQUEST_CONTEXT} so that the span encloses the whole receiver invocation.
+ * The span is made current at subscription time so that instrumentation nested in the receiver (e.g. {@code @WithSpan}
+ * methods) is correlated, and it is ended when the receiver completes, recording the exception and an error status on
+ * failure.
+ * <p>
+ * It is only registered when the OpenTelemetry tracer capability is present.
+ */
+@Identifier(TracingReceiverInterceptor.ID)
+@RelativeOrder(before = ReceiverInterceptor.ID_REQUEST_CONTEXT)
+@Singleton
+public class TracingReceiverInterceptor implements ReceiverInterceptor {
+
+    public static final String ID = "quarkus.tracing";
+
+    // The span name is "receive <raw signal type FQCN>"; the (possibly parameterized) signal type is also recorded in
+    // the "signals.signal.type" attribute (cardinality is bounded by the number of distinct signal types)
+    private static final String SPAN_NAME_PREFIX = "receive ";
+
+    private static final AttributeKey<List<String>> QUALIFIERS = AttributeKey.stringArrayKey("signals.qualifiers");
+
+    private static final Logger LOG = Logger.getLogger(TracingReceiverInterceptor.class);
+
+    private final OpenTelemetry openTelemetry;
+    private final Tracer tracer;
+
+    TracingReceiverInterceptor(OpenTelemetry openTelemetry) {
+        this.openTelemetry = openTelemetry;
+        this.tracer = openTelemetry.getTracer(TracingSupport.TRACER_NAME);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Uni<Object> intercept(InterceptionContext context) {
+        SignalContext<?> signalContext = context.signalContext();
+
+        // INTERNAL is used deliberately: signals are delivered in-process (there is no messaging broker) and we do not
+        // emit the messaging.* semantic conventions nor a PRODUCER counterpart span, so CONSUMER would over-claim
+        // messaging semantics. This may be revisited if signals gain full messaging instrumentation.
+        SpanBuilder spanBuilder = tracer.spanBuilder(SPAN_NAME_PREFIX + rawTypeName(signalContext.signalType()))
+                .setSpanKind(SpanKind.INTERNAL)
+                .setAttribute("signals.signal.type", signalContext.signalType().getTypeName())
+                .setAttribute("signals.emission.type", signalContext.emissionType().toString());
+        // Use the propagated trace context as the parent if available; otherwise start a new root span
+        Object carrier = signalContext.metadata().get(TracingSupport.TRACE_CONTEXT_METADATA_KEY);
+        if (carrier instanceof Map map) {
+            Context parentContext = openTelemetry.getPropagators().getTextMapPropagator()
+                    .extract(Context.root(), map, TracingSupport.GETTER);
+            // A valid parent span makes the receiver span its child; otherwise (e.g. only baggage) start a root span
+            if (Span.fromContext(parentContext).getSpanContext().isValid()) {
+                spanBuilder.setParent(parentContext);
+            } else {
+                spanBuilder.setNoParent();
+            }
+        } else {
+            spanBuilder.setNoParent();
+        }
+        if (signalContext.responseType() != null) {
+            spanBuilder.setAttribute("signals.response.type", signalContext.responseType().getTypeName());
+        }
+        List<String> qualifiers = new ArrayList<>();
+        for (Annotation qualifier : signalContext.qualifiers()) {
+            String name = qualifier.annotationType().getName();
+            if (!Default.class.getName().equals(name) && !Any.class.getName().equals(name)) {
+                qualifiers.add(name);
+            }
+        }
+        if (!qualifiers.isEmpty()) {
+            spanBuilder.setAttribute(QUALIFIERS, qualifiers);
+        }
+        String receiverName = context.receiver().name();
+        if (receiverName != null) {
+            spanBuilder.setAttribute("signals.receiver", receiverName);
+        }
+        Span span = spanBuilder.startSpan();
+        // Report the time elapsed between the emission and the start of this receiver invocation, if available
+        Object emitNanos = signalContext.metadata().get(TracingSupport.EMIT_NANOS_METADATA_KEY);
+        if (emitNanos instanceof Long) {
+            long waitNanos = System.nanoTime() - (Long) emitNanos;
+            if (waitNanos >= 0) {
+                span.setAttribute("signals.receiver.wait_ms", TimeUnit.NANOSECONDS.toMillis(waitNanos));
+            }
+        }
+        LOG.debugf("Started span %s for receiver %s", span.getSpanContext().getSpanId(), context.receiver());
+
+        return Uni.createFrom().deferred(new Supplier<Uni<? extends Object>>() {
+            @Override
+            public Uni<Object> get() {
+                // makeCurrent() attaches to the current (duplicated) context on the receiver's execution thread
+                Scope scope = span.makeCurrent();
+                return context.proceed().onItemOrFailure().invoke((item, failure) -> {
+                    try {
+                        if (failure != null) {
+                            span.recordException(failure);
+                            span.setStatus(StatusCode.ERROR);
+                            span.setAttribute("error.type", failure.getClass().getName());
+                        }
+                    } finally {
+                        scope.close();
+                        span.end();
+                    }
+                });
+            }
+        });
+    }
+
+    private static String rawTypeName(Type type) {
+        if (type instanceof ParameterizedType parameterizedType) {
+            return parameterizedType.getRawType().getTypeName();
+        }
+        return type.getTypeName();
+    }
+}

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/tracing/TracingSignalMetadataEnricher.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/tracing/TracingSignalMetadataEnricher.java
@@ -1,0 +1,58 @@
+package io.quarkus.signals.runtime.tracing;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.inject.Singleton;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.quarkus.signals.spi.SignalMetadataEnricher;
+import io.smallrye.common.annotation.Identifier;
+
+/**
+ * Built-in enricher that records the emit timestamp and captures the current OpenTelemetry trace context so that both can
+ * be used by the {@link TracingReceiverInterceptor} when a receiver is invoked.
+ * <p>
+ * The emit timestamp is stored under the {@link TracingSupport#EMIT_NANOS_METADATA_KEY} key and is always recorded, even
+ * without an active trace, because the receiver always starts a span (a child span if a trace context was propagated, a
+ * new root span otherwise). The trace context is captured only when there is an active span and stored under the
+ * {@link TracingSupport#TRACE_CONTEXT_METADATA_KEY} key as an immutable map of W3C Trace Context headers.
+ * <p>
+ * The enricher runs synchronously on the emitting thread, which is the only place where the caller's active span is
+ * available: receivers are dispatched on a separate (duplicated) context where the trace context would otherwise be
+ * lost.
+ * <p>
+ * It is only registered when the OpenTelemetry tracer capability is present. Existing metadata entries are never
+ * overridden.
+ */
+@Identifier(TracingSignalMetadataEnricher.ID)
+@Singleton
+public class TracingSignalMetadataEnricher implements SignalMetadataEnricher {
+
+    public static final String ID = "quarkus.tracing";
+
+    private final OpenTelemetry openTelemetry;
+
+    TracingSignalMetadataEnricher(OpenTelemetry openTelemetry) {
+        this.openTelemetry = openTelemetry;
+    }
+
+    @Override
+    public void enrich(EnrichmentContext context) {
+        Map<String, Object> metadata = context.signalContext().metadata();
+        // Always record the emit time; the receiver reports the emit-to-receive wait time even for a root span
+        if (!metadata.containsKey(TracingSupport.EMIT_NANOS_METADATA_KEY)) {
+            context.putMetadata(TracingSupport.EMIT_NANOS_METADATA_KEY, System.nanoTime());
+        }
+        // Propagate the active trace context, if any, so that the receiver span becomes a child of the emitter's span
+        if (Span.current().getSpanContext().isValid()
+                && !metadata.containsKey(TracingSupport.TRACE_CONTEXT_METADATA_KEY)) {
+            Map<String, String> carrier = new HashMap<>();
+            openTelemetry.getPropagators().getTextMapPropagator().inject(Context.current(), carrier,
+                    TracingSupport.SETTER);
+            context.putMetadata(TracingSupport.TRACE_CONTEXT_METADATA_KEY, Map.copyOf(carrier));
+        }
+    }
+}

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/tracing/TracingSupport.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/tracing/TracingSupport.java
@@ -1,0 +1,58 @@
+package io.quarkus.signals.runtime.tracing;
+
+import java.util.Collections;
+import java.util.Map;
+
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapSetter;
+
+/**
+ * Shared constants and W3C trace context carrier accessors used by the OpenTelemetry integration.
+ * <p>
+ * The propagated trace context is stored in the signal metadata under a single {@link #TRACE_CONTEXT_METADATA_KEY} entry
+ * whose value is an immutable map of W3C Trace Context headers (e.g. {@code traceparent}). This keeps the
+ * OpenTelemetry-specific keys out of the user-facing metadata namespace.
+ */
+final class TracingSupport {
+
+    /**
+     * The instrumentation name used for the {@link io.opentelemetry.api.trace.Tracer}.
+     */
+    static final String TRACER_NAME = "io.quarkus.signals";
+
+    /**
+     * The signal metadata key under which the W3C trace context map is stored.
+     */
+    static final String TRACE_CONTEXT_METADATA_KEY = "quarkus.tracing";
+
+    /**
+     * The signal metadata key under which the emit timestamp (a {@link System#nanoTime()} value, as a {@link Long}) is
+     * stored, so that a receiver can report the emit-to-receive wait time as a span attribute. It is kept separate from
+     * {@link #TRACE_CONTEXT_METADATA_KEY} so that the W3C trace context carrier map stays a pure propagation carrier.
+     */
+    static final String EMIT_NANOS_METADATA_KEY = "quarkus.tracing.emit-nanos";
+
+    static final TextMapSetter<Map<String, String>> SETTER = new TextMapSetter<Map<String, String>>() {
+        @Override
+        public void set(Map<String, String> carrier, String key, String value) {
+            if (carrier != null) {
+                carrier.put(key, value);
+            }
+        }
+    };
+
+    static final TextMapGetter<Map<String, String>> GETTER = new TextMapGetter<Map<String, String>>() {
+        @Override
+        public Iterable<String> keys(Map<String, String> carrier) {
+            return carrier == null ? Collections.emptyList() : carrier.keySet();
+        }
+
+        @Override
+        public String get(Map<String, String> carrier, String key) {
+            return carrier == null ? null : carrier.get(key);
+        }
+    };
+
+    private TracingSupport() {
+    }
+}


### PR DESCRIPTION
- when the OpenTelemetry extension is present, capture the active trace context into the signal metadata as W3C Trace Context on emission and restore it for each receiver invocation, creating a child span per receiver
- resolves #54677