### PR TITLE
Add synthetic dependency on quarkus-extension-processor for reactor ordering

### DIFF
--- a/extensions/spiffe-client/runtime-api/pom.xml
+++ b/extensions/spiffe-client/runtime-api/pom.xml
@@ -16,6 +16,23 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny</artifactId>
         </dependency>
+        <!--
+          This is required to ensure that the extension processor is built.
+          If we move the extension processor to a separate project, this can be removed.
+        -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-extension-processor</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/extensions/websockets-next/spi/pom.xml
+++ b/extensions/websockets-next/spi/pom.xml
@@ -17,6 +17,23 @@
             <groupId>io.quarkus.security</groupId>
             <artifactId>quarkus-security</artifactId>
         </dependency>
+        <!--
+          This is required to ensure that the extension processor is built.
+          If we move the extension processor to a separate project, this can be removed.
+        -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-extension-processor</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Both `quarkus-websockets-next-spi` and `quarkus-spiffe-client-api` configure quarkus-extension-processor as an annotation processor path, but neither depends (even transitively) on quarkus-core which normally provides the reactor ordering hint. On a clean build with an empty local repository, Maven cannot resolve the processor jar because it does not know to build it first.

Add the same test-scoped, exclusion-only POM dependency already used in quarkus-core to both modules so the reactor schedules the processor build before compiling them.