### PR TITLE
Avoid unnecessary reloads due to using array based values in meta-annotations for QuarkusTestResource

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
@@ -359,7 +359,12 @@ public class TestResourceManager implements Closeable {
             Method[] annotationAttributes = entry.configAnnotation.annotationType().getDeclaredMethods();
             for (Method annotationAttribute : annotationAttributes) {
                 try {
-                    args.put(annotationAttribute.getName(), annotationAttribute.invoke(entry.configAnnotation));
+                    Object annotationValue = annotationAttribute.invoke(entry.configAnnotation);
+                    if (annotationValue.getClass().isArray()) {
+                        args.put(annotationAttribute.getName(), new TestResourceComparisonInfoArrayValue(annotationValue));
+                    } else {
+                        args.put(annotationAttribute.getName(), annotationValue);
+                    }
                 } catch (Exception e) {
                     throw new RuntimeException("Unable to extract configuration values for annotation "
                             + entry.configAnnotation.annotationType().getName(), e);
@@ -662,6 +667,57 @@ public class TestResourceManager implements Closeable {
     public record TestResourceComparisonInfo(String testResourceLifecycleManagerClass, TestResourceScope scope,
             Map<String, Object> args) {
 
+    }
+
+    /**
+     * Utility record to hold an array value as the value of {@link TestResourceComparisonInfo#args()}. Annotation
+     * values are always static array values, cannot be constants, so they are always a new instance. When comparing
+     * annotations with array values, the comparison will always fail and a reload woudl be forced, even if the values
+     * of the actual arrays are equal.
+     * <p/>
+     * By wrapping arrays, we can perform a correct {@link Object#equals(Object)} comparison.
+     *
+     * @param array The array or null, must be an array instance, else an IllegalArgumentException will be thrown.
+     */
+    private record TestResourceComparisonInfoArrayValue(Object array) {
+        public TestResourceComparisonInfoArrayValue {
+            if (array == null || !array.getClass().isArray()) {
+                throw new IllegalArgumentException("Value needs to be an array");
+            }
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (!(o instanceof TestResourceComparisonInfoArrayValue(Object array1)))
+                return false;
+            return Objects.deepEquals(this.array, array1);
+        }
+
+        @Override
+        public int hashCode() {
+            if (array instanceof Object[] objArray)
+                return Arrays.deepHashCode(objArray);
+            if (array instanceof int[] intArray)
+                return Arrays.hashCode(intArray);
+            if (array instanceof byte[] byteArray)
+                return Arrays.hashCode(byteArray);
+            if (array instanceof boolean[] boolArray)
+                return Arrays.hashCode(boolArray);
+            if (array instanceof long[] longArray)
+                return Arrays.hashCode(longArray);
+            if (array instanceof char[] charArray)
+                return Arrays.hashCode(charArray);
+            if (array instanceof short[] shortArray)
+                return Arrays.hashCode(shortArray);
+            if (array instanceof float[] floatArray)
+                return Arrays.hashCode(floatArray);
+            if (array instanceof double[] doubleArray)
+                return Arrays.hashCode(doubleArray);
+
+            return Objects.hashCode(array);
+        }
     }
 
     private static class TestResourceRunnable implements Runnable {

--- a/test-framework/common/src/test/java/io/quarkus/test/common/TestResourceManagerTest.java
+++ b/test-framework/common/src/test/java/io/quarkus/test/common/TestResourceManagerTest.java
@@ -10,9 +10,11 @@ import java.lang.annotation.Target;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -49,6 +51,50 @@ public class TestResourceManagerTest {
         Map<String, String> props = manager.start();
         Assertions.assertEquals("value1", props.get("key1"));
         Assertions.assertEquals("value2", props.get("key2"));
+    }
+
+    @Test
+    void arrayBasedMetaAnnotationDoesNotCauseReload() {
+        TestResourceManager manager1 = new TestResourceManager(ArrayTest1.class);
+        TestResourceManager manager2 = new TestResourceManager(ArrayTest2.class);
+
+        Set<TestResourceManager.TestResourceComparisonInfo> info1 = manager1.testResourceComparisonInfo();
+        Set<TestResourceManager.TestResourceComparisonInfo> info2 = manager2.testResourceComparisonInfo();
+
+        Assertions.assertFalse(TestResourceManager.testResourcesRequireReload(info1, info2));
+    }
+
+    @Test
+    void primitiveArrayBasedMetaAnnotationDoesNotCauseReload() {
+        TestResourceManager manager1 = new TestResourceManager(PrimitiveArrayTest1.class);
+        TestResourceManager manager2 = new TestResourceManager(PrimitiveArrayTest2.class);
+
+        Set<TestResourceManager.TestResourceComparisonInfo> info1 = manager1.testResourceComparisonInfo();
+        Set<TestResourceManager.TestResourceComparisonInfo> info2 = manager2.testResourceComparisonInfo();
+
+        Assertions.assertFalse(TestResourceManager.testResourcesRequireReload(info1, info2));
+    }
+
+    @Test
+    void arrayBasedMetaAnnotationWithDifferentValuesDoReload() {
+        TestResourceManager manager1 = new TestResourceManager(ArrayTest1.class);
+        TestResourceManager manager2 = new TestResourceManager(DiffereringArrayTest.class);
+
+        Set<TestResourceManager.TestResourceComparisonInfo> info1 = manager1.testResourceComparisonInfo();
+        Set<TestResourceManager.TestResourceComparisonInfo> info2 = manager2.testResourceComparisonInfo();
+
+        Assertions.assertTrue(TestResourceManager.testResourcesRequireReload(info1, info2));
+    }
+
+    @Test
+    void arrayBasedMetaAnnotationWithDifferentPrimitivesDoReload() {
+        TestResourceManager manager1 = new TestResourceManager(PrimitiveArrayTest1.class);
+        TestResourceManager manager2 = new TestResourceManager(DifferingPrimitiveArrayTest.class);
+
+        Set<TestResourceManager.TestResourceComparisonInfo> info1 = manager1.testResourceComparisonInfo();
+        Set<TestResourceManager.TestResourceComparisonInfo> info2 = manager2.testResourceComparisonInfo();
+
+        Assertions.assertTrue(TestResourceManager.testResourcesRequireReload(info1, info2));
     }
 
     @WithTestResource(value = FirstLifecycleManager.class, scope = TestResourceScope.GLOBAL)
@@ -298,4 +344,43 @@ public class TestResourceManagerTest {
     @WithAnnotationBasedTestResource2(key = "annotationkey2")
     public static class RepeatableAnnotationBasedTestResourcesTest2 {
     }
+
+    @QuarkusTestResource(AnnotationBasedQuarkusTestResource.class)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public @interface WithArrayBasedTestResource {
+        String[] args();
+    }
+
+    @WithArrayBasedTestResource(args = { "arg1", "arg2" })
+    public static class ArrayTest1 {
+    }
+
+    @WithArrayBasedTestResource(args = { "arg1", "arg2" })
+    public static class ArrayTest2 {
+    }
+
+    @WithArrayBasedTestResource(args = { "arg1", "arg3" })
+    public static class DiffereringArrayTest {
+    }
+
+    @QuarkusTestResource(AnnotationBasedQuarkusTestResource.class)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public @interface WithPrimitiveArrayBasedTestResource {
+        int[] args();
+    }
+
+    @WithPrimitiveArrayBasedTestResource(args = { 1, 2 })
+    public static class PrimitiveArrayTest1 {
+    }
+
+    @WithPrimitiveArrayBasedTestResource(args = { 1, 2 })
+    public static class PrimitiveArrayTest2 {
+    }
+
+    @WithPrimitiveArrayBasedTestResource(args = { 3, 4 })
+    public static class DifferingPrimitiveArrayTest {
+    }
+
 }


### PR DESCRIPTION
Meta-annotations for `QuarkusTestResource` which contain an Array-based annotation value will always cause a restart by the `TestResourceManager`. This is currently true even if the values of said arrays are completely equal.

This is caused by array values in annotations always being new instances, and `equals()` on arrays just defaults to `Object.equals()`, resulting in the Set of TestResourceComparisonInfo being deemed unequal, forcing the reload.

This patch adds handling of arrays as a special case, comparing arrays using `Arrays.equals`.

Context: the quarks-playwright extension has a `@WithPlaywright` annotation which has an args value to pass arguments to the playwright instance. For different tests, this causes a restart of the application and dev services. Especially in integration tests (where quarks-playwright is often used), this can be quite an expensive operation.