### PR TITLE
Drop steps for discarded toc plugin in docs preview

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -73,9 +73,6 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           restore-keys: ${{ runner.os }}-npm-
 
-      - name: Build TOC plugin
-        run: ./roq-plugin-toc/build.sh
-
       - name: Build with Maven
         run: QUARKUS_ROQ_GENERATOR_BATCH=true QUARKUS_PROFILE=only-latest-guides mvn -B package quarkus:run -DskipTests
 


### PR DESCRIPTION
Now that quarkusio no longer packages its own toc plugin, we need to update the mirrored script on the quarkus side.