### PR TITLE
Fix remaining callout list placement issues in docs

### DIFF
--- a/docs/src/main/asciidoc/building-my-first-extension.adoc
+++ b/docs/src/main/asciidoc/building-my-first-extension.adoc
@@ -286,9 +286,6 @@ Let's have a look at the deployment's `./greeting-extension/deployment/pom.xml`.
 
 </project>
 ----
-
-The key points are:
-
 <1> By convention, the deployment module has the `-deployment` suffix (`greeting-extension-deployment`).
 <2> The deployment module depends on the `quarkus-arc-deployment` artifact.
 We will see later which dependencies are convenient to add.
@@ -386,9 +383,6 @@ Finally `./greeting-extension/runtime/pom.xml`.
     </build>
 </project>
 ----
-
-The key points are:
-
 <1> By convention, the runtime module has no suffix (`greeting-extension`) as it is the artifact exposed to the end user.
 <2> The runtime module depends on the `quarkus-arc` artifact.
 <3> We add  the `quarkus-extension-maven-plugin` to generate the Quarkus extension descriptor included into the runtime artifact, which links it with the corresponding deployment artifact.

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -1159,6 +1159,9 @@ public interface LogConfiguration {
     }
 }
 ----
+<1> The `@ConfigMapping` annotation indicates that the interface is a configuration mapping, in this case one which
+corresponds to a `quarkus.log` segment.
+<2> The `@ConfigRoot` annotation indicated to which Config phase, the configuration applies to.
 
 [source%nowrap,java]
 ----
@@ -1168,13 +1171,10 @@ public class LoggingProcessor {
     /*
      * Logging configuration.
      */
-    LogConfiguration config; // <3>
+    LogConfiguration config; // <1>
 }
 ----
-<1> The `@ConfigMapping` annotation indicates that the interface is a configuration mapping, in this case one which
-corresponds to a `quarkus.log` segment.
-<2> The `@ConfigRoot` annotation indicated to which Config phase, the configuration applies to.
-<3> Here the `LoggingProcessor` injects a `LogConfiguration` instance automatically by detecting the `@ConfigRoot`
+<1> Here the `LoggingProcessor` injects a `LogConfiguration` instance automatically by detecting the `@ConfigRoot`
 annotation.
 
 A configuration property name can be split into segments. For example, a property name like


### PR DESCRIPTION
This is a follow-up to #56425, which moved most callout lists to sit directly after their source listing (fixing the bulk of #56386). A couple of the "direct violations" listed in the issue were not covered by that PR, and this handles them.

`writing-extensions.adoc`: the callout list spanned two separate source blocks (`<1>` and `<2>` in the first, `<3>` in the second). A callout list attaches to a single preceding block and must start at 1, so it is split into one list per block, with the second block's callout renumbered.

`building-my-first-extension.adoc`: two callout lists were separated from their listing by a "The key points are:" lead-in. The lead-in is removed so the callouts follow the listing directly, matching how #56425 handled the same kind of lead-in elsewhere.

The "numbered list instead of real callout syntax" and remaining "orphaned callouts" items from #56386 are being handled separately in #56391 and #56432.

Verified locally by building the documentation module (`mvnw clean package` in `docs/`): the build succeeds with no callout warnings for the changed files, and the generated HTML for `writing-extensions` shows the split callout lists rendering with the correct numbering.
