### PR TITLE
Update the build plugin version properties with quarkus update

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
@@ -25,6 +25,7 @@ import io.quarkus.devtools.commands.UpdateProject;
 import io.quarkus.devtools.commands.data.QuarkusCommandException;
 import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
 import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
+import io.quarkus.devtools.commands.handlers.CreateProjectCodestartDataConverter.PlatformPropertiesKey;
 import io.quarkus.devtools.messagewriter.MessageFormatter;
 import io.quarkus.devtools.messagewriter.MessageIcons;
 import io.quarkus.devtools.messagewriter.MessageWriter;
@@ -96,12 +97,18 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
             final BuildTool buildTool = quarkusProject.getExtensionManager().getBuildTool();
             // TODO targetCatalog shouldn't be used here, since it might not be the recommended one according to the calculated recommended state
             String kotlinVersion = getMetadata(targetCatalog, "project", "properties", "kotlin-version");
+            String compilerPluginVersion = getMetadata(targetCatalog, "project", "properties",
+                    PlatformPropertiesKey.MAVEN_COMPILER_PLUGIN_VERSION);
+            String surefirePluginVersion = getMetadata(targetCatalog, "project", "properties",
+                    PlatformPropertiesKey.MAVEN_SUREFIRE_PLUGIN_VERSION);
             final Optional<Integer> updateJavaVersion = resolveUpdateJavaVersion(extensionsUpdateInfo, projectJavaVersion);
             QuarkusUpdates.ProjectUpdateRequest request = new QuarkusUpdates.ProjectUpdateRequest(
                     buildTool,
                     currentQuarkusPlatformBom.getVersion(),
                     recommendedQuarkusPlatformBom.getVersion(),
                     kotlinVersion,
+                    compilerPluginVersion,
+                    surefirePluginVersion,
                     updateJavaVersion,
                     extensionsUpdateInfo);
             Path recipe = null;

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdates.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdates.java
@@ -35,6 +35,21 @@ public final class QuarkusUpdates {
                 request.targetVersion,
                 request.projectExtensionsUpdateInfo
                         .getVersionUpdates());
+        QuarkusUpdateRecipe recipe = createProjectRecipe(request);
+        for (String s : result.getRecipes()) {
+            recipe.addRecipes(QuarkusUpdateRecipeIO.readRecipesYaml(s));
+        }
+
+        QuarkusUpdateRecipeIO.write(log, target, recipe);
+        return result;
+    }
+
+    /**
+     * The operations updating the project itself: Quarkus and platform versions, the Java version, the build plugin
+     * versions the platform recommends, and the extension versions. The migration recipes of the update recipes
+     * artifact are added separately.
+     */
+    static QuarkusUpdateRecipe createProjectRecipe(ProjectUpdateRequest request) {
         QuarkusUpdateRecipe recipe = new QuarkusUpdateRecipe()
                 .buildTool(request.buildTool);
         if (request.updateJavaVersion.isPresent()) {
@@ -53,6 +68,14 @@ public final class QuarkusUpdates {
                         .addOperation(new UpdatePropertyOperation("quarkus-plugin.version", request.targetVersion));
                 if (request.kotlinVersion != null) {
                     recipe.addOperation(new UpdatePropertyOperation("kotlin.version", request.kotlinVersion));
+                }
+                if (request.compilerPluginVersion != null) {
+                    recipe.addOperation(
+                            new UpdatePropertyOperation("compiler-plugin.version", request.compilerPluginVersion));
+                }
+                if (request.surefirePluginVersion != null) {
+                    recipe.addOperation(
+                            new UpdatePropertyOperation("surefire-plugin.version", request.surefirePluginVersion));
                 }
                 break;
             case GRADLE:
@@ -82,12 +105,7 @@ public final class QuarkusUpdates {
 
         }
 
-        for (String s : result.getRecipes()) {
-            recipe.addRecipes(QuarkusUpdateRecipeIO.readRecipesYaml(s));
-        }
-
-        QuarkusUpdateRecipeIO.write(log, target, recipe);
-        return result;
+        return recipe;
     }
 
     public static class ProjectUpdateRequest {
@@ -96,6 +114,8 @@ public final class QuarkusUpdates {
         public final String currentVersion;
         public final String targetVersion;
         public final String kotlinVersion;
+        public final String compilerPluginVersion;
+        public final String surefirePluginVersion;
         public final Optional<Integer> updateJavaVersion;
         public final ProjectExtensionsUpdateInfo projectExtensionsUpdateInfo;
 
@@ -108,10 +128,19 @@ public final class QuarkusUpdates {
         public ProjectUpdateRequest(BuildTool buildTool, String currentVersion, String targetVersion,
                 String kotlinVersion,
                 Optional<Integer> updateJavaVersion, ProjectExtensionsUpdateInfo projectExtensionsUpdateInfo) {
+            this(buildTool, currentVersion, targetVersion, kotlinVersion, null, null, updateJavaVersion,
+                    projectExtensionsUpdateInfo);
+        }
+
+        public ProjectUpdateRequest(BuildTool buildTool, String currentVersion, String targetVersion,
+                String kotlinVersion, String compilerPluginVersion, String surefirePluginVersion,
+                Optional<Integer> updateJavaVersion, ProjectExtensionsUpdateInfo projectExtensionsUpdateInfo) {
             this.buildTool = buildTool;
             this.currentVersion = currentVersion;
             this.targetVersion = targetVersion;
             this.kotlinVersion = kotlinVersion;
+            this.compilerPluginVersion = compilerPluginVersion;
+            this.surefirePluginVersion = surefirePluginVersion;
             this.updateJavaVersion = updateJavaVersion;
             this.projectExtensionsUpdateInfo = projectExtensionsUpdateInfo;
         }

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdatesTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdatesTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.devtools.project.update.rewrite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.devtools.project.update.ProjectExtensionsUpdateInfo;
+
+class QuarkusUpdatesTest {
+
+    @Test
+    void mavenRecipeUpdatesThePluginVersionProperties() {
+        QuarkusUpdates.ProjectUpdateRequest request = new QuarkusUpdates.ProjectUpdateRequest(BuildTool.MAVEN, "3.20.3",
+                "3.27.0", null, "3.14.0", "3.5.3", Optional.empty(), new ProjectExtensionsUpdateInfo(Map.of()));
+
+        String yaml = QuarkusUpdateRecipeIO.toYaml(MessageWriter.info(), QuarkusUpdates.createProjectRecipe(request));
+
+        assertThat(yaml)
+                .contains("key: quarkus.platform.version")
+                .contains("key: compiler-plugin.version")
+                .contains("newValue: 3.14.0")
+                .contains("key: surefire-plugin.version")
+                .contains("newValue: 3.5.3");
+    }
+
+    @Test
+    void pluginVersionPropertiesAreLeftAloneWhenTheCatalogDoesNotProvideThem() {
+        QuarkusUpdates.ProjectUpdateRequest request = new QuarkusUpdates.ProjectUpdateRequest(BuildTool.MAVEN, "3.20.3",
+                "3.27.0", null, null, null, Optional.empty(), new ProjectExtensionsUpdateInfo(Map.of()));
+
+        String yaml = QuarkusUpdateRecipeIO.toYaml(MessageWriter.info(), QuarkusUpdates.createProjectRecipe(request));
+
+        assertThat(yaml)
+                .contains("key: quarkus.platform.version")
+                .doesNotContain("compiler-plugin.version")
+                .doesNotContain("surefire-plugin.version");
+    }
+}


### PR DESCRIPTION
The update recipe bumps `quarkus.platform.version` / `quarkus.version` / `quarkus-plugin.version` and, for Kotlin projects, `kotlin.version`, but never `compiler-plugin.version` and `surefire-plugin.version`. Those two are generated from the platform metadata (`project.properties.compiler-plugin-version` / `surefire-plugin-version`) when the project is created, so after an update the project keeps the plugin versions of the platform it started from. Reproduced with a project created by `quarkus-maven-plugin:3.20.3:create -DplatformVersion=3.20.3` (surefire `3.5.2`) and `quarkus-maven-plugin:3.27.0:update -Dstream=3.27`: the platform moves to 3.27.5.2, surefire stays at 3.5.2 while a project generated for 3.27 gets 3.5.3.

This adds `ChangePropertyValue` operations for both properties, with the versions the target platform catalog recommends (the same metadata the create command uses), only when the catalog provides them. `ChangePropertyValue` does not add missing properties, so projects that do not declare them are untouched.

Verified end to end with the plugin built from this branch on the same 3.20.3 project: after `quarkus-maven-plugin:999-SNAPSHOT:update -Dstream=3.27`, `surefire-plugin.version` is `3.5.3` and `compiler-plugin.version` stays `3.14.0` (what 3.27 recommends), matching a freshly generated 3.27 project. The generated `target/rewrite/rewrite.yaml` contains the two extra `ChangePropertyValue` entries.

The operation composition is extracted into `QuarkusUpdates#createProjectRecipe` so it can be unit tested without the recipe artifact resolution; `QuarkusUpdatesTest` covers the property updates and the case where the catalog provides no plugin versions.

- Fixes: #50850
