### PR TITLE
Fix unrecognized global REST Client response decompression configuration key

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -1951,10 +1951,10 @@ An example configuration could be:
 [source,properties]
 ----
 # global configuration is used for all clients
-quarkus.rest-client.enable-compression=true
+quarkus.rest-client.enable-response-decompression=true
 
 # per-client configuration overrides the global settings for a specific client
-quarkus.rest-client.my-client.enable-compression=true
+quarkus.rest-client.my-client.enable-response-decompression=true
 ----
 
 The REST Client falls back onto the Quarkus wide `quarkus.http.enable-compression` configuration property (which defaults to `false`) if no REST Client specific property is set.

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/AbstractRestClientConfigBuilder.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/AbstractRestClientConfigBuilder.java
@@ -55,6 +55,8 @@ import io.smallrye.config.SmallRyeConfigBuilder;
  */
 public abstract class AbstractRestClientConfigBuilder implements ConfigBuilder {
     private static final String REST_CLIENT_PREFIX = "quarkus.rest-client.";
+    private static final String ENABLE_COMPRESSION = ".enable-compression";
+    private static final String ENABLE_RESPONSE_DECOMPRESSION = ".enable-response-decompression";
 
     @Override
     public SmallRyeConfigBuilder configBuilder(final SmallRyeConfigBuilder builder) {
@@ -448,12 +450,8 @@ public abstract class AbstractRestClientConfigBuilder implements ConfigBuilder {
 
     private static class RenameConfigFallbackInterceptor extends FallbackConfigSourceInterceptor {
         private static final Function<String, String> COMPRESSION_FALLBACK = name -> {
-            if (name.startsWith("quarkus.rest-client")) {
-                int index = name.indexOf(".enable-response-decompression");
-                if (index == -1) { // not the property we care about
-                    return name;
-                }
-                return name.substring(0, index) + ".enable-compression";
+            if (name.startsWith(REST_CLIENT_PREFIX) && name.endsWith(ENABLE_RESPONSE_DECOMPRESSION)) {
+                return name.substring(0, name.length() - ENABLE_RESPONSE_DECOMPRESSION.length()) + ENABLE_COMPRESSION;
             }
             return name;
         };
@@ -465,12 +463,8 @@ public abstract class AbstractRestClientConfigBuilder implements ConfigBuilder {
 
     private static class RenameConfigRelocateInterceptor extends RelocateConfigSourceInterceptor {
         private static final Function<String, String> COMPRESSION_RELOCATION = name -> {
-            if (name.startsWith("quarkus.rest-client")) {
-                int index = name.indexOf(".enable-compression");
-                if (index == -1) { // not the property we care about
-                    return name;
-                }
-                return name.substring(0, index) + ".enable-response-decompression";
+            if (name.startsWith(REST_CLIENT_PREFIX) && name.endsWith(ENABLE_COMPRESSION)) {
+                return name.substring(0, name.length() - ENABLE_COMPRESSION.length()) + ENABLE_RESPONSE_DECOMPRESSION;
             }
             return name;
         };

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -285,7 +285,7 @@ public interface RestClientsConfig {
      * <p>
      * Can be overwritten by client-specific settings.
      */
-    Optional<Boolean> enableCompression();
+    Optional<Boolean> enableResponseDecompression();
 
     /**
      * If the Application-Layer Protocol Negotiation is enabled, the client will negotiate which protocol to use over the

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
@@ -650,8 +650,8 @@ public class RestClientBuilderImpl implements RestClientBuilder, VertxRequestCus
 
         Boolean effectiveEnableCompression = enableCompression;
         if (effectiveEnableCompression == null) {
-            if (restClients.enableCompression().isPresent()) {
-                effectiveEnableCompression = restClients.enableCompression().get();
+            if (restClients.enableResponseDecompression().isPresent()) {
+                effectiveEnableCompression = restClients.enableResponseDecompression().get();
             }
         }
         if (effectiveEnableCompression == null) {

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
@@ -151,7 +151,7 @@ public class RestClientCDIDelegateBuilder<T> {
         builder.property(QuarkusRestClientProperties.MAX_CHUNK_SIZE, maxChunkSize.orElse(DEFAULT_MAX_CHUNK_SIZE));
 
         Optional<Boolean> enableCompressions = oneOf(restClientConfig.enableResponseDecompression(),
-                configRoot.enableCompression());
+                configRoot.enableResponseDecompression());
         if (enableCompressions.isPresent()) {
             builder.enableCompression(enableCompressions.get());
         }


### PR DESCRIPTION
@geoand I propose these changes to complete mission,  started as #50553


Firstly, this started as work to eliminate `Unrecognized configuration key "quarkus.rest-client.enable-response-decompression" was provided`. [Reproducer](https://github.com/lasteris/quarkus-rest-client-global-compression-reproducer)
i found out reason in Relocators, because they not fixed on per client config, but global config has old name (relocator creates non-existed key). So, i've a bit rewrote code.

Also, renamed global Rest Client property name and did changes to docs, so people should know, that property for both global and per client have new names.

