### PR TITLE
Allow TEST_TO_MAIN_MAPPINGS to be set as a system property

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
@@ -16,6 +16,8 @@ public interface BootstrapConstants {
     /**
      * Constant for sharing the additional mappings between test-sources and the corresponding application-sources.
      * The Gradle plugin populates this data which is then read by the PathTestHelper when executing tests.
+     * It can be set either as a system property or as an environment variable.
+     * If both are set, the system property takes precedence.
      */
     String TEST_TO_MAIN_MAPPINGS = "TEST_TO_MAIN_MAPPINGS";
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
@@ -100,7 +100,10 @@ public final class PathTestHelper {
                 File.separator + "classes");
         //endregion
 
-        String mappings = System.getenv(BootstrapConstants.TEST_TO_MAIN_MAPPINGS);
+        String mappings = System.getProperty(BootstrapConstants.TEST_TO_MAIN_MAPPINGS);
+        if (mappings == null) {
+            mappings = System.getenv(BootstrapConstants.TEST_TO_MAIN_MAPPINGS);
+        }
         if (mappings != null) {
             Stream.of(mappings.split(","))
                     .filter(s -> !s.isEmpty())


### PR DESCRIPTION
Some build tools (Kotlin Toolchain) cannot set environment variables (yet) for the test JVM. The system property takes precedence, the environment variable is the fallback.