### PR TITLE
Run the Oracle tests with Podman again

### DIFF
--- a/extensions/jdbc/jdbc-oracle/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-oracle/deployment/pom.xml
@@ -117,26 +117,5 @@
                 </plugins>
             </build>
         </profile>
-
-        <!-- Disabled pending fix of #33094 -->
-        <profile>
-            <id>podman</id>
-            <activation>
-                <property>
-                    <name>env.IS_PODMAN</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/extensions/reactive-oracle-client/deployment/pom.xml
+++ b/extensions/reactive-oracle-client/deployment/pom.xml
@@ -238,27 +238,6 @@
                 </plugins>
             </build>
         </profile>
-
-        <!-- Disabled pending fix of #33094 -->
-        <profile>
-            <id>podman</id>
-            <activation>
-                <property>
-                    <name>env.IS_PODMAN</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 
 </project>

--- a/integration-tests/hibernate-reactive-oracle/pom.xml
+++ b/integration-tests/hibernate-reactive-oracle/pom.xml
@@ -221,27 +221,6 @@
                 </plugins>
             </build>
         </profile>
-
-        <!-- Disabled pending fix of #33094 -->
-        <profile>
-            <id>podman</id>
-            <activation>
-                <property>
-                    <name>env.IS_PODMAN</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 
 


### PR DESCRIPTION
Same treatment as #56193 and #56194: the `podman` profile skipping surefire when `IS_PODMAN` is set, added in 2023 for #33094, is removed from the three Oracle modules after verifying they pass with Podman.

Verified on Linux x86_64 with rootless Podman 5.8.3 (`DOCKER_HOST` pointing at the user socket, no Docker installed), `docker.io/gvenzl/oracle-free:23-slim-faststart`, with `-Dtest-containers -Dstart-containers`:

| Module | Oracle started by | Result |
|---|---|---|
| `extensions/jdbc/jdbc-oracle/deployment` | Dev Services (Testcontainers) | 7/7 |
| `extensions/reactive-oracle-client/deployment` | `docker-maven-plugin` (`docker-start`, healthcheck wait) | 31 run, 1 skipped, 0 failures |
| `integration-tests/hibernate-reactive-oracle` | Dev Services | JVM 11/11, native (Mandrel 25 via Podman) 11/11 |

The 2023 failure in the issue was the Oracle container not becoming ready in time under Podman; with the current image and Podman it starts in well under the configured 60 s wait (`DATABASE IS READY TO USE!` reached before the healthcheck timeout in the `docker-maven-plugin` case).

- Fixes: #33094
