### PR TITLE
OIDC: keep the session when a code flow callback arrives on it (option b)

### DIFF
--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowVirtualCallbackMultiTabTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowVirtualCallbackMultiTabTest.java
@@ -1,0 +1,79 @@
+package io.quarkus.oidc.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
+
+/**
+ * The redirect path has no resource behind it: the code flow callback must be handled by the authentication
+ * mechanism whether or not a session already exists, see <a href="https://github.com/quarkusio/quarkus/issues/35391">
+ * GitHub issue #35391</a>.
+ */
+@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+public class CodeFlowVirtualCallbackMultiTabTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(ProtectedResource.class)
+                    .addAsResource("application-virtual-callback.properties", "application.properties"));
+
+    @Test
+    public void testSingleTab() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+            HtmlPage page = login(webClient.getPage("http://localhost:8081/protected"));
+            assertEquals("http://localhost:8081/protected", page.getUrl().toString());
+            assertEquals("alice", page.getBody().asNormalizedText());
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
+    public void testSecondTabCompletesAfterTheFirstOneLoggedIn() throws Exception {
+        // one WebClient is one browser: both tabs share the cookies
+        try (final WebClient webClient = createWebClient()) {
+            // the second tab reaches the login page and stays there
+            HtmlPage secondTabLoginPage = webClient.getPage("http://localhost:8081/protected");
+            assertEquals("Sign in to quarkus", secondTabLoginPage.getTitleText());
+            String secondTabAuthorizationUrl = secondTabLoginPage.getUrl().toString();
+
+            // the first tab logs in
+            HtmlPage firstTab = login(webClient.getPage("http://localhost:8081/protected"));
+            assertEquals("alice", firstTab.getBody().asNormalizedText());
+
+            // the second tab completes its own code flow: the provider has a session for the user, so its
+            // authorization endpoint redirects straight back with a code for the second tab's state
+            HtmlPage secondTab = webClient.getPage(secondTabAuthorizationUrl);
+            assertEquals("http://localhost:8081/protected", secondTab.getUrl().toString());
+            assertEquals("alice", secondTab.getBody().asNormalizedText());
+
+            // and the session keeps working
+            HtmlPage page = webClient.getPage("http://localhost:8081/protected");
+            assertEquals("alice", page.getBody().asNormalizedText());
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    private static HtmlPage login(HtmlPage loginPage) throws Exception {
+        assertEquals("Sign in to quarkus", loginPage.getTitleText());
+        HtmlForm loginForm = loginPage.getForms().get(0);
+        loginForm.getInputByName("username").setValueAttribute("alice");
+        loginForm.getInputByName("password").setValueAttribute("alice");
+        return loginForm.getButtonByName("login").click();
+    }
+
+    private WebClient createWebClient() {
+        WebClient webClient = new WebClient();
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        return webClient;
+    }
+}

--- a/extensions/oidc/deployment/src/test/resources/application-virtual-callback.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-virtual-callback.properties
@@ -1,0 +1,12 @@
+# Disable Dev Services, we use a test resource manager
+quarkus.keycloak.devservices.enabled=false
+
+quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.client-id=quarkus-web-app
+quarkus.oidc.credentials.secret=secret
+quarkus.oidc.application-type=web-app
+# a redirect path with no resource behind it
+quarkus.oidc.authentication.redirect-path=/oidc-callback
+quarkus.oidc.authentication.restore-path-after-redirect=true
+
+quarkus.log.category."org.htmlunit".level=ERROR

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -106,37 +106,44 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
         // If the session is already established then try to re-authenticate
         if (sessionCookieValue != null) {
             LOG.debug("Session cookie is present, starting the reauthentication");
+            final boolean pendingCodeFlowRedirect = isPendingCodeFlowRedirect(context, cookies, oidcTenantConfig);
             Uni<TenantConfigContext> resolvedContext = resolver.resolveContext(context);
             return resolvedContext.onItem()
                     .transformToUni(new Function<TenantConfigContext, Uni<? extends SecurityIdentity>>() {
                         @Override
                         public Uni<SecurityIdentity> apply(TenantConfigContext tenantContext) {
-                            return reAuthenticate(sessionCookieValue, context, identityProviderManager, tenantContext);
+                            Uni<SecurityIdentity> identity = reAuthenticate(sessionCookieValue, context,
+                                    identityProviderManager, tenantContext);
+                            if (!pendingCodeFlowRedirect) {
+                                return identity;
+                            }
+                            // This request completes a code flow started in another browser tab before the session
+                            // was established: the session is kept and the request is redirected to the path saved
+                            // when that flow was started. If the session turns out to be invalid, the flow is
+                            // completed instead, as when no session exists.
+                            return identity.onItem().transformToUni(
+                                    new Function<SecurityIdentity, Uni<? extends SecurityIdentity>>() {
+                                        @Override
+                                        public Uni<? extends SecurityIdentity> apply(SecurityIdentity identity) {
+                                            return completePendingCodeFlowWithSession(context, tenantContext, cookies,
+                                                    identity);
+                                        }
+                                    }).onFailure(AuthenticationFailedException.class).recoverWithUni(
+                                            new Function<AuthenticationFailedException, Uni<? extends SecurityIdentity>>() {
+                                                @Override
+                                                public Uni<? extends SecurityIdentity> apply(AuthenticationFailedException t) {
+                                                    LOG.debug("Session is not valid, completing the pending code flow");
+                                                    return processPendingCodeFlowRedirect(context, oidcTenantConfig,
+                                                            identityProviderManager, cookies);
+                                                }
+                                            });
                         }
                     });
         }
 
         // Check if the state cookie is available
         if (isStateCookieAvailable(cookies)) {
-            // Authorization code flow is in progress, however it is not necessarily tied to the current request.
-            if (ResponseMode.FORM_POST == oidcTenantConfig.authentication().responseMode().orElse(ResponseMode.QUERY)) {
-                if (OidcUtils.isFormUrlEncodedRequest(context)) {
-                    return OidcUtils.getFormUrlEncodedData(context).onItem()
-                            .transformToUni(new Function<MultiMap, Uni<? extends SecurityIdentity>>() {
-                                @Override
-                                public Uni<? extends SecurityIdentity> apply(MultiMap requestParams) {
-                                    return processRedirectFromOidc(context, oidcTenantConfig, identityProviderManager,
-                                            requestParams, cookies);
-                                }
-                            });
-                }
-                LOG.debug("HTTP POST and " + HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED.toString()
-                        + " content type must be used with the form_post response mode");
-                return Uni.createFrom().failure(new AuthenticationFailedException());
-            } else {
-                return processRedirectFromOidc(context, oidcTenantConfig, identityProviderManager,
-                        context.queryParams(), cookies);
-            }
+            return processPendingCodeFlowRedirect(context, oidcTenantConfig, identityProviderManager, cookies);
         }
 
         // return an empty identity - this will lead to a challenge redirecting the user to OpenId Connect provider
@@ -144,6 +151,110 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
         context.put(NO_OIDC_COOKIES_AVAILABLE, Boolean.TRUE);
         return Uni.createFrom().optional(Optional.empty());
 
+    }
+
+    private Uni<SecurityIdentity> processPendingCodeFlowRedirect(RoutingContext context, OidcTenantConfig oidcTenantConfig,
+            IdentityProviderManager identityProviderManager, Map<String, Cookie> cookies) {
+        // Authorization code flow is in progress, however it is not necessarily tied to the current request.
+        if (ResponseMode.FORM_POST == oidcTenantConfig.authentication().responseMode().orElse(ResponseMode.QUERY)) {
+            if (OidcUtils.isFormUrlEncodedRequest(context)) {
+                return OidcUtils.getFormUrlEncodedData(context).onItem()
+                        .transformToUni(new Function<MultiMap, Uni<? extends SecurityIdentity>>() {
+                            @Override
+                            public Uni<? extends SecurityIdentity> apply(MultiMap requestParams) {
+                                return processRedirectFromOidc(context, oidcTenantConfig, identityProviderManager,
+                                        requestParams, cookies);
+                            }
+                        });
+            }
+            LOG.debug("HTTP POST and " + HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED.toString()
+                    + " content type must be used with the form_post response mode");
+            return Uni.createFrom().failure(new AuthenticationFailedException());
+        } else {
+            return processRedirectFromOidc(context, oidcTenantConfig, identityProviderManager,
+                    context.queryParams(), cookies);
+        }
+    }
+
+    /**
+     * Completes, on behalf of an existing session, a code flow started in another browser tab: the state cookie is
+     * removed, the authorization code is not used, and the request is redirected to the path saved when the flow was
+     * started. When no path was saved the request goes on with the identity of the session.
+     */
+    private Uni<SecurityIdentity> completePendingCodeFlowWithSession(RoutingContext context,
+            TenantConfigContext configContext, Map<String, Cookie> cookies, SecurityIdentity identity) {
+        final OidcTenantConfig oidcTenantConfig = configContext.oidcConfig();
+        Uni<MultiMap> requestParams;
+        if (ResponseMode.FORM_POST == oidcTenantConfig.authentication().responseMode().orElse(ResponseMode.QUERY)) {
+            requestParams = OidcUtils.getFormUrlEncodedData(context);
+        } else {
+            requestParams = Uni.createFrom().item(context.queryParams());
+        }
+        return requestParams.onItem().transformToUni(new Function<MultiMap, Uni<? extends SecurityIdentity>>() {
+            @Override
+            public Uni<? extends SecurityIdentity> apply(MultiMap params) {
+                List<String> stateQueryParam = params.getAll(OidcConstants.CODE_FLOW_STATE);
+                if (stateQueryParam.size() != 1) {
+                    return Uni.createFrom().item(identity);
+                }
+                String stateCookieNameSuffix = oidcTenantConfig.authentication().allowMultipleCodeFlows()
+                        ? "_" + stateQueryParam.get(0)
+                        : "";
+                Cookie stateCookie = context.request().getCookie(getStateCookieName(oidcTenantConfig) + stateCookieNameSuffix);
+                if (stateCookie == null) {
+                    return Uni.createFrom().item(identity);
+                }
+                String[] parsedStateCookieValue = COOKIE_PATTERN.split(stateCookie.getValue());
+                OidcUtils.removeCookie(context, oidcTenantConfig, stateCookie.getName());
+                if (!parsedStateCookieValue[0].equals(stateQueryParam.get(0))) {
+                    final String error = "State cookie value does not match the state query parameter value, "
+                            + "completing the code flow with HTTP status 401";
+                    LOG.error(error);
+                    return Uni.createFrom().failure(new AuthenticationCompletionException(error));
+                }
+                LOG.debug("Code flow started in another tab completed with the existing session, not using its code");
+                CodeAuthenticationStateBean stateBean = getCodeAuthenticationBean(parsedStateCookieValue, configContext);
+                if (stateBean == null || stateBean.getRestorePath() == null
+                        || !isRestorePath(oidcTenantConfig.authentication())) {
+                    return Uni.createFrom().item(identity);
+                }
+                String restorePath = stateBean.getRestorePath();
+                String finalRedirectUri = buildUri(context, isForceHttps(oidcTenantConfig), restorePath);
+                LOG.debugf("Redirecting to the path saved when the code flow was started: %s", finalRedirectUri);
+                return Uni.createFrom().failure(new AuthenticationRedirectException(
+                        filterRedirect(context, configContext, finalRedirectUri, Redirect.Location.LOCAL_ENDPOINT_CALLBACK)));
+            }
+        });
+    }
+
+    /**
+     * Whether the current request is the redirect from the OIDC provider completing a code flow for which a state
+     * cookie exists: the {@code state} parameter matches a state cookie and the request targets the redirect path.
+     */
+    private boolean isPendingCodeFlowRedirect(RoutingContext context, Map<String, Cookie> cookies,
+            OidcTenantConfig oidcTenantConfig) {
+        if (!isStateCookieAvailable(cookies) || !isRedirectPathRequest(context, oidcTenantConfig)) {
+            return false;
+        }
+        if (ResponseMode.FORM_POST == oidcTenantConfig.authentication().responseMode().orElse(ResponseMode.QUERY)) {
+            // the state parameter is in the form body which is read later
+            return OidcUtils.isFormUrlEncodedRequest(context);
+        }
+        List<String> state = context.queryParams().getAll(OidcConstants.CODE_FLOW_STATE);
+        if (state.size() != 1 || !(context.queryParams().contains(OidcConstants.CODE_FLOW_CODE)
+                || context.queryParams().contains(OidcConstants.CODE_FLOW_ERROR))) {
+            return false;
+        }
+        String stateCookieNameSuffix = oidcTenantConfig.authentication().allowMultipleCodeFlows() ? "_" + state.get(0) : "";
+        return cookies.containsKey(getStateCookieName(oidcTenantConfig) + stateCookieNameSuffix);
+    }
+
+    private boolean isRedirectPathRequest(RoutingContext context, OidcTenantConfig oidcTenantConfig) {
+        String redirectPath = getRedirectPath(oidcTenantConfig, context);
+        if (redirectPath.startsWith(HTTP_SCHEME)) {
+            redirectPath = URI.create(redirectPath).getPath();
+        }
+        return context.request().path().equals(redirectPath);
     }
 
     private boolean isStateCookieAvailable(Map<String, Cookie> cookies) {


### PR DESCRIPTION
**Draft, option (b) of two, see #35391.** The alternative is #56456, the *complete the second flow* variant (option (a)), opened alongside so both can be compared; only one should be merged.

When a user opens a protected application in two tabs and logs in from the first one, the second tab still completes its own authorization code flow: the provider redirects it back with a code for the second tab's state. That request carries the session cookie of the first tab, so `CodeAuthenticationMechanism` re-authenticated from the session and let the request through as an ordinary one, which is a 404 when `redirect-path` has no resource behind it.

This variant keeps the existing session. When the request is the redirect completing a code flow (it targets the redirect path and its `state` matches a state cookie) and the session re-authenticates successfully, the state cookie is removed, the authorization code is not used, and the request is redirected to the path saved when that flow was started (when nothing was saved, or `restore-path-after-redirect` is off, the request goes on with the session's identity, so a real resource at the redirect path is still served). When the session is not valid any more, the pending flow is completed as when no session exists, so the user never lands on the login page holding a valid code.

Trade-offs compared to (a):
- no second token exchange, the first tab's session is untouched, no cookie churn;
- the second flow's code is discarded, so scopes or a step-up requested by that flow are lost; the provider invalidates the unused code when it expires.

`CodeFlowVirtualCallbackMultiTabTest` (OIDC deployment module, Keycloak test resource, HtmlUnit with one cookie jar for both tabs): single tab, and second tab completing after the first one logged in; the second test fails on `main` with the 404 from the report. Full `extensions/oidc/deployment` suite green (57).

- Fixes: #35391