### PR TITLE
Do not report a client going away during a chunked servlet response as an error

### DIFF
--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/servlet/ClientAbortChunkedResponseTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/servlet/ClientAbortChunkedResponseTest.java
@@ -1,0 +1,64 @@
+package io.quarkus.resteasy.test.servlet;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.logging.Level;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+/**
+ * A client going away while a chunked response is being written must not be reported as an error: the write to the
+ * closed connection fails, nothing can be sent to the client any more, and that is expected.
+ */
+public class ClientAbortChunkedResponseTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClasses(ClientAbortResource.class))
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-undertow", Version.getVersion())))
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue()
+                    && record.getLoggerName().startsWith("io.undertow"))
+            .assertLogRecords(records -> assertTrue(records.isEmpty(), () -> "Unexpected log records: " + records.stream()
+                    .map(r -> r.getLevel() + " " + r.getLoggerName() + ": " + r.getMessage()).toList()));
+
+    @Path("/client-abort")
+    public static class ClientAbortResource {
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String get() throws InterruptedException {
+            // gives the client time to go away; the response is larger than the buffer so it is chunked
+            Thread.sleep(500);
+            return "A".repeat(64 * 1024);
+        }
+    }
+
+    @Test
+    public void clientClosesTheConnectionBeforeTheChunkedResponse() throws Exception {
+        try (Socket socket = new Socket("localhost", RestAssured.port)) {
+            OutputStream out = socket.getOutputStream();
+            out.write(("GET /client-abort HTTP/1.1\r\nHost: localhost\r\n\r\n").getBytes(StandardCharsets.UTF_8));
+            out.flush();
+            Thread.sleep(100);
+        }
+        // let the endpoint complete and attempt to write to the closed connection
+        Thread.sleep(1500);
+        // and the server still works
+        RestAssured.get("/client-abort").then().statusCode(200);
+    }
+}

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/QuarkusExceptionHandler.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/QuarkusExceptionHandler.java
@@ -40,12 +40,30 @@ public class QuarkusExceptionHandler implements ExceptionHandler {
             Logger.Level stackTraceLevel = log.stackTraceLevel();
             String category = log.category();
             handleCustomLog(exchange, t, level, stackTraceLevel, category, uid);
-        } else if (t instanceof IOException) {
+        } else if (isIOException(t)) {
             //we log IOExceptions at a lower level
             //because they can be easily caused by malicious remote clients in at attempt to DOS the server by filling the logs
             UndertowLogger.REQUEST_IO_LOGGER.debugf(t, "Exception handling request %s to %s", uid, exchange.getRequestURI());
         } else {
             UndertowLogger.REQUEST_IO_LOGGER.errorf(t, "Exception handling request %s to %s", uid, exchange.getRequestURI());
+        }
+        // once the response is complete, typically because the client went away while it was being written, no error
+        // page can be sent any more and attempting it fails in turn
+        return exchange.isResponseComplete();
+    }
+
+    /**
+     * Whether the exception is, or wraps, an {@link IOException}: frameworks such as RESTEasy report a failed write
+     * to the client through their own exception type.
+     */
+    private static boolean isIOException(Throwable t) {
+        for (Throwable cause = t; cause != null; cause = cause.getCause()) {
+            if (cause instanceof IOException) {
+                return true;
+            }
+            if (cause.getCause() == cause) {
+                break;
+            }
         }
         return false;
     }


### PR DESCRIPTION
Reproduced on current `main` with the resource from the report (`quarkus-resteasy-jackson` + `quarkus-undertow`, a 1 s sleep, `curl --max-time 0.5` on a response large enough to be chunked): each cancelled request logs two errors, a cancelled fixed-length response logs none.

What happens: once the client closes the connection the Vert.x exchange marks the response complete, so the next chunk write fails with `UT000127: Response has already been sent`. RESTEasy reports that as an `UnhandledException` wrapping the `IOException`. `QuarkusExceptionHandler` only recognised a bare `IOException` for its DEBUG-level treatment, so this went to ERROR (first stack trace), and it returned "not handled", so `ServletInitialHandler` went on to `response.reset()` to send an error page; the servlet output stream is already committed, so that throws `UT010019: Response already committed`, logged by Undertow as the second error.

Two small changes in `QuarkusExceptionHandler`:

- an `IOException` anywhere in the cause chain gets the same DEBUG treatment as a bare one, whichever framework wraps it;
- the exception is reported as handled when `exchange.isResponseComplete()`: nothing can be sent to the client any more, so the error page dispatch, which can only fail, is skipped.

`ClientAbortChunkedResponseTest` (resteasy-classic deployment, forced `quarkus-undertow`) opens a raw socket, sends the request, closes the socket, waits for the endpoint to write, and asserts no `io.undertow` record at WARNING or above; on `main` it fails with exactly the two errors above. Also re-ran the report's `curl` scenario against the built runtime: 0 errors. `extensions/undertow/deployment` (1050) and `extensions/resteasy-classic/resteasy/deployment` (872) are green.

- Fixes: #47005
