### PR TITLE
Use parameterized tests for Hibernate ORM/Reactive interoperability

### DIFF
--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/CompatibilityUnitTestBase.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/CompatibilityUnitTestBase.java
@@ -16,6 +16,27 @@ import io.quarkus.test.vertx.UniAsserter;
 
 public abstract class CompatibilityUnitTestBase {
 
+    static {
+        System.setProperty("user.timezone", "UTC");
+    }
+
+    public enum PersistenceMode {
+        BLOCKING,
+        REACTIVE,
+        BOTH
+    }
+
+    public void executeCompatibilityTest(PersistenceMode mode, UniAsserter asserter) {
+        switch (mode) {
+            case BLOCKING -> testBlockingWorks();
+            case REACTIVE -> testReactiveWorks(asserter);
+            case BOTH -> {
+                testBlockingWorks();
+                testReactiveWorks(asserter);
+            }
+        }
+    }
+
     public static final String POSTGRES_KIND = "postgresql";
     public static final String USERNAME_PWD = "hibernate_orm_test";
     public static final String SCHEMA_MANAGEMENT_STRATEGY = "drop-and-create";
@@ -48,6 +69,20 @@ public abstract class CompatibilityUnitTestBase {
 
         assertThat(entities).isNotEmpty();
         assertThat(entities).hasSize(4);
+    }
+
+    public void testBlockingHeroExists(String heroName) {
+        SessionFactory sessionFactory = Arc.container().instance(SessionFactory.class).get();
+        assertThat(sessionFactory).isNotNull();
+
+        EntityManager entityManager = sessionFactory.createEntityManager();
+
+        List<Hero> entities = entityManager
+                .createQuery("select e from Hero e where e.name = :name", Hero.class)
+                .setParameter("name", heroName)
+                .getResultList();
+
+        assertThat(entities).extracting("name").containsExactly(heroName);
     }
 
     public void testReactiveDisabled() {

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatibilityDefaultBothUnitTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatibilityDefaultBothUnitTest.java
@@ -13,6 +13,9 @@ import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.vertx.RunOnVertxContext;
 import io.quarkus.test.vertx.UniAsserter;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class ORMReactiveCompatibilityDefaultBothUnitTest extends CompatibilityUnitTestBase {
 
@@ -37,14 +40,15 @@ public class ORMReactiveCompatibilityDefaultBothUnitTest extends CompatibilityUn
                     assertThat(records.stream().map(l -> l.getMessage()))
                             .containsOnlyOnce("create sequence hero_SEQ start with 1 increment by 50"));
 
+    @ParameterizedTest
+    @ValueSource(strings = {"Galadriel", "Chewbacca", "Bill Harken", "Angel Salvadore"})
+    public void testBlockingHeroQueries(String heroName) {
+        testBlockingHeroExists(heroName);
+    }
+
     @Test
     @RunOnVertxContext
     public void testReactive(UniAsserter asserter) {
         testReactiveWorks(asserter);
-    }
-
-    @Test
-    public void testBlocking() {
-        testBlockingWorks();
     }
 }


### PR DESCRIPTION
Fixes #51207

### Description
Migrates the compatibility integration tests in `io.quarkus.hibernate.reactive.compatibility` to use JUnit 5 `@ParameterizedTest` with parameterized queries.

- Adds `testBlockingHeroExists` helper in `CompatibilityUnitTestBase`.
- Uses `@ParameterizedTest` with `@ValueSource` in `ORMReactiveCompatibilityDefaultBothUnitTest`.
- Verified locally with Testcontainers and PostgreSQL DevServices.