### PR TITLE
Qute: require the index parameter for list get/take/takeLast

### DIFF
--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/CollectionTemplateExtensionsTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/CollectionTemplateExtensionsTest.java
@@ -1,6 +1,8 @@
 package io.quarkus.qute.deployment.extensions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 import java.util.List;
@@ -12,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.qute.Engine;
+import io.quarkus.qute.TemplateException;
 import io.quarkus.test.QuarkusExtensionTest;
 
 public class CollectionTemplateExtensionsTest {
@@ -72,6 +75,16 @@ public class CollectionTemplateExtensionsTest {
     @Test
     public void testLast() {
         assertEquals("CHARLIE", engine.getTemplate("last").data("list", listOfNames()).render());
+    }
+
+    @Test
+    public void testIndexParameterIsRequired() {
+        for (String expression : List.of("{list.get}", "{list.take}", "{list.takeLast}")) {
+            TemplateException expected = assertThrows(TemplateException.class,
+                    () -> engine.parse(expression).data("list", listOfNames()).render());
+            assertTrue(expected.getMessage().contains("not found on the base object"), expected.getMessage());
+            assertTrue(expected.getMessage().contains("in expression " + expression), expected.getMessage());
+        }
     }
 
     private List<String> listOfNames() {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ValueResolvers.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ValueResolvers.java
@@ -764,6 +764,7 @@ public final class ValueResolvers {
                         }
                     });
                 }
+                return Results.notFound(context);
             case ListResolver.TAKE:
                 if (context.getParams().size() == 1) {
                     return context.evaluate(context.getParams().get(0)).thenApply(r -> {
@@ -778,6 +779,7 @@ public final class ValueResolvers {
                         }
                     });
                 }
+                return Results.notFound(context);
             case ListResolver.TAKE_LAST:
                 if (context.getParams().size() == 1) {
                     return context.evaluate(context.getParams().get(0)).thenApply(r -> {
@@ -792,6 +794,7 @@ public final class ValueResolvers {
                         }
                     });
                 }
+                return Results.notFound(context);
             case ListResolver.FIRST:
                 if (list.isEmpty()) {
                     throw new NoSuchElementException();

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/ListResolverTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/ListResolverTest.java
@@ -23,4 +23,16 @@ public class ListResolverTest {
                 .withMessageContaining("in expression {list.abc}");
     }
 
+    @Test
+    public void testIndexParameterIsRequired() {
+        List<String> list = List.of("jedna", "dva", "tri");
+        Engine engine = Engine.builder().addDefaults().build();
+        for (String expression : List.of("{list.get}", "{list.take}", "{list.takeLast}")) {
+            assertThatExceptionOfType(TemplateException.class)
+                    .isThrownBy(() -> engine.parse(expression).data("list", list).render())
+                    .withMessageContaining("not found on the base object")
+                    .withMessageContaining("in expression " + expression);
+        }
+    }
+
 }


### PR DESCRIPTION
`{list.get}`, `{list.take}` and `{list.takeLast}` render the first element of the list instead of failing. The switch in `ValueResolvers.listResolveAsync()` guards each of those three cases with `if (context.getParams().size() == 1)` and has nothing after the `if`, so when the index parameter is missing execution falls through to `case ListResolver.FIRST` and returns `list.get(0)`. On an empty list the same fall-through throws a bare `NoSuchElementException` out of the render call.

Each case now returns a not-found result when there is no index parameter, so you get the usual `Property "get" not found on the base object` error instead. Arrays and maps already report an error here, and `ListResolver.getSupportedProperties()` only advertises `first`, `last` and the index, so `get` was never meant to resolve as a property.

The new test in `ListResolverTest` fails on main and passes with the change; `./mvnw install -f independent-projects/qute/` is green.
