### PR TITLE
Stop non-reusable dev services when the JVM shuts down after tests

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItem.java
@@ -228,7 +228,8 @@ public final class DevServicesRegistryBuildItem extends SimpleBuildItem {
                 allDevServicesOverrideConfigs.putAll(overrideConfig);
 
                 RunningService service = new RunningService(request.getName(), request.getDescription(),
-                        new HashMap<>(currentDevServiceConfig), overrideConfig, startable.getContainerId(), startable);
+                        new HashMap<>(currentDevServiceConfig), overrideConfig, startable.getContainerId(), startable,
+                        startable.isReusable());
 
                 for (DevServicesAdditionalConfigBuildItem additionalConfigBuildItem : additionalConfigBuildItems) {
                     Map<String, String> extraFromBuildItem = additionalConfigBuildItem.getConfigProvider()

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/Startable.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/Startable.java
@@ -10,4 +10,17 @@ public interface Startable extends Closeable {
     // This starts to couple to containers, so we could move it to sub-interface and use that in dev services
     String getContainerId();
 
+    /**
+     * Whether this service is configured for Testcontainers-level reuse.
+     * <p>
+     * A reusable service survives the {@link #close()} Quarkus performs on shutdown, so that a later,
+     * separate JVM run can reuse it. It is still closed when its configuration is no longer compatible
+     * with the application being started, such as on an incompatible profile change.
+     *
+     * @return {@code true} if this service is configured for Testcontainers-level reuse
+     */
+    default boolean isReusable() {
+        return false;
+    }
+
 }

--- a/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/RunningDevServicesRegistry.java
+++ b/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/RunningDevServicesRegistry.java
@@ -47,6 +47,14 @@ public final class RunningDevServicesRegistry {
         log.infof(e, "Failed to close dev service for %s in launch mode %s: %s", featureName, launchMode, containerId);
     }
 
+    /**
+     * Closes the services owned by the given application instance, as the shutdown close task.
+     * <p>
+     * Services configured for Testcontainers-level reuse are removed from the registry but left running,
+     * so that a later, separate JVM run can pick them up. They are still stopped by
+     * {@link #closeAllRunningServices(DevServiceOwner)} when their configuration no longer matches the
+     * application being started, such as on an incompatible profile change.
+     */
     public void closeOwnRunningServices(UUID uuid, String launchMode) {
         Set<RunningService> services = servicesIndexedByLaunchMode.get(launchMode);
         Iterator<Map.Entry<ComparableDevServicesConfig, RunningService>> it = servicesIndexedByConfig.entrySet().iterator();
@@ -60,12 +68,17 @@ public final class RunningDevServicesRegistry {
                 if (services != null) {
                     services.remove(service);
                 }
-                try {
-                    logClosing(owner.featureName(), launchMode, service.containerId());
-                    service.close();
-                } catch (Exception e) {
-                    // We don't want to fail the shutdown hook if a service fails to close
-                    logFailedToClose(e, owner.featureName(), launchMode, service.containerId());
+                if (service.isReusable()) {
+                    log.debugf("Not closing reusable dev service for %s in launch mode %s: %s",
+                            owner.featureName(), launchMode, service.containerId());
+                } else {
+                    try {
+                        logClosing(owner.featureName(), launchMode, service.containerId());
+                        service.close();
+                    } catch (Exception e) {
+                        // We don't want to fail the shutdown hook if a service fails to close
+                        logFailedToClose(e, owner.featureName(), launchMode, service.containerId());
+                    }
                 }
             }
         }
@@ -95,6 +108,14 @@ public final class RunningDevServicesRegistry {
 
     }
 
+    /**
+     * Closes every service belonging to the given owner, regardless of reuse configuration.
+     * <p>
+     * This runs when a service's configuration no longer matches the application being started, such as
+     * on an incompatible profile change, where the running container cannot satisfy the new configuration
+     * and has to be replaced. Unlike the shutdown path in {@link #closeOwnRunningServices(UUID, String)},
+     * reuse does not spare a service here.
+     */
     public void closeAllRunningServices(DevServiceOwner owner) {
         Set<RunningService> launchModeServices = servicesIndexedByLaunchMode.get(owner.launchMode());
         var iterator = servicesIndexedByConfig.entrySet().iterator();

--- a/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/RunningService.java
+++ b/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/RunningService.java
@@ -19,16 +19,18 @@ public final class RunningService implements Closeable {
     private final Map<String, String> overrideConfigs;
     private final String containerId;
     private final Closeable closeable;
+    private final boolean reusable;
 
     public RunningService(String feature, String description, Map<String, String> configs, Map<String, String> overrideConfig,
             String containerId,
-            Closeable closeable) {
+            Closeable closeable, boolean reusable) {
         this.feature = feature;
         this.description = description;
         this.configs = configs;
         this.overrideConfigs = overrideConfig;
         this.containerId = containerId;
         this.closeable = closeable;
+        this.reusable = reusable;
     }
 
     @Override
@@ -58,5 +60,9 @@ public final class RunningService implements Closeable {
 
     public String containerId() {
         return containerId;
+    }
+
+    public boolean isReusable() {
+        return reusable;
     }
 }

--- a/docs/src/main/asciidoc/extension-writing-dev-service.adoc
+++ b/docs/src/main/asciidoc/extension-writing-dev-service.adoc
@@ -44,6 +44,10 @@ Instead, extensions provide a `Startable` to a service builder, so that Quarkus 
 Services can be re-used between test profiles and across live reload restarts, or a fresh service can be created each time.
 The extension implementation controls how much reuse there is by setting a `serviceConfig(Object)` with a uniqueness key each build.
 
+Containers can additionally be configured for Testcontainers-level reuse with `withReuse(true)`, which lets a container outlive the JVM that created it so that a later, separate run can pick it up.
+A `Startable` wrapping such a container must declare it by overriding `isReusable()`, otherwise Quarkus stops the container when the application shuts down.
+Reuse-configured services are still stopped when their configuration is no longer compatible with the application being started, such as on an incompatible profile change.
+
 == Creating a Dev Service
 
 === Dependencies
@@ -89,6 +93,15 @@ implementation("io.quarkus:quarkus-devservices")
 Provide an implementation of `io.quarkus.deployment.builditem.Startable` which knows how to start and stop the service.
 For container-based services, extending `GenericContainer` and implementing `Startable` is the recommended pattern.
 In that case, `GenericContainer` already provides a `start()` method, so the only method that needs to be implemented is `close()` (which can delegate to the superclass).
+A container configured with `withReuse(true)` must also override `isReusable()`, so that Quarkus knows not to stop it on shutdown:
+
+[source,java]
+----
+@Override
+public boolean isReusable() {
+    return TestcontainersConfiguration.getInstance().environmentSupportsReuse() && isShouldBeReused();
+}
+----
 
 For example, a minimal `Startable` implementation might look something like this:
 [source,java]

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/StartableContainer.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/StartableContainer.java
@@ -3,6 +3,7 @@ package io.quarkus.devservices.common;
 import java.util.function.Function;
 
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 import io.quarkus.deployment.builditem.Startable;
 
@@ -50,5 +51,15 @@ public class StartableContainer<T extends GenericContainer<?>> implements Starta
     @Override
     public void close() {
         container.close();
+    }
+
+    @Override
+    public boolean isReusable() {
+        return isContainerReusable(container);
+    }
+
+    public static boolean isContainerReusable(GenericContainer<?> container) {
+        return TestcontainersConfiguration.getInstance().environmentSupportsReuse()
+                && container.isShouldBeReused();
     }
 }

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeDevServicesProcessor.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeDevServicesProcessor.java
@@ -137,7 +137,7 @@ public class ComposeDevServicesProcessor {
                 Feature.COMPOSE.getName(), "Compose project: " + result.projectName,
                 result.configs, Map.of(), null,
                 result.isOwner ? result.compose::stop : () -> {
-                });
+                }, false);
         devServicesRegistry.addRunningService(Feature.COMPOSE.getName(), null, configuration, service);
 
         return toComposeBuildItem(result.compose);

--- a/integration-tests/devservices/dependent-extension/deployment/src/main/java/io/quarkus/tests/dependentextension/deployment/DependentContainer.java
+++ b/integration-tests/devservices/dependent-extension/deployment/src/main/java/io/quarkus/tests/dependentextension/deployment/DependentContainer.java
@@ -2,6 +2,7 @@ package io.quarkus.tests.dependentextension.deployment;
 
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 import io.quarkus.deployment.builditem.Startable;
 
@@ -44,5 +45,10 @@ public class DependentContainer extends GenericContainer<io.quarkus.tests.depend
 
     public void setOtherUrl(String value) {
         otherConfig = value;
+    }
+
+    @Override
+    public boolean isReusable() {
+        return TestcontainersConfiguration.getInstance().environmentSupportsReuse() && isShouldBeReused();
     }
 }

--- a/integration-tests/devservices/dependent-extension/deployment/src/main/java/io/quarkus/tests/dependentextension/deployment/OptionallyDependentContainer.java
+++ b/integration-tests/devservices/dependent-extension/deployment/src/main/java/io/quarkus/tests/dependentextension/deployment/OptionallyDependentContainer.java
@@ -2,6 +2,7 @@ package io.quarkus.tests.dependentextension.deployment;
 
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 import io.quarkus.deployment.builditem.Startable;
 
@@ -44,5 +45,10 @@ public class OptionallyDependentContainer extends GenericContainer<OptionallyDep
 
     public boolean isDependencyAvailable() {
         return otherConfig != null;
+    }
+
+    @Override
+    public boolean isReusable() {
+        return TestcontainersConfiguration.getInstance().environmentSupportsReuse() && isShouldBeReused();
     }
 }

--- a/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesContainerNoReuseTest.java
+++ b/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesContainerNoReuseTest.java
@@ -16,7 +16,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.DockerClientFactory;
 
@@ -120,7 +119,6 @@ class DevServicesContainerNoReuseTest extends MojoTestBase {
     /*
      * This is a stronger version of testContainerEventuallyStoppedAfterQuarkusTest, which does not rely on Ryuk.
      */
-    @Disabled("Not yet working, see https://github.com/quarkusio/quarkus/issues/55605")
     @Test
     void testContainerStoppedImmediatelyAfterQuarkusTest() throws Exception {
         List<String> goals = List.of("clean", "test", "-Dquarkus.analytics.disabled=true");

--- a/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/DevServicesPostgresqFixedPortTest.java
+++ b/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/DevServicesPostgresqFixedPortTest.java
@@ -97,6 +97,12 @@ class DevServicesPostgresqFixedPortTest extends MojoTestBase {
         assertThat(result.getProcess().waitFor())
                 .as("Test run should succeed")
                 .isZero();
+
+        // Checked immediately, not via await() - this catches Quarkus relying on Ryuk's eventual
+        // cleanup instead of closing it itself. See https://github.com/quarkusio/quarkus/issues/55605
+        assertThat(findContainerOnPort(FIXED_PORT))
+                .as("Container should NOT still be running after the mvn test subprocess has exited, since reuse is not enabled")
+                .isNull();
     }
 
     static String findContainerOnPort(int publicPort) {

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -98,6 +98,10 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
 
     private static boolean failedBoot;
 
+    // True only while ensureStarted() is closing the previous app for a mid-run transition; lets
+    // ExtensionState.doClose() tell that apart from a truly final close.
+    private static boolean closingForApplicationTransition;
+
     private static Class<?> actualTestClass;
     private static Object actualTestInstance;
     // needed for @Nested
@@ -634,9 +638,12 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             if (isNewApplication) {
                 if (state != null) {
                     try {
+                        closingForApplicationTransition = true;
                         state.close();
                     } catch (Throwable throwable) {
                         markTestAsFailed(extensionContext, throwable);
+                    } finally {
+                        closingForApplicationTransition = false;
                     }
                 }
             }
@@ -1198,6 +1205,13 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             ClassLoader old = Thread.currentThread().getContextClassLoader();
             if (runningQuarkusApplication != null) {
                 Thread.currentThread().setContextClassLoader(runningQuarkusApplication.getClassLoader());
+                if (!closingForApplicationTransition) {
+                    // eligibleForReuse reflects the *next* test only; at a truly final close it's stale
+                    // and would otherwise block close() below from closing the class loaders, leaking
+                    // the dev services they own.
+                    ((QuarkusClassLoader) runningQuarkusApplication.getClassLoader()).getCuratedApplication()
+                            .setEligibleForReuse(false);
+                }
             }
             try {
                 // this will close the application, the test resources, the class loader...


### PR DESCRIPTION
Dev Services containers were never asked to close at the true end of a test run when Testcontainers reuse wasn't enabled. Quarkus relied on Testcontainers' Ryuk reaper to eventually clean them up instead.

The cause is `CuratedApplication.eligibleForReuse`: it's set in `QuarkusTestExtension.ensureStarted()` by comparing the running app to the *next* test about to launch, so it's never corrected at the actual end of a run and stays `true`. That silently skips `CuratedApplication.close()` and the dev services shutdown task tied to it.

This clears the flag at the truly final close, while leaving in-place application restarts within a run untouched (that distinction is what broke the earlier attempt at this in #55471). Since dev services now genuinely get asked to close, `Startable.isReusable()` lets the registry skip containers actually configured for Testcontainers-level reuse, instead of stopping them too.

`Startable.isReusable()` defaults to `false`, so an implementation that wraps a reuse-configured container has to declare it. `StartableContainer` and the database Dev Services do; three in-tree test extensions that call `withReuse(true)` and implement `Startable` directly needed the override as well, without which `DevServicesContainerReuseTest` fails. The extension authoring guide now documents this.

`DevServicesContainerNoReuseTest#testContainerStoppedImmediatelyAfterQuarkusTest` was `@Disabled` pointing at this issue, and is enabled here.

---

Fixes #55605