### PR TITLE
Read a REST Client response received as a Multi according to the subscriber's demand

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -408,6 +408,35 @@ Furthermore, the client can also send arbitrarily large files if one of the foll
 * `File`
 * `Path`
 
+=== Receiving large payloads
+
+Symmetrically, the REST Client can receive arbitrarily large HTTP bodies without buffering the contents in memory, if the method returns one of the following types:
+
+* `InputStream`, read on a worker thread
+* `Multi<byte[]>`, each item being a chunk of the body as it is received
+
+[source,java]
+----
+package org.acme.rest.client;
+
+import io.smallrye.mutiny.Multi;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/files")
+@RegisterRestClient
+public interface FilesService {
+
+    @GET
+    @Path("/large")
+    Multi<byte[]> download();
+}
+----
+
+The body is read according to the demand of the subscriber of the `Multi`: a subscriber that consumes the chunks slowly, for example by writing them to disk one at a time, slows down the reading of the response instead of causing its remaining content to accumulate in memory.
+
 === Getting other response properties
 
 ==== Using RestResponse

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/MultiDownloadBackPressureTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/MultiDownloadBackPressureTest.java
@@ -1,0 +1,130 @@
+package io.quarkus.rest.client.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+
+public class MultiDownloadBackPressureTest {
+
+    private static final int CHUNK_SIZE = 64 * 1024;
+    private static final int CHUNKS = 32 * 1024;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(Resource.class, Client.class));
+
+    @TestHTTPResource
+    URI uri;
+
+    @Test
+    void chunksAreFetchedOnDemand() throws InterruptedException {
+        Client client = RestClientBuilder.newBuilder().baseUri(uri).build(Client.class);
+        Resource.emitted.set(0);
+
+        CountingSubscriber subscriber = new CountingSubscriber();
+        client.download().subscribe().withSubscriber(subscriber);
+        subscriber.request(2);
+        await().atMost(Duration.ofSeconds(10)).until(() -> subscriber.received.get() == 2);
+        await().during(Duration.ofSeconds(2)).atMost(Duration.ofSeconds(10))
+                .until(() -> subscriber.received.get() == 2 && Resource.emitted.get() < 512);
+
+        subscriber.request(Long.MAX_VALUE);
+        assertThat(subscriber.completed.await(120, TimeUnit.SECONDS)).isTrue();
+        assertThat(subscriber.failure.get()).isNull();
+        assertThat(subscriber.bytes.get()).isEqualTo((long) CHUNKS * CHUNK_SIZE);
+        assertThat(Resource.emitted.get()).isEqualTo(CHUNKS);
+    }
+
+    @Test
+    void cancellingStopsTheDownload() {
+        Client client = RestClientBuilder.newBuilder().baseUri(uri).build(Client.class);
+        Resource.emitted.set(0);
+
+        AssertSubscriber<byte[]> subscriber = client.download().subscribe().withSubscriber(AssertSubscriber.create(1));
+        subscriber.awaitItems(1, Duration.ofSeconds(10));
+        subscriber.cancel();
+        AtomicInteger lastSeen = new AtomicInteger(-1);
+        await().during(Duration.ofSeconds(2)).atMost(Duration.ofSeconds(10))
+                .until(() -> {
+                    int now = Resource.emitted.get();
+                    return now == lastSeen.getAndSet(now);
+                });
+        assertThat(Resource.emitted.get()).isLessThan(CHUNKS);
+    }
+
+    static class CountingSubscriber implements Flow.Subscriber<byte[]> {
+
+        final AtomicInteger received = new AtomicInteger();
+        final AtomicLong bytes = new AtomicLong();
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final CountDownLatch completed = new CountDownLatch(1);
+        volatile Flow.Subscription subscription;
+
+        void request(long n) {
+            subscription.request(n);
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            this.subscription = subscription;
+        }
+
+        @Override
+        public void onNext(byte[] item) {
+            received.incrementAndGet();
+            bytes.addAndGet(item.length);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            failure.set(throwable);
+            completed.countDown();
+        }
+
+        @Override
+        public void onComplete() {
+            completed.countDown();
+        }
+    }
+
+    @Path("/download")
+    public static class Resource {
+
+        static final AtomicInteger emitted = new AtomicInteger();
+
+        @GET
+        @Produces("application/octet-stream")
+        public Multi<byte[]> download() {
+            byte[] chunk = new byte[CHUNK_SIZE];
+            return Multi.createFrom().range(0, CHUNKS).map(i -> chunk).onItem().invoke(emitted::incrementAndGet);
+        }
+    }
+
+    @Path("/download")
+    public interface Client {
+
+        @GET
+        Multi<byte[]> download();
+    }
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/MultiInvoker.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/MultiInvoker.java
@@ -7,7 +7,9 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongConsumer;
 import java.util.function.Predicate;
 
 import jakarta.ws.rs.client.Entity;
@@ -22,10 +24,13 @@ import org.jboss.resteasy.reactive.common.util.RestMediaType;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.Subscriptions;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.net.impl.ConnectionBase;
@@ -154,14 +159,15 @@ public class MultiInvoker extends AbstractRxInvoker<Multi<?>> {
                                     (String) restClientRequestContext.getProperties()
                                             .get(RestClientRequestContext.DEFAULT_CONTENT_TYPE_PROP),
                                     restClientRequestContext.getInvokedMethod());
+                            vertxResponse.resume();
                         } else if (response.getStatus() == 200
                                 && isNewlineDelimited(response)) {
                             registerForJsonStream(multiRequest, restClientRequestContext, responseType, response,
                                     vertxResponse);
+                            vertxResponse.resume();
                         } else {
                             registerForChunks(multiRequest, restClientRequestContext, responseType, response, vertxResponse);
                         }
-                        vertxResponse.resume();
                     } else {
                         vertxResponse.request().connection().close();
                     }
@@ -307,6 +313,7 @@ public class MultiInvoker extends AbstractRxInvoker<Multi<?>> {
         // we don't add a closeHandler handler on the connection as it can race with this handler
         // and close before the emitter emits anything
         // see: https://github.com/quarkusio/quarkus/pull/16438
+        DemandDrivenFetch fetch = new DemandDrivenFetch(multiRequest.emitter, vertxClientResponse, Vertx.currentContext());
         vertxClientResponse.handler(new Handler<Buffer>() {
             @Override
             public void handle(Buffer buffer) {
@@ -320,6 +327,7 @@ public class MultiInvoker extends AbstractRxInvoker<Multi<?>> {
                             mediaType,
                             restClientRequestContext.getMethodDeclaredAnnotationsSafe(),
                             response.getMetadata());
+                    fetch.emitted.incrementAndGet();
                     multiRequest.emitter.emit(item);
 
                 } catch (Throwable t) {
@@ -338,6 +346,63 @@ public class MultiInvoker extends AbstractRxInvoker<Multi<?>> {
         multiRequest.onCancel(() -> {
             vertxClientResponse.request().connection().close();
         });
+        fetch.start();
+    }
+
+    private static class DemandDrivenFetch {
+
+        private final MultiEmitter<?> emitter;
+        private final HttpClientResponse response;
+        private final Context context;
+        final AtomicLong emitted = new AtomicLong();
+        private long fetched;
+
+        DemandDrivenFetch(MultiEmitter<?> emitter, HttpClientResponse response, Context context) {
+            this.emitter = emitter;
+            this.response = response;
+            this.context = context;
+        }
+
+        void start() {
+            response.pause();
+            emitter.onRequest(new LongConsumer() {
+                @Override
+                public void accept(long n) {
+                    fetchRequested();
+                }
+            });
+            fetchRequested();
+        }
+
+        private synchronized void fetchRequested() {
+            if (fetched == Long.MAX_VALUE) {
+                return;
+            }
+            long totalRequested = Subscriptions.add(emitter.requested(), emitted.get());
+            if (totalRequested == Long.MAX_VALUE) {
+                fetched = Long.MAX_VALUE;
+                fetch(Long.MAX_VALUE);
+                return;
+            }
+            long toFetch = totalRequested - fetched;
+            if (toFetch > 0) {
+                fetched = totalRequested;
+                fetch(toFetch);
+            }
+        }
+
+        private void fetch(long amount) {
+            if (context == null || Vertx.currentContext() == context) {
+                response.fetch(amount);
+            } else {
+                context.runOnContext(new Handler<Void>() {
+                    @Override
+                    public void handle(Void v) {
+                        response.fetch(amount);
+                    }
+                });
+            }
+        }
     }
 
     private <R> void registerForJsonStream(MultiRequest<? super R> multiRequest,


### PR DESCRIPTION
Relates to #21440 (the unchecked "receiving files as `Multi`" half of the epic).

A response body received as a `Multi` is already streamed, one item per Vert.x buffer (`MultiInvoker.registerForChunks`), but nothing ever pauses the response: the emitter buffers whatever the subscriber has not requested yet (the code carries a `// FIXME: backpressure setting?`). Measured on `main` with a server streaming 300 MB, a client method returning `Multi<byte[]>`, a subscriber taking 1 ms per 64 KB chunk and a 64 MB heap: `OutOfMemoryError` after about a minute, while the same download as `InputStream` goes through fine.

Change: the response is left paused and buffers are fetched as the subscriber requests items. Each buffer is one item, so the subscriber's demand maps to `HttpClientResponse.fetch(n)` directly. The amount to fetch is computed from the totals, the emitter's outstanding demand plus the items already emitted, so it does not depend on when the request signals arrive relative to the response (`MultiEmitter.onRequest` does not replay demand that was signalled before the callback was registered, and the request is performed before the response exists). An unbounded request resumes the response exactly as before, so subscribers that do not apply back-pressure see no change. The SSE and newline-delimited JSON paths are untouched.

`MultiDownloadBackPressureTest` (rest-client deployment): the server counts the 64 KB chunks it emits out of 4096 (256 MB) while the test subscriber requests two of them. On `main` the server emits all 4096 within the two-second wait (the client drains the whole body into memory); with this change it emits 45 to 48, what fits in the socket and write buffers, then everything once the subscriber requests unboundedly. A second test checks that cancelling stops the download. Same 300 MB scenario as above with the change: completes on the 64 MB heap; a 1 GB download with a fast consumer still takes 0.3 s.

The REST Client guide gets a "Receiving large payloads" section next to the existing "Sending large payloads" one. `rest-client/deployment` (391) and the client runtime tests are green.
