### PR TITLE
Honour stop-services and remove-volumes when Compose Dev Services exit

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/ComposeDevServicesBuildTimeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/ComposeDevServicesBuildTimeConfig.java
@@ -47,19 +47,25 @@ public interface ComposeDevServicesBuildTimeConfig {
     boolean startServices();
 
     /**
-     * Whether to run compose down and stop containers at shutdown
+     * Whether to run compose down and stop containers at shutdown.
+     * When disabled, the Ryuk resource reaper is not used either, as it would stop the containers.
      */
     @WithDefault("true")
     boolean stopServices();
 
     /**
-     * Whether to use test containers Ryuk resource reaper to clean up containers
+     * Whether to use the Testcontainers Ryuk resource reaper to clean up the containers, networks, volumes and images
+     * of the project if the application exits without running compose down.
+     * Ryuk is only used when both `stop-services` and `remove-volumes` are enabled, as it removes all of these.
+     *
+     * @asciidoclet
      */
     @WithDefault("true")
     boolean ryukEnabled();
 
     /**
-     * Whether to remove volumes on compose down
+     * Whether to remove volumes on compose down.
+     * When disabled, the Ryuk resource reaper is not used either, as it would remove the volumes.
      */
     @WithDefault("true")
     boolean removeVolumes();

--- a/docs/src/main/asciidoc/compose-dev-services.adoc
+++ b/docs/src/main/asciidoc/compose-dev-services.adoc
@@ -667,6 +667,15 @@ Compose Dev Services will only try to discover existing services with the determ
 When `quarkus.compose.devservices.stop-services=false` is set, services will continue running after the application stops.
 This allows services to be reused by other applications or subsequent runs of the same application.
 
+Volumes are removed by compose down by default; set `quarkus.compose.devservices.remove-volumes=false` to keep them, for example to preserve database data between runs.
+Volumes belong to the compose project, so for tests to find them again the project name has to be stable across runs, see <<Compose Dev Services used for tests>>.
+
+[NOTE]
+====
+By default, the project is also registered with the Testcontainers Ryuk resource reaper, which removes all of the project's containers, networks, volumes and images if the application exits without running compose down (for example when the JVM is killed).
+Ryuk cannot spare some of these resources, so it is not used when `stop-services` or `remove-volumes` is disabled: in that case, resources left behind by an abrupt exit have to be removed manually with `compose down`.
+====
+
 You can also configure the timeout for stopping services with the `quarkus.compose.devservices.stop-timeout` property.
 After the timeout, Compose Dev Services will forcefully stop the services.
 The default timeout is deliberately chosen to be short (1 second) for fast cleanup, but you can increase it as needed:

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeDevServicesProcessor.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeDevServicesProcessor.java
@@ -139,6 +139,12 @@ public class ComposeDevServicesProcessor {
                 result.isOwner ? result.compose::stop : () -> {
                 });
         devServicesRegistry.addRunningService(Feature.COMPOSE.getName(), null, configuration, service);
+        if (result.isOwner && configuration.stopServices && launchMode.getLaunchMode() == LaunchMode.TEST) {
+            // the running services are closed when the curated application is, which does not happen at the end of
+            // a test run: run compose down when the JVM exits, so that the services are stopped and the volumes
+            // handled according to the configuration, whether or not Ryuk is in use
+            Runtime.getRuntime().addShutdownHook(new Thread(result.compose::stop, "compose-devservices-down"));
+        }
 
         return toComposeBuildItem(result.compose);
     }

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeProject.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeProject.java
@@ -249,11 +249,23 @@ public class ComposeProject {
     }
 
     private void registerContainersForShutdown() {
-        if (ryukEnabled) {
+        if (usesRyuk()) {
             ResourceReaper
                     .instance()
                     .registerLabelsFilterForCleanup(Collections.singletonMap(DOCKER_COMPOSE_PROJECT, project));
+        } else if (ryukEnabled) {
+            LOG.infov("Not registering compose project {0} with the Ryuk resource reaper, which would remove the {1} "
+                    + "configured to be kept", project, stopContainers ? "volumes" : "services");
         }
+    }
+
+    /**
+     * Ryuk removes every resource labelled with the project (containers, networks, volumes and images) when the
+     * application exits, so it is only used when the configuration asks for the services and their volumes to be
+     * removed anyway.
+     */
+    boolean usesRyuk() {
+        return ryukEnabled && stopContainers && removeVolumes;
     }
 
     private void startServices() {

--- a/extensions/devservices/deployment/src/test/java/io/quarkus/devservices/deployment/compose/ComposeProjectTest.java
+++ b/extensions/devservices/deployment/src/test/java/io/quarkus/devservices/deployment/compose/ComposeProjectTest.java
@@ -80,6 +80,19 @@ public class ComposeProjectTest {
     }
 
     @Test
+    void testRyukOnlyWhenEverythingIsRemovedAnyway() {
+        ComposeFiles files = new ComposeFiles(List.of(composeFile));
+        assertTrue(new ComposeProject.Builder(files, COMPOSE_EXECUTABLE).withProject("test").build().usesRyuk());
+        assertFalse(new ComposeProject.Builder(files, COMPOSE_EXECUTABLE).withProject("test")
+                .withRyukEnabled(false).build().usesRyuk());
+        // Ryuk would stop the services and remove the volumes regardless of these settings
+        assertFalse(new ComposeProject.Builder(files, COMPOSE_EXECUTABLE).withProject("test")
+                .withStopContainers(false).build().usesRyuk());
+        assertFalse(new ComposeProject.Builder(files, COMPOSE_EXECUTABLE).withProject("test")
+                .withRemoveVolumes(false).build().usesRyuk());
+    }
+
+    @Test
     void testProjectWithWaitStrategies() {
         ComposeFiles files = new ComposeFiles(List.of(composeFileWithProfiles));
         composeProject = new ComposeProject.Builder(files, COMPOSE_EXECUTABLE)


### PR DESCRIPTION
The compose project is registered with the Testcontainers Ryuk resource reaper by its `com.docker.compose.project` label. Ryuk removes every resource carrying that label when the application exits (containers, networks, volumes and images) and cannot spare some of them, so `quarkus.compose.devservices.remove-volumes=false` still lost the volumes and, as @ozangunalp noted, `stop-services=false` still had the services stopped. Reproduced with a compose file declaring a named volume: about fifteen seconds after a `@QuarkusTest` JVM exits, the container and the volume are gone despite `remove-volumes=false`.

While reproducing, a second thing showed up: the running compose service is closed through the curated application's close tasks, which do not run at the end of a test JVM, so in tests Ryuk was the only thing stopping the services; `compose down` never ran. Skipping Ryuk alone would therefore have left the containers running after tests.

Changes:

- the project is registered with Ryuk only when both `stop-services` and `remove-volumes` are enabled, i.e. when everything Ryuk would remove is meant to be removed anyway; otherwise a log line says why Ryuk is not used;
- in test mode, `compose down` is run from a JVM shutdown hook when `stop-services` is enabled, so services are stopped and volumes handled according to the configuration in every mode;
- the property docs and the guide say what Ryuk does and that it is not used when either flag is off, and that keeping volumes across test runs needs a stable project name.

Verified with rootless Podman and a `@QuarkusTest`, checking `podman ps -a` / `podman volume ls` after the JVM exit:

| configuration | `main` | this PR |
|---|---|---|
| default | container and volume removed by Ryuk after ~15 s | removed by `compose down -v` at exit (and Ryuk still registered) |
| `remove-volumes=false` | container and volume removed by Ryuk | container removed by `compose down` at exit, **volume kept** |
| `stop-services=false` | services stopped by Ryuk after ~15 s | services keep running, volume kept |

`ComposeProjectTest` gets a case for the Ryuk condition; `extensions/devservices/deployment` is green (22). `integration-tests/compose-devservices` passed 5/6 with the change (the RabbitMQ test failed on a Podman API "Broken pipe" creating a Redis container and passes alone); a later rerun of that module fails the same way on `main` on this machine, so that is the local Podman service, not the change.

- Fixes: #47980
