### PR TITLE
Run the logging-gelf and Hibernate Reactive with Panache tests with Podman again

### DIFF
--- a/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
@@ -222,32 +222,5 @@
                 </plugins>
             </build>
         </profile>
-        <!-- Disabled pending fix of #33454 -->
-        <profile>
-            <id>podman</id>
-            <activation>
-                <property>
-                    <name>env.IS_PODMAN</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <properties>
-                <skipTests>true</skipTests>
-                <skipITs>true</skipITs>
-                <enforcer.skip>true</enforcer.skip>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
     </profiles>
 </project>

--- a/integration-tests/logging-gelf/pom.xml
+++ b/integration-tests/logging-gelf/pom.xml
@@ -150,8 +150,6 @@
                                             <name>elk</name>
                                             <alias>elasticsearch</alias>
                                         </network>
-                                        <cpus>2</cpus>
-                                        <cpuShares>2048</cpuShares>
                                         <ports>
                                             <port>9200:9200</port>
                                         </ports>
@@ -201,8 +199,6 @@
                                             <name>elk</name>
                                             <alias>logstash</alias>
                                         </network>
-                                        <cpus>2</cpus>
-                                        <cpuShares>2048</cpuShares>
                                         <ports>
                                             <port>12201:12201/udp</port>
                                             <port>5000:5000</port>
@@ -283,32 +279,6 @@
             <properties>
                 <quarkus.native.enable-https-url-handler>true</quarkus.native.enable-https-url-handler>
             </properties>
-        </profile>
-        <!-- Disabled pending fix of #33090 -->
-        <profile>
-            <id>podman</id>
-            <activation>
-                <property>
-                    <name>env.IS_PODMAN</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <properties>
-                <skipTests>true</skipTests>
-                <skipITs>true</skipITs>
-                <enforcer.skip>true</enforcer.skip>
-            </properties>
-            <build>
-            <plugins>
-                <plugin>
-                    <groupId>io.fabric8</groupId>
-                    <artifactId>docker-maven-plugin</artifactId>
-                    <configuration>
-                        <skip>true</skip>
-                    </configuration>
-                </plugin>
-            </plugins>
-            </build>
         </profile>
     </profiles>
 


### PR DESCRIPTION
The last two `IS_PODMAN` guards, after #56193, #56194 and #56454. Two commits, one per issue, since the causes differ.

**#33090, `integration-tests/logging-gelf`.** The 2023 failure was `crun: the requested cgroup controller cpu is not available`: the Elasticsearch and Logstash containers are started with `cpus`/`cpuShares` limits, which need the cpu controller delegated to the rootless user, and the CI runners do not delegate it. The limits only exist to speed up the start of the stack, so the first commit drops them and the guard. Verified with rootless Podman 5.8.3: JVM mode (with and without `IS_PODMAN` set) and native mode both green. (This box delegates the cpu controller, which is also why the failure never reproduced locally in the issue.)

**#33454, `extensions/panache/hibernate-reactive-panache/deployment`.** The 2023 failure was `Broken pipe` starting the PostgreSQL container, with the leftover container cascading into the following modules. That is Podman's socket-activated API service exiting after its idle timeout while the Docker client keeps pooled connections; the Podman workflow has set `service_timeout=0` since e6efe7bc505 (February 2024). The second commit drops the guard. Verified with the same setting locally: the module passes repeatedly (31 tests), with and without `IS_PODMAN`. Without the setting, the same `Broken pipe` shows up intermittently on this box for Dev Services containers too, so it is not specific to the docker-maven-plugin.

With this and #56454 (Oracle), no `env.IS_PODMAN` profile is left in the tree.

- Fixes: #33090
- Fixes: #33454
