### PR TITLE
Support `Multi<byte[]>` as a streamed REST Client request body

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -401,7 +401,11 @@ When the `url` parameter is non-null, it will override the base URL that is conf
 The REST Client is capable of sending arbitrarily large HTTP bodies without buffering the contents in memory, if one of the following types is used:
 
 * `InputStream`
-* `Multi<io.vertx.mutiny.core.buffer.Buffer>`
+* `Multi<byte[]>`
+* `Multi<io.vertx.core.buffer.Buffer>`
+
+The `Multi` variants are consumed lazily, so a large body can be streamed from another source without buffering it in memory.
+For example, a `Multi<byte[]>` returned by another REST Client method can be passed directly as the request body.
 
 Furthermore, the client can also send arbitrarily large files if one of the following types is used:
 

--- a/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -203,6 +203,7 @@ public class JaxrsClientReactiveProcessor {
     private static final String MULTI_BYTE_SIGNATURE = "L" + Multi.class.getName().replace('.', '/') + "<Ljava/lang/Byte;>;";
     private static final String MULTI_BUFFER_SIGNATURE = "L" + Multi.class.getName().replace('.', '/')
             + "<Lio/vertx/core/buffer/Buffer;>;";
+    private static final String MULTI_BYTE_ARRAY_SIGNATURE = "L" + Multi.class.getName().replace('.', '/') + "<[B>;";
     private static final String FILE_SIGNATURE = "L" + File.class.getName().replace('.', '/') + ";";
     private static final String PATH_SIGNATURE = "L" + java.nio.file.Path.class.getName().replace('.', '/') + ";";
     private static final String BUFFER_SIGNATURE = "L" + Buffer.class.getName().replace('.', '/') + ";";
@@ -1172,9 +1173,10 @@ public class JaxrsClientReactiveProcessor {
                                     getAnnotationsFromArray(methodCreator, methodParamAnnotationsField, paramIdx));
                         } else if (param.parameterType == ParameterType.BODY) {
                             if (param.declaredType.equals(Multi.class.getName())) {
-                                if (!param.signature.equals(MULTI_BUFFER_SIGNATURE)) {
+                                if (!param.signature.equals(MULTI_BUFFER_SIGNATURE)
+                                        && !param.signature.equals(MULTI_BYTE_ARRAY_SIGNATURE)) {
                                     throw new IllegalArgumentException(
-                                            "When using Multi as body parameter only Multi<io.vertx.core.buffer.Buffer> is supported");
+                                            "When using Multi as body parameter only Multi<io.vertx.core.buffer.Buffer> and Multi<byte[]> are supported");
                                 }
                             }
 

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/SendMultiBytesTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/SendMultiBytesTest.java
@@ -1,0 +1,110 @@
+package io.quarkus.rest.client.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Arrays;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.smallrye.mutiny.Multi;
+
+public class SendMultiBytesTest {
+
+    private static final int CHUNK_SIZE = 64 * 1024;
+    // 2 GB, larger than the heap of the test JVM: the body can only be sent without buffering it
+    private static final int CHUNKS = 32 * 1024;
+    private static final long TOTAL = (long) CHUNK_SIZE * CHUNKS;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .overrideConfigKey("quarkus.http.limits.max-body-size", "4G");
+
+    @TestHTTPResource
+    URI uri;
+
+    @Test
+    public void sendMultiOfByteArrays() {
+        Client client = RestClientBuilder.newBuilder().baseUri(uri).build(Client.class);
+
+        long result = client.countBytes(chunks());
+
+        assertThat(result).isEqualTo(TOTAL);
+    }
+
+    @Test
+    public void pipeDownloadIntoUpload() {
+        Client client = RestClientBuilder.newBuilder().baseUri(uri).build(Client.class);
+
+        long result = client.countBytes(client.download());
+
+        assertThat(result).isEqualTo(TOTAL);
+    }
+
+    @Test
+    public void failingBodyFailsTheCall() {
+        Client client = RestClientBuilder.newBuilder().baseUri(uri).build(Client.class);
+        Multi<byte[]> body = Multi.createBy().concatenating().streams(
+                chunks().select().first(100),
+                Multi.createFrom().failure(new IOException("source broke")));
+
+        assertThatThrownBy(() -> client.countBytes(body))
+                .isInstanceOf(ProcessingException.class)
+                .hasRootCauseMessage("source broke");
+    }
+
+    private static Multi<byte[]> chunks() {
+        byte[] chunk = new byte[CHUNK_SIZE];
+        Arrays.fill(chunk, (byte) 'x');
+        return Multi.createFrom().range(0, CHUNKS).onItem().transform(i -> chunk);
+    }
+
+    @Path("test")
+    public interface Client {
+
+        @POST
+        @Path("count")
+        long countBytes(Multi<byte[]> body);
+
+        @GET
+        @Path("download")
+        Multi<byte[]> download();
+    }
+
+    @Path("test")
+    public static class Resource {
+
+        @POST
+        @Path("count")
+        public long count(InputStream input) throws IOException {
+            byte[] buf = new byte[CHUNK_SIZE];
+            long total = 0;
+            int n;
+            while ((n = input.read(buf)) != -1) {
+                total += n;
+            }
+            return total;
+        }
+
+        @GET
+        @Path("download")
+        @Produces(MediaType.APPLICATION_OCTET_STREAM)
+        public Multi<byte[]> download() {
+            return chunks();
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
@@ -54,6 +54,7 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.vertx.ReadStreamSubscriber;
 import io.smallrye.stork.api.ServiceInstance;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -74,6 +75,7 @@ import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.internal.http.HttpClientInternal;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.streams.Pipe;
+import io.vertx.core.streams.ReadStream;
 
 public class ClientSendRequestHandler implements ClientRestHandler {
     private static final Logger log = Logger.getLogger(ClientSendRequestHandler.class);
@@ -210,14 +212,31 @@ public class ClientSendRequestHandler implements ClientRestHandler {
                     MultivaluedMap<String, String> headerMap = requestContext.getRequestHeadersAsMap();
                     updateRequestHeadersFromConfig(requestContext, headerMap);
                     setVertxHeaders(httpClientRequest, headerMap);
-                    Future<HttpClientResponse> sent = httpClientRequest.send(ReadStreamSubscriber.asReadStream(
-                            (Multi<Buffer>) requestContext.getEntity().getEntity(),
+                    Multi<Buffer> buffers = ((Multi<?>) requestContext.getEntity().getEntity()).onItem()
+                            .transform(ClientSendRequestHandler::toBuffer);
+                    if (!httpClientRequest.headers().contains(HttpHeaders.CONTENT_LENGTH)) {
+                        httpClientRequest.setChunked(true);
+                    }
+                    // a failing Multi must fail the request: with the default pipe behaviour the body would be ended
+                    // normally and the server response to the truncated body would be reported as a success
+                    ReadStream<Buffer> body = ReadStreamSubscriber.asReadStream(buffers,
                             new Function<>() {
                                 @Override
                                 public Buffer apply(Buffer buffer) {
                                     return buffer;
                                 }
-                            }));
+                            });
+                    Pipe<Buffer> pipe = body.pipe();
+                    pipe.endOnFailure(false);
+                    pipe.to(httpClientRequest).onComplete(new Handler<>() {
+                        @Override
+                        public void handle(AsyncResult<Void> ar) {
+                            if (ar.failed()) {
+                                httpClientRequest.reset(0L, ar.cause());
+                            }
+                        }
+                    });
+                    Future<HttpClientResponse> sent = httpClientRequest.response();
                     attachSentHandlers(sent, httpClientRequest, requestContext);
                 } else {
                     Future<HttpClientResponse> sent;
@@ -324,6 +343,17 @@ public class ClientSendRequestHandler implements ClientRestHandler {
                         });
             });
         });
+    }
+
+    private static Buffer toBuffer(Object item) {
+        if (item instanceof Buffer buffer) {
+            return buffer;
+        }
+        if (item instanceof byte[] bytes) {
+            return Buffer.buffer(bytes);
+        }
+        throw new IllegalArgumentException("Unsupported item type '" + item.getClass().getName()
+                + "' for a streamed request body. Supported types are io.vertx.core.buffer.Buffer and byte[]");
     }
 
     private void attachSentHandlers(Future<HttpClientResponse> sent,

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
@@ -557,7 +557,7 @@ public class RestClientRequestContext extends AbstractResteasyReactiveContext<Re
     }
 
     public boolean isMultiBufferUpload() {
-        // we don't check the generic because Multi<Buffer> is checked at build time
+        // we don't check the generic because the Multi item type is checked at build time
         return entity != null && entity.getEntity() instanceof Multi;
     }
 


### PR DESCRIPTION
The REST Client streams a `Multi<io.vertx.core.buffer.Buffer>` request body without buffering it, but that is the only `Multi` item type accepted by the build-time check in `JaxrsClientReactiveProcessor`. A `Multi<byte[]>` (for example the one returned by another client method declared with that return type) is rejected with `When using Multi as body parameter only Multi<io.vertx.core.buffer.Buffer> is supported`, so the caller has to map it to `Buffer` first.

This PR accepts `Multi<byte[]>` as well:

- the build-time check allows `Multi<byte[]>` next to `Multi<Buffer>`;
- `ClientSendRequestHandler` converts each item to a `Buffer` before handing the stream to Vert.x, so `Buffer` items pass through unchanged and `byte[]` items are wrapped. Programmatic clients (`Entity.entity(multi, ...)`) have no build-time check, so an unsupported item type now fails the request with a clear message instead of a `ClassCastException`;
- a `Multi` body that fails part-way is now reported as a failure. `HttpClientRequest.send(ReadStream)` pipes with the default `endOnFailure(true)` and the Mutiny `ReadStreamSubscriber` invokes the end handler after the exception handler, so the chunked body was ended normally and the server response to the truncated body was returned as a success. The stream is now piped with `endOnFailure(false)` and the request is reset with the source failure, as the multipart path already does, so the call fails with a `ProcessingException`;
- the "Sending large payloads" section of the REST Client guide listed `Multi<io.vertx.mutiny.core.buffer.Buffer>`, a type that no longer exists with the Vert.x 5 Mutiny bindings. It now lists the two accepted types.

Relates to #21440 (request side; the response side is #56462).

