### PR TITLE
Trigger the dev mode scan for changes on incoming WebSockets Next messages

### DIFF
--- a/docs/src/main/asciidoc/websockets-next-reference.adoc
+++ b/docs/src/main/asciidoc/websockets-next-reference.adoc
@@ -1699,6 +1699,13 @@ quarkus.log.category."io.quarkus.websockets.next.traffic".level=DEBUG <3>
 <2> Set the number of characters of a text message payload which will be logged.
 <3> Enable `DEBUG` level is for the logger `io.quarkus.websockets.next.traffic`.
 
+== Dev mode
+
+In dev mode, Quarkus scans for source changes when it receives an HTTP request.
+An application whose clients only communicate over open WebSocket connections would never trigger that scan, so a message received by a server endpoint triggers it as well, at most once every two seconds.
+When a change is detected, the application restarts and the open WebSocket connections are closed, because they belong to the previous deployment.
+Clients must reconnect to the restarted application, and the message that triggered the restart is not delivered to the new endpoint.
+
 [[subscribe-or-not-subscribe]]
 == When to subscribe to a `Uni` or `Multi`
 

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/devmode/Greeting.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/devmode/Greeting.java
@@ -1,0 +1,13 @@
+package io.quarkus.websockets.next.test.devmode;
+
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+
+@WebSocket(path = "/greeting")
+public class Greeting {
+
+    @OnTextMessage
+    String greet(String name) {
+        return "Hello " + name;
+    }
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/devmode/MessageTriggersReloadDevModeTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/devmode/MessageTriggersReloadDevModeTest.java
@@ -1,0 +1,96 @@
+package io.quarkus.websockets.next.test.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.ClientWebSocket;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.http.WebSocketConnectOptions;
+
+/**
+ * An application that only talks to its clients over open WebSocket connections, without any further HTTP request,
+ * must still pick up source changes in dev mode: a message received on an open connection triggers the scan for
+ * changes, and the restart closes the open connections so that clients reconnect to the updated application.
+ */
+public class MessageTriggersReloadDevModeTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot(root -> root.addClass(Greeting.class));
+
+    static Vertx vertx;
+    static WebSocketClient client;
+
+    @BeforeAll
+    static void createClient() {
+        vertx = Vertx.vertx();
+        client = vertx.createWebSocketClient();
+    }
+
+    @AfterAll
+    static void closeClient() {
+        vertx.close().toCompletionStage().toCompletableFuture().join();
+    }
+
+    @Test
+    public void testMessageOnOpenConnectionTriggersReload() {
+        Connection connection = Connection.open();
+        assertThat(connection.sendAndAwaitReply("Alice")).isEqualTo("Hello Alice");
+
+        test.modifySourceFile(Greeting.class, s -> s.replace("\"Hello \"", "\"Hi \""));
+
+        // no HTTP request is made: the message on the open connection is the only activity
+        connection.send("Bob");
+        await().atMost(Duration.ofSeconds(30)).until(connection::isClosed);
+
+        connection = Connection.open();
+        assertThat(connection.sendAndAwaitReply("Bob")).isEqualTo("Hi Bob");
+    }
+
+    static class Connection {
+
+        final ClientWebSocket ws;
+        final List<String> messages = new CopyOnWriteArrayList<>();
+        volatile boolean closed;
+
+        Connection(ClientWebSocket ws) {
+            this.ws = ws;
+        }
+
+        static Connection open() {
+            ClientWebSocket ws = client.webSocket();
+            Connection connection = new Connection(ws);
+            ws.textMessageHandler(connection.messages::add);
+            ws.closeHandler(v -> connection.closed = true);
+            ws.connect(new WebSocketConnectOptions().setHost("localhost").setPort(8080).setURI("/greeting"))
+                    .toCompletionStage().toCompletableFuture().join();
+            return connection;
+        }
+
+        void send(String message) {
+            ws.writeTextMessage(message).toCompletionStage().toCompletableFuture().join();
+        }
+
+        String sendAndAwaitReply(String message) {
+            int expected = messages.size() + 1;
+            send(message);
+            await().atMost(Duration.ofSeconds(10)).until(() -> messages.size() >= expected);
+            return messages.get(messages.size() - 1);
+        }
+
+        boolean isClosed() {
+            return closed;
+        }
+    }
+}

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/Endpoints.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/Endpoints.java
@@ -17,6 +17,7 @@ import io.quarkus.security.UnauthorizedException;
 import io.quarkus.websockets.next.CloseReason;
 import io.quarkus.websockets.next.WebSocketException;
 import io.quarkus.websockets.next.runtime.config.UnhandledFailureStrategy;
+import io.quarkus.websockets.next.runtime.devmode.WebSocketHotReplacementInterceptor;
 import io.quarkus.websockets.next.runtime.telemetry.ErrorInterceptor;
 import io.quarkus.websockets.next.runtime.telemetry.TelemetrySupport;
 import io.smallrye.mutiny.Multi;
@@ -56,6 +57,9 @@ class Endpoints {
         // Create an endpoint that delegates callbacks to the endpoint bean
         WebSocketEndpoint endpoint = createEndpoint(generatedEndpointClass, context, connection, codecs, contextSupport,
                 securitySupport, telemetrySupport);
+
+        // In dev mode, messages received by server endpoints trigger the scan for source changes
+        boolean notifyHotReplacement = connection instanceof WebSocketConnectionImpl && LaunchMode.current().isDevOrTest();
 
         // A broadcast processor is only needed if Multi is consumed by the callback
         BroadcastProcessor<Object> textBroadcastProcessor = endpoint.consumedTextMultiType() != null
@@ -125,7 +129,7 @@ class Endpoints {
 
         if (textBroadcastProcessor == null) {
             // Multi not consumed - invoke @OnTextMessage callback for each message received
-            textMessageHandler(connection, endpoint, ws, onOpenContext, m -> {
+            textMessageHandler(connection, endpoint, ws, onOpenContext, notifyHotReplacement, m -> {
                 if (trafficLogger != null) {
                     trafficLogger.textMessageReceived(connection, m);
                 }
@@ -140,7 +144,7 @@ class Endpoints {
                 });
             }, true);
         } else {
-            textMessageHandler(connection, endpoint, ws, onOpenContext, m -> {
+            textMessageHandler(connection, endpoint, ws, onOpenContext, notifyHotReplacement, m -> {
                 contextSupport.start();
                 try {
                     if (trafficLogger != null) {
@@ -161,7 +165,7 @@ class Endpoints {
 
         if (binaryBroadcastProcessor == null) {
             // Multi not consumed - invoke @OnBinaryMessage callback for each message received
-            binaryMessageHandler(connection, endpoint, ws, onOpenContext, m -> {
+            binaryMessageHandler(connection, endpoint, ws, onOpenContext, notifyHotReplacement, m -> {
                 if (trafficLogger != null) {
                     trafficLogger.binaryMessageReceived(connection, m);
                 }
@@ -176,7 +180,7 @@ class Endpoints {
                 });
             }, true);
         } else {
-            binaryMessageHandler(connection, endpoint, ws, onOpenContext, m -> {
+            binaryMessageHandler(connection, endpoint, ws, onOpenContext, notifyHotReplacement, m -> {
                 contextSupport.start();
                 try {
                     if (trafficLogger != null) {
@@ -358,10 +362,13 @@ class Endpoints {
     }
 
     private static void textMessageHandler(WebSocketConnectionBase connection, WebSocketEndpoint endpoint, WebSocketBase ws,
-            Context context, Consumer<String> textAction, boolean newDuplicatedContext) {
+            Context context, boolean notifyHotReplacement, Consumer<String> textAction, boolean newDuplicatedContext) {
         ws.textMessageHandler(new Handler<String>() {
             @Override
             public void handle(String message) {
+                if (notifyHotReplacement) {
+                    WebSocketHotReplacementInterceptor.messageReceived();
+                }
                 Context duplicatedContext = newDuplicatedContext
                         ? ContextSupport.createNewDuplicatedContext(context, connection)
                         : context;
@@ -376,10 +383,13 @@ class Endpoints {
     }
 
     private static void binaryMessageHandler(WebSocketConnectionBase connection, WebSocketEndpoint endpoint, WebSocketBase ws,
-            Context context, Consumer<Buffer> binaryAction, boolean newDuplicatedContext) {
+            Context context, boolean notifyHotReplacement, Consumer<Buffer> binaryAction, boolean newDuplicatedContext) {
         ws.binaryMessageHandler(new Handler<Buffer>() {
             @Override
             public void handle(Buffer message) {
+                if (notifyHotReplacement) {
+                    WebSocketHotReplacementInterceptor.messageReceived();
+                }
                 Context duplicatedContext = newDuplicatedContext
                         ? ContextSupport.createNewDuplicatedContext(context, connection)
                         : context;

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/devmode/WebSocketHotReplacementInterceptor.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/devmode/WebSocketHotReplacementInterceptor.java
@@ -1,0 +1,63 @@
+package io.quarkus.websockets.next.runtime.devmode;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+/**
+ * Holds the dev mode hot replacement callback invoked when a server endpoint receives a message.
+ * <p>
+ * The scan runs on a dedicated thread: message handlers run on the Vert.x event loop and a restart needs
+ * to stop the application, which must not happen on that thread.
+ */
+public class WebSocketHotReplacementInterceptor {
+
+    private static volatile Supplier<Boolean> onMessageAction;
+    private static volatile ExecutorService scanExecutor;
+    private static final AtomicBoolean scanPending = new AtomicBoolean();
+
+    static void register(Supplier<Boolean> onMessage) {
+        scanExecutor = Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "websockets-next-dev-scan");
+            t.setDaemon(true);
+            return t;
+        });
+        onMessageAction = onMessage;
+    }
+
+    static void shutdown() {
+        ExecutorService executor = scanExecutor;
+        scanExecutor = null;
+        onMessageAction = null;
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * Trigger a scan for source changes, if dev mode hot replacement is active and no scan is pending yet.
+     */
+    public static void messageReceived() {
+        Supplier<Boolean> action = onMessageAction;
+        ExecutorService executor = scanExecutor;
+        if (action == null || executor == null || !scanPending.compareAndSet(false, true)) {
+            return;
+        }
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        try {
+            executor.submit(() -> {
+                try {
+                    Thread.currentThread().setContextClassLoader(tccl);
+                    return action.get();
+                } finally {
+                    scanPending.set(false);
+                }
+            });
+        } catch (RejectedExecutionException ignored) {
+            // shut down between the null check and the submission
+            scanPending.set(false);
+        }
+    }
+}

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/devmode/WebSocketHotReplacementSetup.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/devmode/WebSocketHotReplacementSetup.java
@@ -1,0 +1,62 @@
+package io.quarkus.websockets.next.runtime.devmode;
+
+import java.util.function.Supplier;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.dev.spi.HotReplacementContext;
+import io.quarkus.dev.spi.HotReplacementSetup;
+
+/**
+ * Dev mode hot replacement integration for server endpoints.
+ * <p>
+ * An application whose clients only communicate over open WebSocket connections never makes another HTTP request,
+ * so the scan for source changes triggered by HTTP requests never runs. Messages received by server endpoints trigger
+ * that scan instead, rate-limited to at most once every two seconds. When the application restarts, the open
+ * connections are closed like any other connection of the previous deployment, and clients reconnect to the updated
+ * application.
+ */
+public class WebSocketHotReplacementSetup implements HotReplacementSetup {
+
+    private static final Logger LOG = Logger.getLogger(WebSocketHotReplacementSetup.class);
+
+    private static final long TWO_SECONDS = 2000;
+
+    private HotReplacementContext context;
+    private volatile long nextUpdate;
+
+    @Override
+    public void setupHotDeployment(HotReplacementContext context) {
+        this.context = context;
+        WebSocketHotReplacementInterceptor.register(new ScanAction());
+    }
+
+    @Override
+    public void close() {
+        WebSocketHotReplacementInterceptor.shutdown();
+    }
+
+    private class ScanAction implements Supplier<Boolean> {
+
+        @Override
+        public Boolean get() {
+            boolean restarted = false;
+            synchronized (this) {
+                if (nextUpdate < System.currentTimeMillis() || context.isTest()) {
+                    try {
+                        restarted = context.doScan(true);
+                        if (context.getDeploymentProblem() != null) {
+                            LOG.error("Failed to redeploy application on changes", context.getDeploymentProblem());
+                        }
+                    } catch (RuntimeException e) {
+                        throw e;
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                    nextUpdate = System.currentTimeMillis() + TWO_SECONDS;
+                }
+            }
+            return restarted;
+        }
+    }
+}

--- a/extensions/websockets-next/runtime/src/main/resources/META-INF/services/io.quarkus.dev.spi.HotReplacementSetup
+++ b/extensions/websockets-next/runtime/src/main/resources/META-INF/services/io.quarkus.dev.spi.HotReplacementSetup
@@ -1,0 +1,1 @@
+io.quarkus.websockets.next.runtime.devmode.WebSocketHotReplacementSetup


### PR DESCRIPTION
In dev mode the scan for source changes runs when an HTTP request comes in. As worked out in #55243, an application whose clients load a page once and then only talk over an open WebSocket connection never makes another HTTP request, so its changes are only picked up when the browser is reloaded by hand. The kernel version in the report was a red herring.

This PR adds a `HotReplacementSetup` for WebSockets Next that triggers the scan when a server endpoint receives a text or binary message, the way the Kafka Streams, Reactive Messaging and Aesh integrations already do for their transports:

- the scan runs on a dedicated daemon thread, never on the event loop that received the message;
- at most one scan is queued at a time, so a busy endpoint does not pile up tasks while a restart is in progress, and scans are rate-limited to one every two seconds (bypassed in dev mode tests, like the other integrations);
- client connections are not affected: only server connections trigger the scan;
- when the scan restarts the application, the open connections are closed by the vertx-http layer like any other connection of the previous deployment (they were tracked when their upgrade request went through the hot replacement handler), so clients see a close and reconnect to the updated application. The message that triggered the restart is not replayed to the new endpoint, which the reference guide now says in a short "Dev mode" section.

`MessageTriggersReloadDevModeTest` opens a WebSocket connection, changes the endpoint's source, sends a message on the still-open connection without any HTTP request, and checks that the connection gets closed and that a new connection talks to the updated endpoint. On main the connection stays open for the full 30 second timeout. The whole `websockets-next` deployment module passes (288 tests).

Fixes #55243
