### PR TITLE
Skip the DB2 Dev Services tests on arm64

### DIFF
--- a/extensions/jdbc/jdbc-db2/deployment/src/test/java/io/quarkus/jdbc/db2/deployment/DevServicesDB2DatasourceTestCase.java
+++ b/extensions/jdbc/jdbc-db2/deployment/src/test/java/io/quarkus/jdbc/db2/deployment/DevServicesDB2DatasourceTestCase.java
@@ -11,6 +11,7 @@ import java.util.logging.LogRecord;
 import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.agroal.api.AgroalDataSource;
@@ -18,6 +19,7 @@ import io.agroal.api.configuration.AgroalConnectionPoolConfiguration;
 import io.agroal.api.exceptionsorter.DB2ExceptionSorter;
 import io.quarkus.test.QuarkusExtensionTest;
 
+@DisabledOnOs(architectures = "aarch64", disabledReason = "The DB2 image is not published for arm64")
 public class DevServicesDB2DatasourceTestCase {
 
     @RegisterExtension

--- a/extensions/jdbc/jdbc-db2/deployment/src/test/java/io/quarkus/jdbc/db2/deployment/LicenseAcceptanceDB2ErrorTestCase.java
+++ b/extensions/jdbc/jdbc-db2/deployment/src/test/java/io/quarkus/jdbc/db2/deployment/LicenseAcceptanceDB2ErrorTestCase.java
@@ -3,6 +3,7 @@ package io.quarkus.jdbc.db2.deployment;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusExtensionTest;
 
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Docker not supported on Windows")
+@DisabledIf(value = "isArm64", disabledReason = "The DB2 image is not published for arm64")
 public class LicenseAcceptanceDB2ErrorTestCase {
 
     @RegisterExtension
@@ -33,5 +35,9 @@ public class LicenseAcceptanceDB2ErrorTestCase {
 
     @Test
     public void testErrorMessage() {
+    }
+
+    static boolean isArm64() {
+        return "aarch64".equals(System.getProperty("os.arch"));
     }
 }


### PR DESCRIPTION
The manifest list of `icr.io/db2_community/db2:12.1.5.0` contains `linux/amd64`, `linux/ppc64le` and `linux/s390x` only, so on an arm64 machine the two `jdbc-db2` deployment tests that start the Dev Service retry the pull for two minutes and then fail, as reported in #56446. The retry itself is Testcontainers' `RemoteDockerImage`, and running the amd64 image under emulation would need a platform that Testcontainers does not let us pass to the pull, so this PR takes the second option from the report and skips those two tests on arm64 with a reason, the way the tests that cannot run on Windows are skipped.

Verified on an amd64 Linux box with Podman: both tests run and pass, and with `-Dsurefire.argLine.additional=-Dos.arch=aarch64` both are reported as skipped. I do not have an arm64 machine to reproduce the original failure.

- Fixes: #56446
