### PR TITLE
[3.39] Bump kubernetes-client-bom from 7.8.0 to 7.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <!-- Properties below are set in this file because they are used
              in the BOM as well as other POMs (build-parent/pom.xml, docs/pom.xml, ...) -->
         <jacoco.version>0.8.15</jacoco.version>
-        <kubernetes-client.version>7.8.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <kubernetes-client.version>7.9.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>6.0.1</rest-assured.version>
         <hibernate-orm.version>7.4.5.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below; checked by maven-enforcer-plugin in bom -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->


### PR DESCRIPTION
Kubernetes Client 7.9.0 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v7.9.0

/cc @manusa @metacosm @xstefank