### PR TITLE
Add ways to configure form param separator in REST Client

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -242,12 +242,14 @@ package org.acme.rest.client;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.Separator;
 
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.core.MultivaluedMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -271,8 +273,14 @@ public interface ExtensionsService {
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     Set<Extension> postFilters(@RestForm MultivaluedMap<String, String> filters);
 
+    @POST
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    Set<Extension> postNames(@RestForm @Separator(",") List<String> names); <1>
+
 }
 ----
+<1> Just like for query parameters, `@Separator` lets you specify a custom delimiter between the values of a collection-valued form parameter.
+In this example, the request body will be `names=first,second` instead of `names=first&names=second`.
 
 ==== Using @ClientFormParam
 

--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -282,6 +282,10 @@ public interface ExtensionsService {
 <1> Just like for query parameters, `@Separator` lets you specify a custom delimiter between the values of a collection-valued form parameter.
 In this example, the request body will be `names=first,second` instead of `names=first&names=second`.
 
+By default, multiple values of the same form parameter are sent as repeated `name=value` pairs.
+This can be changed for all the form parameters of a client using the `quarkus.rest-client.form-param-style` configuration property
+(or `quarkus.rest-client."config-key".form-param-style` for a specific client).
+
 ==== Using @ClientFormParam
 
 Form parameters can also be specified using `@ClientFormParam`, similar to `@ClientQueryParam`:

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -177,6 +177,17 @@ public interface RestClientsConfig {
     Optional<QueryParamStyle> queryParamStyle();
 
     /**
+     * An enumerated type string value with possible values of "MULTI_PAIRS" (default), "COMMA_SEPARATED",
+     * or "ARRAY_PAIRS" that specifies the format in which multiple values for the same
+     * {@code application/x-www-form-urlencoded} form parameter is used.
+     * <p>
+     * Can be overwritten by client-specific settings.
+     * <p>
+     * This property is not applicable to the RESTEasy Client.
+     */
+    Optional<QueryParamStyle> formParamStyle();
+
+    /**
      * Set whether hostname verification is enabled. Default is enabled.
      * This setting should not be disabled in production as it makes the client vulnerable to MITM attacks.
      * <p>
@@ -459,6 +470,15 @@ public interface RestClientsConfig {
          * or "ARRAY_PAIRS" that specifies the format in which multiple values for the same query parameter is used.
          */
         Optional<QueryParamStyle> queryParamStyle();
+
+        /**
+         * An enumerated type string value with possible values of "MULTI_PAIRS" (default), "COMMA_SEPARATED",
+         * or "ARRAY_PAIRS" that specifies the format in which multiple values for the same
+         * {@code application/x-www-form-urlencoded} form parameter is used.
+         * <p>
+         * Quarkus RESTEasy client (provided by the quarkus-resteasy-client dependency) does not support this property.
+         */
+        Optional<QueryParamStyle> formParamStyle();
 
         /**
          * Set whether hostname verification is enabled. Default is enabled.

--- a/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -1248,7 +1248,7 @@ public class JaxrsClientReactiveProcessor {
                                     getGenericTypeFromArray(methodCreator, methodGenericParametersField, paramIdx),
                                     getAnnotationsFromArray(methodCreator, methodParamAnnotationsField, paramIdx),
                                     multipart,
-                                    param.mimeType, param.partFileName,
+                                    param.mimeType, param.partFileName, param.separator,
                                     jandexMethod.declaringClass().name() + "." + jandexMethod.name());
                         }
                     }
@@ -3118,7 +3118,7 @@ public class JaxrsClientReactiveProcessor {
                             formParams,
                             getGenericTypeFromParameter(creator, beanParamDescriptorField, item.fieldName()),
                             getAnnotationsFromParameter(creator, beanParamDescriptorField, item.fieldName()),
-                            multipart, formParam.getMimeType(), formParam.getFileName(),
+                            multipart, formParam.getMimeType(), formParam.getFileName(), null,
                             beanParamClass + "." + formParam.getSourceName());
                     break;
                 default:
@@ -3556,7 +3556,7 @@ public class JaxrsClientReactiveProcessor {
             String restClientInterfaceClassName, ResultHandle client, AssignableResultHandle formParams,
             ResultHandle genericType,
             ResultHandle parameterAnnotations, boolean multipart,
-            String mimeType, String partFilename, String errorLocation) {
+            String mimeType, String partFilename, String separator, String errorLocation) {
         if (multipart) {
             handleMultipartField(index, paramName, mimeType, partFilename, parameterType, parameterSignature,
                     formParamHandle,
@@ -3583,7 +3583,8 @@ public class JaxrsClientReactiveProcessor {
                         MethodDescriptor.ofMethod(RestClientBase.class, "convertParamArray", Object[].class, Object[].class,
                                 Class.class, java.lang.reflect.Type.class, Annotation[].class, String.class),
                         client, paramArray, creator.loadClassFromTCCL(componentType), genericType,
-                        creator.newArray(Annotation.class, 0), creator.loadNull());
+                        creator.newArray(Annotation.class, 0),
+                        separator == null ? creator.loadNull() : creator.load(separator));
                 creator.invokeInterfaceMethod(MULTIVALUED_MAP_ADD_ALL, formParams,
                         creator.load(paramName), convertedParamArray);
             } else if (isMap(parameterType, index)) {

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ConfigurationTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ConfigurationTest.java
@@ -91,6 +91,8 @@ class ConfigurationTest {
         assertThat(clientConfig.queryParamStyle().get()).isEqualTo(QueryParamStyle.COMMA_SEPARATED);
 
         if (checkExtraProperties) {
+            assertTrue(clientConfig.formParamStyle().isPresent());
+            assertThat(clientConfig.formParamStyle().get()).isEqualTo(QueryParamStyle.ARRAY_PAIRS);
             assertTrue(clientConfig.connectionTTL().isPresent());
             assertThat(clientConfig.connectionTTL().getAsInt()).isEqualTo(30000);
             assertTrue(clientConfig.connectionPoolSize().isPresent());

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/GlobalConfigurationTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/GlobalConfigurationTest.java
@@ -66,6 +66,7 @@ public class GlobalConfigurationTest {
         assertThat(configRoot.providers().get())
                 .isEqualTo("io.quarkus.rest.client.reactive.HelloClientWithBaseUri$MyResponseFilter");
         assertThat(configRoot.queryParamStyle().get()).isEqualTo(QueryParamStyle.MULTI_PAIRS);
+        assertThat(configRoot.formParamStyle().get()).isEqualTo(QueryParamStyle.COMMA_SEPARATED);
 
         assertThat(configRoot.trustStore().get()).isEqualTo("/path");
         assertThat(configRoot.trustStorePassword().get()).isEqualTo("password");

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/form/FormParamStyleTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/form/FormParamStyleTest.java
@@ -1,0 +1,136 @@
+package io.quarkus.rest.client.reactive.form;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.Separator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.rest.client.reactive.ParamStyle;
+import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class FormParamStyleTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClasses(Resource.class, Client.class, ConfiguredClient.class))
+            .overrideRuntimeConfigKey("quarkus.rest-client.configured-client.url",
+                    "http://localhost:${quarkus.http.test-port:8081}")
+            .overrideRuntimeConfigKey("quarkus.rest-client.configured-client.form-param-style", "COMMA_SEPARATED");
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @RestClient
+    ConfiguredClient configuredClient;
+
+    @Test
+    void defaultIsMultiPairs() {
+        Client client = createClient(null);
+        assertThat(client.list(List.of("QUARKUS", "HELIDON"))).isEqualTo("frameworks=QUARKUS&frameworks=HELIDON");
+    }
+
+    @Test
+    void commaSeparated() {
+        Client client = createClient(ParamStyle.COMMA_SEPARATED);
+        assertThat(client.list(List.of("QUARKUS", "HELIDON"))).isEqualTo("frameworks=QUARKUS%2CHELIDON");
+        assertThat(client.list(List.of("QUARKUS"))).isEqualTo("frameworks=QUARKUS");
+    }
+
+    @Test
+    void arrayPairs() {
+        Client client = createClient(ParamStyle.ARRAY_PAIRS);
+        assertThat(client.list(List.of("QUARKUS", "HELIDON"))).isEqualTo("frameworks[]=QUARKUS&frameworks[]=HELIDON");
+        assertThat(client.list(List.of("QUARKUS"))).isEqualTo("frameworks=QUARKUS");
+    }
+
+    @Test
+    void styleAppliesToMapValuesAndMixedParams() {
+        Client client = createClient(ParamStyle.COMMA_SEPARATED);
+        // the order of the form parameters is not guaranteed
+        assertThat(client.mixed(List.of("QUARKUS", "HELIDON"), Map.of("versions", List.of("21", "25")), "JVM").split("&"))
+                .containsExactlyInAnyOrder("frameworks=QUARKUS%2CHELIDON", "versions=21%2C25", "mode=JVM");
+    }
+
+    @Test
+    void separatorTakesPrecedenceOverStyle() {
+        Client client = createClient(ParamStyle.ARRAY_PAIRS);
+        assertThat(client.separator(List.of("QUARKUS", "HELIDON"))).isEqualTo("frameworks=QUARKUS%3BHELIDON");
+    }
+
+    @Test
+    void styleAppliesToFormEntity() {
+        Client client = createClient(ParamStyle.COMMA_SEPARATED);
+        MultivaluedMap<String, String> form = new MultivaluedHashMap<>();
+        form.addAll("frameworks", "QUARKUS", "HELIDON");
+        assertThat(client.entity(form)).isEqualTo("frameworks=QUARKUS%2CHELIDON");
+    }
+
+    @Test
+    void styleFromConfiguration() {
+        assertThat(configuredClient.list(List.of("QUARKUS", "HELIDON"))).isEqualTo("frameworks=QUARKUS%2CHELIDON");
+    }
+
+    @Path("/style")
+    public interface Client {
+        @POST
+        @Path("/form")
+        String list(@RestForm List<String> frameworks);
+
+        @POST
+        @Path("/form")
+        String mixed(@RestForm List<String> frameworks, @RestForm Map<String, List<String>> map, @RestForm String mode);
+
+        @POST
+        @Path("/form")
+        String separator(@RestForm @Separator(";") List<String> frameworks);
+
+        @POST
+        @Path("/form")
+        @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+        String entity(MultivaluedMap<String, String> form);
+    }
+
+    @Path("/style")
+    @RegisterRestClient(configKey = "configured-client")
+    public interface ConfiguredClient {
+        @POST
+        @Path("/form")
+        String list(@RestForm List<String> frameworks);
+    }
+
+    Client createClient(ParamStyle style) {
+        QuarkusRestClientBuilder builder = QuarkusRestClientBuilder.newBuilder().baseUri(baseUri);
+        if (style != null) {
+            builder.formParamStyle(style);
+        }
+        return builder.build(Client.class);
+    }
+
+    @Path("/style")
+    public static class Resource {
+
+        @POST
+        @Path("/form")
+        @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+        public String form(String rawBody) {
+            return rawBody;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/form/SeparatorFormParamTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/form/SeparatorFormParamTest.java
@@ -1,0 +1,78 @@
+package io.quarkus.rest.client.reactive.form;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.List;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.Separator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class SeparatorFormParamTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClasses(Resource.class));
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @Test
+    void restFormWithSeparatorShouldSendSingleValue() {
+        Client client = createClient();
+        assertThat(client.restForm(List.of("QUARKUS", "HELIDON"))).isEqualTo("frameworks=QUARKUS%2CHELIDON");
+    }
+
+    @Test
+    void formParamWithSeparatorShouldSendSingleValue() {
+        Client client = createClient();
+        assertThat(client.formParam(List.of("QUARKUS", "HELIDON"))).isEqualTo("frameworks=QUARKUS%2CHELIDON");
+    }
+
+    @Test
+    void withoutSeparatorShouldSendMultiplePairs() {
+        Client client = createClient();
+        assertThat(client.plain(List.of("QUARKUS", "HELIDON"))).isEqualTo("frameworks=QUARKUS&frameworks=HELIDON");
+    }
+
+    public interface Client {
+        @POST
+        @Path("/separator/form")
+        String restForm(@RestForm @Separator(",") List<String> frameworks);
+
+        @POST
+        @Path("/separator/form")
+        String formParam(@FormParam("frameworks") @Separator(",") List<String> frameworks);
+
+        @POST
+        @Path("/separator/form")
+        String plain(@RestForm List<String> frameworks);
+    }
+
+    Client createClient() {
+        return RestClientBuilder.newBuilder().baseUri(baseUri).build(Client.class);
+    }
+
+    @Path("/separator")
+    public static class Resource {
+
+        @POST
+        @Path("/form")
+        @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+        public String form(String rawBody) {
+            return rawBody;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/resources/configuration-test-application.properties
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/resources/configuration-test-application.properties
@@ -11,6 +11,7 @@ quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".con
 quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".read-timeout=6000
 quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".follow-redirects=true
 quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".query-param-style=COMMA_SEPARATED
+quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".form-param-style=ARRAY_PAIRS
 quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".connection-ttl=30000
 quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".connection-pool-size=10
 quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".keep-alive-enabled=false
@@ -27,6 +28,7 @@ quarkus.rest-client.client-prefix.connect-timeout=5000
 quarkus.rest-client.client-prefix.read-timeout=6000
 quarkus.rest-client.client-prefix.follow-redirects=true
 quarkus.rest-client.client-prefix.query-param-style=COMMA_SEPARATED
+quarkus.rest-client.client-prefix.form-param-style=ARRAY_PAIRS
 quarkus.rest-client.client-prefix.connection-ttl=30000
 quarkus.rest-client.client-prefix.connection-pool-size=10
 quarkus.rest-client.client-prefix.keep-alive-enabled=false

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/resources/global-configuration-test-application.properties
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/resources/global-configuration-test-application.properties
@@ -15,6 +15,7 @@ quarkus.rest-client.max-redirects=2
 quarkus.rest-client.follow-redirects=true
 quarkus.rest-client.providers=io.quarkus.rest.client.reactive.HelloClientWithBaseUri$MyResponseFilter
 quarkus.rest-client.query-param-style=MULTI_PAIRS
+quarkus.rest-client.form-param-style=COMMA_SEPARATED
 
 quarkus.rest-client.trust-store=/path
 quarkus.rest-client.trust-store-password=password

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/ParamStyle.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/ParamStyle.java
@@ -1,0 +1,35 @@
+package io.quarkus.rest.client.reactive;
+
+import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
+
+/**
+ * Determines how multiple values of the same query parameter or {@code application/x-www-form-urlencoded} form
+ * parameter are sent.
+ * <p>
+ * For query parameters, this is the equivalent of the MicroProfile REST Client {@link QueryParamStyle}.
+ */
+public enum ParamStyle {
+    /**
+     * Multiple key/value pairs, each with the same key: {@code foo=v1&foo=v2&foo=v3}
+     */
+    MULTI_PAIRS,
+    /**
+     * A single key/value pair, with the values separated by commas: {@code foo=v1,v2,v3}
+     */
+    COMMA_SEPARATED,
+    /**
+     * Multiple key/value pairs, with {@code []} appended to the key: {@code foo[]=v1&foo[]=v2&foo[]=v3}
+     */
+    ARRAY_PAIRS;
+
+    public static ParamStyle from(QueryParamStyle queryParamStyle) {
+        if (queryParamStyle == null) {
+            return null;
+        }
+        return switch (queryParamStyle) {
+            case MULTI_PAIRS -> MULTI_PAIRS;
+            case COMMA_SEPARATED -> COMMA_SEPARATED;
+            case ARRAY_PAIRS -> ARRAY_PAIRS;
+        };
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/QuarkusRestClientBuilder.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/QuarkusRestClientBuilder.java
@@ -255,6 +255,23 @@ public interface QuarkusRestClientBuilder extends Configurable<QuarkusRestClient
     QuarkusRestClientBuilder queryParamStyle(QueryParamStyle style);
 
     /**
+     * Specifies the URI formatting style to use when multiple query parameter values are passed to the client.
+     *
+     * @param style the URI formatting style to use for multiple query parameter values
+     * @return the current builder with the style of query params set
+     */
+    QuarkusRestClientBuilder queryParamStyle(ParamStyle style);
+
+    /**
+     * Specifies the formatting style to use when multiple values of the same {@code application/x-www-form-urlencoded}
+     * form parameter are passed to the client.
+     *
+     * @param style the formatting style to use for multiple form parameter values
+     * @return the current builder with the style of form params set
+     */
+    QuarkusRestClientBuilder formParamStyle(ParamStyle style);
+
+    /**
      * Specifies the client headers factory to use.
      *
      * @param clientHeadersFactoryClass the client headers factory class to use.

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/QuarkusRestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/QuarkusRestClientBuilderImpl.java
@@ -21,6 +21,7 @@ import org.jboss.resteasy.reactive.client.api.ClientLogger;
 import org.jboss.resteasy.reactive.client.api.LoggingScope;
 
 import io.quarkus.proxy.ProxyType;
+import io.quarkus.rest.client.reactive.ParamStyle;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.quarkus.rest.client.reactive.runtime.context.ClientHeadersFactoryContextResolver;
 import io.quarkus.tls.TlsConfiguration;
@@ -152,6 +153,18 @@ public class QuarkusRestClientBuilderImpl implements QuarkusRestClientBuilder {
     @Override
     public QuarkusRestClientBuilder queryParamStyle(QueryParamStyle style) {
         delegate.queryParamStyle(style);
+        return this;
+    }
+
+    @Override
+    public QuarkusRestClientBuilder queryParamStyle(ParamStyle style) {
+        delegate.queryParamStyle(style);
+        return this;
+    }
+
+    @Override
+    public QuarkusRestClientBuilder formParamStyle(ParamStyle style) {
+        delegate.formParamStyle(style);
         return this;
     }
 

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
@@ -46,6 +46,7 @@ import org.jboss.resteasy.reactive.client.impl.VertxRequestCustomizingClientBuil
 import org.jboss.resteasy.reactive.client.impl.WebTargetImpl;
 import org.jboss.resteasy.reactive.client.impl.multipart.PausableHttpPostRequestEncoder;
 import org.jboss.resteasy.reactive.common.jaxrs.ConfigurationImpl;
+import org.jboss.resteasy.reactive.common.jaxrs.MultiFormParamMode;
 import org.jboss.resteasy.reactive.common.jaxrs.MultiQueryParamMode;
 import org.jboss.resteasy.reactive.common.util.CaseInsensitiveMap;
 
@@ -54,6 +55,7 @@ import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.proxy.ProxyConfiguration;
 import io.quarkus.proxy.ProxyConfigurationRegistry;
+import io.quarkus.rest.client.reactive.ParamStyle;
 import io.quarkus.rest.client.reactive.runtime.context.HttpClientOptionsContextResolver;
 import io.quarkus.restclient.config.RestClientsConfig;
 import io.quarkus.tls.TlsConfiguration;
@@ -82,7 +84,8 @@ public class RestClientBuilderImpl implements RestClientBuilder, VertxRequestCus
 
     private URI uri;
     private Boolean followRedirects;
-    private QueryParamStyle queryParamStyle;
+    private ParamStyle queryParamStyle;
+    private ParamStyle formParamStyle;
     private MultivaluedMap<String, Object> headers = new CaseInsensitiveMap<>();
 
     private String multipartPostEncoderMode;
@@ -484,7 +487,17 @@ public class RestClientBuilderImpl implements RestClientBuilder, VertxRequestCus
 
     @Override
     public RestClientBuilderImpl queryParamStyle(final QueryParamStyle style) {
+        queryParamStyle = ParamStyle.from(style);
+        return this;
+    }
+
+    public RestClientBuilderImpl queryParamStyle(final ParamStyle style) {
         queryParamStyle = style;
+        return this;
+    }
+
+    public RestClientBuilderImpl formParamStyle(final ParamStyle style) {
+        formParamStyle = style;
         return this;
     }
 
@@ -576,6 +589,7 @@ public class RestClientBuilderImpl implements RestClientBuilder, VertxRequestCus
         }
 
         clientBuilder.multiQueryParamMode(toMultiQueryParamMode(queryParamStyle));
+        clientBuilder.multiFormParamMode(toMultiFormParamMode(formParamStyle));
         clientBuilder.register(new DefaultClientHeadersRequestFilter(headers));
 
         Boolean effectiveTrustAll = trustAll;
@@ -737,7 +751,7 @@ public class RestClientBuilderImpl implements RestClientBuilder, VertxRequestCus
         }
     }
 
-    private MultiQueryParamMode toMultiQueryParamMode(QueryParamStyle queryParamStyle) {
+    private MultiQueryParamMode toMultiQueryParamMode(ParamStyle queryParamStyle) {
         if (queryParamStyle == null) {
             return null;
         }
@@ -750,6 +764,17 @@ public class RestClientBuilderImpl implements RestClientBuilder, VertxRequestCus
                 return MultiQueryParamMode.ARRAY_PAIRS;
         }
         return null;
+    }
+
+    private MultiFormParamMode toMultiFormParamMode(ParamStyle formParamStyle) {
+        if (formParamStyle == null) {
+            return null;
+        }
+        return switch (formParamStyle) {
+            case MULTI_PAIRS -> MultiFormParamMode.MULTI_PAIRS;
+            case COMMA_SEPARATED -> MultiFormParamMode.COMMA_SEPARATED;
+            case ARRAY_PAIRS -> MultiFormParamMode.ARRAY_PAIRS;
+        };
     }
 
 }

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
@@ -33,6 +33,7 @@ import org.jboss.resteasy.reactive.client.impl.multipart.PausableHttpPostRequest
 import io.quarkus.arc.Arc;
 import io.quarkus.proxy.ProxyConfiguration;
 import io.quarkus.proxy.ProxyConfigurationRegistry;
+import io.quarkus.rest.client.reactive.ParamStyle;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.quarkus.restclient.config.RestClientsConfig;
 import io.quarkus.restclient.config.RestClientsConfig.RestClientConfig;
@@ -85,6 +86,7 @@ public class RestClientCDIDelegateBuilder<T> {
         configureTLS(builder);
         configureRedirects(builder);
         configureQueryParamStyle(builder);
+        configureFormParamStyle(builder);
         configureProxy(builder);
         configureShared(builder);
         configureLogging(builder);
@@ -213,6 +215,14 @@ public class RestClientCDIDelegateBuilder<T> {
         if (maybeQueryParamStyle.isPresent()) {
             QueryParamStyle queryParamStyle = maybeQueryParamStyle.get();
             builder.queryParamStyle(queryParamStyle);
+        }
+    }
+
+    private void configureFormParamStyle(QuarkusRestClientBuilder builder) {
+        Optional<QueryParamStyle> maybeFormParamStyle = oneOf(restClientConfig.formParamStyle(),
+                configRoot.formParamStyle());
+        if (maybeFormParamStyle.isPresent()) {
+            builder.formParamStyle(ParamStyle.from(maybeFormParamStyle.get()));
         }
     }
 

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
@@ -40,6 +40,7 @@ import org.jboss.resteasy.reactive.client.api.LoggingScope;
 import org.jboss.resteasy.reactive.client.logging.DefaultClientLogger;
 import org.jboss.resteasy.reactive.client.spi.ClientContextResolver;
 import org.jboss.resteasy.reactive.common.jaxrs.ConfigurationImpl;
+import org.jboss.resteasy.reactive.common.jaxrs.MultiFormParamMode;
 import org.jboss.resteasy.reactive.common.jaxrs.MultiQueryParamMode;
 
 import io.vertx.core.buffer.Buffer;
@@ -91,6 +92,7 @@ public class ClientBuilderImpl extends ClientBuilder {
 
     private int maxChunkSize = 8096;
     private MultiQueryParamMode multiQueryParamMode;
+    private MultiFormParamMode multiFormParamMode;
 
     private String userAgent = RestClientRequestContext.DEFAULT_USER_AGENT_VALUE;
     private String domainSocketPath;
@@ -210,6 +212,11 @@ public class ClientBuilderImpl extends ClientBuilder {
 
     public ClientBuilder multiQueryParamMode(MultiQueryParamMode multiQueryParamMode) {
         this.multiQueryParamMode = multiQueryParamMode;
+        return this;
+    }
+
+    public ClientBuilder multiFormParamMode(MultiFormParamMode multiFormParamMode) {
+        this.multiFormParamMode = multiFormParamMode;
         return this;
     }
 
@@ -363,6 +370,7 @@ public class ClientBuilderImpl extends ClientBuilder {
                 null,
                 followRedirects,
                 multiQueryParamMode,
+                multiFormParamMode,
                 loggingScope,
                 clientLogger, userAgent, tlsConfig != null ? tlsConfig.getName().orElse(null) : null,
                 clientRequestCustomizers,

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientImpl.java
@@ -40,6 +40,7 @@ import org.jboss.resteasy.reactive.client.handlers.AdvancedRedirectHandler;
 import org.jboss.resteasy.reactive.client.handlers.RedirectHandler;
 import org.jboss.resteasy.reactive.client.spi.ClientContext;
 import org.jboss.resteasy.reactive.common.jaxrs.ConfigurationImpl;
+import org.jboss.resteasy.reactive.common.jaxrs.MultiFormParamMode;
 import org.jboss.resteasy.reactive.common.jaxrs.MultiQueryParamMode;
 import org.jboss.resteasy.reactive.common.jaxrs.UriBuilderImpl;
 
@@ -102,6 +103,7 @@ public class ClientImpl implements Client {
     final HandlerChain handlerChain;
     final Vertx vertx;
     private final MultiQueryParamMode multiQueryParamMode;
+    private final MultiFormParamMode multiFormParamMode;
     private final String userAgent;
     private final String tlsConfigName;
 
@@ -109,6 +111,7 @@ public class ClientImpl implements Client {
             HostnameVerifier hostnameVerifier,
             SSLContext sslContext, boolean followRedirects,
             MultiQueryParamMode multiQueryParamMode,
+            MultiFormParamMode multiFormParamMode,
             LoggingScope loggingScope,
             ClientLogger clientLogger, String userAgent,
             String tlsConfigName,
@@ -123,6 +126,7 @@ public class ClientImpl implements Client {
         this.hostnameVerifier = hostnameVerifier;
         this.sslContext = sslContext;
         this.multiQueryParamMode = multiQueryParamMode;
+        this.multiFormParamMode = multiFormParamMode;
         Supplier<Vertx> vertx = clientContext.getVertx();
         if (vertx != null) {
             this.vertx = vertx.get();
@@ -280,6 +284,10 @@ public class ClientImpl implements Client {
 
     public String getTlsConfigName() {
         return tlsConfigName;
+    }
+
+    public MultiFormParamMode getMultiFormParamMode() {
+        return multiFormParamMode;
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
@@ -9,10 +9,12 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
@@ -22,9 +24,11 @@ import jakarta.ws.rs.RuntimeType;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.EntityPart;
+import jakarta.ws.rs.core.Form;
 import jakarta.ws.rs.core.GenericEntity;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.MessageBodyWriter;
@@ -42,6 +46,7 @@ import org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext;
 import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.common.jaxrs.ConfigurationImpl;
 import org.jboss.resteasy.reactive.common.jaxrs.EntityPartImpl;
+import org.jboss.resteasy.reactive.common.jaxrs.MultiFormParamMode;
 import org.jboss.resteasy.reactive.common.jaxrs.ResponseImpl;
 import org.jboss.resteasy.reactive.common.util.CaseInsensitiveMap;
 import org.jboss.resteasy.reactive.spi.ThreadSetupAction;
@@ -301,6 +306,7 @@ public class RestClientRequestContext extends AbstractResteasyReactiveContext<Re
         } else {
             entityType = entityClass = entityObject.getClass();
         }
+        entityObject = applyMultiFormParamMode(entityObject, entity.getMediaType());
         List<MessageBodyWriter<?>> writers = restClient.getClientContext().getSerialisers().findWriters(configuration,
                 entityClass, entity.getMediaType(),
                 RuntimeType.CLIENT);
@@ -313,6 +319,48 @@ public class RestClientRequestContext extends AbstractResteasyReactiveContext<Re
         }
         // FIXME: exception?
         return null;
+    }
+
+    /**
+     * Applies the {@link MultiFormParamMode} configured on the client to {@code application/x-www-form-urlencoded}
+     * entities. Form parameters that have a single value are always left untouched.
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private Object applyMultiFormParamMode(Object entityObject, MediaType mediaType) {
+        MultiFormParamMode mode = restClient.getMultiFormParamMode();
+        if (mode == null || mode == MultiFormParamMode.MULTI_PAIRS || mediaType == null
+                || !MediaType.APPLICATION_FORM_URLENCODED_TYPE.getType().equalsIgnoreCase(mediaType.getType())
+                || !MediaType.APPLICATION_FORM_URLENCODED_TYPE.getSubtype().equalsIgnoreCase(mediaType.getSubtype())) {
+            return entityObject;
+        }
+        if (entityObject instanceof Form form) {
+            return new Form(applyMultiFormParamMode(form.asMap(), mode));
+        }
+        if (entityObject instanceof MultivaluedMap map) {
+            return applyMultiFormParamMode(map, mode);
+        }
+        return entityObject;
+    }
+
+    private static MultivaluedMap<String, String> applyMultiFormParamMode(MultivaluedMap<String, String> formParams,
+            MultiFormParamMode mode) {
+        MultivaluedMap<String, String> result = new MultivaluedHashMap<>();
+        for (Map.Entry<?, List<String>> entry : formParams.entrySet()) {
+            String name = String.valueOf(entry.getKey());
+            List<String> values = entry.getValue();
+            if (values.size() < 2) {
+                result.put(name, new ArrayList<>(values));
+            } else if (mode == MultiFormParamMode.COMMA_SEPARATED) {
+                StringJoiner joiner = new StringJoiner(",");
+                for (String value : values) {
+                    joiner.add(String.valueOf(value));
+                }
+                result.add(name, joiner.toString());
+            } else { // ARRAY_PAIRS
+                result.put(name + "[]", new ArrayList<>(values));
+            }
+        }
+        return result;
     }
 
     public void setEntity(Object entity, Annotation[] annotations, MediaType mediaType) {

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/Separator.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/Separator.java
@@ -9,6 +9,9 @@ import java.util.List;
 /**
  * When used on a {@link List} parameter annotated with {@link RestQuery}, RESTEasy Reactive will split the value of the
  * parameter (using the value of the annotation) and populate the list with those values.
+ * <p>
+ * The REST Client also honors this annotation on collection parameters annotated with {@link RestQuery} or
+ * {@link RestForm}, joining the values of the collection using the value of the annotation.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.PARAMETER, ElementType.FIELD })

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/MultiFormParamMode.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/MultiFormParamMode.java
@@ -1,0 +1,19 @@
+package org.jboss.resteasy.reactive.common.jaxrs;
+
+/**
+ * Determines how multiple values of the same {@code application/x-www-form-urlencoded} form parameter are encoded
+ */
+public enum MultiFormParamMode {
+    /**
+     * <code>foo=v1&amp;foo=v2&amp;foo=v3</code>
+     */
+    MULTI_PAIRS,
+    /**
+     * <code>foo=v1,v2,v3</code>
+     */
+    COMMA_SEPARATED,
+    /**
+     * <code>foo[]=v1&amp;foo[]=v2&amp;foo[]=v3</code>
+     */
+    ARRAY_PAIRS
+}


### PR DESCRIPTION
These are analogous to what we allow for query params

- Fixes: #56375 