### PR TITLE
Remove unnecessary quarkus-extension-processor from SPI modules

### DIFF
--- a/extensions/spiffe-client/runtime-api/pom.xml
+++ b/extensions/spiffe-client/runtime-api/pom.xml
@@ -17,25 +17,4 @@
             <artifactId>mutiny</artifactId>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-compile</id>
-                        <configuration>
-                            <annotationProcessorPaths>
-                                <path>
-                                    <groupId>io.quarkus</groupId>
-                                    <artifactId>quarkus-extension-processor</artifactId>
-                                    <version>${project.version}</version>
-                                </path>
-                            </annotationProcessorPaths>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/extensions/websockets-next/spi/pom.xml
+++ b/extensions/websockets-next/spi/pom.xml
@@ -18,26 +18,4 @@
             <artifactId>quarkus-security</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-compile</id>
-                        <configuration>
-                            <annotationProcessorPaths>
-                                <path>
-                                    <groupId>io.quarkus</groupId>
-                                    <artifactId>quarkus-extension-processor</artifactId>
-                                    <version>${project.version}</version>
-                                </path>
-                            </annotationProcessorPaths>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
`quarkus-websockets-next-spi` and `quarkus-spiffe-client-api` configured `quarkus-extension-processor` as an annotation processor, but neither module contains build steps or config mappings, so the processor is not needed. Its presence caused build failures on a clean local repository because Maven could not resolve the processor jar before it was built.

Remove the annotation processor configuration entirely instead of adding a reactor ordering workaround (see #56442).