### PR TITLE
fix: align docs-preview.sh default port to 8042

### DIFF
--- a/.agents/skills/building-docs/SKILL.md
+++ b/.agents/skills/building-docs/SKILL.md
@@ -166,7 +166,7 @@ upstream changes.
 
 ## Troubleshooting
 
-**Port 8042 already in use** — Another process is using port 8042 (`docs-preview.sh` uses this via `serve-only-latest-guides.sh`, which reads `config/application.properties`).
+**Port 8042 already in use** — Another process is using port 8042.
 First, check whether it is a leftover preview from a previous run
 (e.g. a `java` process launched by `mvnw`). If so, kill it and retry.
 **Always tell the user before using a different port** — do not

--- a/docs/docs-preview.sh
+++ b/docs/docs-preview.sh
@@ -15,7 +15,7 @@ LOGDIR=$(mktemp -d "${TMPDIR:-/tmp}/quarkus-docs-build-XXXXXX") || exit 1
 
 # The website uses Roq (a Quarkus-based static site generator).
 # Step 4 serves via ./mvnw quarkus:dev — no container runtime required.
-ROQ_PORT="${QUARKUS_HTTP_PORT:-8080}"
+ROQ_PORT="${QUARKUS_HTTP_PORT:-8042}"
 
 # Validate explicitly supplied port
 if [ -n "${QUARKUS_HTTP_PORT:-}" ]; then


### PR DESCRIPTION
## Summary

- `docs-preview.sh` defaulted to port 8080 while the website's `config/application.properties` uses 8042 — the env var override silently beat the config, so the actual port didn't match what the skill doc promised
- Removed incorrect reference to `serve-only-latest-guides.sh` in the troubleshooting section — `docs-preview.sh` runs `./mvnw quarkus:dev` directly
- Companion to quarkusio/quarkusio.github.io#2967 which fixed the same 8080→8042 mismatch in `blog-preview.sh`

## Test plan

- [ ] Run `bash docs/docs-preview.sh` without `QUARKUS_HTTP_PORT` set — server should start on 8042
- [ ] Run `QUARKUS_HTTP_PORT=8081 bash docs/docs-preview.sh` — server should start on 8081
- [ ] Existing `docs/test-preview-scripts.sh` port validation tests still pass (they test that 8080 is a valid port number, not the default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)