### PR TITLE
Improve `ServerRestHandler` invocation

### DIFF
--- a/extensions/jfr/deployment/src/main/java/io/quarkus/jfr/deployment/JfrProcessor.java
+++ b/extensions/jfr/deployment/src/main/java/io/quarkus/jfr/deployment/JfrProcessor.java
@@ -29,6 +29,7 @@ import io.quarkus.jfr.runtime.internal.runtime.JfrRuntimeBean;
 import io.quarkus.jfr.runtime.internal.runtime.QuarkusRuntimeInfo;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.GlobalHandlerCustomizerBuildItem;
+import io.quarkus.resteasy.reactive.server.spi.KnownServerRestHandlerBuildItem;
 import io.quarkus.resteasy.reactive.spi.CustomContainerRequestFilterBuildItem;
 
 @BuildSteps
@@ -83,7 +84,8 @@ public class JfrProcessor {
     void registerRestIntegration(Capabilities capabilities,
             BuildProducer<CustomContainerRequestFilterBuildItem> filterBeans,
             BuildProducer<AdditionalBeanBuildItem> additionalBeans,
-            BuildProducer<GlobalHandlerCustomizerBuildItem> globalHandlerCustomizerProducer) {
+            BuildProducer<GlobalHandlerCustomizerBuildItem> globalHandlerCustomizerProducer,
+            BuildProducer<KnownServerRestHandlerBuildItem> knownServerRestHandlerProducer) {
 
         if (capabilities.isPresent(Capability.RESTEASY_REACTIVE)) {
 
@@ -96,6 +98,8 @@ public class JfrProcessor {
 
             globalHandlerCustomizerProducer
                     .produce(new GlobalHandlerCustomizerBuildItem(new ServerStartRecordingHandler.Customizer()));
+            knownServerRestHandlerProducer
+                    .produce(new KnownServerRestHandlerBuildItem(ServerStartRecordingHandler.class.getName()));
         }
     }
 

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/tracing/instrumentation/InstrumentationProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/tracing/instrumentation/InstrumentationProcessor.java
@@ -30,6 +30,7 @@ import io.quarkus.opentelemetry.runtime.tracing.instrumentation.resteasy.AttachE
 import io.quarkus.opentelemetry.runtime.tracing.instrumentation.resteasy.OpenTelemetryClassicServerFilter;
 import io.quarkus.opentelemetry.runtime.tracing.instrumentation.resteasy.OpenTelemetryReactiveServerFilter;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
+import io.quarkus.resteasy.reactive.server.spi.KnownServerRestHandlerBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.PreExceptionMapperHandlerBuildItem;
 import io.quarkus.resteasy.reactive.spi.CustomContainerRequestFilterBuildItem;
 import io.quarkus.vertx.deployment.spi.VertxBootstrapConsumerBuildItem;
@@ -148,12 +149,15 @@ public class InstrumentationProcessor {
             Capabilities capabilities,
             BuildProducer<CustomContainerRequestFilterBuildItem> containerRequestFilterBuildItemBuildProducer,
             BuildProducer<PreExceptionMapperHandlerBuildItem> preExceptionMapperHandlerBuildItemBuildProducer,
+            BuildProducer<KnownServerRestHandlerBuildItem> knownServerRestHandlerBuildItemBuildProducer,
             OTelBuildConfig config) {
         if (capabilities.isPresent(Capability.RESTEASY_REACTIVE) && config.instrument().rest()) {
             containerRequestFilterBuildItemBuildProducer
                     .produce(new CustomContainerRequestFilterBuildItem(OpenTelemetryReactiveServerFilter.class.getName()));
             preExceptionMapperHandlerBuildItemBuildProducer
                     .produce(new PreExceptionMapperHandlerBuildItem(new AttachExceptionHandler()));
+            knownServerRestHandlerBuildItemBuildProducer
+                    .produce(new KnownServerRestHandlerBuildItem(AttachExceptionHandler.class.getName()));
         }
 
     }

--- a/extensions/resteasy-reactive/rest-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContext.java
+++ b/extensions/resteasy-reactive/rest-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContext.java
@@ -78,9 +78,9 @@ public class ServletRequestContext extends ResteasyReactiveRequestContext
 
     public ServletRequestContext(Deployment deployment,
             HttpServletRequest request, HttpServletResponse response,
-            ThreadSetupAction requestContext, ServerRestHandler[] handlerChain, ServerRestHandler[] abortHandlerChain,
-            RoutingContext context, HttpServerExchange exchange) {
-        super(deployment, requestContext, handlerChain, abortHandlerChain);
+            ThreadSetupAction requestContext, ServerRestHandler[] handlerChain, byte[] handlerKinds,
+            ServerRestHandler[] abortHandlerChain, RoutingContext context, HttpServerExchange exchange) {
+        super(deployment, requestContext, handlerChain, handlerKinds, abortHandlerChain);
         this.request = request;
         this.response = response;
         this.context = context;

--- a/extensions/resteasy-reactive/rest-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContextFactory.java
+++ b/extensions/resteasy-reactive/rest-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContextFactory.java
@@ -18,11 +18,12 @@ public class ServletRequestContextFactory implements RequestContextFactory {
 
     @Override
     public ResteasyReactiveRequestContext createContext(Deployment deployment,
-            Object context, ThreadSetupAction requestContext, ServerRestHandler[] handlerChain,
+            Object context, ThreadSetupAction requestContext, ServerRestHandler[] handlerChain, byte[] handlerKinds,
             ServerRestHandler[] abortHandlerChain) {
         io.undertow.servlet.handlers.ServletRequestContext src = (io.undertow.servlet.handlers.ServletRequestContext) context;
         return new ServletRequestContext(deployment, (HttpServletRequest) src.getServletRequest(),
-                (HttpServletResponse) src.getServletResponse(), requestContext, handlerChain, abortHandlerChain,
+                (HttpServletResponse) src.getServletResponse(), requestContext, handlerChain, handlerKinds,
+                abortHandlerChain,
                 (RoutingContext) ((VertxHttpExchange) src.getExchange().getDelegate()).getContext(), src.getExchange());
     }
 

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -16,6 +16,8 @@ import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNa
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.constant.ClassDesc;
+import java.lang.reflect.Modifier;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -99,8 +101,22 @@ import org.jboss.resteasy.reactive.common.util.types.Types;
 import org.jboss.resteasy.reactive.server.core.Deployment;
 import org.jboss.resteasy.reactive.server.core.DeploymentInfo;
 import org.jboss.resteasy.reactive.server.core.ExceptionMapping;
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.server.core.ServerSerialisers;
+import org.jboss.resteasy.reactive.server.handlers.AbortChainHandler;
+import org.jboss.resteasy.reactive.server.handlers.BlockingHandler;
+import org.jboss.resteasy.reactive.server.handlers.ClassRoutingHandler;
+import org.jboss.resteasy.reactive.server.handlers.FixedProducesHandler;
+import org.jboss.resteasy.reactive.server.handlers.InputHandler;
+import org.jboss.resteasy.reactive.server.handlers.InstanceHandler;
+import org.jboss.resteasy.reactive.server.handlers.InvocationHandler;
+import org.jboss.resteasy.reactive.server.handlers.MatrixParamHandler;
+import org.jboss.resteasy.reactive.server.handlers.NonBlockingHandler;
 import org.jboss.resteasy.reactive.server.handlers.ParameterHandler;
+import org.jboss.resteasy.reactive.server.handlers.RequestDeserializeHandler;
+import org.jboss.resteasy.reactive.server.handlers.ResourceRequestFilterHandler;
+import org.jboss.resteasy.reactive.server.handlers.ResponseHandler;
+import org.jboss.resteasy.reactive.server.handlers.ResponseWriterHandler;
 import org.jboss.resteasy.reactive.server.handlers.RestInitialHandler;
 import org.jboss.resteasy.reactive.server.model.ContextResolvers;
 import org.jboss.resteasy.reactive.server.model.DelegatingServerRestHandler;
@@ -120,6 +136,7 @@ import org.jboss.resteasy.reactive.server.processor.scanning.ResponseHeaderMetho
 import org.jboss.resteasy.reactive.server.processor.scanning.ResponseStatusMethodScanner;
 import org.jboss.resteasy.reactive.server.processor.util.ResteasyReactiveServerDotNames;
 import org.jboss.resteasy.reactive.server.providers.serialisers.ServerFileBodyHandler;
+import org.jboss.resteasy.reactive.server.spi.HandlerKindResolver;
 import org.jboss.resteasy.reactive.server.spi.RuntimeConfiguration;
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
 import org.jboss.resteasy.reactive.server.vertx.serializers.ServerMutinyAsyncFileMessageBodyWriter;
@@ -141,6 +158,7 @@ import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.GeneratedClassGizmo2Adaptor;
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -152,6 +170,7 @@ import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.LogCategoryBuildItem;
 import io.quarkus.deployment.builditem.RecordableConstructorBuildItem;
@@ -165,6 +184,10 @@ import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.Gizmo;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.ParamVar;
+import io.quarkus.gizmo2.desc.ClassMethodDesc;
+import io.quarkus.gizmo2.desc.MethodDesc;
 import io.quarkus.netty.deployment.MinNettyAllocatorMaxOrderBuildItem;
 import io.quarkus.resteasy.reactive.common.deployment.AggregatedParameterContainersBuildItem;
 import io.quarkus.resteasy.reactive.common.deployment.ApplicationResultBuildItem;
@@ -179,11 +202,13 @@ import io.quarkus.resteasy.reactive.common.deployment.SerializersUtil;
 import io.quarkus.resteasy.reactive.common.deployment.ServerDefaultProducesHandlerBuildItem;
 import io.quarkus.resteasy.reactive.common.runtime.ResteasyReactiveConfig;
 import io.quarkus.resteasy.reactive.server.EndpointDisabled;
+import io.quarkus.resteasy.reactive.server.runtime.QuarkusResteasyReactiveRequestContext;
 import io.quarkus.resteasy.reactive.server.runtime.QuarkusServerFileBodyHandler;
 import io.quarkus.resteasy.reactive.server.runtime.QuarkusServerPathBodyHandler;
 import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveInitialiser;
 import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveRecorder;
 import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveRuntimeRecorder;
+import io.quarkus.resteasy.reactive.server.runtime.ServerRestHandlerDispatcher;
 import io.quarkus.resteasy.reactive.server.runtime.StandardSecurityCheckInterceptor;
 import io.quarkus.resteasy.reactive.server.runtime.exceptionmappers.AuthenticationCompletionExceptionMapper;
 import io.quarkus.resteasy.reactive.server.runtime.exceptionmappers.AuthenticationFailedExceptionMapper;
@@ -201,6 +226,7 @@ import io.quarkus.resteasy.reactive.server.spi.AnnotationsTransformerBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.ContextTypeBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.GlobalHandlerCustomizerBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.HandlerConfigurationProviderBuildItem;
+import io.quarkus.resteasy.reactive.server.spi.KnownServerRestHandlerBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.MethodScannerBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.NonBlockingReturnTypeBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.PreExceptionMapperHandlerBuildItem;
@@ -242,6 +268,28 @@ public class ResteasyReactiveProcessor {
     private static final int REST_ROUTE_ORDER_OFFSET = 500;
 
     private static final String QUARKUS_INIT_CLASS = "io.quarkus.rest.runtime.__QuarkusInit";
+    private static final String HANDLER_DISPATCHER_CLASS = ServerRestHandlerDispatcher.class.getName() + "$Generated";
+    /**
+     * The RESTEasy Reactive handlers that get a dedicated case in the generated {@link ServerRestHandlerDispatcher}.
+     * Extensions add their own via {@link KnownServerRestHandlerBuildItem}.
+     */
+    private static final List<String> CORE_HANDLERS = List.of(
+            MatrixParamHandler.class.getName(),
+            SecurityContextOverrideHandler.class.getName(),
+            RestInitialHandler.class.getName(),
+            ClassRoutingHandler.class.getName(),
+            AbortChainHandler.class.getName(),
+            NonBlockingHandler.class.getName(),
+            BlockingHandler.class.getName(),
+            ResourceRequestFilterHandler.class.getName(),
+            InputHandler.class.getName(),
+            RequestDeserializeHandler.class.getName(),
+            ParameterHandler.class.getName(),
+            InstanceHandler.class.getName(),
+            InvocationHandler.class.getName(),
+            FixedProducesHandler.class.getName(),
+            ResponseHandler.class.getName(),
+            ResponseWriterHandler.class.getName());
 
     private static final Logger log = Logger.getLogger("io.quarkus.resteasy.reactive.server");
 
@@ -1432,6 +1480,143 @@ public class ResteasyReactiveProcessor {
         return new GlobalHandlerCustomizerBuildItem(new SecurityContextOverrideHandler.Customizer());
     }
 
+    /**
+     * Fails the build if a class registered via {@link KnownServerRestHandlerBuildItem} cannot get a dedicated case
+     * in the generated dispatcher, i.e. if it cannot be loaded, does not implement {@link ServerRestHandler}
+     * or is not a concrete class.
+     * The generated case casts the handler to the registered class and invokes {@code handle} on it with
+     * {@code invokevirtual}: for an interface that bytecode is invalid, while for an abstract class the call
+     * is polymorphic again, which defeats the purpose of the dedicated case.
+     */
+    private static void validateKnownHandler(String handlerClass) {
+        Class<?> clazz;
+        try {
+            clazz = Class.forName(handlerClass, false, Thread.currentThread().getContextClassLoader());
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Unable to load handler class '" + handlerClass + "' registered via "
+                    + KnownServerRestHandlerBuildItem.class.getSimpleName(), e);
+        }
+        if (!ServerRestHandler.class.isAssignableFrom(clazz) || clazz.isInterface()
+                || Modifier.isAbstract(clazz.getModifiers())) {
+            throw new IllegalStateException("Handler class '" + handlerClass + "' registered via "
+                    + KnownServerRestHandlerBuildItem.class.getSimpleName() + " must be a concrete class implementing "
+                    + ServerRestHandler.class.getName());
+        }
+    }
+
+    @BuildStep
+    public void coreHandlers(BuildProducer<KnownServerRestHandlerBuildItem> knownServerRestHandlers) {
+        for (String handlerClass : CORE_HANDLERS) {
+            knownServerRestHandlers.produce(new KnownServerRestHandlerBuildItem(handlerClass));
+        }
+    }
+
+    /**
+     * Generates the {@link ServerRestHandlerDispatcher} used by {@link QuarkusResteasyReactiveRequestContext}
+     * to invoke the handlers of a chain.
+     * <p>
+     * Each class registered via {@link KnownServerRestHandlerBuildItem} gets a kind, which is its position in the
+     * sorted list of registered classes, and a dedicated {@code switch} case in which the handler is cast to that class
+     * and {@code handle} is invoked on it, making it a monomorphic call.
+     * The kinds are assigned to the handlers of a chain once, when the chain is built at deployment.
+     * <p>
+     * For example, if the registered handler classes are {@code AbortChainHandler}, {@code BlockingHandler} and
+     * {@code ClassRoutingHandler}, the generated class is equivalent to:
+     *
+     * <pre>{@code
+     * public final class ServerRestHandlerDispatcher$Generated extends ServerRestHandlerDispatcher {
+     *
+     *     public byte kindOf(ServerRestHandler handler) {
+     *         if (handler instanceof AbortChainHandler) {
+     *             return 1;
+     *         }
+     *         if (handler instanceof BlockingHandler) {
+     *             return 2;
+     *         }
+     *         if (handler instanceof ClassRoutingHandler) {
+     *             return 3;
+     *         }
+     *         return UNKNOWN;
+     *     }
+     *
+     *     public void dispatch(int kind, ServerRestHandler handler, QuarkusResteasyReactiveRequestContext context)
+     *             throws Exception {
+     *         switch (kind) {
+     *             case 1 -> ((AbortChainHandler) handler).handle(context);
+     *             case 2 -> ((BlockingHandler) handler).handle(context);
+     *             case 3 -> ((ClassRoutingHandler) handler).handle(context);
+     *             default -> handler.handle(context);
+     *         }
+     *     }
+     * }
+     * }</pre>
+     */
+    @BuildStep
+    public void generateHandlerDispatcher(Optional<ResourceScanningResultBuildItem> resourceScanningResultBuildItem,
+            List<KnownServerRestHandlerBuildItem> knownServerRestHandlers,
+            BuildProducer<GeneratedClassBuildItem> generatedClass,
+            BuildProducer<GeneratedResourceBuildItem> generatedResource) {
+        if (!resourceScanningResultBuildItem.isPresent()) {
+            // no detected @Path, bail out
+            return;
+        }
+        // sorted so that the kinds don't depend on the order in which the build items were produced
+        List<String> orderedHandlerClasses = knownServerRestHandlers.stream()
+                .map(KnownServerRestHandlerBuildItem::getClassName).distinct().sorted().collect(Collectors.toList());
+        for (String handlerClass : orderedHandlerClasses) {
+            validateKnownHandler(handlerClass);
+        }
+        if (orderedHandlerClasses.size() > Byte.MAX_VALUE) {
+            // kinds are stored as bytes, the remaining handlers simply get the default (megamorphic) treatment
+            orderedHandlerClasses = orderedHandlerClasses.subList(0, Byte.MAX_VALUE);
+        }
+        List<String> handlers = orderedHandlerClasses;
+
+        MethodDesc handleMethod = MethodDesc.of(ServerRestHandler.class, "handle", void.class,
+                ResteasyReactiveRequestContext.class);
+        io.quarkus.gizmo2.Gizmo gizmo = io.quarkus.gizmo2.Gizmo
+                .create(new GeneratedClassGizmo2Adaptor(generatedClass, generatedResource, true));
+        gizmo.class_(HANDLER_DISPATCHER_CLASS, cc -> {
+            cc.final_();
+            cc.extends_(ServerRestHandlerDispatcher.class);
+            cc.defaultConstructor();
+
+            cc.method("kindOf", mc -> {
+                mc.returning(byte.class);
+                ParamVar handler = mc.parameter("handler", ServerRestHandler.class);
+                mc.body(b0 -> {
+                    // this runs once per handler chain at deployment, so a linear scan is fine
+                    for (int i = 0; i < handlers.size(); i++) {
+                        byte kind = (byte) (i + 1);
+                        b0.if_(b0.instanceOf(handler, ClassDesc.of(handlers.get(i))),
+                                b1 -> b1.return_(Const.of(kind)));
+                    }
+                    b0.return_(Const.of(HandlerKindResolver.UNKNOWN));
+                });
+            });
+
+            cc.method("dispatch", mc -> {
+                ParamVar kind = mc.parameter("kind", int.class);
+                ParamVar handler = mc.parameter("handler", ServerRestHandler.class);
+                ParamVar context = mc.parameter("context", QuarkusResteasyReactiveRequestContext.class);
+                mc.body(b0 -> {
+                    b0.switch_(kind, sc -> {
+                        for (int i = 0; i < handlers.size(); i++) {
+                            ClassDesc handlerClass = ClassDesc.of(handlers.get(i));
+                            sc.caseOf(i + 1, b1 -> b1.invokeVirtual(
+                                    ClassMethodDesc.of(handlerClass, "handle", void.class,
+                                            ResteasyReactiveRequestContext.class),
+                                    b1.cast(handler, handlerClass), context));
+                        }
+                        // megamorphic call for other handlers
+                        sc.default_(b1 -> b1.invokeInterface(handleMethod, handler, context));
+                    });
+                    b0.return_();
+                });
+            });
+        });
+    }
+
     @BuildStep
     @Record(value = ExecutionTime.STATIC_INIT, useIdentityComparisonForParameters = false)
     public void setupDeployment(BeanContainerBuildItem beanContainerBuildItem,
@@ -1537,6 +1722,8 @@ public class ResteasyReactiveProcessor {
 
         BeanFactory<ResteasyReactiveInitialiser> initClassFactory = recorder.factory(QUARKUS_INIT_CLASS,
                 beanContainerBuildItem.getValue());
+        // the generated dispatcher is instantiated reflectively by the recorder
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(HANDLER_DISPATCHER_CLASS).build());
 
         String applicationPath = determineApplicationPath(appResult, getAppPath(serverConfig.path()));
         // spec allows the path contain encoded characters
@@ -1583,7 +1770,7 @@ public class ResteasyReactiveProcessor {
         RuntimeValue<Deployment> deployment = recorder.createDeployment(deploymentPath, deploymentInfo,
                 beanContainerBuildItem.getValue(), shutdownContext, httpBuildTimeConfig,
                 requestContextFactoryBuildItem.map(RequestContextFactoryBuildItem::getFactory).orElse(null),
-                initClassFactory, launchModeBuildItem.getLaunchMode(), servletPresent);
+                initClassFactory, launchModeBuildItem.getLaunchMode(), servletPresent, HANDLER_DISPATCHER_CLASS);
 
         quarkusRestDeploymentBuildItemBuildProducer
                 .produce(new ResteasyReactiveDeploymentBuildItem(deployment, deploymentPath));

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
@@ -26,14 +26,16 @@ public class QuarkusResteasyReactiveRequestContext extends VertxResteasyReactive
 
     private static final String QUARKUS_REST_KEY = "quarkus-rest";
     final CurrentIdentityAssociation association;
+    final ServerRestHandlerDispatcher dispatcher;
     boolean userSetup = false;
 
     public QuarkusResteasyReactiveRequestContext(Deployment deployment,
             RoutingContext context, ThreadSetupAction requestContext, ServerRestHandler[] handlerChain,
-            ServerRestHandler[] abortHandlerChain, ClassLoader devModeTccl,
-            CurrentIdentityAssociation currentIdentityAssociation) {
-        super(deployment, context, requestContext, handlerChain, abortHandlerChain, devModeTccl);
+            byte[] handlerKinds, ServerRestHandler[] abortHandlerChain, ClassLoader devModeTccl,
+            CurrentIdentityAssociation currentIdentityAssociation, ServerRestHandlerDispatcher dispatcher) {
+        super(deployment, context, requestContext, handlerChain, handlerKinds, abortHandlerChain, devModeTccl);
         this.association = currentIdentityAssociation;
+        this.dispatcher = dispatcher;
         if (VertxContext.isOnDuplicatedContext()) {
             VertxContextSafetyToggle.setCurrentContextSafe(true);
         }
@@ -158,51 +160,9 @@ public class QuarkusResteasyReactiveRequestContext extends VertxResteasyReactive
         throw (E) e;
     }
 
-    /**
-     * The implementation looks like it makes no sense, but it in fact does make sense from a performance perspective.
-     * The idea is to reduce the use instances of megamorphic calls into a series of instance checks and monomorphic calls.
-     * The rationale behind this is fully explored in
-     * https://shipilev.net/blog/2015/black-magic-method-dispatch/#_cheating_the_runtime_2
-     * and this specific instance has been verified experimentally to result in better performance.
-     */
     @Override
     protected void invokeHandler(int pos) throws Exception {
-        var handler = handlers[pos];
-        if (handler instanceof org.jboss.resteasy.reactive.server.handlers.MatrixParamHandler) {
-            handler.handle(this);
-        } else if (handler instanceof io.quarkus.resteasy.reactive.server.runtime.security.SecurityContextOverrideHandler) {
-            handler.handle(this);
-        } else if (handler instanceof org.jboss.resteasy.reactive.server.handlers.RestInitialHandler) {
-            handler.handle(this);
-        } else if (handler instanceof org.jboss.resteasy.reactive.server.handlers.ClassRoutingHandler) {
-            handler.handle(this);
-        } else if (handler instanceof org.jboss.resteasy.reactive.server.handlers.AbortChainHandler) {
-            handler.handle(this);
-        } else if (handler instanceof org.jboss.resteasy.reactive.server.handlers.NonBlockingHandler) {
-            handler.handle(this);
-        } else if (handler instanceof org.jboss.resteasy.reactive.server.handlers.BlockingHandler) {
-            handler.handle(this);
-        } else if (handler instanceof org.jboss.resteasy.reactive.server.handlers.ResourceRequestFilterHandler) {
-            handler.handle(this);
-        } else if (handler instanceof org.jboss.resteasy.reactive.server.handlers.InputHandler) {
-            handler.handle(this);
-        } else if (handler instanceof org.jboss.resteasy.reactive.server.handlers.RequestDeserializeHandler) {
-            handler.handle(this);
-        } else if (handler instanceof org.jboss.resteasy.reactive.server.handlers.ParameterHandler) {
-            handler.handle(this);
-        } else if (handler instanceof org.jboss.resteasy.reactive.server.handlers.InstanceHandler) {
-            handler.handle(this);
-        } else if (handler instanceof org.jboss.resteasy.reactive.server.handlers.InvocationHandler) {
-            handler.handle(this);
-        } else if (handler instanceof org.jboss.resteasy.reactive.server.handlers.FixedProducesHandler) {
-            handler.handle(this);
-        } else if (handler instanceof org.jboss.resteasy.reactive.server.handlers.ResponseHandler) {
-            handler.handle(this);
-        } else if (handler instanceof org.jboss.resteasy.reactive.server.handlers.ResponseWriterHandler) {
-            handler.handle(this);
-        } else {
-            // megamorphic call for other handlers
-            handler.handle(this);
-        }
+        // see ServerRestHandlerDispatcher for the rationale
+        dispatcher.dispatch(handlerKinds[pos], handlers[pos], this);
     }
 }

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
@@ -112,9 +112,11 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
             RequestContextFactory contextFactory,
             BeanFactory<ResteasyReactiveInitialiser> initClassFactory,
             LaunchMode launchMode,
-            boolean servletPresent) {
+            boolean servletPresent,
+            String dispatcherClassName) {
 
         info.setServletPresent(servletPresent);
+        ServerRestHandlerDispatcher dispatcher = createDispatcher(dispatcherClassName);
 
         CurrentRequestManager
                 .setCurrentRequestInstance(new QuarkusCurrentRequest(beanContainer.beanInstance(CurrentVertxRequest.class)));
@@ -140,11 +142,13 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
                 @Override
                 public ResteasyReactiveRequestContext createContext(Deployment deployment,
                         Object context, ThreadSetupAction requestContext,
-                        ServerRestHandler[] handlerChain, ServerRestHandler[] abortHandlerChain) {
+                        ServerRestHandler[] handlerChain, byte[] handlerKinds, ServerRestHandler[] abortHandlerChain) {
                     return new QuarkusResteasyReactiveRequestContext(deployment, (RoutingContext) context,
                             requestContext,
                             handlerChain,
-                            abortHandlerChain, launchMode == LaunchMode.DEVELOPMENT ? tccl : null, currentIdentityAssociation);
+                            handlerKinds,
+                            abortHandlerChain, launchMode == LaunchMode.DEVELOPMENT ? tccl : null, currentIdentityAssociation,
+                            dispatcher);
                 }
 
             };
@@ -153,7 +157,7 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
         RuntimeDeploymentManager runtimeDeploymentManager = new RuntimeDeploymentManager(info, EXECUTOR_SUPPLIER,
                 VTHREAD_EXECUTOR_SUPPLIER,
                 closeTaskHandler, contextFactory, new ArcThreadSetupAction(beanContainer.requestContext()),
-                httpBuildTimeConfig.rootPath());
+                httpBuildTimeConfig.rootPath(), dispatcher);
         Deployment deployment = runtimeDeploymentManager.deploy();
         DisabledRestEndpoints.set(deployment.getDisabledEndpoints());
         initClassFactory.createInstance().getInstance().init(deployment);
@@ -167,6 +171,16 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
                     ScoreSystem.ScoreVisitor);
         }
         return new RuntimeValue<>(deployment);
+    }
+
+    private ServerRestHandlerDispatcher createDispatcher(String className) {
+        try {
+            return (ServerRestHandlerDispatcher) Class
+                    .forName(className, true, Thread.currentThread().getContextClassLoader())
+                    .getDeclaredConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Unable to create the generated handler dispatcher " + className, e);
+        }
     }
 
     public RuntimeValue<RestInitialHandler> restInitialHandler(RuntimeValue<Deployment> deploymentRuntimeValue) {

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ServerRestHandlerDispatcher.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ServerRestHandlerDispatcher.java
@@ -1,0 +1,71 @@
+package io.quarkus.resteasy.reactive.server.runtime;
+
+import org.jboss.resteasy.reactive.server.spi.HandlerKindResolver;
+import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
+
+/**
+ * Invokes the handlers of a handler chain on behalf of {@link QuarkusResteasyReactiveRequestContext},
+ * avoiding the megamorphic {@link ServerRestHandler#handle} call that a plain interface call would result in.
+ * <p>
+ * The implementation is generated at build time from the handler classes registered via
+ * {@code KnownServerRestHandlerBuildItem}. Each registered class is assigned a kind, which is simply its position
+ * in the sorted list of registered classes, so a kind identifies exactly one concrete handler class and has
+ * no meaning outside the generated implementation.
+ * <p>
+ * The kinds are used in two steps:
+ * <ul>
+ * <li>{@link #kindOf(ServerRestHandler)} is invoked once per handler when a handler chain is built at deployment,
+ * and the resulting kinds are stored alongside the chain.
+ * Handlers that were not registered get {@link HandlerKindResolver#UNKNOWN}.</li>
+ * <li>{@link #dispatch(int, ServerRestHandler, QuarkusResteasyReactiveRequestContext)} is invoked for every handler
+ * of every request. It is a {@code switch} on the kind with one case per registered class, in which the handler
+ * is cast to that class and {@code handle} is invoked on it. Each case is thus a separate call site with a statically
+ * known receiver type, which allows the JIT to devirtualize and inline the call.
+ * The {@code switch} compiles to a {@code tableswitch}, so the cost of dispatching is the same for every kind
+ * and the order of the kinds is irrelevant.
+ * Handlers with {@link HandlerKindResolver#UNKNOWN} kind fall into the default case, which is a regular
+ * (megamorphic) interface call.</li>
+ * </ul>
+ * Only the chains used to process a request normally carry kinds. The abort chains that are used when an exception
+ * occurs do not, so all their handlers are invoked via the default case.
+ * <p>
+ * For example, if the registered handler classes are {@code AbortChainHandler}, {@code BlockingHandler} and
+ * {@code ClassRoutingHandler}, the generated class is equivalent to:
+ *
+ * <pre>{@code
+ * public final class ServerRestHandlerDispatcher$Generated extends ServerRestHandlerDispatcher {
+ *
+ *     public byte kindOf(ServerRestHandler handler) {
+ *         if (handler instanceof AbortChainHandler) {
+ *             return 1;
+ *         }
+ *         if (handler instanceof BlockingHandler) {
+ *             return 2;
+ *         }
+ *         if (handler instanceof ClassRoutingHandler) {
+ *             return 3;
+ *         }
+ *         return UNKNOWN;
+ *     }
+ *
+ *     public void dispatch(int kind, ServerRestHandler handler, QuarkusResteasyReactiveRequestContext context)
+ *             throws Exception {
+ *         switch (kind) {
+ *             case 1 -> ((AbortChainHandler) handler).handle(context);
+ *             case 2 -> ((BlockingHandler) handler).handle(context);
+ *             case 3 -> ((ClassRoutingHandler) handler).handle(context);
+ *             default -> handler.handle(context);
+ *         }
+ *     }
+ * }
+ * }</pre>
+ *
+ * This is the "switch on a byte id" dispatch strategy for megamorphic call sites that is benchmarked against
+ * an {@code instanceof} cascade and plain interface dispatch in
+ * <a href="https://shipilev.net/blog/2015/black-magic-method-dispatch/#_cheating_the_runtime_2">this</a> article
+ */
+public abstract class ServerRestHandlerDispatcher implements HandlerKindResolver {
+
+    public abstract void dispatch(int kind, ServerRestHandler handler, QuarkusResteasyReactiveRequestContext context)
+            throws Exception;
+}

--- a/extensions/resteasy-reactive/rest/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/server/spi/KnownServerRestHandlerBuildItem.java
+++ b/extensions/resteasy-reactive/rest/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/server/spi/KnownServerRestHandlerBuildItem.java
@@ -1,0 +1,25 @@
+package io.quarkus.resteasy.reactive.server.spi;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * A build item that allows extensions to register the {@link org.jboss.resteasy.reactive.server.spi.ServerRestHandler}
+ * classes they add to handler chains (via {@link GlobalHandlerCustomizerBuildItem}, {@link MethodScannerBuildItem}
+ * or {@link PreExceptionMapperHandlerBuildItem}).
+ * <p>
+ * Registered handler classes get a dedicated, monomorphic call site in the generated handler dispatcher,
+ * instead of being invoked through a megamorphic interface call.
+ * This only makes sense for handlers that run for most requests.
+ */
+public final class KnownServerRestHandlerBuildItem extends MultiBuildItem {
+
+    private final String className;
+
+    public KnownServerRestHandlerBuildItem(String className) {
+        this.className = className;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+}

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
@@ -24,7 +24,13 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
         implements Runnable, Closeable, ResteasyReactiveCallbackContext {
     protected static final Logger log = Logger.getLogger(AbstractResteasyReactiveContext.class);
     protected static final Logger logWebApplicationExceptions = Logger.getLogger(WebApplicationException.class.getSimpleName());
+    private static final byte[] NO_KINDS = new byte[0];
     protected H[] handlers;
+    /**
+     * The kind of each handler in {@link #handlers}, as determined when the chain was built.
+     * Only meaningful to implementations that use it to speed up handler dispatch, see {@link #invokeHandler(int)}
+     */
+    protected byte[] handlerKinds;
     protected H[] abortHandlerChain;
     protected int position;
     protected Throwable throwable;
@@ -44,7 +50,13 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
     protected boolean closed = false;
 
     public AbstractResteasyReactiveContext(H[] handlerChain, H[] abortHandlerChain, ThreadSetupAction requestContext) {
+        this(handlerChain, unknownKinds(handlerChain), abortHandlerChain, requestContext);
+    }
+
+    public AbstractResteasyReactiveContext(H[] handlerChain, byte[] handlerKinds, H[] abortHandlerChain,
+            ThreadSetupAction requestContext) {
         this.handlers = handlerChain;
+        this.handlerKinds = handlerKinds;
         this.abortHandlerChain = abortHandlerChain;
         this.requestContext = requestContext;
     }
@@ -103,6 +115,10 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
     public T setAbortHandlerChain(H[] abortHandlerChain) {
         this.abortHandlerChain = abortHandlerChain;
         return (T) this;
+    }
+
+    private static byte[] unknownKinds(Object[] chain) {
+        return chain.length == 0 ? NO_KINDS : new byte[chain.length];
     }
 
     public void close() {
@@ -298,7 +314,12 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
     }
 
     public void restart(H[] newHandlerChain, boolean keepTarget) {
+        restart(newHandlerChain, unknownKinds(newHandlerChain), keepTarget);
+    }
+
+    public void restart(H[] newHandlerChain, byte[] newHandlerKinds, boolean keepTarget) {
         this.handlers = newHandlerChain;
+        this.handlerKinds = newHandlerKinds;
         position = 0;
         restarted(keepTarget);
     }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/Deployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/Deployment.java
@@ -26,6 +26,7 @@ import org.jboss.resteasy.reactive.server.mapping.RequestMapper;
 import org.jboss.resteasy.reactive.server.model.ContextResolvers;
 import org.jboss.resteasy.reactive.server.model.ParamConverterProviders;
 import org.jboss.resteasy.reactive.server.spi.GenericRuntimeConfigurableServerRestHandler;
+import org.jboss.resteasy.reactive.server.spi.HandlerKindResolver;
 import org.jboss.resteasy.reactive.server.spi.RuntimeConfiguration;
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
 import org.jboss.resteasy.reactive.spi.BeanFactory.BeanInstance;
@@ -36,6 +37,7 @@ public class Deployment {
     private final ContextResolvers contextResolvers;
     private final ServerSerialisers serialisers;
     private final ServerRestHandler[] abortHandlerChain;
+    private final HandlerKindResolver handlerKindResolver;
     private final EntityWriter dynamicEntityWriter;
     private final String prefix;
     private final ParamConverterProviders paramConverterProviders;
@@ -56,7 +58,7 @@ public class Deployment {
     public Deployment(ExceptionMapping exceptionMapping,
             ContextResolvers contextResolvers,
             ServerSerialisers serialisers,
-            ServerRestHandler[] abortHandlerChain,
+            ServerRestHandler[] abortHandlerChain, HandlerKindResolver handlerKindResolver,
             EntityWriter dynamicEntityWriter, String prefix, ParamConverterProviders paramConverterProviders,
             ConfigurationImpl configuration, Supplier<Application> applicationSupplier,
             ThreadSetupAction threadSetupAction, RequestContextFactory requestContextFactory,
@@ -71,6 +73,7 @@ public class Deployment {
         this.contextResolvers = contextResolvers;
         this.serialisers = serialisers;
         this.abortHandlerChain = abortHandlerChain;
+        this.handlerKindResolver = handlerKindResolver;
         this.dynamicEntityWriter = dynamicEntityWriter;
         this.prefix = prefix;
         this.paramConverterProviders = paramConverterProviders;
@@ -121,6 +124,10 @@ public class Deployment {
 
     public ServerRestHandler[] getAbortHandlerChain() {
         return abortHandlerChain;
+    }
+
+    public HandlerKindResolver getHandlerKindResolver() {
+        return handlerKindResolver;
     }
 
     public EntityWriter getDynamicEntityWriter() {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/RequestContextFactory.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/RequestContextFactory.java
@@ -7,7 +7,8 @@ public interface RequestContextFactory {
 
     ResteasyReactiveRequestContext createContext(Deployment deployment,
             Object context,
-            ThreadSetupAction requestContext, ServerRestHandler[] handlerChain, ServerRestHandler[] abortHandlerChain);
+            ThreadSetupAction requestContext, ServerRestHandler[] handlerChain, byte[] handlerKinds,
+            ServerRestHandler[] abortHandlerChain);
 
     /**
      * @return <code>true</code> if requests default to blocking when created by this factory

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -165,8 +165,9 @@ public abstract class ResteasyReactiveRequestContext
     private volatile boolean connectionClosed;
 
     public ResteasyReactiveRequestContext(Deployment deployment,
-            ThreadSetupAction requestContext, ServerRestHandler[] handlerChain, ServerRestHandler[] abortHandlerChain) {
-        super(handlerChain, abortHandlerChain, requestContext);
+            ThreadSetupAction requestContext, ServerRestHandler[] handlerChain, byte[] handlerKinds,
+            ServerRestHandler[] abortHandlerChain) {
+        super(handlerChain, handlerKinds, abortHandlerChain, requestContext);
         this.deployment = deployment;
         this.parameters = EMPTY_ARRAY;
     }
@@ -202,6 +203,7 @@ public abstract class ResteasyReactiveRequestContext
 
     public void restart(RuntimeResource target, boolean setLocatorTarget) {
         this.handlers = target.getHandlerChain();
+        this.handlerKinds = target.getHandlerKinds();
         position = 0;
         parameters = target.getParameterTypes().length == 0 ? EMPTY_ARRAY : new Object[target.getParameterTypes().length];
         if (setLocatorTarget) {
@@ -216,7 +218,7 @@ public abstract class ResteasyReactiveRequestContext
 
         serverResponse().addCloseHandler(new ConnectionCloseHandler(this));
 
-        restart(initialMatch.value.handlers);
+        restart(initialMatch.value.handlers, initialMatch.value.handlerKinds, false);
         setMaxPathParams(initialMatch.value.maxPathParams);
         setRemaining(initialMatch.remaining);
         for (int i = 0; i < initialMatch.pathParamValues.length; ++i) {
@@ -238,7 +240,7 @@ public abstract class ResteasyReactiveRequestContext
         if (initialMatch == null) {
             return false;
         }
-        restart(initialMatch.value.handlers);
+        restart(initialMatch.value.handlers, initialMatch.value.handlerKinds, false);
         setMaxPathParams(initialMatch.value.maxPathParams);
         setRemaining(initialMatch.remaining);
         for (int i = 0; i < initialMatch.pathParamValues.length; ++i) {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
@@ -48,6 +48,7 @@ import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer;
 import org.jboss.resteasy.reactive.server.model.ParamConverterProviders;
 import org.jboss.resteasy.reactive.server.model.ServerResourceMethod;
 import org.jboss.resteasy.reactive.server.spi.GenericRuntimeConfigurableServerRestHandler;
+import org.jboss.resteasy.reactive.server.spi.HandlerKindResolver;
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
 import org.jboss.resteasy.reactive.spi.BeanFactory;
 import org.jboss.resteasy.reactive.spi.ThreadSetupAction;
@@ -62,6 +63,7 @@ public class RuntimeDeploymentManager {
     private final RequestContextFactory requestContextFactory;
     private final ThreadSetupAction threadSetupAction;
     private final String rootPath;
+    private final HandlerKindResolver handlerKindResolver;
 
     private ArrayList<RequestMapper.RequestPath<RestInitialHandler.InitialMatch>> classMappers;
 
@@ -70,6 +72,16 @@ public class RuntimeDeploymentManager {
             Supplier<Executor> virtualExecutorSupplier,
             Consumer<Closeable> closeTaskHandler,
             RequestContextFactory requestContextFactory, ThreadSetupAction threadSetupAction, String rootPath) {
+        this(info, executorSupplier, virtualExecutorSupplier, closeTaskHandler, requestContextFactory, threadSetupAction,
+                rootPath, HandlerKindResolver.NONE);
+    }
+
+    public RuntimeDeploymentManager(DeploymentInfo info,
+            Supplier<Executor> executorSupplier,
+            Supplier<Executor> virtualExecutorSupplier,
+            Consumer<Closeable> closeTaskHandler,
+            RequestContextFactory requestContextFactory, ThreadSetupAction threadSetupAction, String rootPath,
+            HandlerKindResolver handlerKindResolver) {
         this.info = info;
         this.executorSupplier = executorSupplier;
         this.virtualExecutorSupplier = virtualExecutorSupplier;
@@ -77,6 +89,7 @@ public class RuntimeDeploymentManager {
         this.requestContextFactory = requestContextFactory;
         this.threadSetupAction = threadSetupAction;
         this.rootPath = rootPath;
+        this.handlerKindResolver = handlerKindResolver;
     }
 
     public Deployment deploy() {
@@ -121,7 +134,8 @@ public class RuntimeDeploymentManager {
         String finalPrefix = prefix;
 
         List<GenericRuntimeConfigurableServerRestHandler<?>> runtimeConfigurableServerRestHandlers = new ArrayList<>();
-        RuntimeResourceDeployment runtimeResourceDeployment = new RuntimeResourceDeployment(info, executorSupplier,
+        RuntimeResourceDeployment runtimeResourceDeployment = new RuntimeResourceDeployment(info, handlerKindResolver,
+                executorSupplier,
                 virtualExecutorSupplier,
                 interceptorDeployment, dynamicEntityWriter, resourceLocatorHandler, requestContextFactory.isDefaultBlocking());
         List<ResourceClass> possibleSubResource = new ArrayList<>(locatableResourceClasses);
@@ -236,7 +250,7 @@ public class RuntimeDeploymentManager {
                             null, null));
         }
         return new Deployment(exceptionMapping, info.getCtxResolvers(), serialisers,
-                abortHandlingChain.toArray(EMPTY_REST_HANDLER_ARRAY), dynamicEntityWriter,
+                abortHandlingChain.toArray(EMPTY_REST_HANDLER_ARRAY), handlerKindResolver, dynamicEntityWriter,
                 prefix, paramConverterProviders, configurationImpl, applicationSupplier,
                 threadSetupAction, requestContextFactory, preMatchHandlers, classMappers,
                 runtimeConfigurableServerRestHandlers, exceptionMapper, info.isServletPresent(),
@@ -250,8 +264,10 @@ public class RuntimeDeploymentManager {
         RuntimeMappingDeployment runtimeMappingDeployment = new RuntimeMappingDeployment(classTemplates);
         ClassRoutingHandler classRoutingHandler = new ClassRoutingHandler(runtimeMappingDeployment.buildClassMapper(),
                 classTemplateNameCount, info.isServletPresent());
+        ServerRestHandler[] classRoutingChain = new ServerRestHandler[] { classRoutingHandler };
         classMappers.add(new RequestMapper.RequestPath<>(true, key.path,
-                new RestInitialHandler.InitialMatch(new ServerRestHandler[] { classRoutingHandler },
+                new RestInitialHandler.InitialMatch(classRoutingChain,
+                        handlerKindResolver.kindsOf(classRoutingChain),
                         runtimeMappingDeployment.getMaxMethodTemplateNameCount() + classTemplateNameCount)));
     }
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeMappingDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeMappingDeployment.java
@@ -90,7 +90,7 @@ class RuntimeMappingDeployment {
 
             RuntimeResource fake = new RuntimeResource(currentHttpMethod, path, null, null, Collections.emptyList(),
                     null, null,
-                    new ServerRestHandler[] { mapper }, null, new Class[0], null, false,
+                    new ServerRestHandler[] { mapper }, new byte[1], null, new Class[0], null, false,
                     false, null, null, null, null, null,
                     resources.get(0).getClassExceptionMappers());
             currentMapperPerMethodTemplates.add(new RequestMapper.RequestPath<>(false, fake.getPath(), fake));

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -92,6 +92,7 @@ import org.jboss.resteasy.reactive.server.model.ParamConverterProviders;
 import org.jboss.resteasy.reactive.server.model.ServerMethodParameter;
 import org.jboss.resteasy.reactive.server.model.ServerResourceMethod;
 import org.jboss.resteasy.reactive.server.spi.EndpointInvoker;
+import org.jboss.resteasy.reactive.server.spi.HandlerKindResolver;
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
@@ -110,6 +111,7 @@ public class RuntimeResourceDeployment {
     private static final Logger log = Logger.getLogger(RuntimeResourceDeployment.class);
 
     private final DeploymentInfo info;
+    private final HandlerKindResolver handlerKindResolver;
     private final ServerSerialisers serialisers;
     private final ResteasyReactiveConfig resteasyReactiveConfig;
     private final Supplier<Executor> executorSupplier;
@@ -124,11 +126,13 @@ public class RuntimeResourceDeployment {
     private final BlockingHandler blockingHandlerVirtualThread;
     private final ResponseWriterHandler responseWriterHandler;
 
-    public RuntimeResourceDeployment(DeploymentInfo info, Supplier<Executor> executorSupplier,
+    public RuntimeResourceDeployment(DeploymentInfo info, HandlerKindResolver handlerKindResolver,
+            Supplier<Executor> executorSupplier,
             Supplier<Executor> virtualExecutorSupplier,
             RuntimeInterceptorDeployment runtimeInterceptorDeployment, DynamicEntityWriter dynamicEntityWriter,
             ResourceLocatorHandler resourceLocatorHandler, boolean defaultBlocking) {
         this.info = info;
+        this.handlerKindResolver = handlerKindResolver;
         this.serialisers = info.getSerialisers();
         this.resteasyReactiveConfig = info.getResteasyReactiveConfig();
         this.executorSupplier = executorSupplier;
@@ -495,11 +499,13 @@ public class RuntimeResourceDeployment {
 
         handlers.set(0, new AbortChainHandler(abortHandlingChain.toArray(EMPTY_REST_HANDLER_ARRAY)));
 
+        ServerRestHandler[] handlerChain = handlers.toArray(EMPTY_REST_HANDLER_ARRAY);
         return new RuntimeResource(method.getHttpMethod(), methodPathTemplate,
                 classPathTemplate,
                 method.getProduces() == null ? null : serverMediaType,
                 consumesMediaTypes, invoker,
-                clazz.getFactory(), handlers.toArray(EMPTY_REST_HANDLER_ARRAY), method.getName(), parameterDeclaredTypes,
+                clazz.getFactory(), handlerChain, handlerKindResolver.kindsOf(handlerChain), method.getName(),
+                parameterDeclaredTypes,
                 effectiveReturnType, method.isBlocking(), method.isRunOnVirtualThread(), resourceClass,
                 lazyMethod,
                 pathParameterIndexes, info.isDevelopmentMode() ? score : null, streamElementType,

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/RestInitialHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/RestInitialHandler.java
@@ -19,6 +19,7 @@ public class RestInitialHandler implements ServerRestHandler {
     final Deployment deployment;
     final List<ServerRestHandler> preMappingHandlers;
     final ServerRestHandler[] initialChain;
+    final byte[] initialChainKinds;
 
     final ThreadSetupAction requestContext;
     final RequestContextFactory requestContextFactory;
@@ -37,6 +38,7 @@ public class RestInitialHandler implements ServerRestHandler {
             }
             initialChain[initialChain.length - 1] = this;
         }
+        this.initialChainKinds = deployment.getHandlerKindResolver().kindsOf(initialChain);
         this.requestContext = deployment.getThreadSetupAction();
         this.requestContextFactory = deployment.getRequestContextFactory();
     }
@@ -44,14 +46,14 @@ public class RestInitialHandler implements ServerRestHandler {
     public void beginProcessing(Object externalHttpContext) {
         ResteasyReactiveRequestContext rq = requestContextFactory.createContext(deployment, externalHttpContext,
                 requestContext,
-                initialChain, deployment.getAbortHandlerChain());
+                initialChain, initialChainKinds, deployment.getAbortHandlerChain());
         rq.run();
     }
 
     public void beginProcessing(Object externalHttpContext, Throwable throwable) {
         ResteasyReactiveRequestContext rq = requestContextFactory.createContext(deployment, externalHttpContext,
                 requestContext,
-                initialChain, deployment.getAbortHandlerChain());
+                initialChain, initialChainKinds, deployment.getAbortHandlerChain());
         rq.handleException(throwable);
         rq.run();
     }
@@ -78,10 +80,12 @@ public class RestInitialHandler implements ServerRestHandler {
 
     public static class InitialMatch {
         public final ServerRestHandler[] handlers;
+        public final byte[] handlerKinds;
         public final int maxPathParams;
 
-        public InitialMatch(ServerRestHandler[] handlers, int maxPathParams) {
+        public InitialMatch(ServerRestHandler[] handlers, byte[] handlerKinds, int maxPathParams) {
             this.handlers = handlers;
+            this.handlerKinds = handlerKinds;
             this.maxPathParams = maxPathParams;
         }
     }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RuntimeResource.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RuntimeResource.java
@@ -26,6 +26,7 @@ public class RuntimeResource {
     private final EndpointInvoker invoker;
     private final BeanFactory<Object> endpointFactory;
     private final ServerRestHandler[] handlerChain;
+    private final byte[] handlerKinds;
     private final String javaMethodName;
     private final Class<?>[] parameterTypes;
     private final Type returnType;
@@ -41,7 +42,7 @@ public class RuntimeResource {
     public RuntimeResource(String httpMethod, URITemplate path, URITemplate classPath, ServerMediaType produces,
             List<MediaType> consumes,
             EndpointInvoker invoker,
-            BeanFactory<Object> endpointFactory, ServerRestHandler[] handlerChain, String javaMethodName,
+            BeanFactory<Object> endpointFactory, ServerRestHandler[] handlerChain, byte[] handlerKinds, String javaMethodName,
             Class<?>[] parameterTypes,
             Type returnType, boolean blocking, boolean runOnVirtualThread, Class<?> resourceClass,
             ResteasyReactiveResourceInfo lazyMethod,
@@ -56,6 +57,7 @@ public class RuntimeResource {
         this.invoker = invoker;
         this.endpointFactory = endpointFactory;
         this.handlerChain = handlerChain;
+        this.handlerKinds = handlerKinds;
         this.javaMethodName = javaMethodName;
         this.parameterTypes = parameterTypes;
         this.returnType = returnType;
@@ -71,6 +73,10 @@ public class RuntimeResource {
 
     public ServerRestHandler[] getHandlerChain() {
         return handlerChain;
+    }
+
+    public byte[] getHandlerKinds() {
+        return handlerKinds;
     }
 
     public String getJavaMethodName() {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/HandlerKindResolver.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/HandlerKindResolver.java
@@ -1,0 +1,36 @@
+package org.jboss.resteasy.reactive.server.spi;
+
+/**
+ * Assigns a small integer "kind" to each handler of a handler chain when the chain is built.
+ * <p>
+ * The kinds are opaque to RESTEasy Reactive itself: they are stored next to each handler chain and made available
+ * to {@link org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext} so that an implementation can
+ * dispatch to the handler of a given position without having to determine its type on every request.
+ * The value {@link #UNKNOWN} is used for handlers the resolver does not know about.
+ */
+public interface HandlerKindResolver {
+
+    byte UNKNOWN = 0;
+
+    byte[] NO_KINDS = new byte[0];
+
+    HandlerKindResolver NONE = new HandlerKindResolver() {
+        @Override
+        public byte kindOf(ServerRestHandler handler) {
+            return UNKNOWN;
+        }
+    };
+
+    byte kindOf(ServerRestHandler handler);
+
+    default byte[] kindsOf(ServerRestHandler[] chain) {
+        if (chain.length == 0) {
+            return NO_KINDS;
+        }
+        byte[] kinds = new byte[chain.length];
+        for (int i = 0; i < chain.length; i++) {
+            kinds[i] = kindOf(chain[i]);
+        }
+        return kinds;
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/ResteasyReactiveRequestContextTest.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/ResteasyReactiveRequestContextTest.java
@@ -16,7 +16,7 @@ public class ResteasyReactiveRequestContextTest {
     @Test
     void testAbsoluteUriWithOverrides() {
         var request = Mockito.mock(ServerHttpRequest.class);
-        var context = new ResteasyReactiveRequestContext(null, null, null, null) {
+        var context = new ResteasyReactiveRequestContext(null, null, null, null, null) {
 
             @Override
             public ServerHttpResponse serverResponse() {

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxRequestContextFactory.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxRequestContextFactory.java
@@ -12,8 +12,8 @@ public class VertxRequestContextFactory implements RequestContextFactory {
     @Override
     public ResteasyReactiveRequestContext createContext(Deployment deployment,
             Object context, ThreadSetupAction requestContext,
-            ServerRestHandler[] handlerChain, ServerRestHandler[] abortHandlerChain) {
+            ServerRestHandler[] handlerChain, byte[] handlerKinds, ServerRestHandler[] abortHandlerChain) {
         return new VertxResteasyReactiveRequestContext(deployment, (RoutingContext) context,
-                requestContext, handlerChain, abortHandlerChain, null);
+                requestContext, handlerChain, handlerKinds, abortHandlerChain, null);
     }
 }

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
@@ -73,9 +73,9 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
 
     public VertxResteasyReactiveRequestContext(Deployment deployment,
             RoutingContext context,
-            ThreadSetupAction requestContext, ServerRestHandler[] handlerChain, ServerRestHandler[] abortHandlerChain,
-            ClassLoader devModeTccl) {
-        super(deployment, requestContext, handlerChain, abortHandlerChain);
+            ThreadSetupAction requestContext, ServerRestHandler[] handlerChain, byte[] handlerKinds,
+            ServerRestHandler[] abortHandlerChain, ClassLoader devModeTccl) {
+        super(deployment, requestContext, handlerChain, handlerKinds, abortHandlerChain);
         this.context = context;
         this.request = context.request();
         this.response = context.response();


### PR DESCRIPTION
This speeds up dispatch to the correct `handle` implementation.
The way it is done is by assigning each type of handler an index and using a `switch` to find the proper index, as opposed to the old way of using a bunch of hardcoded `instanceof` statements

@franz1981 you had told me long ago to do something like this IIRC :)