### PR TITLE
Add AutoUUIDv7 class for UUID generation for Hibernate Data

### DIFF
--- a/docs/src/main/asciidoc/quarkus-data-hibernate.adoc
+++ b/docs/src/main/asciidoc/quarkus-data-hibernate.adoc
@@ -451,7 +451,8 @@ In the example above, we extended the `ManagedEntity` type, and did not define a
 because `ManagedEntity` comes with a default generated database identifier, so you don't have to worry about it. It
 does this by extending the `WithId.AutoLong` class, which provides a generated database identifier of type `Long`.
 
-You can choose to extend the `WithId.AutoString` for a `String` identifier, or `WithId.AutoUUID` for a `UUID`
+You can choose to extend the `WithId.AutoString` for a `String` identifier, `WithId.AutoUUID` for a `UUID`
+identifier, or `WithId.AutoUUIDv7` for a Unique by time sortable `UUID`
 identifier to automatically get an attribute of the form:
 
 [source,java]
@@ -520,6 +521,10 @@ extend any of these types if you define you own ID:
 
 |`UUID`
 |`WithId.AutoUUID`
+|
+
+|`UUID`
+|`WithId.AutoUUIDv7`
 |
 
 |`String`

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/WithId.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/WithId.java
@@ -56,4 +56,16 @@ public abstract class WithId<Identifier> {
         }
     }
 
+    @MappedSuperclass
+    public abstract static class AutoUUIDv7 {
+        @Id
+        @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+        public UUID id;
+
+        @Override
+        public String toString() {
+            return this.getClass().getSimpleName() + "<" + id + ">";
+        }
+    }
+
 }


### PR DESCRIPTION
Add UUIDv7 as an option for Hibernate Data WithId<...> instead of the standard UUIDv4

UUIDv7's are preferable for many database use cases of UUID as the primary key due to UUIDv7 being both unique and sortable over time which reduces a major performance hit on large database tables that prevented the use of UUIDs.