### PR TITLE
Restore the third callout entry in the Hibernate ORM interceptor example

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -1919,7 +1919,8 @@ public static class MyInterceptor implements Interceptor, Serializable { // <2>
 to tell Quarkus it should be used in the default persistence unit.
 +
 For <<multiple-persistence-units,named persistence units>>, use `@PersistenceUnitExtension("nameOfYourPU")`
-<2> Implement methods of `org.hibernate.Interceptor` as necessary.
+<2> Implement `org.hibernate.Interceptor`. All its methods have default implementations, so you only need to override the ones you use.
+<3> For example, override `onLoad`, which Hibernate ORM calls just before it initializes an entity instance.
 
 [TIP]
 ====


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

Hibernate ORM guide, Interceptors example: the `<3>` marker on the `onLoad` method had no callout entry, so the rendered page shows a circled 3 that points nowhere, and a strict AsciiDoc parser rejects the page.

The 2021 original had `<2> Either extend org.hibernate.EmptyInterceptor or implement org.hibernate.Interceptor directly.` and `<3> Implement methods as necessary.`. #47184 replaced `EmptyInterceptor` with `Interceptor` and folded both entries into one `<2>`, leaving the `<3>` marker behind. This restores the split: `<2>` says to implement `org.hibernate.Interceptor`, whose methods all have default implementations, and `<3>` names `onLoad` as the example callback.

Removing the `<3>` marker instead is fine by me if you prefer.

Part of #56509

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->
