### PR TITLE
Add the missing callout entry in the Infinispan client Greeting example

### DIFF
--- a/docs/src/main/asciidoc/infinispan-client.adoc
+++ b/docs/src/main/asciidoc/infinispan-client.adoc
@@ -80,6 +80,7 @@ import org.infinispan.protostream.annotations.Proto;
 public record Greeting(String name, String message) {} //<2>
 ----
 <1> You only need an annotation to tag the record to be marshalled by Protostream
+<2> The record components become the fields of the generated Protobuf message, numbered in declaration order, so you do not need `@ProtoField` annotations
 
 Note that we are not going to use Java serialization. https://github.com/infinispan/protostream[Protostream] is
 a serialization library based on Protobuf data format part of Infinispan. Using an annotation based API, we


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

Infinispan client guide, "Creating the Greeting POJO": the `<2>` marker on the `Greeting` record had no callout entry, so the rendered page shows a circled 2 that points nowhere, and a strict AsciiDoc parser rejects the page.

The marker is left over from the Protostream 5 update (03130c723a8), which replaced a class with two `@ProtoField` fields (entries `<2>` and `<3>` explained the fields) by the `@Proto` record and dropped the entries. The new `<2>` entry says what `@Proto` does with the record components, following its Javadoc: "Fields must be public and they will be assigned incremental numbers based on the declaration order. It is possible to override the automated defaults for a field by using the ProtoField annotation."

Removing the `<2>` marker instead is fine by me if you prefer.

Part of #56509

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->
