### PR TITLE
Add a callout list to the Publisher listing in the Quarkus Data tutorial

### DIFF
--- a/docs/src/main/asciidoc/quarkus-data-hibernate-getting-started.adoc
+++ b/docs/src/main/asciidoc/quarkus-data-hibernate-getting-started.adoc
@@ -421,6 +421,8 @@ public class Publisher extends ManagedEntity { // <1>
     }
 }
 ----
+<1> `ManagedEntity` replaces `RecordEntity`. This tells Hibernate to track this entity in its persistence context.
+<2> The repository uses `ManagedRepository` instead of `RecordRepository`.
 
 [source,java]
 ----


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

Quarkus Data Hibernate tutorial, "Managed session": the `Publisher` and `Book` listings both carry `<1>` and `<2>` markers, but the single callout list sits under `Book` only. A callout list attaches to the block directly above it, so the `Publisher` markers render as circled numbers that point nowhere, and a strict AsciiDoc parser rejects the page.

This gives each listing its own list, the way the tutorial already shows the two classes in "Creating a Discount Service": the full entries move under `Publisher`, and `Book` gets two short entries that say the same change applies.

If you would rather keep one list, the alternative is to leave the full list under `Publisher` and drop the two markers from the `Book` listing.

Part of #56509

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->
