### PR TITLE
Keep the Keycloak Dev Services resource-mapping callout list together

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -303,9 +303,7 @@ For example, if your application configures Keycloak authorization with link:htt
 quarkus.keycloak.devservices.resource-aliases.policies=/policies.jar <1>
 quarkus.keycloak.devservices.resource-mappings.policies=/opt/keycloak/providers/policies.jar <2>
 ----
-<1> `policies` alias is created for the classpath `/policies.jar` resource.
-
-Policy jars can also be located in the file system.
+<1> `policies` alias is created for the classpath `/policies.jar` resource. Policy jars can also be located in the file system.
 <2> The policies jar is mapped to the `/opt/keycloak/providers/policies.jar` container location.
 
 == Disable HTTPS


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

Dev Services for Keycloak guide, resource aliases and mappings example: the sentence "Policy jars can also be located in the file system." sat between the `<1>` and `<2>` callout entries. A callout list ends at the first paragraph, so `<2>` was a new list that did not belong to the block, and the block's `<2>` marker rendered as a circled number that points nowhere; a strict AsciiDoc parser rejects the page.

This folds the sentence into the `<1>` entry, which it qualifies (the alias can name a file system resource as well as a classpath one), so both entries attach to the block.

Part of #56509

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->
