### PR TITLE
Use a callout list for the generated resources extension example

### DIFF
--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -1638,9 +1638,8 @@ public void generateResources(
     );
 }
 ----
-
-1. Registering a SPI service provider via `GeneratedServiceProviderBuildItem` — do NOT use `GeneratedResourceBuildItem` for `META-INF/services/` paths
-2. Producing a static resource (e.g., JavaScript file) served by Vertx
+<1> Registering a SPI service provider via `GeneratedServiceProviderBuildItem`. Do NOT use `GeneratedResourceBuildItem` for `META-INF/services/` paths.
+<2> Producing a static resource (e.g., JavaScript file) served by Vertx.
 
 ==== Key Points
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

Writing extensions guide, "Generating Resources": the `<1>` and `<2>` markers in the listing were explained by a plain numbered list (`1.`, `2.`) after a blank line. Asciidoctor renders that as circled numbers in the block and an unrelated ordered list under it, and a strict AsciiDoc parser rejects the page.

This turns the two items into a callout list attached to the block. The wording is unchanged apart from the em dash in the first item, which becomes a full stop so the entry reads as two sentences, and a matching full stop on the second item.

Part of #56509

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->
