### PR TITLE
Fix Javadoc of `quarkus.otel.traces.sampler.arg`

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/TracesRuntimeConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/TracesRuntimeConfig.java
@@ -57,8 +57,6 @@ public interface TracesRuntimeConfig {
      * When setting the stock sampler to `traceidratio` or `parentbased_traceidratio` you need to set a `double` compatible
      * value between `0.0d` and `1.0d`, like `0.01d` or `0.5d`. It is kept as a `String` to allow the flexible customisation of
      * alternative samplers.
-     * <p>
-     * Defaults to `1.0d`.
      */
     @WithName("sampler.arg")
     @WithDefault("0.1d")


### PR DESCRIPTION
The sampling rate has been changed to 10%, so
the previous Javadoc was wrong.
Moreover, there is no real reason to explicitly add this default as the tooling understands `@WithDefault`
