### PR TITLE
Bump Netty from 4.2.17.Final to 4.2.18.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -138,7 +138,7 @@
         <infinispan.protostream.version>6.0.7</infinispan.protostream.version>
         <caffeine.version>3.2.4</caffeine.version>
         <netty-tcnative.version>2.0.81.Final</netty-tcnative.version>
-        <netty.version>4.2.17.Final</netty.version>
+        <netty.version>4.2.18.Final</netty.version>
         <brotli4j.version>1.23.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>


### PR DESCRIPTION
Netty has fixed a few CVE-Findings

https://github.com/netty/netty/releases/tag/netty-4.2.18.Final

