### PR TITLE
Signals: collect Micrometer metrics for emissions, executions and errors

### DIFF
--- a/docs/src/main/asciidoc/signals.adoc
+++ b/docs/src/main/asciidoc/signals.adoc
@@ -520,6 +520,7 @@ NOTE: The Signals resolution model deviates from CDI observer resolution in two 
 * Use *CDI events* for simple publish/subscribe notifications between components, especially when you need synchronous delivery, transactional observers, or ordering of observers, or when you need to stay with the standard Jakarta EE API.
 * Use the *Vert.x EventBus* when you need to interact with the underlying Vert.x runtime directly or integrate with existing Vert.x components.
 
+[[opentelemetry-tracing]]
 == OpenTelemetry Tracing
 
 If the xref:opentelemetry.adoc[OpenTelemetry extension] is present, the active trace context is automatically propagated from the signal emission to the receiver invocations.
@@ -547,6 +548,35 @@ This integration is enabled by default and can be disabled with the following co
 [source,properties]
 ----
 quarkus.signals.telemetry.traces.enabled=false
+----
+
+== Micrometer Metrics
+
+If the xref:telemetry-micrometer.adoc[Micrometer extension] is present, the following counters are registered:
+
+* `signals.emissions` -- incremented once per emission (i.e., per call to `publish()`, `send()`, or `request()`), regardless of the number of matching receivers,
+* `signals.receiver.executions` -- incremented once per completed receiver invocation; a `publish` emission that reaches multiple receivers therefore increments this counter once per receiver. The outcome is distinguished by the `error.type` tag.
+
+The counters are tagged with the following dimensions:
+
+* `signal.type` -- the raw signal type name (generic type arguments are omitted to keep the cardinality bounded),
+* `emission.type` -- the emission type (`PUBLISH`, `SEND` or `REQUEST`),
+* `response.type` -- the expected response type for request-reply emissions, or `none` otherwise (only on `signals.emissions`),
+* `error.type` -- the exception class name of a failed receiver invocation, or `none` if it completed successfully (only on `signals.receiver.executions`). The number of failures can be obtained by filtering on `error.type != "none"`.
+
+[NOTE]
+====
+The counters are deliberately _not_ tagged with the receiver identity, nor with the emission qualifiers.
+
+* Receivers may be registered programmatically at runtime and may be anonymous, which would result in unbounded or missing tag values; receiver-level detail is available through <<opentelemetry-tracing,tracing spans>> instead.
+* Qualifiers are omitted to keep the number of time series bounded. As a consequence, emissions of the same signal type that differ only by qualifier are counted together.
+====
+
+This integration is enabled by default and can be disabled with the following configuration property:
+
+[source,properties]
+----
+quarkus.signals.telemetry.metrics.enabled=false
 ----
 
 == SPI

--- a/docs/src/main/asciidoc/telemetry-micrometer.adoc
+++ b/docs/src/main/asciidoc/telemetry-micrometer.adoc
@@ -712,6 +712,7 @@ java -Dio.netty.leakDetection.level=advanced ...
 * https://quarkus.io/guides/resteasy[`quarkus-resteasy-jackson`]
 * https://quarkus.io/guides/resteasy-client[`quarkus-resteasy-client`]
 * https://quarkus.io/guides/scheduler[`quarkus-scheduler`]
+* https://quarkus.io/guides/signals[`quarkus-signals`]
 * https://quarkus.io/guides/smallrye-graphql[`quarkus-smallrye-graphql`]
 * https://quarkus.io/extensions/io.quarkus/quarkus-messaging[`quarkus-messaging`]
 ** AMQP 1.0

--- a/extensions/signals/deployment/pom.xml
+++ b/extensions/signals/deployment/pom.xml
@@ -46,6 +46,12 @@
             <artifactId>opentelemetry-sdk-testing</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Needed to verify captured metrics; the deployment artifact is forced as a dependency in the tests -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/extensions/signals/deployment/src/main/java/io/quarkus/signals/deployment/SignalsBuildTimeConfig.java
+++ b/extensions/signals/deployment/src/main/java/io/quarkus/signals/deployment/SignalsBuildTimeConfig.java
@@ -26,5 +26,15 @@ public interface SignalsBuildTimeConfig {
         @WithName("traces.enabled")
         @WithDefault("true")
         boolean tracesEnabled();
+
+        /**
+         * If collection of signal metrics is enabled. When enabled, counters are registered for the number of emissions,
+         * receiver invocations and failed receiver invocations.
+         * <p>
+         * Only applicable when the Micrometer extension is present.
+         */
+        @WithName("metrics.enabled")
+        @WithDefault("true")
+        boolean metricsEnabled();
     }
 }

--- a/extensions/signals/deployment/src/main/java/io/quarkus/signals/deployment/SignalsProcessor.java
+++ b/extensions/signals/deployment/src/main/java/io/quarkus/signals/deployment/SignalsProcessor.java
@@ -61,6 +61,7 @@ import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.execannotations.ExecutionModelAnnotationsAllowedBuildItem;
+import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
 import io.quarkus.gizmo2.ClassOutput;
 import io.quarkus.gizmo2.Const;
 import io.quarkus.gizmo2.Expr;
@@ -71,6 +72,7 @@ import io.quarkus.gizmo2.TypeArgument;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
 import io.quarkus.gizmo2.desc.FieldDesc;
 import io.quarkus.gizmo2.desc.MethodDesc;
+import io.quarkus.runtime.metrics.MetricsFactory;
 import io.quarkus.runtime.util.HashUtil;
 import io.quarkus.signals.Receivers.ExecutionModel;
 import io.quarkus.signals.Signal;
@@ -371,6 +373,20 @@ class SignalsProcessor {
                     .addBeanClasses(
                             "io.quarkus.signals.runtime.tracing.TracingSignalMetadataEnricher",
                             "io.quarkus.signals.runtime.tracing.TracingReceiverInterceptor")
+                    .build());
+        }
+    }
+
+    @BuildStep
+    void registerMetrics(Optional<MetricsCapabilityBuildItem> metricsCapability, SignalsBuildTimeConfig config,
+            BuildProducer<AdditionalBeanBuildItem> beans) {
+        if (config.telemetry().metricsEnabled()
+                && metricsCapability.map(mc -> mc.metricsSupported(MetricsFactory.MICROMETER)).orElse(false)) {
+            // The classes are referenced by name so that Micrometer types are not loaded when the capability is absent
+            beans.produce(AdditionalBeanBuildItem.builder()
+                    .addBeanClasses(
+                            "io.quarkus.signals.runtime.metrics.MetricsSignalMetadataEnricher",
+                            "io.quarkus.signals.runtime.metrics.MetricsReceiverInterceptor")
                     .build());
         }
     }

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/metrics/MetricsDisabledSignalsTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/metrics/MetricsDisabledSignalsTest.java
@@ -1,0 +1,79 @@
+package io.quarkus.signals.deployment.test.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.Duration;
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.signals.Receives;
+import io.quarkus.signals.Signal;
+import io.quarkus.signals.runtime.metrics.MetricsSupport;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Verifies that no signal counters are registered when metrics are disabled via configuration, even though the
+ * Micrometer extension is present.
+ */
+public class MetricsDisabledSignalsTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(PingReceiver.class, Ping.class)
+                    .addAsResource(new StringAsset("""
+                            quarkus.signals.telemetry.metrics.enabled=false
+                            """), "application.properties"))
+            .setForcedDependencies(
+                    List.of(Dependency.of("io.quarkus", "quarkus-micrometer-deployment", Version.getVersion())));
+
+    @Inject
+    MeterRegistry registry;
+
+    @Inject
+    Signal<Ping> ping;
+
+    @BeforeAll
+    static void addSimpleRegistry() {
+        Metrics.globalRegistry.add(new SimpleMeterRegistry());
+    }
+
+    @Test
+    public void testNoSignalMetricsWhenDisabled() {
+        // Setup: signals metrics are turned off via quarkus.signals.telemetry.metrics.enabled=false, so the built-in
+        // metrics enricher/interceptor are not registered - even though the Micrometer extension is present. The
+        // emission itself must still work normally.
+        // Expected: the request completes, but none of the signals counters exist.
+        String result = ping.reactive().request(new Ping("hello"), String.class)
+                .ifNoItem().after(Duration.ofSeconds(5)).fail()
+                .await().indefinitely();
+        assertEquals("hello", result);
+
+        assertNull(registry.find(MetricsSupport.EMISSIONS).counter());
+        assertNull(registry.find(MetricsSupport.RECEIVER_EXECUTIONS).counter());
+    }
+
+    record Ping(String value) {
+    }
+
+    @Singleton
+    public static class PingReceiver {
+
+        String ping(@Receives Ping ping) {
+            return ping.value();
+        }
+    }
+}

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/metrics/SignalsMetricsTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/metrics/SignalsMetricsTest.java
@@ -1,0 +1,181 @@
+package io.quarkus.signals.deployment.test.metrics;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.time.Duration;
+import java.util.List;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Inject;
+import jakarta.inject.Qualifier;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.signals.Receives;
+import io.quarkus.signals.Signal;
+import io.quarkus.signals.SignalContext.EmissionType;
+import io.quarkus.signals.runtime.metrics.MetricsSupport;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Verifies that Micrometer counters are registered for signal emissions, receiver invocations and failures.
+ */
+public class SignalsMetricsTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(PingReceivers.class, Ping.class, Pong.class, Urgent.class))
+            .setForcedDependencies(
+                    List.of(Dependency.of("io.quarkus", "quarkus-micrometer-deployment", Version.getVersion())));
+
+    @Inject
+    MeterRegistry registry;
+
+    @Inject
+    Signal<Ping> ping;
+
+    @Inject
+    Signal<Pong> pong;
+
+    @BeforeAll
+    static void addSimpleRegistry() {
+        Metrics.globalRegistry.add(new SimpleMeterRegistry());
+    }
+
+    @BeforeEach
+    void clear() {
+        // Reset the counters so each test asserts absolute values
+        registry.clear();
+    }
+
+    @Test
+    public void testRequestCounted() {
+        // Setup: request(Ping, String.class); only the "ping" receiver returns a String, so a single receiver runs.
+        // Expected: one emission (REQUEST, response.type=String) and one receiver execution, no errors.
+        String result = ping.reactive().request(new Ping("hello"), String.class)
+                .ifNoItem().after(Duration.ofSeconds(5)).fail()
+                .await().indefinitely();
+        assertEquals("hello", result);
+
+        assertEquals(1, count(MetricsSupport.EMISSIONS, MetricsSupport.TAG_SIGNAL_TYPE, Ping.class.getTypeName(),
+                MetricsSupport.TAG_EMISSION_TYPE, EmissionType.REQUEST.toString(),
+                MetricsSupport.TAG_RESPONSE_TYPE, String.class.getTypeName()));
+        assertEquals(1, count(MetricsSupport.RECEIVER_EXECUTIONS, MetricsSupport.TAG_SIGNAL_TYPE,
+                Ping.class.getTypeName(), MetricsSupport.TAG_EMISSION_TYPE, EmissionType.REQUEST.toString(),
+                MetricsSupport.TAG_ERROR_TYPE, MetricsSupport.ERROR_TYPE_NONE));
+    }
+
+    @Test
+    public void testPublishCountsExecutionPerReceiver() {
+        // Setup: publish (multicast) a Ping; both unqualified receivers ("ping" and "observe") match.
+        // Expected: a single emission (PUBLISH, response.type=none) but two receiver executions.
+        ping.reactive().publish(new Ping("multi"))
+                .ifNoItem().after(Duration.ofSeconds(5)).fail()
+                .await().indefinitely();
+
+        assertEquals(1, count(MetricsSupport.EMISSIONS, MetricsSupport.TAG_SIGNAL_TYPE, Ping.class.getTypeName(),
+                MetricsSupport.TAG_EMISSION_TYPE, EmissionType.PUBLISH.toString(),
+                MetricsSupport.TAG_RESPONSE_TYPE, MetricsSupport.RESPONSE_TYPE_NONE));
+        assertEquals(2, count(MetricsSupport.RECEIVER_EXECUTIONS, MetricsSupport.TAG_SIGNAL_TYPE,
+                Ping.class.getTypeName(), MetricsSupport.TAG_EMISSION_TYPE, EmissionType.PUBLISH.toString(),
+                MetricsSupport.TAG_ERROR_TYPE, MetricsSupport.ERROR_TYPE_NONE));
+    }
+
+    @Test
+    public void testSendCounted() {
+        // Setup: send (fire-and-forget) a Pong; a single Pong receiver matches.
+        // Expected: one emission (SEND, response.type=none) and one receiver execution.
+        pong.reactive().send(new Pong("fire"))
+                .ifNoItem().after(Duration.ofSeconds(5)).fail()
+                .await().indefinitely();
+
+        assertEquals(1, count(MetricsSupport.EMISSIONS, MetricsSupport.TAG_SIGNAL_TYPE, Pong.class.getTypeName(),
+                MetricsSupport.TAG_EMISSION_TYPE, EmissionType.SEND.toString(),
+                MetricsSupport.TAG_RESPONSE_TYPE, MetricsSupport.RESPONSE_TYPE_NONE));
+        assertEquals(1, count(MetricsSupport.RECEIVER_EXECUTIONS, MetricsSupport.TAG_SIGNAL_TYPE,
+                Pong.class.getTypeName(), MetricsSupport.TAG_EMISSION_TYPE, EmissionType.SEND.toString(),
+                MetricsSupport.TAG_ERROR_TYPE, MetricsSupport.ERROR_TYPE_NONE));
+    }
+
+    @Test
+    public void testErrorCounted() {
+        // Setup: the "ping" receiver throws IllegalStateException for the "boom" payload.
+        // Expected: the execution is counted with error.type set to the exception class, and not with error.type=none.
+        assertThrows(RuntimeException.class, () -> ping.reactive().request(new Ping("boom"), String.class)
+                .ifNoItem().after(Duration.ofSeconds(5)).fail()
+                .await().indefinitely());
+
+        assertEquals(1, count(MetricsSupport.RECEIVER_EXECUTIONS, MetricsSupport.TAG_SIGNAL_TYPE,
+                Ping.class.getTypeName(), MetricsSupport.TAG_EMISSION_TYPE, EmissionType.REQUEST.toString(),
+                MetricsSupport.TAG_ERROR_TYPE, IllegalStateException.class.getName()));
+        assertEquals(0, count(MetricsSupport.RECEIVER_EXECUTIONS, MetricsSupport.TAG_SIGNAL_TYPE,
+                Ping.class.getTypeName(), MetricsSupport.TAG_EMISSION_TYPE, EmissionType.REQUEST.toString(),
+                MetricsSupport.TAG_ERROR_TYPE, MetricsSupport.ERROR_TYPE_NONE));
+    }
+
+    private double count(String name, String... tags) {
+        Counter counter = registry.find(name).tags(tags).counter();
+        return counter == null ? 0 : counter.count();
+    }
+
+    record Ping(String value) {
+    }
+
+    record Pong(String value) {
+    }
+
+    @Qualifier
+    @Target({ FIELD, METHOD, PARAMETER })
+    @Retention(RUNTIME)
+    public @interface Urgent {
+
+        final class Literal extends AnnotationLiteral<Urgent> implements Urgent {
+            public static final Literal INSTANCE = new Literal();
+            private static final long serialVersionUID = 1L;
+        }
+    }
+
+    @Singleton
+    public static class PingReceivers {
+
+        // The unqualified request receiver: returns a String (so request(..., String.class) resolves to it) and throws
+        // for the "boom" payload to exercise the failure path
+        String ping(@Receives Ping ping) {
+            if ("boom".equals(ping.value())) {
+                throw new IllegalStateException("boom");
+            }
+            return ping.value();
+        }
+
+        // A second unqualified receiver so that a publish (multicast) delivers to two receivers
+        void observe(@Receives Ping ping) {
+        }
+
+        // A @Urgent-qualified receiver, only reached when the emission is narrowed with select(@Urgent)
+        String urgentPing(@Receives @Urgent Ping ping) {
+            return ping.value();
+        }
+
+        // A Pong receiver to exercise the fire-and-forget (send) path
+        void pong(@Receives Pong pong) {
+        }
+    }
+}

--- a/extensions/signals/runtime-api/src/main/java/io/quarkus/signals/spi/ReceiverInterceptor.java
+++ b/extensions/signals/runtime-api/src/main/java/io/quarkus/signals/spi/ReceiverInterceptor.java
@@ -40,6 +40,20 @@ public interface ReceiverInterceptor {
      * <p>
      * The interceptor must call {@link InterceptionContext#proceed()} to continue the interceptor chain and eventually invoke
      * the receiver. It may transform the result, handle errors, or skip invocation by returning a different {@link Uni}.
+     * <p>
+     * This method is invoked at <em>assembly time</em>, i.e. when the returned {@link Uni} pipeline is being built, not
+     * when the receiver actually runs. The receiver runs later, at <em>subscription time</em>, when the returned
+     * {@link Uni} is subscribed. Consequently, side effects that must be tied to the actual execution of the receiver
+     * (e.g. metrics, logging or context propagation) should be deferred to subscription rather than performed directly in
+     * the body of this method; otherwise they would run even if the returned {@link Uni} is never subscribed, and would
+     * not run again on a re-subscription. A common way to defer such a side effect is:
+     *
+     * <pre>
+     * return Uni.createFrom().deferred(() -&gt; {
+     *     // executed at subscription time, once per actual execution
+     *     return context.proceed();
+     * });
+     * </pre>
      *
      * @param context the interception context
      * @return a {@link Uni} that completes with the receiver's response

--- a/extensions/signals/runtime/pom.xml
+++ b/extensions/signals/runtime/pom.xml
@@ -30,6 +30,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/metrics/MetricsReceiverInterceptor.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/metrics/MetricsReceiverInterceptor.java
@@ -1,0 +1,68 @@
+package io.quarkus.signals.runtime.metrics;
+
+import java.util.function.Supplier;
+
+import jakarta.inject.Singleton;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Meter.MeterProvider;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.quarkus.signals.SignalContext;
+import io.quarkus.signals.spi.ReceiverInterceptor;
+import io.quarkus.signals.spi.RelativeOrder;
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Built-in interceptor that increments the {@value MetricsSupport#RECEIVER_EXECUTIONS} counter once per completed
+ * receiver invocation. The outcome is distinguished by the {@value MetricsSupport#TAG_ERROR_TYPE} tag, which is set to
+ * {@value MetricsSupport#ERROR_TYPE_NONE} on success and to the exception class name on failure.
+ * <p>
+ * The interceptor is ordered before {@link #ID_REQUEST_CONTEXT} so that an invocation is counted even if the request
+ * context activation or the receiver itself fails. The counter is incremented when the invocation completes, so it
+ * reflects the receiver actually running.
+ * <p>
+ * The meter is deliberately not tagged with the receiver identity: programmatic receivers may be anonymous and may be
+ * registered and unregistered at runtime, which would produce {@code null} tag values and unbounded cardinality.
+ * Receiver-level detail is available through tracing spans instead.
+ * <p>
+ * It is only registered when the Micrometer metrics capability is present.
+ */
+@Identifier(MetricsReceiverInterceptor.ID)
+@RelativeOrder(before = ReceiverInterceptor.ID_REQUEST_CONTEXT)
+@Singleton
+public class MetricsReceiverInterceptor implements ReceiverInterceptor {
+
+    public static final String ID = "quarkus.metrics";
+
+    private final MeterProvider<Counter> executions;
+
+    MetricsReceiverInterceptor(MeterRegistry registry) {
+        this.executions = Counter.builder(MetricsSupport.RECEIVER_EXECUTIONS).withRegistry(registry);
+    }
+
+    @Override
+    public Uni<Object> intercept(InterceptionContext context) {
+        SignalContext<?> signalContext = context.signalContext();
+        String signalType = MetricsSupport.rawTypeName(signalContext.signalType());
+        String emissionType = signalContext.emissionType().toString();
+
+        // intercept() runs at assembly time (when the Uni pipeline is built), whereas the receiver only runs at
+        // subscription time. proceed() is wrapped in deferred() and the counter is incremented in onItemOrFailure() so
+        // that it happens once per actual execution: it is not incremented for a Uni that is never subscribed, it is
+        // incremented again on a re-subscription, and the outcome (success or the exception class) is known at that point.
+        return Uni.createFrom().deferred(new Supplier<Uni<? extends Object>>() {
+            @Override
+            public Uni<Object> get() {
+                return context.proceed().onItemOrFailure().invoke((item, failure) -> {
+                    String errorType = failure != null ? failure.getClass().getName() : MetricsSupport.ERROR_TYPE_NONE;
+                    executions.withTags(Tags.of(
+                            MetricsSupport.TAG_SIGNAL_TYPE, signalType,
+                            MetricsSupport.TAG_EMISSION_TYPE, emissionType,
+                            MetricsSupport.TAG_ERROR_TYPE, errorType)).increment();
+                });
+            }
+        });
+    }
+}

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/metrics/MetricsSignalMetadataEnricher.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/metrics/MetricsSignalMetadataEnricher.java
@@ -1,0 +1,44 @@
+package io.quarkus.signals.runtime.metrics;
+
+import jakarta.inject.Singleton;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Meter.MeterProvider;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.quarkus.signals.SignalContext;
+import io.quarkus.signals.spi.SignalMetadataEnricher;
+import io.smallrye.common.annotation.Identifier;
+
+/**
+ * Built-in enricher that increments the {@value MetricsSupport#EMISSIONS} counter once per emission.
+ * <p>
+ * The enricher runs synchronously on the emitting thread, which is invoked exactly once per emission (regardless of the
+ * number of matching receivers), so it is the natural place to count emissions. It does not add any metadata.
+ * <p>
+ * It is only registered when the Micrometer metrics capability is present.
+ */
+@Identifier(MetricsSignalMetadataEnricher.ID)
+@Singleton
+public class MetricsSignalMetadataEnricher implements SignalMetadataEnricher {
+
+    public static final String ID = "quarkus.metrics";
+
+    private final MeterProvider<Counter> emissions;
+
+    MetricsSignalMetadataEnricher(MeterRegistry registry) {
+        this.emissions = Counter.builder(MetricsSupport.EMISSIONS).withRegistry(registry);
+    }
+
+    @Override
+    public void enrich(EnrichmentContext context) {
+        SignalContext<?> signalContext = context.signalContext();
+        String responseType = signalContext.responseType() != null
+                ? MetricsSupport.rawTypeName(signalContext.responseType())
+                : MetricsSupport.RESPONSE_TYPE_NONE;
+        emissions.withTags(Tags.of(
+                MetricsSupport.TAG_SIGNAL_TYPE, MetricsSupport.rawTypeName(signalContext.signalType()),
+                MetricsSupport.TAG_EMISSION_TYPE, signalContext.emissionType().toString(),
+                MetricsSupport.TAG_RESPONSE_TYPE, responseType)).increment();
+    }
+}

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/metrics/MetricsSupport.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/metrics/MetricsSupport.java
@@ -1,0 +1,68 @@
+package io.quarkus.signals.runtime.metrics;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+/**
+ * Shared constants and helpers used by the Micrometer metrics integration.
+ * <p>
+ * All meters are simple counters and are deliberately tagged only with code-bounded dimensions (the raw signal type, the
+ * emission type and, for request-reply, the response type) so that the total number of time series stays bounded by the
+ * application code and does not grow with traffic or with the number of receivers.
+ */
+public final class MetricsSupport {
+
+    /**
+     * Counter incremented once per emission (i.e., per {@code publish}/{@code send}/{@code request} call).
+     */
+    public static final String EMISSIONS = "signals.emissions";
+
+    /**
+     * Counter incremented once per completed receiver invocation. For a multicast {@code publish} with N matching
+     * receivers it is incremented N times. The outcome is distinguished by the {@link #TAG_ERROR_TYPE} tag.
+     */
+    public static final String RECEIVER_EXECUTIONS = "signals.receiver.executions";
+
+    /**
+     * The raw signal type FQCN, e.g. {@code com.example.OrderPlaced}. The raw type is used (not the parameterized type
+     * name) to keep the cardinality bounded.
+     */
+    public static final String TAG_SIGNAL_TYPE = "signal.type";
+
+    /**
+     * The emission type: {@code PUBLISH}, {@code SEND} or {@code REQUEST}.
+     */
+    public static final String TAG_EMISSION_TYPE = "emission.type";
+
+    /**
+     * The raw response type FQCN for a request-reply emission, or {@link #RESPONSE_TYPE_NONE} otherwise. A single meter
+     * must always carry the same tag keys, hence the sentinel value.
+     */
+    public static final String TAG_RESPONSE_TYPE = "response.type";
+
+    /**
+     * The exception class name of a failed receiver invocation, or {@link #ERROR_TYPE_NONE} for a successful one. A
+     * single meter must always carry the same tag keys, hence the sentinel value.
+     */
+    public static final String TAG_ERROR_TYPE = "error.type";
+
+    /**
+     * The value of the {@link #TAG_RESPONSE_TYPE} tag when the emission is not a request-reply.
+     */
+    public static final String RESPONSE_TYPE_NONE = "none";
+
+    /**
+     * The value of the {@link #TAG_ERROR_TYPE} tag when the receiver invocation completed successfully.
+     */
+    public static final String ERROR_TYPE_NONE = "none";
+
+    static String rawTypeName(Type type) {
+        if (type instanceof ParameterizedType parameterizedType) {
+            return parameterizedType.getRawType().getTypeName();
+        }
+        return type.getTypeName();
+    }
+
+    private MetricsSupport() {
+    }
+}


### PR DESCRIPTION
- register three counters when the Micrometer extension is present
- signals.emissions (per emission), signals.receiver.executions (per receiver invocation) and signals.receiver.errors (per failure)
- tagged with signal.type, emission.type, response.type and error.type
- receiver identity and qualifiers are deliberately omitted to keep cardinality bounded
- controlled by quarkus.signals.telemetry.metrics.enabled (default true)
- resolves #56495