### PR TITLE
Reinstate MemorySize*

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/MemorySize.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/MemorySize.java
@@ -48,6 +48,17 @@ public final class MemorySize implements Comparable<MemorySize> {
     }
 
     /**
+     * Construct a new instance from a {@link BigInteger}.
+     *
+     * @param value the value (must not be {@code null})
+     * @deprecated Use one of the {@code of(*)} methods instead.
+     */
+    @Deprecated(forRemoval = true, since = "3.38")
+    public MemorySize(BigInteger value) {
+        this(value.shiftRight(64).longValueExact(), value.longValue());
+    }
+
+    /**
      * {@return the memory size, in bytes}
      */
     public long asLongValue() {

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/MemorySizeConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/MemorySizeConverter.java
@@ -1,0 +1,33 @@
+package io.quarkus.runtime.configuration;
+
+import static io.quarkus.runtime.configuration.ConverterSupport.DEFAULT_QUARKUS_CONVERTER_PRIORITY;
+
+import java.io.Serializable;
+
+import jakarta.annotation.Priority;
+
+import org.eclipse.microprofile.config.spi.Converter;
+
+/**
+ * A converter to support data sizes.
+ *
+ * @deprecated Use {@link MemorySize#of(String)} directly; this converter is retained only for
+ *             backward compatibility with code that references it explicitly.
+ */
+@Priority(DEFAULT_QUARKUS_CONVERTER_PRIORITY)
+@Deprecated(forRemoval = true, since = "3.38")
+public class MemorySizeConverter implements Converter<MemorySize>, Serializable {
+    private static final long serialVersionUID = -1988485929047973068L;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public MemorySize convert(String value) {
+        value = value.trim();
+        if (value.isEmpty()) {
+            return null;
+        }
+        return MemorySize.of(value);
+    }
+}


### PR DESCRIPTION
These got mistakenly removed here: https://github.com/quarkusio/quarkus/pull/56260 .

But they were actually marked as deprecated very recently during the 3.38 development cycle, not more than 12 months ago: https://github.com/quarkusio/quarkus/commit/5d567430df9f7dd7717d3ff9f3cb178a0cbac71e .

/cc @zakkak 
