### PR TITLE
[3.33] Remove the CI job that runs k8s tests on Windows

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -1042,14 +1042,6 @@ jobs:
             runs-on: true
           }
           - {
-            name: "17 Windows",
-            java-version: 17,
-            java-distribution: "temurin",
-            os-name: "windows-latest",
-            tag: "kubernetes-jdk-25-windows",
-            runs-on: false
-          }
-          - {
             name: "25 Semeru",
             java-version: 25,
             java-distribution: "semeru",


### PR DESCRIPTION
backport of https://github.com/quarkusio/quarkus/pull/56409 (until we can somehow reinstate this in main)