### PR TITLE
Bump GraalVM SDK version to 25.0.4.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -87,8 +87,7 @@
         <jboss-metadata-web.version>17.1.0</jboss-metadata-web.version>
         <maven-toolchain.version>3.0-alpha-2</maven-toolchain.version>
         <plexus-component-annotations.version>2.1.0</plexus-component-annotations.version>
-        <!-- GraalVM sdk 23.1.2 has a minimum JDK requirement of 17+ at runtime -->
-        <graal-sdk.version>23.1.2</graal-sdk.version>
+        <graal-sdk.version>25.0.4.1</graal-sdk.version>
         <gizmo.version>1.10.1</gizmo.version>
         <gizmo2.version>2.1.1</gizmo2.version>
         <jackson-bom.version>3.1.4</jackson-bom.version>


### PR DESCRIPTION
Quarkus 4 is using Mandrel/GraalVM 25.0 instead of 23.1. The library versions should match that.

Note, it's not critical to be on par with the latest 25.0 version available, as these dependencies are only needed to satisfy compile time references. The actual implementation is picked by the Mandrel/GraalVM version used to compile the native image.