### PR TITLE
PQC tests - Downgrade setup-java

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -2024,7 +2024,8 @@ jobs:
           apt-get update && apt-get install -y git curl unzip openssl libssl-dev libapr1t64 p7zip-full
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up JDK 21
-        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        # v6 is not supported at the moment as the container image doesn't contain gpg
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
           java-version: 21


### PR DESCRIPTION
The new setup-java version requires gpg and apparently the container image is not containing it.
Downgrading for now.
