### PR TITLE
SBOM entry for Quarkus Bot

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -797,5 +797,12 @@ triage:
       labels: [area/virtual-threads]
       title: "(virtual.thread|RunOnVirtualThread)"
       notify: [cescoffier, ozangunalp]
+    - id: sbom
+      labels: [area/sbom]
+      title: "(sbom|cyclonedx)"
+      notify: [aloubyansky]
+      notifyInPullRequest: true
+      directories:
+        - extensions/cyclonedx/
   qe:
     notify: [rsvoboda, mjurc]


### PR DESCRIPTION
SBOM entry for Quarkus Bot

Motivation: CycloneDX extension is receiving full support