### PR TITLE
Resolve dev service config dependency chains deeper than one level

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItem.java
@@ -1,5 +1,6 @@
 package io.quarkus.deployment.builditem;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -101,14 +102,47 @@ public final class DevServicesRegistryBuildItem extends SimpleBuildItem {
         startSelectedServices(services, customizers, additionalConfigBuildItems, deploymentClassLoader,
                 dr -> !dr.hasDependencies(), config, overrideConfig);
 
-        // Now start everything with a dependency
-        // This won't handle the case where the dependencies also have dependencies, but that can be a follow-on work item if people ask for it
-        // I think we could implement it by getting the actual dependencies and seeing if any of them are also in the list of things we're starting, and then recursing
-        startSelectedServices(services, customizers, additionalConfigBuildItems, deploymentClassLoader,
-                DevServicesResultBuildItem::hasDependencies, config, overrideConfig);
+        // Now start everything with a dependency, one wave at a time, so that chains of dependencies
+        // (a service depending on a service which itself depends on another, and so on) are resolved
+        // regardless of how deep the chain is. Each wave starts the services whose required dependency
+        // config is already available; that may unblock further services for the next wave.
+        List<DevServicesResultBuildItem> pending = services.stream()
+                .filter(DevServicesResultBuildItem::isStartable)
+                .filter(DevServicesResultBuildItem::hasDependencies)
+                .collect(Collectors.toCollection(ArrayList::new));
+        while (!pending.isEmpty()) {
+            List<DevServicesResultBuildItem> ready = pending.stream()
+                    .filter(dr -> requiredDependenciesAvailable(dr, config))
+                    .toList();
+
+            if (ready.isEmpty()) {
+                // None of the remaining services are ready: their dependencies are missing or circular.
+                // Start them anyway so they go through the existing "did not become available" handling.
+                startSelectedServices(pending, customizers, additionalConfigBuildItems, deploymentClassLoader,
+                        dr -> true, config, overrideConfig);
+                break;
+            }
+
+            startSelectedServices(ready, customizers, additionalConfigBuildItems, deploymentClassLoader,
+                    dr -> true, config, overrideConfig);
+            pending.removeAll(ready);
+        }
 
         return new DevServicesStartResult(Collections.unmodifiableMap(config),
                 Collections.unmodifiableMap(overrideConfig));
+    }
+
+    private static boolean requiredDependenciesAvailable(DevServicesResultBuildItem dr, Map<String, String> config) {
+        var dependencies = dr.getDependencies();
+        if (dependencies == null) {
+            return true;
+        }
+        for (var dependency : dependencies) {
+            if (!config.containsKey(dependency.requiredConfigKey())) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private void startSelectedServices(Collection<DevServicesResultBuildItem> services,
@@ -116,8 +150,6 @@ public final class DevServicesRegistryBuildItem extends SimpleBuildItem {
             List<DevServicesAdditionalConfigBuildItem> additionalConfigBuildItems,
             ClassLoader deploymentClassLoader, Predicate<? super DevServicesResultBuildItem> filter,
             Map<String, String> config, Map<String, String> overrideConfig) {
-        // TODO Note that this does not handle chained dependencies; dependencies can only be one level deep for now
-        // It would be easy to fix that, but let's wait until we need to
         CompletableFuture.allOf(services.stream()
                 .filter(DevServicesResultBuildItem::isStartable)
                 .filter(filter)

--- a/core/deployment/src/test/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItemTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItemTest.java
@@ -1,0 +1,172 @@
+package io.quarkus.deployment.builditem;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.runtime.LaunchMode;
+
+class DevServicesRegistryBuildItemTest {
+
+    private final DevServicesRegistryBuildItem registry = new DevServicesRegistryBuildItem(UUID.randomUUID(), null,
+            LaunchMode.TEST);
+
+    @AfterEach
+    void cleanup() {
+        registry.closeOwnRunningServices();
+    }
+
+    @Test
+    void shouldResolveDependencyChainsMoreThanOneLevelDeep() {
+        DevServicesResultBuildItem serviceA = DevServicesResultBuildItem.owned()
+                .feature("A")
+                .startable(() -> new RecordingStartable("valueA", 0))
+                .configProvider(Map.of("test.a.value", RecordingStartable::getConnectionInfo))
+                .build();
+
+        DevServicesResultBuildItem serviceB = DevServicesResultBuildItem.owned()
+                .feature("B")
+                .startable(() -> new RecordingStartable("valueB", 300))
+                .dependsOnConfig("test.a.value", RecordingStartable::setInjectedValue)
+                .configProvider(Map.of("test.b.value",
+                        s -> s.getConnectionInfo() + "-" + s.getInjectedValue()))
+                .build();
+
+        DevServicesResultBuildItem serviceC = DevServicesResultBuildItem.owned()
+                .feature("C")
+                .startable(() -> new RecordingStartable("valueC", 0))
+                .dependsOnConfig("test.b.value", RecordingStartable::setInjectedValue)
+                .configProvider(Map.of("test.c.value",
+                        s -> s.getConnectionInfo() + "-" + s.getInjectedValue()))
+                .build();
+
+        // Services are passed in an order which does not match the dependency chain, on purpose
+        DevServicesRegistryBuildItem.DevServicesStartResult result = registry.startAll(
+                List.of(serviceC, serviceA, serviceB), List.of(), List.of(), null);
+
+        assertEquals("valueA", result.configs().get("test.a.value"));
+        assertEquals("valueB-valueA", result.configs().get("test.b.value"));
+        assertEquals("valueC-valueB-valueA", result.configs().get("test.c.value"));
+    }
+
+    @Test
+    void shouldNotStartAServiceWhoseTransitiveDependencyNeverBecomesAvailable() {
+        DevServicesResultBuildItem serviceB = DevServicesResultBuildItem.owned()
+                .feature("B")
+                .startable(() -> new RecordingStartable("valueB", 0))
+                .dependsOnConfig("test.never.available", RecordingStartable::setInjectedValue)
+                .configProvider(Map.of("test.b.value", RecordingStartable::getConnectionInfo))
+                .build();
+
+        DevServicesResultBuildItem serviceC = DevServicesResultBuildItem.owned()
+                .feature("C")
+                .startable(() -> new RecordingStartable("valueC", 0))
+                .dependsOnConfig("test.b.value", RecordingStartable::setInjectedValue)
+                .configProvider(Map.of("test.c.value", RecordingStartable::getConnectionInfo))
+                .build();
+
+        DevServicesRegistryBuildItem.DevServicesStartResult result = registry.startAll(
+                List.of(serviceB, serviceC), List.of(), List.of(), null);
+
+        assertNull(result.configs().get("test.b.value"));
+        assertNull(result.configs().get("test.c.value"));
+    }
+
+    @Test
+    void shouldNotHangOnACircularDependency() {
+        DevServicesResultBuildItem serviceX = DevServicesResultBuildItem.owned()
+                .feature("X")
+                .startable(() -> new RecordingStartable("valueX", 0))
+                .dependsOnConfig("test.y.value", RecordingStartable::setInjectedValue)
+                .configProvider(Map.of("test.x.value", RecordingStartable::getConnectionInfo))
+                .build();
+
+        DevServicesResultBuildItem serviceY = DevServicesResultBuildItem.owned()
+                .feature("Y")
+                .startable(() -> new RecordingStartable("valueY", 0))
+                .dependsOnConfig("test.x.value", RecordingStartable::setInjectedValue)
+                .configProvider(Map.of("test.y.value", RecordingStartable::getConnectionInfo))
+                .build();
+
+        DevServicesRegistryBuildItem.DevServicesStartResult result = registry.startAll(
+                List.of(serviceX, serviceY), List.of(), List.of(), null);
+
+        assertNull(result.configs().get("test.x.value"));
+        assertNull(result.configs().get("test.y.value"));
+    }
+
+    @Test
+    void shouldNotBlockChainOnAnUnsatisfiedOptionalDependency() {
+        DevServicesResultBuildItem serviceB = DevServicesResultBuildItem.owned()
+                .feature("B")
+                .startable(() -> new RecordingStartable("valueB", 0))
+                .dependsOnConfig("test.never.available", RecordingStartable::setInjectedValue, true)
+                .configProvider(Map.of("test.b.value", RecordingStartable::getConnectionInfo))
+                .build();
+
+        DevServicesResultBuildItem serviceC = DevServicesResultBuildItem.owned()
+                .feature("C")
+                .startable(() -> new RecordingStartable("valueC", 0))
+                .dependsOnConfig("test.b.value", RecordingStartable::setInjectedValue)
+                .configProvider(Map.of("test.c.value",
+                        s -> s.getConnectionInfo() + "-" + s.getInjectedValue()))
+                .build();
+
+        DevServicesRegistryBuildItem.DevServicesStartResult result = registry.startAll(
+                List.of(serviceB, serviceC), List.of(), List.of(), null);
+
+        assertEquals("valueB", result.configs().get("test.b.value"));
+        assertEquals("valueC-valueB", result.configs().get("test.c.value"));
+    }
+
+    public static class RecordingStartable implements Startable {
+
+        private final String connectionInfo;
+        private final long startDelayMillis;
+        private volatile String injectedValue;
+
+        public RecordingStartable(String connectionInfo, long startDelayMillis) {
+            this.connectionInfo = connectionInfo;
+            this.startDelayMillis = startDelayMillis;
+        }
+
+        public void setInjectedValue(String injectedValue) {
+            this.injectedValue = injectedValue;
+        }
+
+        public String getInjectedValue() {
+            return injectedValue;
+        }
+
+        @Override
+        public void start() {
+            if (startDelayMillis > 0) {
+                try {
+                    Thread.sleep(startDelayMillis);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+
+        @Override
+        public String getConnectionInfo() {
+            return connectionInfo;
+        }
+
+        @Override
+        public String getContainerId() {
+            return null;
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}


### PR DESCRIPTION
Dev services can depend on config produced by another dev service via `dependsOnConfig`, but `DevServicesRegistryBuildItem#startAll` only ever resolved one level of that dependency: a service depending on a service which itself depends on another would start in the same wave as its producer instead of waiting for it, so the config was never actually available yet.

This starts dependent services in successive waves instead, only starting a service once all of its required dependency config keys are already present. Circular or permanently unsatisfied dependencies still fall back to the existing "did not become available" behavior.

---

Fixes #56323