### PR TITLE
Generate the getEntityClass into repository impl rather than rely on a map lookups

### DIFF
--- a/extensions/data/hibernate/deployment/src/main/java/io/quarkus/data/hibernate/deployment/EntityClassMethodEnhancer.java
+++ b/extensions/data/hibernate/deployment/src/main/java/io/quarkus/data/hibernate/deployment/EntityClassMethodEnhancer.java
@@ -1,0 +1,48 @@
+package io.quarkus.data.hibernate.deployment;
+
+import java.util.function.BiFunction;
+
+import io.quarkus.deployment.util.AsmUtil;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+/**
+ * Adds a {@code doGetEntityClass()} method to generated repository implementation
+ * classes, returning the concrete entity class known at build time.
+ *
+ * <p>
+ * This is the final piece of the entity class lookup fix. The method overrides the
+ * default from the (now-public) {@code doGetEntityClass()} declared in the repository
+ * interfaces. When ArC generates a {@code _Subclass} for intercepted repositories,
+ * this override is inherited, so the entity class is always resolved correctly.
+ *
+ * @see RepositoryInterfaceEnhancer
+ * @see RepositoryBaseDiamondResolver
+ */
+final class EntityClassMethodEnhancer implements BiFunction<String, ClassVisitor, ClassVisitor> {
+
+    private final String entityInternalName;
+
+    EntityClassMethodEnhancer(String entityInternalName) {
+        this.entityInternalName = entityInternalName;
+    }
+
+    @Override
+    public ClassVisitor apply(String className, ClassVisitor outputClassVisitor) {
+        return new ClassVisitor(AsmUtil.ASM_API_VERSION, outputClassVisitor) {
+            @Override
+            public void visitEnd() {
+                MethodVisitor mv = super.visitMethod(
+                        Opcodes.ACC_PUBLIC, "doGetEntityClass", "()Ljava/lang/Class;", null, null);
+                mv.visitCode();
+                mv.visitLdcInsn(Type.getObjectType(entityInternalName));
+                mv.visitInsn(Opcodes.ARETURN);
+                mv.visitMaxs(1, 1);
+                mv.visitEnd();
+                super.visitEnd();
+            }
+        };
+    }
+}

--- a/extensions/data/hibernate/deployment/src/main/java/io/quarkus/data/hibernate/deployment/QuarkusDataHibernateProcessor.java
+++ b/extensions/data/hibernate/deployment/src/main/java/io/quarkus/data/hibernate/deployment/QuarkusDataHibernateProcessor.java
@@ -102,6 +102,26 @@ public final class QuarkusDataHibernateProcessor {
 
     private static final DotName DOTNAME_ID = DotName.createSimple(Id.class.getName());
 
+    // Repository interfaces whose private doGetEntityClass()/getEntityClass() methods need
+    // bytecode transformation -- see RepositoryInterfaceEnhancer javadoc for the full explanation.
+    private static final List<String> REPOSITORY_LEAF_INTERFACES = List.of(
+            "io.quarkus.data.hibernate.managed.blocking.BlockingManagedRepositoryOperations",
+            "io.quarkus.data.hibernate.managed.blocking.BlockingManagedRepositoryQueries",
+            "io.quarkus.data.hibernate.managed.reactive.ReactiveManagedRepositoryOperations",
+            "io.quarkus.data.hibernate.managed.reactive.ReactiveManagedRepositoryQueries",
+            "io.quarkus.data.hibernate.stateless.blocking.BlockingRecordRepositoryOperations",
+            "io.quarkus.data.hibernate.stateless.blocking.BlockingRecordRepositoryQueries",
+            "io.quarkus.data.hibernate.stateless.reactive.ReactiveRecordRepositoryOperations",
+            "io.quarkus.data.hibernate.stateless.reactive.ReactiveRecordRepositoryQueries");
+
+    // Base interfaces that extend both an Operations and a Queries interface -- they need
+    // a doGetEntityClass() override to resolve the diamond created by the leaf transforms.
+    private static final List<String> REPOSITORY_BASE_INTERFACES = List.of(
+            "io.quarkus.data.hibernate.managed.blocking.BlockingManagedRepositoryBase",
+            "io.quarkus.data.hibernate.managed.reactive.ReactiveManagedRepositoryBase",
+            "io.quarkus.data.hibernate.stateless.blocking.BlockingRecordRepositoryBase",
+            "io.quarkus.data.hibernate.stateless.reactive.ReactiveRecordRepositoryBase");
+
     @BuildStep
     FeatureBuildItem featureBuildItem() {
         return new FeatureBuildItem(Feature.QUARKUS_DATA_HIBERNATE);
@@ -194,6 +214,27 @@ public final class QuarkusDataHibernateProcessor {
             List<org.jboss.jandex.Type> typeParameters = JandexUtil
                     .resolveTypeParameters(classInfo.name(), DOTNAME_PANACHE_REPOSITORY_SWITCHER, index.getIndex());
             panacheEntities.add(typeParameters.get(0).name().toString());
+
+            // Register a bytecode transformer to add doGetEntityClass() to each concrete
+            // repository implementation. This overrides the default (throwing) version made
+            // public by RepositoryInterfaceEnhancer, returning the actual entity class.
+            if (!classInfo.isInterface() && typeParameters.get(0).kind() == Kind.CLASS) {
+                String entityInternalName = typeParameters.get(0).name().toString().replace('.', '/');
+                transformers.produce(new BytecodeTransformerBuildItem(classInfo.name().toString(),
+                        new EntityClassMethodEnhancer(entityInternalName)));
+            }
+        }
+
+        // Transform the leaf repository interfaces: make doGetEntityClass() public and
+        // rewrite getEntityClass() to use invokeinterface for virtual dispatch.
+        for (String iface : REPOSITORY_LEAF_INTERFACES) {
+            transformers.produce(new BytecodeTransformerBuildItem(iface, RepositoryInterfaceEnhancer.INSTANCE));
+        }
+
+        // Transform the base interfaces to resolve the doGetEntityClass() diamond
+        // inherited from their Operations and Queries parents.
+        for (String iface : REPOSITORY_BASE_INTERFACES) {
+            transformers.produce(new BytecodeTransformerBuildItem(iface, RepositoryBaseDiamondResolver.INSTANCE));
         }
 
         Set<String> modelClasses = new HashSet<>();
@@ -226,24 +267,6 @@ public final class QuarkusDataHibernateProcessor {
                         // This happens if there is no persistence unit, in which case we definitely know this metadata is complete.
                         .orElse(false),
                 capabilities.isPresent(Capability.HIBERNATE_REACTIVE));
-        // Panache 2 repos
-        Map<String, String> repositoryClassesToEntityClasses = new HashMap<>();
-        for (ClassInfo classInfo : index.getIndex().getAllKnownImplementations(DOTNAME_PANACHE_REPOSITORY_SWITCHER)) {
-            // Only keep concrete classes
-            if (classInfo.isInterface() || classInfo.isAbstract()) {
-                continue;
-            }
-            List<org.jboss.jandex.Type> typeParameters = JandexUtil
-                    .resolveTypeParameters(classInfo.name(), DOTNAME_PANACHE_REPOSITORY_SWITCHER, index.getIndex());
-            if (typeParameters.get(0).kind() == Kind.CLASS) {
-                String entityClassName = typeParameters.get(0).name().toString();
-                repositoryClassesToEntityClasses.put(classInfo.name().toString(), entityClassName);
-            } else {
-                throw new RuntimeException("Failed to find entity linked to repository: " + classInfo + ", it appears to be: "
-                        + typeParameters.get(0) + " but we don't know what to do with it, it should be an entity type");
-            }
-        }
-        recorder.setRepositoryClassesToEntityClasses(repositoryClassesToEntityClasses);
     }
 
     @BuildStep

--- a/extensions/data/hibernate/deployment/src/main/java/io/quarkus/data/hibernate/deployment/RepositoryBaseDiamondResolver.java
+++ b/extensions/data/hibernate/deployment/src/main/java/io/quarkus/data/hibernate/deployment/RepositoryBaseDiamondResolver.java
@@ -1,0 +1,53 @@
+package io.quarkus.data.hibernate.deployment;
+
+import java.util.function.BiFunction;
+
+import io.quarkus.deployment.util.AsmUtil;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * Resolves the diamond inheritance of {@code doGetEntityClass()} in Base interfaces.
+ *
+ * <p>
+ * Each Base interface (e.g. {@code BlockingManagedRepositoryBase}) extends both an
+ * Operations and a Queries interface. After {@link RepositoryInterfaceEnhancer} makes
+ * {@code doGetEntityClass()} public in both parents, the JVM requires the Base interface
+ * to explicitly select one -- otherwise it throws {@code IncompatibleClassChangeError}.
+ *
+ * <p>
+ * This transformer adds a public {@code doGetEntityClass()} that throws
+ * {@code UnsupportedOperationException}. The method is never actually called on the
+ * interface -- it exists solely to satisfy the JVM's diamond resolution requirement.
+ * The real implementation lives on the generated repository class via
+ * {@link EntityClassMethodEnhancer}.
+ *
+ * @see RepositoryInterfaceEnhancer
+ * @see EntityClassMethodEnhancer
+ */
+final class RepositoryBaseDiamondResolver implements BiFunction<String, ClassVisitor, ClassVisitor> {
+
+    static final RepositoryBaseDiamondResolver INSTANCE = new RepositoryBaseDiamondResolver();
+
+    @Override
+    public ClassVisitor apply(String className, ClassVisitor outputClassVisitor) {
+        return new ClassVisitor(AsmUtil.ASM_API_VERSION, outputClassVisitor) {
+            @Override
+            public void visitEnd() {
+                MethodVisitor mv = super.visitMethod(
+                        Opcodes.ACC_PUBLIC, "doGetEntityClass", "()Ljava/lang/Class;", null, null);
+                mv.visitCode();
+                mv.visitTypeInsn(Opcodes.NEW, "java/lang/UnsupportedOperationException");
+                mv.visitInsn(Opcodes.DUP);
+                mv.visitLdcInsn("doGetEntityClass() should be provided by the generated repository implementation");
+                mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/UnsupportedOperationException",
+                        "<init>", "(Ljava/lang/String;)V", false);
+                mv.visitInsn(Opcodes.ATHROW);
+                mv.visitMaxs(3, 1);
+                mv.visitEnd();
+                super.visitEnd();
+            }
+        };
+    }
+}

--- a/extensions/data/hibernate/deployment/src/main/java/io/quarkus/data/hibernate/deployment/RepositoryInterfaceEnhancer.java
+++ b/extensions/data/hibernate/deployment/src/main/java/io/quarkus/data/hibernate/deployment/RepositoryInterfaceEnhancer.java
@@ -1,0 +1,88 @@
+package io.quarkus.data.hibernate.deployment;
+
+import java.util.function.BiFunction;
+
+import io.quarkus.deployment.util.AsmUtil;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * Bytecode transformer for repository interfaces that makes the entity class lookup
+ * work through virtual dispatch instead of statically-bound private method calls.
+ *
+ * <p>
+ * <b>Problem:</b> The repository interfaces declare {@code private getEntityClass()} which
+ * calls {@code private doGetEntityClass()}. Since both are private, the JVM uses
+ * {@code invokespecial} which is statically bound -- the call always resolves to the
+ * interface's version, regardless of what the implementing class provides.
+ *
+ * <p>
+ * <b>Solution:</b> This transformer:
+ * <ol>
+ * <li>Changes {@code doGetEntityClass()} from {@code ACC_PRIVATE} to {@code ACC_PUBLIC},
+ * making it a virtual dispatch target</li>
+ * <li>Rewrites the body of {@code getEntityClass()} to call {@code doGetEntityClass()}
+ * via {@code invokeinterface} instead of {@code invokespecial}</li>
+ * </ol>
+ *
+ * <p>
+ * After transformation, the call chain becomes:
+ * {@code findById() --invokespecial--> getEntityClass() --invokeinterface--> doGetEntityClass()}
+ * where the last step dispatches to the impl class override provided by
+ * {@link EntityClassMethodEnhancer}.
+ *
+ * <p>
+ * Both methods remain private in the source code, so they never appear in the
+ * user-facing API.
+ *
+ * @see EntityClassMethodEnhancer
+ */
+final class RepositoryInterfaceEnhancer implements BiFunction<String, ClassVisitor, ClassVisitor> {
+
+    static final RepositoryInterfaceEnhancer INSTANCE = new RepositoryInterfaceEnhancer();
+
+    private static final String DO_GET_ENTITY_CLASS = "doGetEntityClass";
+    private static final String GET_ENTITY_CLASS = "getEntityClass";
+    private static final String DESCRIPTOR = "()Ljava/lang/Class;";
+
+    @Override
+    public ClassVisitor apply(String className, ClassVisitor outputClassVisitor) {
+        String internalName = className.replace('.', '/');
+        return new ClassVisitor(AsmUtil.ASM_API_VERSION, outputClassVisitor) {
+
+            @Override
+            public MethodVisitor visitMethod(int access, String name, String descriptor,
+                    String signature, String[] exceptions) {
+
+                if (DO_GET_ENTITY_CLASS.equals(name) && DESCRIPTOR.equals(descriptor)) {
+                    // Make doGetEntityClass() public so it becomes a virtual dispatch target.
+                    // The original private body (throws UnsupportedOperationException) is kept
+                    // as a fallback -- it will be overridden by EntityClassMethodEnhancer on
+                    // the implementing class.
+                    int publicAccess = (access & ~Opcodes.ACC_PRIVATE) | Opcodes.ACC_PUBLIC;
+                    return super.visitMethod(publicAccess, name, descriptor, signature, exceptions);
+                }
+
+                if (GET_ENTITY_CLASS.equals(name) && DESCRIPTOR.equals(descriptor)) {
+                    // Replace the body of getEntityClass() to call doGetEntityClass() via
+                    // invokeinterface instead of invokespecial. The method stays private --
+                    // only its body changes.
+                    MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
+                    mv.visitCode();
+                    mv.visitVarInsn(Opcodes.ALOAD, 0);
+                    mv.visitMethodInsn(Opcodes.INVOKEINTERFACE, internalName,
+                            DO_GET_ENTITY_CLASS, DESCRIPTOR, true);
+                    mv.visitInsn(Opcodes.ARETURN);
+                    mv.visitMaxs(1, 1);
+                    mv.visitEnd();
+                    // Return a no-op visitor to discard the original method body
+                    return new MethodVisitor(Opcodes.ASM9) {
+                    };
+                }
+
+                return super.visitMethod(access, name, descriptor, signature, exceptions);
+            }
+        };
+    }
+}

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/managed/blocking/BlockingManagedRepositoryOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/managed/blocking/BlockingManagedRepositoryOperations.java
@@ -7,13 +7,24 @@ import org.hibernate.Session;
 import io.quarkus.data.hibernate.managed.ManagedRepositoryOperations;
 import io.quarkus.data.hibernate.runtime.spi.PanacheBlockingOperations;
 import io.quarkus.data.hibernate.runtime.spi.PanacheOperations;
-import io.quarkus.hibernate.orm.panache.common.runtime.AbstractJpaOperations;
 
 public interface BlockingManagedRepositoryOperations<Entity, Id>
         extends ManagedRepositoryOperations<Entity, Session, Void, Boolean, Id> {
 
+    // At build time, a bytecode transformer rewrites getEntityClass() to call doGetEntityClass()
+    // via invokeinterface (instead of invokespecial), and makes doGetEntityClass() public.
+    // The generated repository implementation then overrides doGetEntityClass() to return the
+    // concrete entity class. This avoids the fragile AbstractJpaOperations.getRepositoryEntityClass(getClass())
+    // map lookup, which breaks when ArC generates a _Subclass for intercepted repositories.
+    // Both methods stay private in source so they don't leak into the user-facing API.
+
+    private Class<? extends Entity> doGetEntityClass() {
+        throw new UnsupportedOperationException(
+                "doGetEntityClass() should be provided by the generated repository implementation");
+    }
+
     private Class<? extends Entity> getEntityClass() {
-        return AbstractJpaOperations.getRepositoryEntityClass(getClass());
+        return doGetEntityClass();
     }
 
     private PanacheBlockingOperations operations() {

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/managed/blocking/BlockingManagedRepositoryQueries.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/managed/blocking/BlockingManagedRepositoryQueries.java
@@ -11,11 +11,18 @@ import io.quarkus.data.hibernate.blocking.BlockingDataQuery;
 import io.quarkus.data.hibernate.blocking.BlockingRepositoryQueries;
 import io.quarkus.data.hibernate.runtime.spi.PanacheBlockingOperations;
 import io.quarkus.data.hibernate.runtime.spi.PanacheOperations;
-import io.quarkus.hibernate.orm.panache.common.runtime.AbstractJpaOperations;
 
 public interface BlockingManagedRepositoryQueries<Entity, Id> extends BlockingRepositoryQueries<Entity, Id> {
+
+    // See BlockingManagedRepositoryOperations for the explanation of the doGetEntityClass() pattern.
+
+    private Class<? extends Entity> doGetEntityClass() {
+        throw new UnsupportedOperationException(
+                "doGetEntityClass() should be provided by the generated repository implementation");
+    }
+
     private Class<? extends Entity> getEntityClass() {
-        return AbstractJpaOperations.getRepositoryEntityClass(getClass());
+        return doGetEntityClass();
     }
 
     private PanacheBlockingOperations operations() {

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/managed/reactive/ReactiveManagedRepositoryOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/managed/reactive/ReactiveManagedRepositoryOperations.java
@@ -7,14 +7,20 @@ import org.hibernate.reactive.mutiny.Mutiny;
 import io.quarkus.data.hibernate.managed.ManagedRepositoryOperations;
 import io.quarkus.data.hibernate.runtime.spi.PanacheOperations;
 import io.quarkus.data.hibernate.runtime.spi.PanacheReactiveOperations;
-import io.quarkus.hibernate.orm.panache.common.runtime.AbstractJpaOperations;
 import io.smallrye.mutiny.Uni;
 
 public interface ReactiveManagedRepositoryOperations<Entity, Id>
         extends ManagedRepositoryOperations<Entity, Uni<Mutiny.Session>, Uni<Void>, Uni<Boolean>, Id> {
 
+    // See BlockingManagedRepositoryOperations for the explanation of the doGetEntityClass() pattern.
+
+    private Class<? extends Entity> doGetEntityClass() {
+        throw new UnsupportedOperationException(
+                "doGetEntityClass() should be provided by the generated repository implementation");
+    }
+
     private Class<? extends Entity> getEntityClass() {
-        return AbstractJpaOperations.getRepositoryEntityClass(getClass());
+        return doGetEntityClass();
     }
 
     private PanacheReactiveOperations operations() {

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/managed/reactive/ReactiveManagedRepositoryQueries.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/managed/reactive/ReactiveManagedRepositoryQueries.java
@@ -9,12 +9,19 @@ import io.quarkus.data.hibernate.reactive.ReactiveDataQuery;
 import io.quarkus.data.hibernate.reactive.ReactiveRepositoryQueries;
 import io.quarkus.data.hibernate.runtime.spi.PanacheOperations;
 import io.quarkus.data.hibernate.runtime.spi.PanacheReactiveOperations;
-import io.quarkus.hibernate.orm.panache.common.runtime.AbstractJpaOperations;
 import io.smallrye.mutiny.Uni;
 
 public interface ReactiveManagedRepositoryQueries<Entity, Id> extends ReactiveRepositoryQueries<Entity, Id> {
+
+    // See BlockingManagedRepositoryOperations for the explanation of the doGetEntityClass() pattern.
+
+    private Class<? extends Entity> doGetEntityClass() {
+        throw new UnsupportedOperationException(
+                "doGetEntityClass() should be provided by the generated repository implementation");
+    }
+
     private Class<? extends Entity> getEntityClass() {
-        return AbstractJpaOperations.getRepositoryEntityClass(getClass());
+        return doGetEntityClass();
     }
 
     private PanacheReactiveOperations operations() {

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/runtime/PanacheHibernateRecorder.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/runtime/PanacheHibernateRecorder.java
@@ -15,8 +15,4 @@ public class PanacheHibernateRecorder {
                     .addEntityTypesToPersistenceUnit(entityToPersistenceUnit);
         }
     }
-
-    public void setRepositoryClassesToEntityClasses(Map<String, String> repositoryClassesToEntityClasses) {
-        AbstractJpaOperations.setRepositoryClassesToEntityClasses(repositoryClassesToEntityClasses);
-    }
 }

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/stateless/blocking/BlockingRecordRepositoryOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/stateless/blocking/BlockingRecordRepositoryOperations.java
@@ -7,13 +7,19 @@ import org.hibernate.StatelessSession;
 import io.quarkus.data.hibernate.runtime.spi.PanacheBlockingOperations;
 import io.quarkus.data.hibernate.runtime.spi.PanacheOperations;
 import io.quarkus.data.hibernate.stateless.RecordRepositoryOperations;
-import io.quarkus.hibernate.orm.panache.common.runtime.AbstractJpaOperations;
 
 public interface BlockingRecordRepositoryOperations<Entity, Id>
         extends RecordRepositoryOperations<Entity, StatelessSession, Void, Boolean, Id> {
 
+    // See BlockingManagedRepositoryOperations for the explanation of the doGetEntityClass() pattern.
+
+    private Class<? extends Entity> doGetEntityClass() {
+        throw new UnsupportedOperationException(
+                "doGetEntityClass() should be provided by the generated repository implementation");
+    }
+
     private Class<? extends Entity> getEntityClass() {
-        return AbstractJpaOperations.getRepositoryEntityClass(getClass());
+        return doGetEntityClass();
     }
 
     private PanacheBlockingOperations operations() {

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/stateless/blocking/BlockingRecordRepositoryQueries.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/stateless/blocking/BlockingRecordRepositoryQueries.java
@@ -11,11 +11,18 @@ import io.quarkus.data.hibernate.blocking.BlockingDataQuery;
 import io.quarkus.data.hibernate.blocking.BlockingRepositoryQueries;
 import io.quarkus.data.hibernate.runtime.spi.PanacheBlockingOperations;
 import io.quarkus.data.hibernate.runtime.spi.PanacheOperations;
-import io.quarkus.hibernate.orm.panache.common.runtime.AbstractJpaOperations;
 
 public interface BlockingRecordRepositoryQueries<Entity, Id> extends BlockingRepositoryQueries<Entity, Id> {
+
+    // See BlockingManagedRepositoryOperations for the explanation of the doGetEntityClass() pattern.
+
+    private Class<? extends Entity> doGetEntityClass() {
+        throw new UnsupportedOperationException(
+                "doGetEntityClass() should be provided by the generated repository implementation");
+    }
+
     private Class<? extends Entity> getEntityClass() {
-        return AbstractJpaOperations.getRepositoryEntityClass(getClass());
+        return doGetEntityClass();
     }
 
     private PanacheBlockingOperations operations() {

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/stateless/reactive/ReactiveRecordRepositoryOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/stateless/reactive/ReactiveRecordRepositoryOperations.java
@@ -7,14 +7,20 @@ import org.hibernate.reactive.mutiny.Mutiny;
 import io.quarkus.data.hibernate.runtime.spi.PanacheOperations;
 import io.quarkus.data.hibernate.runtime.spi.PanacheReactiveOperations;
 import io.quarkus.data.hibernate.stateless.RecordRepositoryOperations;
-import io.quarkus.hibernate.orm.panache.common.runtime.AbstractJpaOperations;
 import io.smallrye.mutiny.Uni;
 
 public interface ReactiveRecordRepositoryOperations<Entity, Id>
         extends RecordRepositoryOperations<Entity, Uni<Mutiny.StatelessSession>, Uni<Void>, Uni<Boolean>, Id> {
 
+    // See BlockingManagedRepositoryOperations for the explanation of the doGetEntityClass() pattern.
+
+    private Class<? extends Entity> doGetEntityClass() {
+        throw new UnsupportedOperationException(
+                "doGetEntityClass() should be provided by the generated repository implementation");
+    }
+
     private Class<? extends Entity> getEntityClass() {
-        return AbstractJpaOperations.getRepositoryEntityClass(getClass());
+        return doGetEntityClass();
     }
 
     private PanacheReactiveOperations operations() {

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/stateless/reactive/ReactiveRecordRepositoryQueries.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/data/hibernate/stateless/reactive/ReactiveRecordRepositoryQueries.java
@@ -9,12 +9,19 @@ import io.quarkus.data.hibernate.reactive.ReactiveDataQuery;
 import io.quarkus.data.hibernate.reactive.ReactiveRepositoryQueries;
 import io.quarkus.data.hibernate.runtime.spi.PanacheOperations;
 import io.quarkus.data.hibernate.runtime.spi.PanacheReactiveOperations;
-import io.quarkus.hibernate.orm.panache.common.runtime.AbstractJpaOperations;
 import io.smallrye.mutiny.Uni;
 
 public interface ReactiveRecordRepositoryQueries<Entity, Id> extends ReactiveRepositoryQueries<Entity, Id> {
+
+    // See BlockingManagedRepositoryOperations for the explanation of the doGetEntityClass() pattern.
+
+    private Class<? extends Entity> doGetEntityClass() {
+        throw new UnsupportedOperationException(
+                "doGetEntityClass() should be provided by the generated repository implementation");
+    }
+
     private Class<? extends Entity> getEntityClass() {
-        return AbstractJpaOperations.getRepositoryEntityClass(getClass());
+        return doGetEntityClass();
     }
 
     private PanacheReactiveOperations operations() {

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
@@ -2,7 +2,6 @@ package io.quarkus.hibernate.orm.panache.common.runtime;
 
 import static io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,35 +46,6 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType extend
         } else {
             entityToPersistenceUnitIsIncomplete = entityToPersistenceUnitIsIncomplete || incomplete;
         }
-    }
-
-    private static volatile Map<Class<?>, Class<?>> repositoryClassToEntityClass = Collections.emptyMap();
-
-    public static void setRepositoryClassesToEntityClasses(Map<String, String> map) {
-        Map<Class<?>, Class<?>> converted = new HashMap<>();
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        for (Entry<String, String> entry : map.entrySet()) {
-            try {
-                Class<?> repoClass = Class.forName(entry.getKey(), false, classLoader);
-                Class<?> entityClass = Class.forName(entry.getValue(), false, classLoader);
-                converted.put(repoClass, entityClass);
-            } catch (ClassNotFoundException e) {
-                throw new RuntimeException("Unable to load repository/entity class mapping "
-                        + entry.getKey() + " -> " + entry.getValue(), e);
-            }
-        }
-        repositoryClassToEntityClass = Collections.unmodifiableMap(converted);
-    }
-
-    public static <Entity> Class<? extends Entity> getRepositoryEntityClass(
-            // FIXME: if we move this to JpaOperations we can add a type constraint on the repo class
-            Class<?> repositoryImplementationClass) {
-        Class<?> ret = repositoryClassToEntityClass.get(repositoryImplementationClass);
-        if (ret == null) {
-            throw new RuntimeException("Your repository class " + repositoryImplementationClass
-                    + " was not properly detected and assigned an entity type");
-        }
-        return (Class<? extends Entity>) ret;
     }
 
     //

--- a/integration-tests/data-hibernate/src/main/java/io/quarkus/it/data/hibernate/InterceptedPersonRepository.java
+++ b/integration-tests/data-hibernate/src/main/java/io/quarkus/it/data/hibernate/InterceptedPersonRepository.java
@@ -1,0 +1,11 @@
+package io.quarkus.it.data.hibernate;
+
+import io.quarkus.data.hibernate.ManagedRepository;
+
+@Logged
+public interface InterceptedPersonRepository extends ManagedRepository<Person> {
+
+    default String interceptedMethod(String input) {
+        return input;
+    }
+}

--- a/integration-tests/data-hibernate/src/main/java/io/quarkus/it/data/hibernate/InterceptedPersonResource.java
+++ b/integration-tests/data-hibernate/src/main/java/io/quarkus/it/data/hibernate/InterceptedPersonResource.java
@@ -1,0 +1,71 @@
+package io.quarkus.it.data.hibernate;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/intercepted-persons")
+public class InterceptedPersonResource {
+
+    @Inject
+    InterceptedPersonRepository repository;
+
+    @GET
+    @Path("/test")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Transactional
+    public String test() {
+        repository.deleteAll();
+
+        Person person1 = new Person();
+        person1.name = "Charlie";
+        person1.age = 40;
+        person1.persist();
+
+        Person person2 = new Person();
+        person2.name = "Diana";
+        person2.age = 35;
+        person2.persist();
+
+        repository.flush();
+
+        long count = repository.count();
+        if (count != 2) {
+            return "Failed: Expected 2 persons, found " + count;
+        }
+
+        List<Person> all = repository.listAll();
+        if (all.size() != 2) {
+            return "Failed: Expected 2 persons in listAll, found " + all.size();
+        }
+
+        List<Person> found = repository.find("name", "Charlie").list();
+        if (found.size() != 1) {
+            return "Failed: Expected 1 person named Charlie, found " + found.size();
+        }
+
+        Person charlie = found.get(0);
+        Person byId = repository.findById(charlie.id);
+        if (byId == null || !byId.name.equals("Charlie")) {
+            return "Failed: findById did not return Charlie";
+        }
+
+        repository.delete("name", "Diana");
+        count = repository.count();
+        if (count != 1) {
+            return "Failed: Expected 1 person after delete, found " + count;
+        }
+
+        String intercepted = repository.interceptedMethod("hello");
+        if (!"hello".equals(intercepted)) {
+            return "Failed: interceptedMethod did not return expected value";
+        }
+
+        return "OK";
+    }
+}

--- a/integration-tests/data-hibernate/src/main/java/io/quarkus/it/data/hibernate/Logged.java
+++ b/integration-tests/data-hibernate/src/main/java/io/quarkus/it/data/hibernate/Logged.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.data.hibernate;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.interceptor.InterceptorBinding;
+
+@InterceptorBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Inherited
+public @interface Logged {
+}

--- a/integration-tests/data-hibernate/src/main/java/io/quarkus/it/data/hibernate/LoggedInterceptor.java
+++ b/integration-tests/data-hibernate/src/main/java/io/quarkus/it/data/hibernate/LoggedInterceptor.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.data.hibernate;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+@Logged
+@Interceptor
+@Priority(Interceptor.Priority.APPLICATION)
+public class LoggedInterceptor {
+
+    @AroundInvoke
+    Object intercept(InvocationContext context) throws Exception {
+        return context.proceed();
+    }
+}

--- a/integration-tests/data-hibernate/src/test/java/io/quarkus/it/data/hibernate/QuarkusDataHibernateFunctionalityTest.java
+++ b/integration-tests/data-hibernate/src/test/java/io/quarkus/it/data/hibernate/QuarkusDataHibernateFunctionalityTest.java
@@ -36,4 +36,13 @@ public class QuarkusDataHibernateFunctionalityTest {
                 .statusCode(200)
                 .body(is("OK"));
     }
+
+    @Test
+    public void testInterceptedPersonEndpoint() {
+        given()
+                .when().get("/intercepted-persons/test")
+                .then()
+                .statusCode(200)
+                .body(is("OK"));
+    }
 }


### PR DESCRIPTION
Hey @FroMage 🙂 👋🏻 

the problem is that when we have BV enabled for a repository -- it has an interceptor, and that one is not registered in the panache's map .... so I thought let's just replace that fragile map lookup with ... a fragile code gen 🙂 and simply "implement" the get entity class into repository implementations ? 
I'll open it as a draft to see if you like/agree with the idea 🙂 

* Fixes https://github.com/quarkusio/quarkus/issues/56542

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

