### PR TITLE
Customize OIDC token decryption algorithm

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
+++ b/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
@@ -795,6 +795,7 @@ ID and access tokens may have to be decrypted or their headers preprocessed for 
 |quarkus.oidc.token.decryption-key-location || Decryption key location
 |quarkus.oidc.token.decrypt-id-token || Decrypt ID token if this property is `true` or if `quarkus.oidc.token.decryption-key-location` is set
 |quarkus.oidc.token.decrypt-access-token |false| Decrypt access token
+|quarkus.oidc.token.decryption-algorithm |`RSA-OAEP` for private decryption keys, `A256GCMKW` for secret decryption keys| Key decryption algorithm
 |quarkus.oidc.token.customizer-name || Customizer name
 |====
 
@@ -805,6 +806,8 @@ Both ID and access tokens are considered encrypted if they contain 5 parts separ
 For backward compatibility reasons, ID token decryption is attempted if  `quarkus.oidc.token.decryption-key-location` is configured, but using an optional `quarkus.oidc.token.decrypt-id-token` boolean property is RECOMMENDED instead, to allow for more flexibility in selecting decryption keys.
 
 When either ID or access token must be decrypted, `quarkus.oidc.token.decryption-key-location` is checked first. If this property is not configured, then the <<jwt-client-credentials>> key, if available, is used. Finally, if the decryption key is still not initialized, the configured client secret is used as a decryption key.
+
+The key decryption algorithm is selected according to the decryption key type: `RSA-OAEP` is expected when a private decryption key is used, and `A256GCMKW` when the client secret is used to create a secret decryption key. Set `quarkus.oidc.token.decryption-algorithm` if the OpenID Connect provider uses a different algorithm, for example, `quarkus.oidc.token.decryption-algorithm=RSA-OAEP-256`.
 
 `quarkus.oidc.token.customizer-name` is an advanced property that may be used to select a specific `io.quarkus.oidc.TokenCustomizer` implementation which can pre-process JWT token headers before its signature can be verified. The main use-case is to support verifying legacy Azure JWT tokens which must have their `nonce` header recalculated for the signature verification to succeed.
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -14,6 +14,7 @@ import io.quarkus.oidc.common.runtime.OidcClientCommonConfig;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.oidc.common.runtime.config.OidcCommonConfig;
 import io.quarkus.oidc.runtime.OidcConfig;
+import io.quarkus.oidc.runtime.OidcTenantConfig.Token.DecryptionAlgorithm;
 import io.quarkus.oidc.runtime.builders.AuthenticationConfigBuilder;
 import io.quarkus.oidc.runtime.builders.LogoutConfigBuilder;
 import io.quarkus.oidc.runtime.builders.TokenConfigBuilder;
@@ -2406,6 +2407,11 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
         boolean decryptAccessToken;
 
         /**
+         * ID and access token key decryption algorithm
+         */
+        Optional<DecryptionAlgorithm> decryptionAlgorithm = Optional.empty();
+
+        /**
          * Allow the remote introspection of JWT tokens when no matching JWK key is available.
          *
          * This property is set to `true` by default for backward-compatibility reasons. It is planned that this default value
@@ -2648,6 +2654,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
             decryptionKeyLocation = mapping.decryptionKeyLocation();
             decryptIdToken = mapping.decryptIdToken();
             decryptAccessToken = mapping.decryptAccessToken();
+            decryptionAlgorithm = mapping.decryptionAlgorithm();
             allowJwtIntrospection = mapping.allowJwtIntrospection();
             requireJwtIntrospectionOnly = mapping.requireJwtIntrospectionOnly();
             allowOpaqueTokenIntrospection = mapping.allowOpaqueTokenIntrospection();
@@ -2750,6 +2757,11 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
         @Override
         public boolean decryptAccessToken() {
             return decryptAccessToken;
+        }
+
+        @Override
+        public Optional<DecryptionAlgorithm> decryptionAlgorithm() {
+            return decryptionAlgorithm;
         }
 
         @Override

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -1257,6 +1257,21 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
         boolean decryptAccessToken();
 
         /**
+         * Supported ID and access token key decryption algorithms
+         */
+        enum DecryptionAlgorithm {
+            RSA_OAEP,
+            RSA_OAEP_256,
+            A256GCMKW
+        }
+
+        /**
+         * ID and access token key decryption algorithm
+         */
+        @ConfigDocDefault("RSA-OAEP if the decryption key is a private key, A256GCMKW if it is a secret key")
+        Optional<DecryptionAlgorithm> decryptionAlgorithm();
+
+        /**
          * Allow the remote introspection of JWT tokens when no matching JWK key is available.
          *
          * This property is set to `true` by default for backward-compatibility reasons. It is planned that this default value

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -10,7 +10,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -954,7 +953,7 @@ public final class OidcUtils {
         }
     }
 
-    public static Key readDecryptionKey(String decryptionKeyLocation) throws Exception {
+    public static Key readDecryptionKey(String decryptionKeyLocation, KeyEncryptionAlgorithm algorithm) throws Exception {
         Key key = null;
 
         String keyContent = KeyUtils.readKeyContent(decryptionKeyLocation);
@@ -962,15 +961,25 @@ public final class OidcUtils {
             List<JsonWebKey> keys = KeyUtils.loadJsonWebKeys(keyContent);
             if (keys != null && keys.size() == 1 &&
                     (keys.get(0).getAlgorithm() == null
-                            || keys.get(0).getAlgorithm().equals(KeyEncryptionAlgorithm.RSA_OAEP.getAlgorithm()))
+                            || keys.get(0).getAlgorithm().equals(algorithm.getAlgorithm()))
                     && ("enc".equals(keys.get(0).getUse()) || keys.get(0).getUse() == null)) {
                 key = PublicJsonWebKey.class.cast(keys.get(0)).getPrivateKey();
             }
         }
         if (key == null) {
-            key = KeyUtils.decodeDecryptionPrivateKey(keyContent);
+            key = KeyUtils.decodeDecryptionPrivateKey(keyContent, algorithm);
         }
         return key;
+    }
+
+    /**
+     * Returns the configured ID and access token key decryption algorithm.
+     */
+    public static KeyEncryptionAlgorithm getTokenDecryptionAlgorithm(Token token, Key decryptionKey) {
+        if (token.decryptionAlgorithm().isPresent()) {
+            return KeyEncryptionAlgorithm.valueOf(token.decryptionAlgorithm().get().name());
+        }
+        return decryptionKey instanceof SecretKey ? KeyEncryptionAlgorithm.A256GCMKW : KeyEncryptionAlgorithm.RSA_OAEP;
     }
 
     public static String decryptToken(TenantConfigContext resolvedContext, String token) {
@@ -982,9 +991,8 @@ public final class OidcUtils {
                 throw new AuthenticationFailedException();
             }
 
-            //TODO: Make the encryption algorithm configurable
-            KeyEncryptionAlgorithm encryptionAlgorithm = decryptionKey instanceof PrivateKey ? KeyEncryptionAlgorithm.RSA_OAEP
-                    : KeyEncryptionAlgorithm.A256GCMKW;
+            KeyEncryptionAlgorithm encryptionAlgorithm = getTokenDecryptionAlgorithm(
+                    resolvedContext.oidcConfig().token(), decryptionKey);
 
             try {
                 return OidcUtils.decryptString(token, decryptionKey, encryptionAlgorithm);

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContextImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContextImpl.java
@@ -20,6 +20,8 @@ import io.quarkus.oidc.OidcRedirectFilter;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.Redirect;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
+import io.quarkus.oidc.runtime.OidcTenantConfig.Token;
+import io.quarkus.oidc.runtime.OidcTenantConfig.Token.DecryptionAlgorithm;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.smallrye.mutiny.Uni;
 
@@ -103,25 +105,48 @@ final class TenantConfigContextImpl implements TenantConfigContext {
         Key key = null;
 
         OidcTenantConfig oidcConfig = provider.oidcConfig;
-        if (oidcConfig.token().decryptionKeyLocation().isPresent()) {
+        Token tokenConfig = oidcConfig.token();
+        if (tokenConfig.decryptionKeyLocation().isPresent()) {
+            verifyTokenDecryptionAlgorithm(oidcConfig, true);
             try {
-                return OidcUtils.readDecryptionKey(oidcConfig.token().decryptionKeyLocation().get());
+                key = OidcUtils.readDecryptionKey(tokenConfig.decryptionKeyLocation().get(),
+                        OidcUtils.getTokenDecryptionAlgorithm(tokenConfig, null));
             } catch (Exception ex) {
                 throw new ConfigurationException(
                         String.format("Token decryption key for tenant %s can not be read from %s",
-                                oidcConfig.tenantId().get(), oidcConfig.token().decryptionKeyLocation().get()),
+                                oidcConfig.tenantId().get(), tokenConfig.decryptionKeyLocation().get()),
                         ex);
             }
+        } else {
+            if (tokenConfig.decryptIdToken().orElse(false) || tokenConfig.decryptAccessToken()) {
+                if (provider.client.getClientJwtKey() != null) {
+                    key = provider.client.getClientJwtKey();
+                } else if (clientSecret != null) {
+                    key = OidcUtils.createSecretKeyFromDigest(clientSecret);
+                }
+            }
+            verifyTokenDecryptionAlgorithm(oidcConfig, key instanceof PrivateKey);
         }
 
-        if (oidcConfig.token().decryptIdToken().orElse(false) || oidcConfig.token().decryptAccessToken()) {
-            if (provider.client.getClientJwtKey() != null) {
-                key = provider.client.getClientJwtKey();
-            } else if (clientSecret != null) {
-                key = OidcUtils.createSecretKeyFromDigest(clientSecret);
-            }
-        }
         return key;
+    }
+
+    static void verifyTokenDecryptionAlgorithm(OidcTenantConfig oidcConfig, boolean privateKeyAvailable) {
+        DecryptionAlgorithm decryptionAlgorithm = oidcConfig.token().decryptionAlgorithm().orElse(null);
+        if (decryptionAlgorithm == null) {
+            return;
+        }
+        if (decryptionAlgorithm == DecryptionAlgorithm.A256GCMKW) {
+            if (privateKeyAvailable) {
+                throw new ConfigurationException(
+                        String.format("Tenant %s requires the %s token decryption algorithm but a private decryption key"
+                                + " is configured", oidcConfig.tenantId().get(), decryptionAlgorithm));
+            }
+        } else if (!privateKeyAvailable) {
+            throw new ConfigurationException(
+                    String.format("Tenant %s requires the %s token decryption algorithm but no private decryption key"
+                            + " is available", oidcConfig.tenantId().get(), decryptionAlgorithm));
+        }
     }
 
     private static SecretKey createStateSecretKey(OidcTenantConfig config, String possiblePkceSecret) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/TokenConfigBuilder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/TokenConfigBuilder.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import io.quarkus.oidc.OidcTenantConfigBuilder;
 import io.quarkus.oidc.runtime.OidcTenantConfig;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Binding;
+import io.quarkus.oidc.runtime.OidcTenantConfig.Token.DecryptionAlgorithm;
 
 /**
  * Builder for the {@link OidcTenantConfig.Token}.
@@ -29,6 +30,7 @@ public final class TokenConfigBuilder {
             Duration forcedJwkRefreshInterval, Optional<String> header,
             String authorizationScheme, Optional<OidcTenantConfig.SignatureAlgorithm> signatureAlgorithm,
             Optional<String> decryptionKeyLocation, Optional<Boolean> decryptIdToken, boolean decryptAccessToken,
+            Optional<DecryptionAlgorithm> decryptionAlgorithm,
             boolean allowJwtIntrospection, boolean requireJwtIntrospectionOnly,
             boolean allowOpaqueTokenIntrospection, Optional<String> customizerName,
             Optional<Boolean> verifyAccessTokenWithUserInfo, Binding binding) implements OidcTenantConfig.Token {
@@ -54,6 +56,7 @@ public final class TokenConfigBuilder {
     private Optional<String> decryptionKeyLocation;
     Optional<Boolean> decryptIdToken;
     private boolean decryptAccessToken;
+    private Optional<DecryptionAlgorithm> decryptionAlgorithm;
     private boolean allowJwtIntrospection;
     private boolean requireJwtIntrospectionOnly;
     private boolean allowOpaqueTokenIntrospection;
@@ -91,6 +94,7 @@ public final class TokenConfigBuilder {
         this.decryptionKeyLocation = token.decryptionKeyLocation();
         this.decryptIdToken = token.decryptIdToken();
         this.decryptAccessToken = token.decryptAccessToken();
+        this.decryptionAlgorithm = token.decryptionAlgorithm();
         this.allowJwtIntrospection = token.allowJwtIntrospection();
         this.requireJwtIntrospectionOnly = token.requireJwtIntrospectionOnly();
         this.allowOpaqueTokenIntrospection = token.allowOpaqueTokenIntrospection();
@@ -386,6 +390,15 @@ public final class TokenConfigBuilder {
     }
 
     /**
+     * @param decryptionAlgorithm {@link OidcTenantConfig.Token#decryptionAlgorithm()}
+     * @return this builder
+     */
+    public TokenConfigBuilder decryptionAlgorithm(DecryptionAlgorithm decryptionAlgorithm) {
+        this.decryptionAlgorithm = Optional.ofNullable(decryptionAlgorithm);
+        return this;
+    }
+
+    /**
      * Sets {@link OidcTenantConfig.Token#allowJwtIntrospection()} to true.
      *
      * @return this builder
@@ -502,7 +515,8 @@ public final class TokenConfigBuilder {
                 refreshTokenCacheTimeToLive,
                 forcedJwkRefreshInterval, header, authorizationScheme, signatureAlgorithm, decryptionKeyLocation,
                 decryptIdToken,
-                decryptAccessToken, allowJwtIntrospection, requireJwtIntrospectionOnly, allowOpaqueTokenIntrospection,
+                decryptAccessToken, decryptionAlgorithm, allowJwtIntrospection, requireJwtIntrospectionOnly,
+                allowOpaqueTokenIntrospection,
                 customizerName,
                 verifyAccessTokenWithUserInfo, binding);
     }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigBuilderTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigBuilderTest.java
@@ -36,6 +36,7 @@ import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfigBuilder.Secre
 import io.quarkus.oidc.runtime.OidcTenantConfig.ApplicationType;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Authentication.CookieSameSite;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Provider;
+import io.quarkus.oidc.runtime.OidcTenantConfig.Token.DecryptionAlgorithm;
 import io.quarkus.oidc.runtime.OidcTenantConfig.TokenStateManager.EncryptionAlgorithm;
 import io.quarkus.oidc.runtime.OidcTenantConfig.TokenStateManager.Strategy;
 import io.quarkus.oidc.runtime.builders.AuthenticationConfigBuilder;
@@ -95,6 +96,7 @@ public class OidcTenantConfigBuilderTest {
         assertEquals(OidcConstants.BEARER_SCHEME, token.authorizationScheme());
         assertTrue(token.signatureAlgorithm().isEmpty());
         assertTrue(token.decryptionKeyLocation().isEmpty());
+        assertTrue(token.decryptionAlgorithm().isEmpty());
         assertTrue(token.allowJwtIntrospection());
         assertFalse(token.requireJwtIntrospectionOnly());
         assertTrue(token.allowOpaqueTokenIntrospection());
@@ -270,6 +272,7 @@ public class OidcTenantConfigBuilderTest {
                 .requireJwtIntrospectionOnly()
                 .allowJwtIntrospection(false)
                 .decryptionKeyLocation("decryption-key-location-test")
+                .decryptionAlgorithm(DecryptionAlgorithm.RSA_OAEP_256)
                 .signatureAlgorithm(PS384)
                 .authorizationScheme("bearer-1234")
                 .header("doloris")
@@ -470,6 +473,7 @@ public class OidcTenantConfigBuilderTest {
         assertEquals("bearer-1234", token.authorizationScheme());
         assertEquals(PS384, token.signatureAlgorithm().orElse(null));
         assertEquals("decryption-key-location-test", token.decryptionKeyLocation().orElse(null));
+        assertEquals(DecryptionAlgorithm.RSA_OAEP_256, token.decryptionAlgorithm().orElse(null));
         assertFalse(token.allowJwtIntrospection());
         assertTrue(token.requireJwtIntrospectionOnly());
         assertFalse(token.allowOpaqueTokenIntrospection());

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
@@ -180,6 +180,7 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
         TOKEN_DECRYPTION_KEY_LOCATION,
         TOKEN_DECRYPT_ID_TOKEN,
         TOKEN_DECRYPT_ACCESS_TOKEN,
+        TOKEN_DECRYPTION_ALGORITHM,
         TOKEN_ALLOW_JWT_INTROSPECTION,
         TOKEN_REQUIRE_JWT_INTROSPECTION_ONLY,
         TOKEN_ALLOW_OPAQUE_TOKEN_INTROSPECTION,
@@ -432,6 +433,12 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
             public boolean decryptAccessToken() {
                 invocationsRecorder.put(ConfigMappingMethods.TOKEN_DECRYPT_ACCESS_TOKEN, true);
                 return false;
+            }
+
+            @Override
+            public Optional<DecryptionAlgorithm> decryptionAlgorithm() {
+                invocationsRecorder.put(ConfigMappingMethods.TOKEN_DECRYPTION_ALGORITHM, true);
+                return Optional.empty();
             }
 
             @Override

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/TokenDecryptionAlgorithmTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/TokenDecryptionAlgorithmTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.oidc.runtime;
+
+import static io.quarkus.oidc.runtime.OidcTenantConfig.Token.DecryptionAlgorithm.A256GCMKW;
+import static io.quarkus.oidc.runtime.OidcTenantConfig.Token.DecryptionAlgorithm.RSA_OAEP_256;
+import static io.quarkus.oidc.runtime.TenantConfigContextImpl.verifyTokenDecryptionAlgorithm;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.runtime.OidcTenantConfig.Token.DecryptionAlgorithm;
+import io.quarkus.runtime.configuration.ConfigurationException;
+
+public class TokenDecryptionAlgorithmTest {
+
+    @Test
+    public void testAlgorithmIsNotConfigured() {
+        verifyTokenDecryptionAlgorithm(config(null), true);
+        verifyTokenDecryptionAlgorithm(config(null), false);
+    }
+
+    @Test
+    public void testAsymmetricAlgorithmWithPrivateKey() {
+        verifyTokenDecryptionAlgorithm(config(RSA_OAEP_256), true);
+    }
+
+    @Test
+    public void testAsymmetricAlgorithmWithoutPrivateKey() {
+        var ex = assertThrows(ConfigurationException.class,
+                () -> verifyTokenDecryptionAlgorithm(config(RSA_OAEP_256), false));
+        assertEquals("Tenant tenant-a requires the RSA_OAEP_256 token decryption algorithm"
+                + " but no private decryption key is available", ex.getMessage());
+    }
+
+    @Test
+    public void testSymmetricAlgorithmWithoutPrivateKey() {
+        verifyTokenDecryptionAlgorithm(config(A256GCMKW), false);
+    }
+
+    @Test
+    public void testSymmetricAlgorithmWithPrivateKey() {
+        var ex = assertThrows(ConfigurationException.class,
+                () -> verifyTokenDecryptionAlgorithm(config(A256GCMKW), true));
+        assertEquals("Tenant tenant-a requires the A256GCMKW token decryption algorithm"
+                + " but a private decryption key is configured", ex.getMessage());
+    }
+
+    private static OidcTenantConfig config(DecryptionAlgorithm decryptionAlgorithm) {
+        return OidcTenantConfig.builder().tenantId("tenant-a")
+                .token().decryptionAlgorithm(decryptionAlgorithm).end()
+                .build();
+    }
+}

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowEncryptedIdTokenResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowEncryptedIdTokenResource.java
@@ -32,6 +32,13 @@ public class CodeFlowEncryptedIdTokenResource {
 
     @GET
     @Authenticated
+    @Path("/code-flow-encrypted-id-token-rsa-oaep-256")
+    public String accessRsaOaep256() {
+        return "user: " + idToken.getName();
+    }
+
+    @GET
+    @Authenticated
     @Path("/code-flow-encrypted-id-token-disabled")
     public String idTokenDecryptionDisabled() {
         throw new RuntimeException("ID token decryption disabled");

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -86,6 +86,15 @@ quarkus.oidc.code-flow-encrypted-id-token-pem.token-path=encrypted-id-token
 quarkus.oidc.code-flow-encrypted-id-token-pem.token.decryption-key-location=privateKey.pem
 quarkus.oidc.code-flow-encrypted-id-token-pem.token.audience=any
 
+quarkus.oidc.code-flow-encrypted-id-token-rsa-oaep-256.auth-server-url=${keycloak.url:replaced-by-test-resource}/realms/quarkus/
+quarkus.oidc.code-flow-encrypted-id-token-rsa-oaep-256.client-id=quarkus-web-app
+quarkus.oidc.code-flow-encrypted-id-token-rsa-oaep-256.credentials.secret=secret
+quarkus.oidc.code-flow-encrypted-id-token-rsa-oaep-256.application-type=web-app
+quarkus.oidc.code-flow-encrypted-id-token-rsa-oaep-256.token-path=rsa-oaep-256-encrypted-id-token
+quarkus.oidc.code-flow-encrypted-id-token-rsa-oaep-256.token.decryption-key-location=privateKey.pem
+quarkus.oidc.code-flow-encrypted-id-token-rsa-oaep-256.token.decryption-algorithm=RSA-OAEP-256
+quarkus.oidc.code-flow-encrypted-id-token-rsa-oaep-256.token.audience=any
+
 quarkus.oidc.code-flow-encrypted-id-token-disabled.auth-server-url=${keycloak.url:replaced-by-test-resource}/realms/quarkus/
 quarkus.oidc.code-flow-encrypted-id-token-disabled.client-id=quarkus-web-app
 quarkus.oidc.code-flow-encrypted-id-token-disabled.credentials.secret=secret

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -201,6 +201,11 @@ public class CodeFlowAuthorizationTest {
         doTestCodeFlowEncryptedIdToken("code-flow-encrypted-id-token-pem", KeyEncryptionAlgorithm.A256GCMKW);
     }
 
+    @Test
+    public void testCodeFlowEncryptedIdTokenRsaOaep256() throws IOException {
+        doTestCodeFlowEncryptedIdToken("code-flow-encrypted-id-token-rsa-oaep-256", KeyEncryptionAlgorithm.A256GCMKW);
+    }
+
     private void doTestCodeFlowEncryptedIdToken(String tenant, KeyEncryptionAlgorithm alg) throws IOException {
         try (final WebClient webClient = createWebClient()) {
             webClient.getOptions().setRedirectEnabled(true);

--- a/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
+++ b/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
@@ -33,6 +33,7 @@ import com.github.tomakehurst.wiremock.extension.TemplateHelperProviderExtension
 import com.google.common.collect.ImmutableSet;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.smallrye.jwt.algorithm.KeyEncryptionAlgorithm;
 import io.smallrye.jwt.build.Jwt;
 import io.smallrye.jwt.build.JwtClaimsBuilder;
 import wiremock.com.github.jknack.handlebars.Helper;
@@ -161,6 +162,7 @@ public class OidcWiremockTestResource implements QuarkusTestResourceLifecycleMan
         // Code Flow Authorization Mock
         defineCodeFlowAuthorizationMockTokenStub();
         defineCodeFlowAuthorizationMockEncryptedTokenStub();
+        defineCodeFlowAuthorizationMockRsaOaep256EncryptedTokenStub();
 
         //JWT bearer token grant
         defineJwtBearerGrantTokenStub();
@@ -363,11 +365,31 @@ public class OidcWiremockTestResource implements QuarkusTestResourceLifecycleMan
                                 "}")));
     }
 
+    private void defineCodeFlowAuthorizationMockRsaOaep256EncryptedTokenStub() {
+        server.stubFor(post("/auth/realms/quarkus/rsa-oaep-256-encrypted-id-token")
+                .withRequestBody(containing("authorization_code"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\n" +
+                                "  \"access_token\": \""
+                                + getAccessToken("alice", getAdminRoles()) + "\",\n" +
+                                "  \"refresh_token\": \"07e08903-1263-4dd1-9fd1-4a59b0db5283\",\n" +
+                                "  \"id_token\": \""
+                                + getEncryptedIdToken("alice", getAdminRoles(), "123456", KeyEncryptionAlgorithm.RSA_OAEP_256)
+                                + "\"\n" +
+                                "}")));
+    }
+
     public static String getEncryptedIdToken(String userName, Set<String> groups) {
         return getEncryptedIdToken(userName, groups, "123456");
     }
 
     public static String getEncryptedIdToken(String userName, Set<String> groups, String sub) {
+        return getEncryptedIdToken(userName, groups, sub, KeyEncryptionAlgorithm.RSA_OAEP);
+    }
+
+    public static String getEncryptedIdToken(String userName, Set<String> groups, String sub,
+            KeyEncryptionAlgorithm keyEncryptionAlgorithm) {
         return Jwt.preferredUserName(userName)
                 .groups(groups)
                 .issuer(TOKEN_ISSUER)
@@ -375,7 +397,9 @@ public class OidcWiremockTestResource implements QuarkusTestResourceLifecycleMan
                 .subject(sub)
                 .jws()
                 .keyId("1")
-                .innerSign("privateKey.jwk").encrypt("publicKey.jwk");
+                .innerSign("privateKey.jwk")
+                .keyAlgorithm(keyEncryptionAlgorithm)
+                .encrypt("publicKey.jwk");
     }
 
     public static X509Certificate getCertificate() {


### PR DESCRIPTION
Fixes #55763.

Awhile back we had the first request to support the case where an ID token returned from the provider was already encrypted, as allowed in the OIDC spec, and `RSA-OAEP` was the algorithm that was working back then to decrypt it for Quarkus to make any sense of it.

Much later, to support a case where `quarkus-oidc-proxy` encrypts access tokens before returning them to SPA, an option to also decrypt access tokens was added. At that point, one more algorithm, `A256GCMKW` was added to support a more effective encryption with the client secret serving as a symmetric key since `quarkus-oidc-proxy` has access to it.

In #55763, the user needs to support a stronger `RSA-OAEP-256` and has to go through having to write a custom OIDC response filter to decrypt the ID token which is not a great experience.

This PR introduces an optional token `DecryptionAlgorithm` property, that contains a restricted set of algorithms and will be expanded only based on the actual prod requirements, at the moment it only adds `RSA-OAEP-256` to the already supported `RSA-OAEP` and `A256GCMKW`.

It is a rather simple update that does not change any OIDC logic, if would be good to have it in LTS.

Once it is merged, I'll switch the default decryption algorithm for 4.0 from `RSA-OAEP` to `RSA-OAEP-256`, `RSA-OAEP` is a weak default option for RSA based encryption