### PR TITLE
[3.33] Bump to Vert.x 4.5.34

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -55,7 +55,7 @@
         <smallrye-context-propagation.version>2.3.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>3.21.6</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>3.23.1</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.33.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.7.9</smallrye-stork.version>
         <jakarta.activation.version>2.1.4</jakarta.activation.version>
@@ -110,7 +110,7 @@
         <wildfly-elytron.version>2.8.4.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.3.0</jboss-marshalling.version>
         <jboss-threads.version>3.9.2</jboss-threads.version>
-        <vertx.version>4.5.32</vertx.version>
+        <vertx.version>4.5.34</vertx.version>
         <httpclient5.version>5.5.2</httpclient5.version>
         <httpcore5.version>5.3.6</httpcore5.version>
         <httpclient.version>4.5.14</httpclient.version>
@@ -132,7 +132,8 @@
         <junit.jupiter.version>6.0.3</junit.jupiter.version>
         <infinispan.version>16.0.13</infinispan.version>
         <infinispan.protostream.version>6.0.7</infinispan.protostream.version>
-        <caffeine.version>3.2.3</caffeine.version>
+        <caffeine.version>3.2.4</caffeine.version>
+        <netty-tcnative.version>2.0.81.Final</netty-tcnative.version>
         <netty.version>4.1.137.Final</netty.version>
         <brotli4j.version>1.23.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
@@ -408,6 +409,11 @@
                 <version>${vertx.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-codegen</artifactId>
+                <version>${vertx.version}</version>
             </dependency>
 
             <!-- gRPC dependencies, imported as a BOM -->

--- a/extensions/micrometer/runtime/pom.xml
+++ b/extensions/micrometer/runtime/pom.xml
@@ -28,6 +28,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http</artifactId>
+    </dependency>
+
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- Needed for the JSON meter registry -->
@@ -45,7 +51,7 @@
             <artifactId>slf4j-jboss-logmanager</artifactId>
         </dependency>
 
-        <!-- Registry providers (optional) -->
+    <!-- Registry providers (optional) -->
 
         <dependency>
             <groupId>io.micrometer</groupId>

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/VertxUtilTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/VertxUtilTest.java
@@ -10,7 +10,6 @@ import javax.security.cert.X509Certificate;
 import org.junit.jupiter.api.Test;
 
 import io.netty.handler.codec.DecoderResult;
-import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -110,7 +109,7 @@ class VertxUtilTest {
             }
 
             @Override
-            public @Nullable String scheme() {
+            public String scheme() {
                 return "";
             }
 
@@ -120,27 +119,27 @@ class VertxUtilTest {
             }
 
             @Override
-            public @Nullable String path() {
+            public String path() {
                 return "";
             }
 
             @Override
-            public @Nullable String query() {
+            public String query() {
                 return "";
             }
 
             @Override
-            public @Nullable HostAndPort authority() {
+            public HostAndPort authority() {
                 return null;
             }
 
             @Override
-            public @Nullable HostAndPort authority(boolean b) {
+            public HostAndPort authority(boolean b) {
                 return null;
             }
 
             @Override
-            public @Nullable String host() {
+            public String host() {
                 return "";
             }
 
@@ -217,7 +216,7 @@ class VertxUtilTest {
             }
 
             @Override
-            public HttpServerRequest uploadHandler(@Nullable Handler<HttpServerFileUpload> uploadHandler) {
+            public HttpServerRequest uploadHandler(Handler<HttpServerFileUpload> uploadHandler) {
                 return null;
             }
 
@@ -227,7 +226,7 @@ class VertxUtilTest {
             }
 
             @Override
-            public @Nullable String getFormAttribute(String attributeName) {
+            public String getFormAttribute(String attributeName) {
                 return "";
             }
 
@@ -262,12 +261,12 @@ class VertxUtilTest {
             }
 
             @Override
-            public @Nullable Cookie getCookie(String name) {
+            public Cookie getCookie(String name) {
                 return null;
             }
 
             @Override
-            public @Nullable Cookie getCookie(String name, String domain, String path) {
+            public Cookie getCookie(String name, String domain, String path) {
                 return null;
             }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/ObservableRedis.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/ObservableRedis.java
@@ -2,7 +2,6 @@ package io.quarkus.redis.runtime.client;
 
 import java.util.List;
 
-import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -47,7 +46,7 @@ public class ObservableRedis implements Redis {
     }
 
     @Override
-    public Redis send(Request command, Handler<AsyncResult<@Nullable Response>> onSend) {
+    public Redis send(Request command, Handler<AsyncResult<Response>> onSend) {
         long begin = System.nanoTime();
         redis.send(command, ar -> {
             report(System.nanoTime() - begin, ar.succeeded());
@@ -57,7 +56,7 @@ public class ObservableRedis implements Redis {
     }
 
     @Override
-    public Redis batch(List<Request> commands, Handler<AsyncResult<List<@Nullable Response>>> onSend) {
+    public Redis batch(List<Request> commands, Handler<AsyncResult<List<Response>>> onSend) {
         long begin = System.nanoTime();
         redis.batch(commands, ar -> {
             report(System.nanoTime() - begin, ar.succeeded());
@@ -106,7 +105,7 @@ public class ObservableRedis implements Redis {
         }
 
         @Override
-        public RedisConnection handler(@Nullable Handler<Response> handler) {
+        public RedisConnection handler(Handler<Response> handler) {
             delegate.handler(handler);
             return this;
         }
@@ -130,7 +129,7 @@ public class ObservableRedis implements Redis {
         }
 
         @Override
-        public RedisConnection endHandler(@Nullable Handler<Void> endHandler) {
+        public RedisConnection endHandler(Handler<Void> endHandler) {
             delegate.endHandler(endHandler);
             return this;
         }

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -56,10 +56,10 @@
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
 
         <mutiny.version>3.3.0</mutiny.version>
-        <smallrye-mutiny-vertx-core.version>3.23.0</smallrye-mutiny-vertx-core.version>
+        <smallrye-mutiny-vertx-core.version>3.23.1</smallrye-mutiny-vertx-core.version>
         <smallrye-common.version>2.19.0</smallrye-common.version>
-        <vertx.version>4.5.32</vertx.version>
-        <rest-assured.version>6.0.0</rest-assured.version>
+        <vertx.version>4.5.34</vertx.version>
+        <rest-assured.version>6.0.1</rest-assured.version>
         <commons-logging-jboss-logging.version>2.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.21.4</jackson-bom.version>
         <smallrye-stork.version>2.7.9</smallrye-stork.version>

--- a/independent-projects/vertx-utils/pom.xml
+++ b/independent-projects/vertx-utils/pom.xml
@@ -17,8 +17,8 @@
     <description>Ancillary classes for making third party frameworks to run on top of Vert.x</description>
 
     <properties>
-        <jboss-logging.version>3.6.2.Final</jboss-logging.version>
-        <vertx.version>4.5.32</vertx.version>
+        <jboss-logging.version>3.6.3.Final</jboss-logging.version>
+        <vertx.version>4.5.34</vertx.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Also bumped:

- Mutiny Vert.x bindings 3.23.1
- Netty 4.1.138.Final
- Netty tcnative 2.0.84.Final

See the following link for the CVEs fixed in Netty: https://netty.io/news/2026/09/09/4-1-138-Final.html

I had to fix vertx-codegen issues:

- usage of annotations for no reason
- missing dependency for compilation purposes (quarkus-micrometer)

