### PR TITLE
Abort the response when an InputStream entity fails after the headers were written

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/providers/InputStreamResponseErrorTestCase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/providers/InputStreamResponseErrorTestCase.java
@@ -1,0 +1,144 @@
+package io.quarkus.resteasy.reactive.server.test.providers;
+
+import static io.restassured.RestAssured.get;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClosedException;
+import io.vertx.core.http.HttpMethod;
+
+public class InputStreamResponseErrorTestCase {
+
+    private static final long LARGE_SIZE = 2L * 1024 * 1024 * 1024;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(Resource.class, GeneratedInputStream.class));
+
+    @TestHTTPResource
+    URL url;
+
+    private Vertx vertx;
+    private HttpClient client;
+
+    @BeforeEach
+    void setUp() {
+        vertx = Vertx.vertx();
+        client = vertx.createHttpClient();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        client.close().toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+        vertx.close().toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void streamLargerThanTheHeapIsFullyWritten() throws Exception {
+        AtomicLong received = new AtomicLong();
+        download("/input-stream?size=" + LARGE_SIZE, received).get(2, TimeUnit.MINUTES);
+        assertThat(received.get()).isEqualTo(LARGE_SIZE);
+    }
+
+    @Test
+    void failureAfterTheHeadersAbortsTheResponse() {
+        AtomicLong received = new AtomicLong();
+        CompletableFuture<Void> result = download("/input-stream?size=" + LARGE_SIZE + "&failAt=" + LARGE_SIZE / 2,
+                received);
+
+        assertThatThrownBy(() -> result.get(2, TimeUnit.MINUTES))
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(HttpClosedException.class);
+        assertThat(received.get()).isLessThan(LARGE_SIZE);
+    }
+
+    @Test
+    void failureBeforeTheHeadersReturnsServerError() {
+        get("/input-stream?size=1024&failAt=10")
+                .then()
+                .statusCode(500);
+    }
+
+    private CompletableFuture<Void> download(String uri, AtomicLong received) {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        client.request(HttpMethod.GET, url.getPort(), url.getHost(), uri)
+                .onFailure(result::completeExceptionally)
+                .onSuccess(request -> request.connect()
+                        .onFailure(result::completeExceptionally)
+                        .onSuccess(response -> {
+                            response.request().connection().closeHandler(
+                                    v -> result.completeExceptionally(new HttpClosedException("Connection was closed")));
+                            response.exceptionHandler(result::completeExceptionally);
+                            response.handler(buffer -> received.addAndGet(buffer.length()));
+                            response.endHandler(v -> result.complete(null));
+                        }));
+        return result;
+    }
+
+    @Path("input-stream")
+    public static class Resource {
+
+        @GET
+        public Response get(@QueryParam("size") long size, @QueryParam("failAt") @DefaultValue("-1") long failAt) {
+            return Response.ok(new GeneratedInputStream(size, failAt), MediaType.APPLICATION_OCTET_STREAM_TYPE).build();
+        }
+    }
+
+    public static class GeneratedInputStream extends InputStream {
+
+        private final long size;
+        private final long failAt;
+        private long position;
+
+        public GeneratedInputStream(long size, long failAt) {
+            this.size = size;
+            this.failAt = failAt;
+        }
+
+        @Override
+        public int read() throws IOException {
+            byte[] b = new byte[1];
+            return read(b, 0, 1) == -1 ? -1 : b[0] & 0xFF;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            if (position == size) {
+                return -1;
+            }
+            if (position == failAt) {
+                throw new IOException("Failure while reading the entity");
+            }
+            long limit = failAt >= 0 ? Math.min(size, failAt) : size;
+            int n = (int) Math.min(len, limit - position);
+            Arrays.fill(b, off, off + n, (byte) 'a');
+            position += n;
+            return n;
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerInputStreamMessageBodyHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerInputStreamMessageBodyHandler.java
@@ -2,6 +2,7 @@ package org.jboss.resteasy.reactive.server.providers.serialisers;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
@@ -9,6 +10,7 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.resteasy.reactive.common.providers.serialisers.InputStreamMessageBodyHandler;
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
@@ -43,6 +45,25 @@ public class ServerInputStreamMessageBodyHandler extends InputStreamMessageBodyH
     @Override
     public void writeResponse(InputStream is, Type genericType, ServerRequestContext context)
             throws WebApplicationException, IOException {
-        writeTo(is, context.getOrCreateOutputStream());
+        OutputStream entityStream = context.getOrCreateOutputStream();
+        try {
+            try {
+                is.transferTo(entityStream);
+            } finally {
+                try {
+                    is.close();
+                } catch (IOException e) {
+                    // Drop the exception so we don't mask real IO errors
+                }
+            }
+        } catch (Throwable t) {
+            if (context.serverResponse().headWritten()) {
+                context.serverResponse().reset();
+                ((ResteasyReactiveRequestContext) context).resume(t);
+                return;
+            }
+            throw t;
+        }
+        entityStream.close();
     }
 }


### PR DESCRIPTION
When a resource returns an `InputStream` entity and reading it fails part way, the client receives a complete-looking response: HTTP 1.1 ends with the terminating chunk, so a download that stopped after 100 MB is indistinguishable from a successful one. `ServerInputStreamMessageBodyHandler` delegates to `InputStreamMessageBodyHandler.writeTo`, which closes the entity stream in a `finally` block, as kottmann pointed out in the issue; closing the response output stream ends the HTTP response, so by the time the exception is handled the response is already over and nothing resets the connection.

`StreamingOutput` had the same problem and got a fix in [f2542913b69](https://github.com/quarkusio/quarkus/commit/f2542913b69cdaec0a3ab98f3c13d78d91e73df0) (#50754). The `InputStream` writer now does the same: it copies the stream itself and always closes the input; if the copy fails once the headers are written, it resets the response and resumes the request with the failure, otherwise it rethrows it. The entity stream is only closed on success. The shared `InputStreamMessageBodyHandler`, which the REST Client also uses, is unchanged.

One visible difference: a failure before anything has been flushed now produces the usual error response (500 without a mapper) instead of a 200 with a partial body, which is also what `StreamingOutput` does.

`InputStreamResponseErrorTestCase` (rest deployment) streams 2 GB, more than the heap of the test JVM, and counts the bytes on a Vert.x client without retaining them: a successful download, a stream failing after 1 GB, which must close the connection, and a stream failing after 10 bytes, which must return 500. Without the change the two failure cases fail (the 1 GB body ends normally, the early failure returns 200). With the reporter's reproducer on current `main`, `curl` exits 0 after about 101 MB when the stream throws; with the change it exits 18 (transfer closed with outstanding read data remaining), and the download without an error still delivers the full 438,888,890 bytes. `rest/deployment` (1384) and `resteasy-reactive/server/vertx` (397) are green.

- Fixes: #40288
