### PR TITLE
Bump aesh 3.18.0, add pipeline stage results, lazy runtime startup

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -204,8 +204,8 @@
         <!-- Check the compatibility matrix (https://github.com/opensearch-project/opensearch-testcontainers) before upgrading: -->
         <opensearch-testcontainers.version>2.1.3</opensearch-testcontainers.version>
         <com.dajudge.kindcontainer>2.1.0</com.dajudge.kindcontainer>
-        <aesh.version>3.17.5</aesh.version>
-        <aesh-readline.version>3.17.2</aesh-readline.version>
+        <aesh.version>3.18.0</aesh.version>
+        <aesh-readline.version>3.18.0</aesh-readline.version>
         <jline.version>4.2.1</jline.version> <!-- Keep in sync with dekorate -->
         <!-- these two artifacts needs to be compatible together -->
         <strimzi-oauth.version>0.16.1</strimzi-oauth.version>

--- a/docs/src/main/asciidoc/aesh.adoc
+++ b/docs/src/main/asciidoc/aesh.adoc
@@ -1216,6 +1216,62 @@ launcher.execute("setup", ExecuteOptions.defaults().input("admin", "password123"
 For more complex interactive scenarios, `sendInput()` provides low-level
 access to the REPL's stdin:
 
+==== Pipeline commands
+
+Aesh supports Unix-style pipe operators (`cmd1 | cmd2`). When testing pipeline
+commands, `getStageResults()` returns per-stage outcomes so you can inspect
+each stage independently -- including upstream failures that Unix semantics
+would otherwise hide (only the last stage's exit code is returned).
+
+[source,java]
+----
+@Test
+void testPipelineStages(AeshLauncher launcher) {
+    launcher.execute("echo --text hello | upper");
+
+    // Terminal stage output
+    assertThat(launcher.getCommandOutput()).isEqualTo("HELLO\n");
+
+    // Per-stage results
+    List<StageResult> stages = launcher.getStageResults();
+    assertThat(stages).hasSize(2);
+
+    assertThat(stages.get(0).commandName()).isEqualTo("EchoCommand");
+    assertThat(stages.get(0).isSuccess()).isTrue();
+
+    assertThat(stages.get(1).commandName()).isEqualTo("UpperCommand");
+    assertThat(stages.get(1).isSuccess()).isTrue();
+}
+----
+
+For non-pipeline (single) commands, `getStageResults()` returns an empty list.
+
+Upstream failures are visible even when the terminal stage succeeds:
+
+[source,java]
+----
+@Test
+void testUpstreamFailure(AeshLauncher launcher) {
+    // failpipe throws after writing partial output — terminal still succeeds
+    launcher.execute("failpipe | upper");
+
+    StageResult upstream = launcher.getStageResults().get(0);
+    assertThat(upstream.isSuccess()).isFalse();
+    assertThat(upstream.errorMessage()).contains("upstream boom");
+
+    StageResult terminal = launcher.getStageResults().get(1);
+    assertThat(terminal.isSuccess()).isTrue();
+}
+----
+
+Each `StageResult` carries:
+
+* `commandName()` -- the command's simple class name
+* `stageIndex()` / `stageCount()` -- position in the pipeline
+* `exitCode()` / `isSuccess()` -- the stage's result
+* `errorMessage()` / `errorClass()` -- error details if the stage failed
+* `durationMs()` -- wall-clock execution time
+
 ==== AeshLauncher API summary
 
 * `execute(String command)` -- executes and asserts `SUCCESS`
@@ -1224,6 +1280,7 @@ access to the REPL's stdin:
 * `sendInput(String input)` -- send raw input for interactive commands
 * `getCommandOutput()` -- clean output from the last command
 * `getOutput()` / `resetOutput()` -- accumulated command output
+* `getStageResults()` -- per-stage results for pipeline commands (empty for single commands)
 * `getLastExitCode()` -- exit code from the last command
 * `getLastError()` / `getErrorOutput()` -- exception from the last failed command
 * `isRunning()` / `waitForExit(Duration)` -- REPL lifecycle state

--- a/extensions/aesh/README.md
+++ b/extensions/aesh/README.md
@@ -409,3 +409,14 @@ The REPL auto-launches on the first `execute()` call and auto-closes after each 
 launcher.execute("slow-cmd", ExecuteOptions.defaults().timeout(Duration.ofMinutes(2)));
 ```
 
+For pipeline commands (`cmd1 | cmd2`), `getStageResults()` returns per-stage outcomes:
+
+```java
+launcher.execute("echo --text hello | upper");
+assertThat(launcher.getCommandOutput()).isEqualTo("HELLO\n");
+assertThat(launcher.getStageResults()).hasSize(2);
+assertThat(launcher.getStageResults().get(0).isSuccess()).isTrue();
+```
+
+Each `StageResult` carries the command's simple class name, stage index/count, exit code, error details (`errorMessage()`/`errorClass()`), and duration. For non-pipeline (single) commands, `getStageResults()` returns an empty list.
+

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/AeshContextTest.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/AeshContextTest.java
@@ -45,12 +45,19 @@ public class AeshContextTest {
 
     @Test
     public void testAeshContextMode() {
-        // With multiple commands + commands, should resolve to console mode
+        // With multiple independent commands, should resolve to console mode
         AeshMode mode = aeshContext.getMode();
         Assertions.assertThat(mode).isNotNull();
         Assertions.assertThat(mode).isNotEqualTo(AeshMode.auto);
-        // With commands and multiple commands, should be console mode
         Assertions.assertThat(mode).isEqualTo(AeshMode.console);
+    }
+
+    @Test
+    public void testTopCommandNullInConsoleMode() {
+        // Console mode should not have a top command set
+        Assertions.assertThat(aeshContext.getTopCommandClassName())
+                .as("Top command should be null in console mode")
+                .isNull();
     }
 
     @Test

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/AutoRuntimeModeDetectionTest.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/AutoRuntimeModeDetectionTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.aesh.deployment;
+
+import jakarta.inject.Inject;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.option.Option;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.aesh.runtime.AeshContext;
+import io.quarkus.aesh.runtime.AeshMode;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies that {@code quarkus.aesh.mode=auto} (the default) with exactly one
+ * root command resolves to runtime mode and sets the top command class name.
+ * No explicit mode override — relies on auto-detection.
+ */
+public class AutoRuntimeModeDetectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClass(SingleCommand.class))
+            .overrideConfigKey("quarkus.aesh.mode", "auto");
+
+    @Inject
+    AeshContext aeshContext;
+
+    @Test
+    public void testSingleCommandAutoDetectsRuntimeMode() {
+        Assertions.assertThat(aeshContext.getMode())
+                .as("Single command should auto-detect as runtime mode")
+                .isEqualTo(AeshMode.runtime);
+    }
+
+    @Test
+    public void testTopCommandClassNameSet() {
+        Assertions.assertThat(aeshContext.getTopCommandClassName())
+                .as("Top command class name should be set in runtime mode")
+                .isEqualTo(SingleCommand.class.getName());
+    }
+
+    @CommandDefinition(name = "single", description = "A single command")
+    public static class SingleCommand implements Command<CommandInvocation> {
+
+        @Option(name = "name", defaultValue = "World")
+        String name;
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("Hello " + name + "!");
+            return CommandResult.SUCCESS;
+        }
+    }
+}

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/AutoRuntimeModeGroupDetectionTest.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/AutoRuntimeModeGroupDetectionTest.java
@@ -1,0 +1,79 @@
+package io.quarkus.aesh.deployment;
+
+import jakarta.inject.Inject;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.option.Option;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.aesh.runtime.AeshContext;
+import io.quarkus.aesh.runtime.AeshMode;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies that {@code quarkus.aesh.mode=auto} (the default) with a single
+ * group command that covers all subcommands resolves to runtime mode.
+ * The group command should be detected as the top command.
+ */
+public class AutoRuntimeModeGroupDetectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(
+                    AppCommand.class,
+                    RunSubCommand.class,
+                    BuildSubCommand.class))
+            .overrideConfigKey("quarkus.aesh.mode", "auto");
+
+    @Inject
+    AeshContext aeshContext;
+
+    @Test
+    public void testGroupCoveringAllAutoDetectsRuntimeMode() {
+        Assertions.assertThat(aeshContext.getMode())
+                .as("Group covering all subcommands should auto-detect as runtime mode")
+                .isEqualTo(AeshMode.runtime);
+    }
+
+    @Test
+    public void testTopCommandIsGroupCommand() {
+        Assertions.assertThat(aeshContext.getTopCommandClassName())
+                .as("Top command should be the group command")
+                .isEqualTo(AppCommand.class.getName());
+    }
+
+    @CommandDefinition(name = "app", description = "App CLI", groupCommands = { RunSubCommand.class, BuildSubCommand.class })
+    public static class AppCommand implements Command<CommandInvocation> {
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("app root");
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(name = "run", description = "Run the app")
+    public static class RunSubCommand implements Command<CommandInvocation> {
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("running");
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(name = "build", description = "Build the app")
+    public static class BuildSubCommand implements Command<CommandInvocation> {
+        @Option(name = "target", defaultValue = "jar")
+        String target;
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("building " + target);
+            return CommandResult.SUCCESS;
+        }
+    }
+}

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/LazyStartupVerificationTest.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/LazyStartupVerificationTest.java
@@ -1,0 +1,132 @@
+package io.quarkus.aesh.deployment;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.inject.Inject;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.invocation.CommandInvocation;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Verifies that aesh lazy startup works on the Quarkus runtime path:
+ * when running a single subcommand of a group command, only the selected
+ * path is constructed — the unselected sibling is never instantiated.
+ * <p>
+ * Each command class has a static construction counter that increments in its
+ * constructor. The test runs {@code app run} and asserts that {@code AppCmd}
+ * and {@code RunCmd} were constructed but {@code BuildCmd} was not.
+ * {@code RunCmd} also injects a CDI bean to prove injection works when the
+ * command is constructed lazily during {@code execute()}.
+ * <p>
+ * The counters are reported via the command's output so they survive the
+ * prod-mode process boundary. Note the test is limited to one subcommand:
+ * the prod-mode app boots once per test class, so a second subcommand
+ * would need its own test class.
+ */
+public class LazyStartupVerificationTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot(jar -> jar.addClasses(
+                    AppCmd.class,
+                    RunCmd.class,
+                    BuildCmd.class,
+                    GreetingService.class))
+            .setApplicationName("lazy-startup-app")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setExpectExit(true)
+            .setRun(true)
+            .setCommandLineParameters("run");
+
+    @Test
+    public void testOnlySelectedSubcommandConstructed() {
+        String output = config.getStartupConsoleOutput();
+        Assertions.assertThat(config.getExitCode()).isZero();
+
+        // AppCmd (top command) should have been constructed during execute()
+        Assertions.assertThat(output)
+                .as("AppCmd should be constructed")
+                .contains("app:constructed=1");
+
+        // RunCmd should have been constructed (counter = 1)
+        Assertions.assertThat(output)
+                .as("RunCmd should be constructed")
+                .contains("run:constructed=1");
+
+        // BuildCmd should NOT have been constructed (counter = 0)
+        Assertions.assertThat(output)
+                .as("BuildCmd should not be constructed (lazy startup)")
+                .contains("build:constructed=0");
+    }
+
+    @Test
+    public void testCdiInjectionOnLazyPath() {
+        Assertions.assertThat(config.getStartupConsoleOutput())
+                .as("CDI injection should work for lazily constructed commands")
+                .contains("Hello Lazy from CDI!");
+        Assertions.assertThat(config.getExitCode()).isZero();
+    }
+
+    @CommandDefinition(name = "app", description = "App with lazy subcommands", groupCommands = { RunCmd.class,
+            BuildCmd.class })
+    public static class AppCmd implements Command<CommandInvocation> {
+        static final AtomicInteger constructionCount = new AtomicInteger();
+
+        public AppCmd() {
+            constructionCount.incrementAndGet();
+        }
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("app:constructed=" + constructionCount.get());
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(name = "run", description = "Run subcommand")
+    public static class RunCmd implements Command<CommandInvocation> {
+        static final AtomicInteger constructionCount = new AtomicInteger();
+
+        @Inject
+        GreetingService greetingService;
+
+        public RunCmd() {
+            constructionCount.incrementAndGet();
+        }
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println(greetingService.greet("Lazy"));
+            // The top command is constructed during execute() but its own
+            // execute() is not invoked for subcommand runs, so its counter
+            // is reported from here.
+            invocation.println("app:constructed=" + AppCmd.constructionCount.get());
+            invocation.println("run:constructed=" + constructionCount.get());
+            invocation.println("build:constructed=" + BuildCmd.constructionCount.get());
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(name = "build", description = "Build subcommand")
+    public static class BuildCmd implements Command<CommandInvocation> {
+        static final AtomicInteger constructionCount = new AtomicInteger();
+
+        public BuildCmd() {
+            constructionCount.incrementAndGet();
+        }
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("build:constructed=" + constructionCount.get());
+            invocation.println("run:constructed=" + RunCmd.constructionCount.get());
+            return CommandResult.SUCCESS;
+        }
+    }
+}

--- a/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/AeshStreamConnection.java
+++ b/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/AeshStreamConnection.java
@@ -115,6 +115,13 @@ class AeshStreamConnection extends AbstractConnection {
         return false;
     }
 
+    @Override
+    public boolean isInteractive() {
+        // Report as interactive so aesh does not switch to synchronous mode.
+        // The test framework simulates an interactive session via piped streams.
+        return true;
+    }
+
     private void startReader() {
         if (readerThread != null) {
             return;

--- a/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/CliRunner.java
+++ b/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/CliRunner.java
@@ -4,7 +4,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import jakarta.enterprise.context.Dependent;
@@ -16,6 +19,9 @@ import org.aesh.command.CommandExecutionListener;
 import org.aesh.command.CommandNotFoundHandler;
 import org.aesh.command.CommandResult;
 import org.aesh.command.CommandRuntime;
+import org.aesh.command.PipelineExecutionListener;
+import org.aesh.command.PipelineResult;
+import org.aesh.command.StageOutcome;
 import org.aesh.command.impl.registry.AeshCommandRegistryBuilder;
 import org.aesh.command.settings.SubCommandModeSettings;
 import org.jboss.logging.Logger;
@@ -147,29 +153,104 @@ public class CliRunner implements QuarkusApplication {
         runner.connection(new AeshStreamConnection(testInput, testOutput));
 
         if (signalQueue != null) {
-            // Create a listener that composes user listener (if any) with
-            // test signal. Passes exit code and error through the signal
-            // queue as Object[] to cross the classloader boundary safely.
-            runner.commandExecutionListener(new CommandExecutionListener() {
+            // Create a PipelineExecutionListener that composes user listener
+            // (if any) with the test signal. Passes exit code, error, and
+            // stage data through the signal queue as Object[] to cross the
+            // classloader boundary safely.
+            //
+            // Event order from ProcessManager:
+            //   1. onStageComplete(stage[0]) .. onStageComplete(stage[N])
+            //   2. onPipelineComplete(result)
+            //   3. onCommandComplete(commandLine, result, durationMs, error)
+            //
+            // We collect stage snapshots in onPipelineComplete and include
+            // them in the signal sent by onCommandComplete.
+            runner.commandExecutionListener(new PipelineExecutionListener() {
+
+                // Collected per-pipeline, consumed by onCommandComplete.
+                // AtomicReference gives atomic read-and-clear. Event order
+                // (onPipelineComplete before onCommandComplete, same REPL thread)
+                // is guaranteed by ProcessManager.firePipelineEvents in aesh 3.18.0.
+                private final AtomicReference<List<Object[]>> pendingStages = new AtomicReference<>();
+
                 @Override
                 public void onCommandComplete(String commandLine, CommandResult result, long durationMs) {
-                    if (userListener != null) {
-                        userListener.onCommandComplete(commandLine, result, durationMs);
-                    }
+                    // The 3-arg form carries no error — forward to the 4-arg form
+                    // so the test signal is always sent.
+                    onCommandComplete(commandLine, result, durationMs, null);
                 }
 
                 @Override
                 public void onCommandComplete(String commandLine, CommandResult result,
                         long durationMs, Throwable error) {
-                    if (userListener != null) {
-                        userListener.onCommandComplete(commandLine, result, durationMs, error);
+                    // Take the stage snapshots first so a throwing user listener
+                    // cannot suppress the test signal.
+                    List<Object[]> stages = pendingStages.getAndSet(null);
+                    try {
+                        if (userListener != null) {
+                            userListener.onCommandComplete(commandLine, result, durationMs, error);
+                        }
+                    } finally {
+                        // Signal: {exitCode, error, stageData}
+                        // stageData is null for single commands, List<Object[]> for pipelines
+                        signalQueue.offer(new Object[] { result.getExitCode(), error, stages });
                     }
-                    signalQueue.offer(new Object[] { result.getExitCode(), error });
+                }
+
+                @Override
+                public void onStageComplete(StageOutcome stage) {
+                    if (userListener instanceof PipelineExecutionListener pel) {
+                        pel.onStageComplete(stage);
+                    }
+                }
+
+                @Override
+                public void onPipelineComplete(PipelineResult result) {
+                    // Snapshot before delegating so a throwing user listener
+                    // cannot suppress the stage data.
+                    pendingStages.set(snapshotStages(result));
+                    if (userListener instanceof PipelineExecutionListener pel) {
+                        pel.onPipelineComplete(result);
+                    }
                 }
             });
         } else if (userListener != null) {
             runner.commandExecutionListener(userListener);
         }
+    }
+
+    /**
+     * Converts pipeline stage outcomes to classloader-safe snapshots.
+     * Each entry is {@code Object[] {commandName, stageIndex, stageCount,
+     * exitCode, errorMessage, errorClass, durationMs}} — primitives and
+     * Strings only, safe to pass through the signal queue.
+     * <p>
+     * Returns {@code null} when there is no pipeline data (null result,
+     * null/empty stage list, or a single stage) so single commands report
+     * no stage results. Null stages are skipped defensively.
+     */
+    static List<Object[]> snapshotStages(PipelineResult result) {
+        if (result == null || result.stages() == null || result.stages().size() <= 1) {
+            return null;
+        }
+        List<StageOutcome> stages = result.stages();
+        List<Object[]> snapshots = new ArrayList<>(stages.size());
+        for (StageOutcome stage : stages) {
+            if (stage == null || stage.result() == null) {
+                continue;
+            }
+            Throwable stageError = stage.error();
+            snapshots.add(new Object[] {
+                    stage.commandName(),
+                    stage.stageIndex(),
+                    stage.stageCount(),
+                    stage.result().getExitCode(),
+                    stageError != null ? stageError.getMessage() : null,
+                    stageError != null ? stageError.getClass().getName() : null,
+                    stage.durationMs()
+            });
+        }
+        return snapshots;
     }
 
     /**

--- a/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/DefaultAeshRuntimeRunnerFactory.java
+++ b/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/DefaultAeshRuntimeRunnerFactory.java
@@ -5,14 +5,21 @@ import jakarta.enterprise.inject.Instance;
 
 import org.aesh.AeshRuntimeRunner;
 import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
 import org.aesh.command.DefaultValueProvider;
-
-import io.quarkus.arc.Arc;
 
 /**
  * Default implementation of AeshRuntimeRunnerFactory that resolves the top command
  * from the build-time detected top command class name (via {@link AeshContext})
  * or from the {@code quarkus.aesh.top-command} config property.
+ * <p>
+ * The top command is passed to {@link AeshRuntimeRunner} as a {@link Class},
+ * not a pre-constructed instance. With aesh lazy startup (the default), the
+ * command is constructed during {@code execute()} via
+ * {@link AeshCdiCommandContainerBuilder}, which resolves CDI beans. This means
+ * construction failures (missing constructor, invalid definition) surface at
+ * execution time rather than at factory creation time — only class loading
+ * and structural validation happen eagerly here.
  */
 @ApplicationScoped
 public class DefaultAeshRuntimeRunnerFactory implements AeshRuntimeRunnerFactory {
@@ -35,15 +42,21 @@ public class DefaultAeshRuntimeRunnerFactory implements AeshRuntimeRunnerFactory
     @Override
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public AeshRuntimeRunner create() {
-        Command<?> commandInstance = resolveTopCommand();
-        if (commandInstance != null) {
+        Class<? extends Command> commandClass = resolveTopCommandClass();
+        if (commandClass != null) {
             // Build settings with customizers applied so that custom providers
             // (e.g. CommandInvocationProvider) are available for runtime execution.
             var settings = CliSettingsHelper.createBaseSettings(configuration, customizers).build();
 
+            // Pass the Class rather than a pre-constructed instance.
+            // AeshRuntimeRunner defers construction to execute() when
+            // lazyStartup is true (the default), so the command and its
+            // subcommands are only instantiated when actually needed.
+            // The AeshCdiCommandContainerBuilder handles CDI lookup
+            // during materialization.
             AeshRuntimeRunner runner = AeshRuntimeRunner.builder()
                     .containerBuilder(new AeshCdiCommandContainerBuilder<>())
-                    .command(commandInstance);
+                    .command(commandClass);
             if (settings.commandInvocationProvider() != null) {
                 runner.commandInvocationProvider(
                         (org.aesh.command.invocation.CommandInvocationProvider<?>) settings.commandInvocationProvider());
@@ -65,36 +78,35 @@ public class DefaultAeshRuntimeRunnerFactory implements AeshRuntimeRunnerFactory
     }
 
     @SuppressWarnings("unchecked")
-    private Command<?> resolveTopCommand() {
+    private Class<? extends Command> resolveTopCommandClass() {
         // 1. Explicit config property overrides everything
         if (configuration.topCommand().isPresent()) {
             String topCommandName = configuration.topCommand().get();
-            return loadCommand(topCommandName);
+            return loadCommandClass(topCommandName);
         }
 
         // 2. Use the build-time detected top command
         String topClassName = aeshContext.getTopCommandClassName();
         if (topClassName != null) {
-            return loadCommand(topClassName);
+            return loadCommandClass(topClassName);
         }
 
         return null;
     }
 
     @SuppressWarnings("unchecked")
-    private Command<?> loadCommand(String className) {
+    private Class<? extends Command> loadCommandClass(String className) {
         try {
             Class<?> commandClass = Thread.currentThread().getContextClassLoader().loadClass(className);
             if (!Command.class.isAssignableFrom(commandClass)) {
                 throw new IllegalStateException(
                         "Top command must implement org.aesh.command.Command interface: " + className);
             }
-            var handle = Arc.container().instance(commandClass);
-            if (handle.isAvailable()) {
-                return (Command<?>) handle.get();
+            if (commandClass.getAnnotation(CommandDefinition.class) == null) {
+                throw new IllegalStateException(
+                        "Top command must have a @CommandDefinition annotation: " + className);
             }
-            // Not a CDI bean — fall back to direct instantiation
-            return (Command<?>) commandClass.getConstructor().newInstance();
+            return (Class<? extends Command>) commandClass;
         } catch (IllegalStateException e) {
             throw e;
         } catch (Exception e) {

--- a/integration-tests/aesh/src/main/java/io/quarkus/it/aesh/FailPipeCommand.java
+++ b/integration-tests/aesh/src/main/java/io/quarkus/it/aesh/FailPipeCommand.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.aesh;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.invocation.CommandInvocation;
+
+/**
+ * A pipe-friendly upstream command that writes a partial line then throws.
+ * Used to test that upstream pipeline failures are visible in stage results.
+ * <p>
+ * Named {@code failpipe} on the CLI to distinguish it from the existing
+ * {@code fail} command ({@code FailCommand}); the "partial" line flows
+ * downstream, so {@code failpipe | upper} outputs {@code PARTIAL}.
+ */
+@CommandDefinition(name = "failpipe", description = "Upstream that writes then fails")
+public class FailPipeCommand implements Command<CommandInvocation> {
+
+    @Override
+    public CommandResult execute(CommandInvocation invocation) throws CommandException {
+        invocation.println("partial");
+        throw new CommandException("upstream boom");
+    }
+}

--- a/integration-tests/aesh/src/main/java/io/quarkus/it/aesh/UpperCommand.java
+++ b/integration-tests/aesh/src/main/java/io/quarkus/it/aesh/UpperCommand.java
@@ -1,0 +1,38 @@
+package io.quarkus.it.aesh;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.invocation.CommandInvocation;
+
+/**
+ * A pipe-friendly command that reads stdin and prints each line in uppercase.
+ * Used for pipeline integration tests. Returns FAILURE (instead of silently
+ * succeeding) when stdin cannot be read, so terminal-stage failures are
+ * observable in stage results.
+ */
+@CommandDefinition(name = "upper", description = "Uppercase lines from stdin")
+public class UpperCommand implements Command<CommandInvocation> {
+
+    @Override
+    public CommandResult execute(CommandInvocation invocation) {
+        try {
+            java.io.InputStream stdin = invocation.getStdin();
+            if (stdin != null) {
+                BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(stdin, StandardCharsets.UTF_8));
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    invocation.println(line.toUpperCase());
+                }
+            }
+        } catch (Exception e) {
+            return CommandResult.FAILURE;
+        }
+        return CommandResult.SUCCESS;
+    }
+}

--- a/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/AeshLauncherApiTest.java
+++ b/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/AeshLauncherApiTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.aesh.AeshLauncher;
 import io.quarkus.test.aesh.ExecuteOptions;
+import io.quarkus.test.aesh.StageResult;
 import io.quarkus.test.junit.main.QuarkusMainTest;
 
 /**
@@ -213,5 +214,74 @@ public class AeshLauncherApiTest {
                 ExecuteOptions.expecting(CommandResult.FAILURE).input("n"));
         assertThat(launcher.getCommandOutput())
                 .contains("Cancelled: delete");
+    }
+
+    // --- Pipeline stage result tests ---
+
+    @Test
+    void singleCommandReturnsEmptyStageResults(AeshLauncher launcher) {
+        launcher.execute("hello --name=World");
+        assertThat(launcher.getStageResults()).isEmpty();
+    }
+
+    @Test
+    void pipelineReturnsStageResults(AeshLauncher launcher) {
+        launcher.execute("echo --text hello | upper");
+
+        assertThat(launcher.getStageResults())
+                .hasSize(2);
+
+        StageResult upstream = launcher.getStageResults().get(0);
+        assertThat(upstream.commandName()).isEqualTo("EchoCommand");
+        assertThat(upstream.stageIndex()).isZero();
+        assertThat(upstream.stageCount()).isEqualTo(2);
+        assertThat(upstream.isSuccess()).isTrue();
+        assertThat(upstream.exitCode()).isZero();
+        assertThat(upstream.errorMessage()).isNull();
+        assertThat(upstream.errorClass()).isNull();
+
+        StageResult terminal = launcher.getStageResults().get(1);
+        assertThat(terminal.stageIndex()).isEqualTo(1);
+        assertThat(terminal.stageCount()).isEqualTo(2);
+        assertThat(terminal.isSuccess()).isTrue();
+
+        assertThat(launcher.getCommandOutput()).isEqualTo("HELLO\n");
+    }
+
+    @Test
+    void pipelineUpstreamFailureVisibleInStageResults(AeshLauncher launcher) {
+        // failpipe throws but the terminal (upper) still succeeds (Unix semantics):
+        // only the last stage's exit code is returned.
+        launcher.execute("failpipe | upper");
+
+        assertThat(launcher.getLastExitCode()).isZero();
+        assertThat(launcher.getLastError()).isNull();
+        // The partial line written before the failure flows downstream uppercased
+        assertThat(launcher.getCommandOutput()).isEqualTo("PARTIAL\n");
+
+        assertThat(launcher.getStageResults())
+                .hasSize(2);
+
+        StageResult upstream = launcher.getStageResults().get(0);
+        assertThat(upstream.commandName()).isEqualTo("FailPipeCommand");
+        assertThat(upstream.isSuccess()).isFalse();
+        assertThat(upstream.exitCode()).isEqualTo(CommandResult.FAILURE.getExitCode());
+        assertThat(upstream.errorMessage()).contains("upstream boom");
+        assertThat(upstream.errorClass()).contains("CommandException");
+
+        StageResult terminal = launcher.getStageResults().get(1);
+        assertThat(terminal.commandName()).isEqualTo("UpperCommand");
+        assertThat(terminal.isSuccess()).isTrue();
+    }
+
+    @Test
+    void stageResultsClearedBetweenCommands(AeshLauncher launcher) {
+        // First: pipeline command
+        launcher.execute("echo --text hello | upper");
+        assertThat(launcher.getStageResults()).hasSize(2);
+
+        // Second: single command — stages should be empty again
+        launcher.execute("hello --name=World");
+        assertThat(launcher.getStageResults()).isEmpty();
     }
 }

--- a/test-framework/aesh/src/main/java/io/quarkus/test/aesh/AeshLauncher.java
+++ b/test-framework/aesh/src/main/java/io/quarkus/test/aesh/AeshLauncher.java
@@ -1,6 +1,7 @@
 package io.quarkus.test.aesh;
 
 import java.time.Duration;
+import java.util.List;
 
 import org.aesh.command.CommandResult;
 
@@ -158,6 +159,22 @@ public interface AeshLauncher extends AutoCloseable {
      */
     default Throwable getLastError() {
         return null;
+    }
+
+    /**
+     * Returns the per-stage results of the last executed pipeline command.
+     * <p>
+     * For a pipeline command ({@code cmd1 | cmd2 | cmd3}), returns one
+     * {@link StageResult} per stage in pipeline order. For a non-pipeline
+     * (single) command, returns an empty list.
+     * <p>
+     * Each {@link StageResult} carries the command name, stage index,
+     * exit code, error info, and duration — all classloader-safe types.
+     *
+     * @return an unmodifiable list of stage results, empty for non-pipeline commands
+     */
+    default List<StageResult> getStageResults() {
+        return List.of();
     }
 
     /**

--- a/test-framework/aesh/src/main/java/io/quarkus/test/aesh/AeshLauncherImpl.java
+++ b/test-framework/aesh/src/main/java/io/quarkus/test/aesh/AeshLauncherImpl.java
@@ -6,6 +6,9 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -35,6 +38,7 @@ public class AeshLauncherImpl implements AeshLauncher {
     private volatile LaunchResult launchResult;
     private volatile int lastExitCode;
     private volatile Throwable lastError;
+    private volatile List<StageResult> lastStageResults = List.of();
     private volatile String lastCommandOutput;
     private final StringBuilder accumulatedOutput = new StringBuilder();
 
@@ -96,6 +100,7 @@ public class AeshLauncherImpl implements AeshLauncher {
         signalQueue.clear();
         lastExitCode = 0;
         lastError = null;
+        lastStageResults = List.of();
         lastCommandOutput = null;
 
         // Load pre-canned input responses into the queue for invocation.inputLine()
@@ -116,13 +121,19 @@ public class AeshLauncherImpl implements AeshLauncher {
                 throw new RuntimeException(
                         "Command '" + command + "' did not complete within " + options.timeout());
             }
-            // Extract exit code and error from the signal.
-            // The signal is Object[] { exitCode, error } from CliRunner.
-            if (signal instanceof Object[] arr) {
-                lastExitCode = (int) arr[0];
-                if (arr[1] instanceof Throwable t) {
-                    lastError = t;
-                }
+            // Extract exit code, error, and stage data from the signal.
+            // The signal is Object[] { exitCode, error, stageData } from CliRunner.
+            // stageData is null for single commands, List<Object[]> for pipelines.
+            if (!(signal instanceof Object[] arr) || arr.length < 2 || !(arr[0] instanceof Integer exitCode)) {
+                throw new RuntimeException(
+                        "Unexpected signal from REPL for command '" + command + "': " + signal);
+            }
+            lastExitCode = exitCode;
+            if (arr[1] instanceof Throwable t) {
+                lastError = t;
+            }
+            if (arr.length > 2 && arr[2] instanceof List<?> rawStages) {
+                lastStageResults = toStageResults(command, rawStages);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -193,6 +204,11 @@ public class AeshLauncherImpl implements AeshLauncher {
     }
 
     @Override
+    public List<StageResult> getStageResults() {
+        return lastStageResults;
+    }
+
+    @Override
     public LaunchResult getLaunchResult() {
         return launchResult;
     }
@@ -239,6 +255,39 @@ public class AeshLauncherImpl implements AeshLauncher {
                 Thread.currentThread().interrupt();
             }
         }
+    }
+
+    /**
+     * Convert raw stage data from the signal queue to {@link StageResult} records.
+     * Each raw entry is {@code Object[] {commandName, stageIndex, stageCount,
+     * exitCode, errorMessage, errorClass, durationMs}} — all classloader-safe types.
+     * Malformed entries fail fast with a descriptive error rather than a
+     * {@link ClassCastException} deep in the conversion.
+     */
+    private static List<StageResult> toStageResults(String command, List<?> rawStages) {
+        List<StageResult> results = new ArrayList<>(rawStages.size());
+        for (Object raw : rawStages) {
+            if (!(raw instanceof Object[] arr) || arr.length != 7
+                    || !(arr[0] instanceof String commandName)
+                    || !(arr[1] instanceof Integer stageIndex)
+                    || !(arr[2] instanceof Integer stageCount)
+                    || !(arr[3] instanceof Integer exitCode)
+                    || (arr[4] != null && !(arr[4] instanceof String))
+                    || (arr[5] != null && !(arr[5] instanceof String))
+                    || !(arr[6] instanceof Long durationMs)) {
+                throw new RuntimeException(
+                        "Malformed stage data from REPL for command '" + command + "'");
+            }
+            results.add(new StageResult(
+                    commandName,
+                    stageIndex,
+                    stageCount,
+                    exitCode,
+                    (String) arr[4],
+                    (String) arr[5],
+                    durationMs));
+        }
+        return Collections.unmodifiableList(results);
     }
 
     /**

--- a/test-framework/aesh/src/main/java/io/quarkus/test/aesh/StageResult.java
+++ b/test-framework/aesh/src/main/java/io/quarkus/test/aesh/StageResult.java
@@ -1,0 +1,45 @@
+package io.quarkus.test.aesh;
+
+/**
+ * A classloader-safe snapshot of one pipeline stage's outcome.
+ * <p>
+ * Aesh's {@code StageOutcome} carries an {@code Execution} reference that
+ * cannot cross the split classloader boundary. This record captures only
+ * primitive and {@link String} data that both classloaders share.
+ * <p>
+ * Instances are built by {@link AeshLauncherImpl} from the raw signal data
+ * sent by {@code CliRunner} through the signal queue.
+ *
+ * @param commandName the command's simple class name (e.g. {@code "EchoCommand"})
+ * @param stageIndex 0-based position in the pipeline
+ * @param stageCount total number of stages in the pipeline
+ * @param exitCode the stage's exit code (0 = success)
+ * @param errorMessage the error message if the stage failed, or {@code null}
+ * @param errorClass the fully qualified error class name, or {@code null}
+ * @param durationMs wall-clock execution time in milliseconds
+ */
+public record StageResult(
+        String commandName,
+        int stageIndex,
+        int stageCount,
+        int exitCode,
+        String errorMessage,
+        String errorClass,
+        long durationMs) {
+
+    /**
+     * Returns {@code true} if this stage completed successfully.
+     */
+    public boolean isSuccess() {
+        return exitCode == 0;
+    }
+
+    @Override
+    public String toString() {
+        return "StageResult{command=" + commandName
+                + ", index=" + stageIndex + "/" + stageCount
+                + ", exitCode=" + exitCode
+                + (errorMessage != null ? ", error=" + errorMessage : "")
+                + ", duration=" + durationMs + "ms}";
+    }
+}


### PR DESCRIPTION
- Bump aesh to 3.18.0 and aesh-readline to 3.18.0
- Add pipeline stage results to AeshLauncher test framework:
  - StageResult record (classloader-safe pipeline stage snapshot)
  - getStageResults() on AeshLauncher interface
  - CliRunner uses PipelineExecutionListener to collect stage data

