### PR TITLE
Convert multipart parts using the charset declared by the part

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/EntityPartCharsetTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/EntityPartCharsetTest.java
@@ -1,0 +1,105 @@
+package io.quarkus.resteasy.reactive.server.test.multipart;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.EntityPart;
+import jakarta.ws.rs.core.MediaType;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class EntityPartCharsetTest {
+
+    private static final String BOUNDARY = "XyZ";
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(Resource.class));
+
+    @Test
+    void fieldPartReadAsEntityPart() {
+        assertThat(post("/charset/entity-part", field())).isEqualTo("café");
+    }
+
+    @Test
+    void fieldPartReadAsString() {
+        assertThat(post("/charset/string", field())).isEqualTo("café");
+    }
+
+    @Test
+    void filePartReadAsEntityPart() {
+        assertThat(post("/charset/entity-part", file())).isEqualTo("café");
+    }
+
+    @Test
+    void filePartReadAsString() {
+        assertThat(post("/charset/string", file())).isEqualTo("café");
+    }
+
+    @Test
+    void partWithoutCharsetIsReadAsUtf8() {
+        byte[] body = part("Content-Disposition: form-data; name=\"text\"\r\nContent-Type: text/plain\r\n",
+                "café".getBytes(StandardCharsets.UTF_8));
+        assertThat(post("/charset/entity-part", body)).isEqualTo("café");
+    }
+
+    private static String post(String path, byte[] body) {
+        return given()
+                .contentType("multipart/form-data; boundary=" + BOUNDARY)
+                .body(body)
+                .when().post(path)
+                .then().statusCode(200)
+                .extract().asString();
+    }
+
+    private static byte[] field() {
+        return part("Content-Disposition: form-data; name=\"text\"\r\nContent-Type: text/plain; charset=ISO-8859-1\r\n",
+                "café".getBytes(StandardCharsets.ISO_8859_1));
+    }
+
+    private static byte[] file() {
+        return part(
+                "Content-Disposition: form-data; name=\"text\"; filename=\"t.txt\"\r\nContent-Type: text/plain; charset=ISO-8859-1\r\n",
+                "café".getBytes(StandardCharsets.ISO_8859_1));
+    }
+
+    private static byte[] part(String headers, byte[] content) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.writeBytes(("--" + BOUNDARY + "\r\n" + headers + "\r\n").getBytes(StandardCharsets.US_ASCII));
+        out.writeBytes(content);
+        out.writeBytes(("\r\n--" + BOUNDARY + "--\r\n").getBytes(StandardCharsets.US_ASCII));
+        return out.toByteArray();
+    }
+
+    @Path("/charset")
+    public static class Resource {
+
+        @POST
+        @Path("entity-part")
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        @Produces(MediaType.TEXT_PLAIN + ";charset=UTF-8")
+        public String entityPart(@FormParam("text") EntityPart part) throws IOException {
+            return part.getContent(String.class);
+        }
+
+        @POST
+        @Path("string")
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        @Produces(MediaType.TEXT_PLAIN + ";charset=UTF-8")
+        public String string(@FormParam("text") String text) {
+            return text;
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/EntityPartImpl.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/EntityPartImpl.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.MessageBodyReader;
 
 import org.jboss.resteasy.reactive.common.core.Serialisers;
+import org.jboss.resteasy.reactive.common.providers.serialisers.MessageReaderUtil;
 
 public class EntityPartImpl implements EntityPart {
 
@@ -83,7 +84,7 @@ public class EntityPartImpl implements EntityPart {
             return rawType.cast(content);
         }
         if (rawType == String.class) {
-            return rawType.cast(new String(content.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8));
+            return rawType.cast(MessageReaderUtil.readString(content, mediaType));
         }
         if (rawType == byte[].class) {
             return rawType.cast(content.readAllBytes());

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartSupport.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartSupport.java
@@ -29,6 +29,7 @@ import jakarta.ws.rs.ext.MessageBodyReader;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.common.jaxrs.EntityPartImpl;
+import org.jboss.resteasy.reactive.common.providers.serialisers.MessageReaderUtil;
 import org.jboss.resteasy.reactive.common.util.Encode;
 import org.jboss.resteasy.reactive.common.util.QuarkusMultivaluedHashMap;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
@@ -205,7 +206,7 @@ public final class MultipartSupport {
         // this is only for the TCK and regular form params
         if (value.isFileItem()) {
             try {
-                return new String(value.getFileItem().getInputStream().readAllBytes());
+                return new String(value.getFileItem().getInputStream().readAllBytes(), partCharset(value));
             } catch (IOException e) {
                 throw new MultipartPartReadingException(e);
             }
@@ -214,6 +215,14 @@ public final class MultipartSupport {
                 return Encode.encodeQueryParam(value.getValue());
             return value.getValue();
         }
+    }
+
+    private static Charset partCharset(FormValue value) {
+        String contentType = value.getHeaders() != null ? value.getHeaders().getFirst("Content-Type") : null;
+        if (contentType == null) {
+            return StandardCharsets.UTF_8;
+        }
+        return Charset.forName(MessageReaderUtil.charsetFromMediaType(MediaType.valueOf(contentType)));
     }
 
     public static List<String> getStrings(String formName, ResteasyReactiveRequestContext context) {
@@ -231,7 +240,7 @@ public final class MultipartSupport {
         for (FormValue value : values) {
             if (value.isFileItem()) {
                 try {
-                    ret.add(new String(readAllBytes(value.getFileItem()), Charset.defaultCharset()));
+                    ret.add(new String(readAllBytes(value.getFileItem()), partCharset(value)));
                 } catch (IOException e) {
                     throw new MultipartPartReadingException(e);
                 }
@@ -449,9 +458,9 @@ public final class MultipartSupport {
             }
             mediaType = contentType != null ? MediaType.valueOf(contentType) : MediaType.APPLICATION_OCTET_STREAM_TYPE;
         } else {
-            content = new ByteArrayInputStream(value.getValue().getBytes(
-                    value.getCharset() != null ? Charset.forName(value.getCharset()) : StandardCharsets.UTF_8));
-            mediaType = MediaType.TEXT_PLAIN_TYPE;
+            Charset charset = value.getCharset() != null ? Charset.forName(value.getCharset()) : StandardCharsets.UTF_8;
+            content = new ByteArrayInputStream(value.getValue().getBytes(charset));
+            mediaType = new MediaType("text", "plain", charset.name());
         }
 
         MultivaluedMap<String, String> headers = new QuarkusMultivaluedHashMap<>();


### PR DESCRIPTION
Jakarta REST 3.1 (section 3.5.2) requires that the content of a `multipart/form-data` part is converted using the charset given in the part's own `Content-Type` header, falling back to UTF-8 when the part does not declare one. Quarkus REST only honours that for a form field read as a `String`; a part sent as `text/plain; charset=ISO-8859-1` containing `café` comes back with a replacement character instead of the final letter in the other cases:

- `EntityPartImpl.readContent` converted `String` content with a hard-coded UTF-8, so `EntityPart.getContent(String.class)` ignored the part's charset. It now uses `MessageReaderUtil.readString`, which reads the charset from the media type and defaults to UTF-8. This class is shared with the REST Client.
- `MultipartSupport.formValueToEntityPart` encoded a form field's value with the part's charset but then described the part as plain `text/plain`, dropping the charset from both the media type and the `Content-Type` header it writes, so the `EntityPart` could not be read back correctly. The media type now keeps the charset.
- `MultipartSupport.getString` and `getStrings` converted a file part with the JVM's default charset. They now use the charset declared by the part, and UTF-8 when there is none. On a platform whose default charset is not UTF-8, a file part read as a `String` without a declared charset changes accordingly, which is what the specification asks for.

`EntityPartCharsetTest` posts a hand-built multipart body so the part headers are exact, and reads an ISO-8859-1 part four ways: as a field and as a file part, each through `EntityPart.getContent(String.class)` and through `@FormParam String`. Three of the four fail without this change. A part without a charset is checked to still be read as UTF-8.

The `@FormParam EntityPart` support that #41186 asks for works on main since #55768; this fixes the charset handling around it.

- Relates to: #41186
