### PR TITLE
Apply the resource method serialization annotations to streamed responses

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
@@ -207,8 +207,10 @@ public abstract class AbstractSimpleJsonTest {
 
     @Test
     public void testJsonMulti() {
+        TestIdentityController.resetRoles().add("max", "max", "admin");
         RestAssured
-                .with()
+                .given()
+                .auth().preemptive().basic("max", "max")
                 .get("/simple/multi2")
                 .then()
                 .statusCode(200)
@@ -218,7 +220,8 @@ public abstract class AbstractSimpleJsonTest {
                 .body("[1].first", Matchers.equalTo("Bob2"))
                 .body("[1].last", Matchers.equalTo("Builder2"));
         RestAssured
-                .with()
+                .given()
+                .auth().preemptive().basic("max", "max")
                 .get("/simple/multi1")
                 .then()
                 .statusCode(200)

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/CustomSerializationOnMultiTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/CustomSerializationOnMultiTest.java
@@ -1,0 +1,90 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.lang.reflect.Type;
+import java.util.function.BiFunction;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.resteasy.reactive.jackson.CustomSerialization;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.smallrye.mutiny.Multi;
+import tools.jackson.core.json.JsonWriteFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectWriter;
+
+public class CustomSerializationOnMultiTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(Resource.class, Item.class, UnquotedFieldNamesSerialization.class));
+
+    @Test
+    void multi() {
+        when().get("/custom-serialization-multi/multi")
+                .then().statusCode(200)
+                .body(equalTo("[{name:\"first\",quantity:1},{name:\"second\",quantity:2}]"));
+    }
+
+    @Test
+    void plain() {
+        when().get("/custom-serialization-multi/plain")
+                .then().statusCode(200)
+                .body(equalTo("{name:\"first\",quantity:1}"));
+    }
+
+    @Path("custom-serialization-multi")
+    public static class Resource {
+
+        @GET
+        @Path("multi")
+        @Produces(MediaType.APPLICATION_JSON)
+        @CustomSerialization(UnquotedFieldNamesSerialization.class)
+        public Multi<Item> multi() {
+            return Multi.createFrom().items(new Item("first", 1), new Item("second", 2));
+        }
+
+        @GET
+        @Path("plain")
+        @Produces(MediaType.APPLICATION_JSON)
+        @CustomSerialization(UnquotedFieldNamesSerialization.class)
+        public Item plain() {
+            return new Item("first", 1);
+        }
+    }
+
+    public static class Item {
+
+        private final String name;
+        private final int quantity;
+
+        public Item(String name, int quantity) {
+            this.name = name;
+            this.quantity = quantity;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getQuantity() {
+            return quantity;
+        }
+    }
+
+    public static class UnquotedFieldNamesSerialization implements BiFunction<ObjectMapper, Type, ObjectWriter> {
+
+        @Override
+        public ObjectWriter apply(ObjectMapper objectMapper, Type type) {
+            return objectMapper.writer().without(JsonWriteFeature.QUOTE_PROPERTY_NAMES);
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ResponseType.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ResponseType.java
@@ -16,8 +16,7 @@ public enum ResponseType {
     /**
      * Returns {@link Multi} with DTOs.
      */
-    // TODO: enable when https://github.com/quarkusio/quarkus/issues/40447 gets fixed
-    //MULTI(true, "multi"),
+    MULTI(true, "multi"),
     /**
      * Returns {@link Uni} with DTOs.
      */

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/FullyFeaturedServerJacksonMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/FullyFeaturedServerJacksonMessageBodyWriter.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.ContextResolver;
 import jakarta.ws.rs.ext.Providers;
 
+import org.jboss.resteasy.reactive.server.core.CurrentRequestManager;
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
@@ -75,41 +76,45 @@ public class FullyFeaturedServerJacksonMessageBodyWriter extends ServerMessageBo
         if (o instanceof String) { // YUK: done in order to avoid adding extra quotes...
             stream.write(((String) o).getBytes(StandardCharsets.UTF_8));
         } else {
-            ObjectMapper effectiveMapper = getEffectiveMapper(o, context);
-            ObjectWriter effectiveWriter = getEffectiveWriter(effectiveMapper);
-            ResteasyReactiveResourceInfo resourceInfo = context.getResteasyReactiveResourceInfo();
-            if (resourceInfo != null) {
-                ObjectWriter writerFromAnnotation = getObjectWriterFromAnnotations(resourceInfo, genericType, effectiveMapper);
-                if (writerFromAnnotation != null) {
-                    effectiveWriter = writerFromAnnotation;
-                }
-
-                Class<?> jsonViewValue = ResteasyReactiveServerJacksonRecorder.jsonViewForMethod(resourceInfo.getMethodId());
-                if (jsonViewValue != null) {
-                    effectiveWriter = effectiveWriter.withView(jsonViewValue);
-                } else {
-                    jsonViewValue = ResteasyReactiveServerJacksonRecorder
-                            .jsonViewForClass(resourceInfo.getResourceClass());
-                    if (jsonViewValue != null) {
-                        effectiveWriter = effectiveWriter.withView(jsonViewValue);
-                    }
-
-                }
-            }
-            // make sure we properly handle polymorphism in generic collections
-            if (genericType != null && o != null) {
-                JavaType rootType = JacksonMapperUtil.getGenericRootType(genericType, effectiveWriter);
-                // Check that the determined root type is really assignable from the given entity.
-                // A mismatch can happen, if a ServerResponseFilter replaces the response entity with another object
-                // that does not match the original signature of the method (see HalServerResponseFilter for an example)
-                if (rootType != null && rootType.isTypeOrSuperTypeOf(o.getClass())) {
-                    effectiveWriter = effectiveWriter.forType(rootType);
-                }
-            }
-            effectiveWriter.writeValue(stream, o);
+            effectiveWriter(o, genericType, context).writeValue(stream, o);
         }
         // we don't use try-with-resources because that results in writing to the http output without the exception mapping coming into play
         stream.close();
+    }
+
+    private ObjectWriter effectiveWriter(Object o, Type genericType, ServerRequestContext context) {
+        ObjectMapper effectiveMapper = getEffectiveMapper(o, context);
+        ObjectWriter effectiveWriter = getEffectiveWriter(effectiveMapper);
+        ResteasyReactiveResourceInfo resourceInfo = context.getResteasyReactiveResourceInfo();
+        if (resourceInfo != null) {
+            ObjectWriter writerFromAnnotation = getObjectWriterFromAnnotations(resourceInfo, genericType, effectiveMapper);
+            if (writerFromAnnotation != null) {
+                effectiveWriter = writerFromAnnotation;
+            }
+
+            Class<?> jsonViewValue = ResteasyReactiveServerJacksonRecorder.jsonViewForMethod(resourceInfo.getMethodId());
+            if (jsonViewValue != null) {
+                effectiveWriter = effectiveWriter.withView(jsonViewValue);
+            } else {
+                jsonViewValue = ResteasyReactiveServerJacksonRecorder
+                        .jsonViewForClass(resourceInfo.getResourceClass());
+                if (jsonViewValue != null) {
+                    effectiveWriter = effectiveWriter.withView(jsonViewValue);
+                }
+
+            }
+        }
+        // make sure we properly handle polymorphism in generic collections
+        if (genericType != null && o != null) {
+            JavaType rootType = JacksonMapperUtil.getGenericRootType(genericType, effectiveWriter);
+            // Check that the determined root type is really assignable from the given entity.
+            // A mismatch can happen, if a ServerResponseFilter replaces the response entity with another object
+            // that does not match the original signature of the method (see HalServerResponseFilter for an example)
+            if (rootType != null && rootType.isTypeOrSuperTypeOf(o.getClass())) {
+                effectiveWriter = effectiveWriter.forType(rootType);
+            }
+        }
+        return effectiveWriter;
     }
 
     private ObjectWriter getObjectWriterFromAnnotations(ResteasyReactiveResourceInfo resourceInfo, Type type,
@@ -193,7 +198,9 @@ public class FullyFeaturedServerJacksonMessageBodyWriter extends ServerMessageBo
     @Override
     public void writeTo(Object o, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
             MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
-        doLegacyWrite(o, annotations, httpHeaders, entityStream, defaultWriter.get());
+        ServerRequestContext context = CurrentRequestManager.get();
+        ObjectWriter writer = context == null ? defaultWriter.get() : effectiveWriter(o, genericType, context);
+        doLegacyWrite(o, annotations, httpHeaders, entityStream, writer);
     }
 
     private static class MethodObjectWriterFunction implements Function<String, ObjectWriter> {


### PR DESCRIPTION
A resource method returning a `Multi` is serialised one item at a time through `StreamingUtil.serialiseEntity`, which uses the plain `MessageBodyWriter.writeTo` contract rather than `ServerMessageBodyWriter.writeResponse`. `FullyFeaturedServerJacksonMessageBodyWriter.writeTo` passed the default `ObjectWriter`, so everything that is resolved per resource method was silently dropped for streamed responses: the `@CustomSerialization` writer, the `@JsonView` recorded for the method or the resource class, and the `ObjectMapper` from a `ContextResolver`.

This also affects `@SecureField`, which is implemented as a `@CustomSerialization` provider (`SecurityCustomSerialization`): a method returning `Multi<SomeDtoWithSecureField>` wrote the secured field out in full. The detection code at build time already handles `Multi`, so only the runtime side was missing.

The writer resolution that `writeResponse` performed inline is now a method used by both entry points, and `writeTo` recovers the current request context through `CurrentRequestManager` in order to use it, falling back to the default writer when there is no request context. Both streaming paths benefit, as `SseUtil` serialises items the same way.

`ResponseType.MULTI` in `SecureFieldDetectionTest` was disabled with a reference to this issue; it is enabled again, and it fails without this change with `[{"withSecureField":{"secured":"hush hush"}}]`. `CustomSerializationOnMultiTest` covers `@CustomSerialization` over a `Multi` and, as a control, the same annotation on a method returning the entity directly.

`AbstractSimpleJsonTest.testJsonMulti` asserted that `Person.last` was present in the two `Multi` responses while making anonymous requests, although that field carries `@SecureField(rolesAllowed = "admin")` and those endpoints, unlike `/simple/person`, are not annotated with `@DisableSecureSerialization`. In other words it asserted the unredacted output. The two requests now authenticate as `admin`, the same way `testSecureFieldRolesAllowedConfigExp` does, so the test keeps checking that items of a `Multi` are serialised correctly.

- Fixes: #40447
