### PR TITLE
Replace the response content type instead of adding it when it comes from the resource method

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/headers/ConfiguredContentTypeHeaderTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/headers/ConfiguredContentTypeHeaderTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.resteasy.reactive.server.test.headers;
+
+import static io.restassured.RestAssured.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class ConfiguredContentTypeHeaderTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(Resource.class))
+            .overrideRuntimeConfigKey("quarkus.http.header.\"Content-Type\".value", "text/html");
+
+    @Test
+    void responseWithoutMediaTypeUsesProduces() {
+        assertThat(contentTypes("/configured-header/response")).containsExactly("text/plain;charset=UTF-8");
+    }
+
+    @Test
+    void entityReturnUsesProduces() {
+        assertThat(contentTypes("/configured-header/plain")).containsExactly("text/plain;charset=UTF-8");
+    }
+
+    @Test
+    void responseWithMediaTypeKeepsIt() {
+        assertThat(contentTypes("/configured-header/response-with-type")).containsExactly("application/json");
+    }
+
+    private static java.util.List<String> contentTypes(String path) {
+        return when().get(path).then().statusCode(200).extract().headers().getValues("Content-Type");
+    }
+
+    @Path("/configured-header")
+    public static class Resource {
+
+        @GET
+        @Path("response")
+        @Produces(MediaType.TEXT_PLAIN)
+        public Response response() {
+            return Response.ok("hello").build();
+        }
+
+        @GET
+        @Path("plain")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String plain() {
+            return "hello";
+        }
+
+        @GET
+        @Path("response-with-type")
+        @Produces(MediaType.TEXT_PLAIN)
+        public Response responseWithType() {
+            return Response.ok("{}", MediaType.APPLICATION_JSON_TYPE).build();
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/serialization/DynamicEntityWriter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/serialization/DynamicEntityWriter.java
@@ -106,7 +106,7 @@ public class DynamicEntityWriter implements EntityWriter {
                     serverSerializersMediaType = selectedMediaType;
                     context.setResponseContentType(selectedMediaType);
                     // this will be used as the fallback if Response does NOT contain a type
-                    context.serverResponse().addResponseHeader(HttpHeaders.CONTENT_TYPE,
+                    context.serverResponse().setResponseHeader(HttpHeaders.CONTENT_TYPE,
                             context.getResponseContentType().toString());
                 }
             }


### PR DESCRIPTION
With a configured response header such as `quarkus.http.header."Content-Type".value=text/html`, a resource method annotated `@Produces(MediaType.TEXT_PLAIN)` that returns a `Response` without an explicit media type produced two `Content-Type` values: `text/html, text/plain;charset=UTF-8`. The configured value is applied by a route handler that runs first, and `DynamicEntityWriter` then added the media type negotiated from `@Produces` instead of replacing it, although its own comment describes that write as the fallback used when the `Response` does not carry a type. A method returning the entity directly was already correct, because that path sets the header.

The write now replaces the header, so the media type of the resource method wins over a configured default and the response carries a single `Content-Type`. A `Response` that sets its own media type is unaffected, as that goes through a different branch.

`ConfiguredContentTypeHeaderTest` covers the three cases with the configured header in place: a `Response` without a media type, an entity return, and a `Response` that sets `application/json` explicitly. The first of them fails without this change.

This leaves the precedence between `quarkus.http.header` and the media type of a resource method defined in the only way that produces a valid response: the resource method wins. Note that the reference documentation for the configuration property does not describe how it composes with the media type of an endpoint.

- Fixes: #42729
