### PR TITLE
Convert OffsetDateTime values sent by the REST Client

### DIFF
--- a/extensions/resteasy-reactive/rest-client-jaxrs/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/RestClientBase.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/RestClientBase.java
@@ -3,6 +3,7 @@ package io.quarkus.jaxrs.client.reactive.runtime;
 import java.io.Closeable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
@@ -114,6 +115,19 @@ public abstract class RestClientBase implements Closeable {
             return value == null ? null : value.toString();
         }
     };
+
+    private static final ParamConverter<OffsetDateTime> OFFSET_DATE_TIME_CONVERTER = new ParamConverter<>() {
+        @Override
+        public OffsetDateTime fromString(String value) {
+            return value == null ? null : OffsetDateTime.parse(value);
+        }
+
+        @Override
+        public String toString(OffsetDateTime value) {
+            return value == null ? null : value.toString();
+        }
+    };
+
     private final List<ParamConverterProvider> paramConverterProviders;
     private final Map<Class<?>, ParamConverterProvider> providerForClass = new ConcurrentHashMap<>();
 
@@ -217,6 +231,9 @@ public abstract class RestClientBase implements Closeable {
             }
             if (rawType == UUID.class) {
                 return (ParamConverter<T>) UUID_CONVERTER;
+            }
+            if (rawType == OffsetDateTime.class) {
+                return (ParamConverter<T>) OFFSET_DATE_TIME_CONVERTER;
             }
             return null;
         }

--- a/integration-tests/rest-client-reactive-multipart/src/main/java/io/quarkus/it/rest/client/multipart/MultipartClient.java
+++ b/integration-tests/rest-client-reactive-multipart/src/main/java/io/quarkus/it/rest/client/multipart/MultipartClient.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.rest.client.multipart;
 
 import java.io.File;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 import jakarta.ws.rs.Consumes;
@@ -183,6 +184,18 @@ public interface MultipartClient {
         @FormParam("uuid")
         @PartType(MediaType.TEXT_PLAIN)
         private UUID uuid;
+
+        @FormParam("offsetDateTime")
+        @PartType(MediaType.TEXT_PLAIN)
+        private OffsetDateTime offsetDateTime;
+
+        public OffsetDateTime getOffsetDateTime() {
+            return offsetDateTime;
+        }
+
+        public void setOffsetDateTime(OffsetDateTime offsetDateTime) {
+            this.offsetDateTime = offsetDateTime;
+        }
 
         public String getFileName() {
             return fileName;

--- a/integration-tests/rest-client-reactive-multipart/src/main/java/io/quarkus/it/rest/client/multipart/MultipartResource.java
+++ b/integration-tests/rest-client-reactive-multipart/src/main/java/io/quarkus/it/rest/client/multipart/MultipartResource.java
@@ -8,6 +8,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -56,6 +57,7 @@ public class MultipartResource {
 
     public static final String HELLO_WORLD = "HELLO WORLD";
     public static final String GREETING_TXT = "greeting.txt";
+    public static final OffsetDateTime OFFSET_DATE_TIME = OffsetDateTime.parse("2023-02-21T10:15:30+01:00");
     public static final int NUMBER = 12342;
     @RestClient
     MultipartClient client;
@@ -83,6 +85,7 @@ public class MultipartResource {
         data.file = HELLO_WORLD.getBytes(UTF_8);
         data.setFileName(GREETING_TXT);
         data.setUuid(UUID.randomUUID());
+        data.setOffsetDateTime(OFFSET_DATE_TIME);
         if (withPojo) {
             Pojo pojo = new Pojo();
             pojo.setName("some-name");
@@ -425,12 +428,13 @@ public class MultipartResource {
     @Path("/echo/with-pojo")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     public String consumeBinaryWithPojo(@MultipartForm MultipartBodyWithBinaryFileAndPojo fileWithPojo) {
-        return String.format("fileOk:%s,nameOk:%s,pojoOk:%s,uuidNull:%s",
+        return String.format("fileOk:%s,nameOk:%s,pojoOk:%s,uuidNull:%s,offsetDateTimeOk:%s",
                 containsHelloWorld(fileWithPojo.file),
                 GREETING_TXT.equals(fileWithPojo.fileName),
                 fileWithPojo.pojo == null ? "null"
                         : "some-name".equals(fileWithPojo.pojo.getName()) && "some-value".equals(fileWithPojo.pojo.getValue()),
-                fileWithPojo.uuid == null);
+                fileWithPojo.uuid == null,
+                fileWithPojo.offsetDateTime == null ? "null" : OFFSET_DATE_TIME.toString().equals(fileWithPojo.offsetDateTime));
     }
 
     @GET
@@ -526,6 +530,10 @@ public class MultipartResource {
         @FormParam("uuid")
         @PartType(MediaType.TEXT_PLAIN)
         public String uuid;
+
+        @FormParam("offsetDateTime")
+        @PartType(MediaType.TEXT_PLAIN)
+        public String offsetDateTime;
     }
 
 }

--- a/integration-tests/rest-client-reactive-multipart/src/test/java/io/quarkus/it/rest/client/multipart/MultipartResourceTest.java
+++ b/integration-tests/rest-client-reactive-multipart/src/test/java/io/quarkus/it/rest/client/multipart/MultipartResourceTest.java
@@ -270,13 +270,13 @@ public class MultipartResourceTest {
         .when().get("/client/byte-array-as-binary-file-with-pojo")
         .then()
                 .statusCode(200)
-                .body(equalTo("fileOk:true,nameOk:true,pojoOk:true,uuidNull:false"));
+                .body(equalTo("fileOk:true,nameOk:true,pojoOk:true,uuidNull:false,offsetDateTimeOk:true"));
         given()
         .header("Content-Type", "text/plain")
 .when().get("/client/params/byte-array-as-binary-file-with-pojo")
 .then()
         .statusCode(200)
-        .body(equalTo("fileOk:true,nameOk:true,pojoOk:true,uuidNull:true"));
+        .body(equalTo("fileOk:true,nameOk:true,pojoOk:true,uuidNull:true,offsetDateTimeOk:null"));
         // @formatter:on
     }
 
@@ -289,14 +289,14 @@ public class MultipartResourceTest {
         .when().get("/client/byte-array-as-binary-file-with-pojo")
         .then()
                 .statusCode(200)
-                .body(equalTo("fileOk:true,nameOk:true,pojoOk:null,uuidNull:false"));
+                .body(equalTo("fileOk:true,nameOk:true,pojoOk:null,uuidNull:false,offsetDateTimeOk:true"));
         given()
         .queryParam("withPojo", "false")
         .header("Content-Type", "text/plain")
 .when().get("/client/params/byte-array-as-binary-file-with-pojo")
 .then()
         .statusCode(200)
-        .body(equalTo("fileOk:true,nameOk:true,pojoOk:null,uuidNull:true"));
+        .body(equalTo("fileOk:true,nameOk:true,pojoOk:null,uuidNull:true,offsetDateTimeOk:null"));
         // @formatter:on
     }
 


### PR DESCRIPTION
`RestClientBase` carries a small set of default `ParamConverter` instances that the generated client code uses to turn a value into its string form, among them one for `UUID` added for #31298. `java.time.OffsetDateTime` has no such converter, so a multipart form field declared with that type is not converted and the part is not sent as the ISO-8601 string the receiving side expects.

This adds an `OffsetDateTime` converter next to the `UUID` one, using `OffsetDateTime.parse` and `toString`, and the corresponding branch in the default provider.

The approach and the shape of the converter come from #31321 by @hbelmiro, which was closed for inactivity in June 2024 rather than rejected; the file has since moved from `jaxrs-client-reactive` to `rest-client-jaxrs`.

The `rest-client-reactive-multipart` integration test grows an `offsetDateTime` part next to the existing `uuid` one, in the same `with-pojo` flow that #31389 used to cover `UUID`: the client sends a fixed `OffsetDateTime`, the receiving resource echoes whether the value arrived as expected, and the four assertions check it. Without the converter the two cases that send the part fail.

- Fixes: #31320
