### PR TITLE
Add a Gradle build init spec to scaffold Quarkus projects

### DIFF
--- a/devtools/gradle/gradle-init-plugin/build.gradle.kts
+++ b/devtools/gradle/gradle-init-plugin/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    id("io.quarkus.devtools.gradle-plugin")
+}
+
+group = "io.quarkus"
+
+gradlePlugin {
+    plugins.create("quarkusInitPlugin") {
+        id = "io.quarkus.init"
+        implementationClass = "io.quarkus.gradle.init.QuarkusInitSpecsPlugin"
+        displayName = "Quarkus Init Plugin"
+        description =
+            "Registers a 'quarkus-app' build init spec so 'gradle init --type quarkus-app' can scaffold a Quarkus project without the Quarkus CLI"
+        tags.addAll("quarkus", "quarkusio", "init")
+    }
+}
+
+// RegistryClientTestHelper (used by tests to resolve the locally-built platform BOM
+// instead of the live registry) reads these two system properties.
+tasks.test {
+    systemProperty("project.version", project.version.toString())
+    systemProperty("project.groupId", project.group.toString())
+}
+
+// to generate reproducible jars
+tasks.withType<Jar>().configureEach {
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+}

--- a/devtools/gradle/gradle-init-plugin/pom.xml
+++ b/devtools/gradle/gradle-init-plugin/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>io.quarkus.gradle.plugin.parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>io.quarkus.gradle.init.plugin</artifactId>
+    <packaging>pom</packaging>
+    <name>Quarkus - Init Gradle Plugin</name>
+    <description>Quarkus - Init Gradle Plugin</description>
+
+    <properties>
+        <artifactFilePrefix>gradle-init-plugin</artifactFilePrefix>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-gradle-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-bootstrap-gradle-resolver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devtools-common</artifactId>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>deploy-gradle-plugins</id>
+            <activation>
+                <property>
+                    <name>deploy-gradle-plugins</name>
+                </property>
+            </activation>
+            <properties>
+                <maven.deploy.skip>false</maven.deploy.skip>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/devtools/gradle/gradle-init-plugin/src/main/java/io/quarkus/gradle/init/BooleanInitParameter.java
+++ b/devtools/gradle/gradle-init-plugin/src/main/java/io/quarkus/gradle/init/BooleanInitParameter.java
@@ -1,0 +1,26 @@
+package io.quarkus.gradle.init;
+
+import org.gradle.buildinit.specs.BuildInitParameter;
+
+final class BooleanInitParameter implements BuildInitParameter<Boolean> {
+
+    static final BooleanInitParameter NO_DOCKERFILES = new BooleanInitParameter("noDockerfiles");
+    static final BooleanInitParameter NO_BUILD_TOOL_WRAPPER = new BooleanInitParameter("noBuildToolWrapper");
+    static final BooleanInitParameter NO_CODE = new BooleanInitParameter("noCode");
+
+    private final String name;
+
+    private BooleanInitParameter(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Boolean getParameterType() {
+        return Boolean.FALSE;
+    }
+}

--- a/devtools/gradle/gradle-init-plugin/src/main/java/io/quarkus/gradle/init/DslParameter.java
+++ b/devtools/gradle/gradle-init-plugin/src/main/java/io/quarkus/gradle/init/DslParameter.java
@@ -1,0 +1,21 @@
+package io.quarkus.gradle.init;
+
+import org.gradle.buildinit.specs.BuildInitParameter;
+
+final class DslParameter implements BuildInitParameter<String> {
+
+    static final DslParameter INSTANCE = new DslParameter();
+
+    private DslParameter() {
+    }
+
+    @Override
+    public String getName() {
+        return "dsl";
+    }
+
+    @Override
+    public String getParameterType() {
+        return "";
+    }
+}

--- a/devtools/gradle/gradle-init-plugin/src/main/java/io/quarkus/gradle/init/ExtensionsParameter.java
+++ b/devtools/gradle/gradle-init-plugin/src/main/java/io/quarkus/gradle/init/ExtensionsParameter.java
@@ -1,0 +1,21 @@
+package io.quarkus.gradle.init;
+
+import org.gradle.buildinit.specs.BuildInitParameter;
+
+final class ExtensionsParameter implements BuildInitParameter<String> {
+
+    static final ExtensionsParameter INSTANCE = new ExtensionsParameter();
+
+    private ExtensionsParameter() {
+    }
+
+    @Override
+    public String getName() {
+        return "extensions";
+    }
+
+    @Override
+    public String getParameterType() {
+        return "";
+    }
+}

--- a/devtools/gradle/gradle-init-plugin/src/main/java/io/quarkus/gradle/init/GroupIdParameter.java
+++ b/devtools/gradle/gradle-init-plugin/src/main/java/io/quarkus/gradle/init/GroupIdParameter.java
@@ -1,0 +1,21 @@
+package io.quarkus.gradle.init;
+
+import org.gradle.buildinit.specs.BuildInitParameter;
+
+final class GroupIdParameter implements BuildInitParameter<String> {
+
+    static final GroupIdParameter INSTANCE = new GroupIdParameter();
+
+    private GroupIdParameter() {
+    }
+
+    @Override
+    public String getName() {
+        return "groupId";
+    }
+
+    @Override
+    public String getParameterType() {
+        return "";
+    }
+}

--- a/devtools/gradle/gradle-init-plugin/src/main/java/io/quarkus/gradle/init/ProjectNameParameter.java
+++ b/devtools/gradle/gradle-init-plugin/src/main/java/io/quarkus/gradle/init/ProjectNameParameter.java
@@ -1,0 +1,21 @@
+package io.quarkus.gradle.init;
+
+import org.gradle.buildinit.specs.BuildInitParameter;
+
+final class ProjectNameParameter implements BuildInitParameter<String> {
+
+    static final ProjectNameParameter INSTANCE = new ProjectNameParameter();
+
+    private ProjectNameParameter() {
+    }
+
+    @Override
+    public String getName() {
+        return "projectName";
+    }
+
+    @Override
+    public String getParameterType() {
+        return "";
+    }
+}

--- a/devtools/gradle/gradle-init-plugin/src/main/java/io/quarkus/gradle/init/QuarkusAppInitGenerator.java
+++ b/devtools/gradle/gradle-init-plugin/src/main/java/io/quarkus/gradle/init/QuarkusAppInitGenerator.java
@@ -1,0 +1,112 @@
+package io.quarkus.gradle.init;
+
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+import javax.inject.Inject;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.file.Directory;
+import org.gradle.buildinit.specs.BuildInitConfig;
+import org.gradle.buildinit.specs.BuildInitGenerator;
+import org.gradle.buildinit.specs.BuildInitParameter;
+
+import io.quarkus.devtools.commands.CreateProject;
+import io.quarkus.devtools.commands.data.QuarkusCommandException;
+import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.devtools.project.QuarkusProject;
+import io.quarkus.devtools.project.QuarkusProjectHelper;
+import io.quarkus.registry.RegistryResolutionException;
+
+public class QuarkusAppInitGenerator implements BuildInitGenerator {
+
+    private static final String DEFAULT_PROJECT_NAME = "code-with-quarkus";
+    private static final String DEFAULT_GROUP_ID = "org.acme";
+    private static final String DEFAULT_VERSION = "1.0.0-SNAPSHOT";
+    private static final String GROOVY_DSL = "groovy";
+
+    @Inject
+    public QuarkusAppInitGenerator() {
+    }
+
+    @Override
+    public void generate(BuildInitConfig config, Directory targetDirectory) {
+        String projectName = stringArgument(config, ProjectNameParameter.INSTANCE, DEFAULT_PROJECT_NAME);
+        String groupId = stringArgument(config, GroupIdParameter.INSTANCE, DEFAULT_GROUP_ID);
+        String version = stringArgument(config, StringInitParameter.VERSION, DEFAULT_VERSION);
+        Set<String> extensions = parseExtensions(stringArgument(config, ExtensionsParameter.INSTANCE, ""));
+        BuildTool buildTool = buildTool(stringArgument(config, DslParameter.INSTANCE, ""));
+        String quarkusVersion = stringArgumentOrNull(config, StringInitParameter.QUARKUS_VERSION);
+        Path targetPath = targetDirectory.getAsFile().toPath();
+
+        try {
+            QuarkusProject quarkusProject = resolveProject(targetPath, buildTool, quarkusVersion);
+            new CreateProject(quarkusProject)
+                    .groupId(groupId)
+                    .artifactId(projectName)
+                    .version(version)
+                    .description(stringArgumentOrNull(config, StringInitParameter.DESCRIPTION))
+                    .resourceClassName(stringArgumentOrNull(config, StringInitParameter.CLASS_NAME))
+                    .resourcePath(stringArgumentOrNull(config, StringInitParameter.PATH))
+                    .extensions(extensions)
+                    .noDockerfiles(booleanArgument(config, BooleanInitParameter.NO_DOCKERFILES))
+                    .noBuildToolWrapper(booleanArgument(config, BooleanInitParameter.NO_BUILD_TOOL_WRAPPER))
+                    .noCode(booleanArgument(config, BooleanInitParameter.NO_CODE))
+                    .execute();
+        } catch (QuarkusCommandException | RegistryResolutionException e) {
+            throw new GradleException("Failed to generate the Quarkus project", e);
+        }
+    }
+
+    /**
+     * Resolves the extension catalog explicitly instead of using the deprecated
+     * {@link QuarkusProjectHelper#getProject(Path, BuildTool, String)} overload.
+     */
+    private QuarkusProject resolveProject(Path targetPath, BuildTool buildTool, String quarkusVersion)
+            throws RegistryResolutionException {
+        if (quarkusVersion == null) {
+            return QuarkusProjectHelper.getProject(targetPath, buildTool);
+        }
+        return QuarkusProjectHelper.getProject(targetPath,
+                QuarkusProjectHelper.getCatalogResolver().resolveExtensionCatalog(quarkusVersion), buildTool);
+    }
+
+    private String stringArgument(BuildInitConfig config, BuildInitParameter<String> parameter, String defaultValue) {
+        Object value = config.getArguments().get(parameter);
+        if (value instanceof String stringValue && !stringValue.isBlank()) {
+            return stringValue;
+        }
+        return defaultValue;
+    }
+
+    private String stringArgumentOrNull(BuildInitConfig config, BuildInitParameter<String> parameter) {
+        Object value = config.getArguments().get(parameter);
+        if (value instanceof String stringValue && !stringValue.isBlank()) {
+            return stringValue;
+        }
+        return null;
+    }
+
+    private boolean booleanArgument(BuildInitConfig config, BuildInitParameter<Boolean> parameter) {
+        Object value = config.getArguments().get(parameter);
+        return value instanceof Boolean booleanValue && booleanValue;
+    }
+
+    private BuildTool buildTool(String dsl) {
+        return GROOVY_DSL.equalsIgnoreCase(dsl) ? BuildTool.GRADLE : BuildTool.GRADLE_KOTLIN_DSL;
+    }
+
+    private Set<String> parseExtensions(String extensions) {
+        Set<String> result = new HashSet<>();
+        StringTokenizer tokenizer = new StringTokenizer(extensions, ",");
+        while (tokenizer.hasMoreTokens()) {
+            String extension = tokenizer.nextToken().trim();
+            if (!extension.isEmpty()) {
+                result.add(extension);
+            }
+        }
+        return result;
+    }
+}

--- a/devtools/gradle/gradle-init-plugin/src/main/java/io/quarkus/gradle/init/QuarkusAppInitSpec.java
+++ b/devtools/gradle/gradle-init-plugin/src/main/java/io/quarkus/gradle/init/QuarkusAppInitSpec.java
@@ -1,0 +1,23 @@
+package io.quarkus.gradle.init;
+
+import java.util.List;
+
+import org.gradle.buildinit.specs.BuildInitParameter;
+import org.gradle.buildinit.specs.BuildInitSpec;
+
+class QuarkusAppInitSpec implements BuildInitSpec {
+
+    @Override
+    public String getType() {
+        return "quarkus-app";
+    }
+
+    @Override
+    public List<BuildInitParameter<?>> getParameters() {
+        return List.of(ProjectNameParameter.INSTANCE, GroupIdParameter.INSTANCE, ExtensionsParameter.INSTANCE,
+                DslParameter.INSTANCE, StringInitParameter.VERSION, StringInitParameter.DESCRIPTION,
+                StringInitParameter.CLASS_NAME, StringInitParameter.PATH, StringInitParameter.QUARKUS_VERSION,
+                BooleanInitParameter.NO_DOCKERFILES, BooleanInitParameter.NO_BUILD_TOOL_WRAPPER,
+                BooleanInitParameter.NO_CODE);
+    }
+}

--- a/devtools/gradle/gradle-init-plugin/src/main/java/io/quarkus/gradle/init/QuarkusInitSpecsPlugin.java
+++ b/devtools/gradle/gradle-init-plugin/src/main/java/io/quarkus/gradle/init/QuarkusInitSpecsPlugin.java
@@ -1,0 +1,28 @@
+package io.quarkus.gradle.init;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.initialization.Settings;
+import org.gradle.buildinit.specs.internal.BuildInitSpecRegistry;
+
+/**
+ * Supplies the {@code quarkus-app} build init spec so it can be picked up by
+ * {@code gradle init -Dorg.gradle.buildinit.specs=<this-plugin-coordinates> --type quarkus-app}.
+ */
+public class QuarkusInitSpecsPlugin implements Plugin<Settings> {
+
+    private final BuildInitSpecRegistry registry;
+
+    @Inject
+    public QuarkusInitSpecsPlugin(BuildInitSpecRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public void apply(Settings settings) {
+        registry.register(QuarkusAppInitGenerator.class, List.of(new QuarkusAppInitSpec()));
+    }
+}

--- a/devtools/gradle/gradle-init-plugin/src/main/java/io/quarkus/gradle/init/StringInitParameter.java
+++ b/devtools/gradle/gradle-init-plugin/src/main/java/io/quarkus/gradle/init/StringInitParameter.java
@@ -1,0 +1,28 @@
+package io.quarkus.gradle.init;
+
+import org.gradle.buildinit.specs.BuildInitParameter;
+
+final class StringInitParameter implements BuildInitParameter<String> {
+
+    static final StringInitParameter VERSION = new StringInitParameter("version");
+    static final StringInitParameter DESCRIPTION = new StringInitParameter("description");
+    static final StringInitParameter CLASS_NAME = new StringInitParameter("className");
+    static final StringInitParameter PATH = new StringInitParameter("path");
+    static final StringInitParameter QUARKUS_VERSION = new StringInitParameter("quarkusVersion");
+
+    private final String name;
+
+    private StringInitParameter(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getParameterType() {
+        return "";
+    }
+}

--- a/devtools/gradle/gradle-init-plugin/src/test/java/io/quarkus/gradle/init/QuarkusAppInitGeneratorTest.java
+++ b/devtools/gradle/gradle-init-plugin/src/test/java/io/quarkus/gradle/init/QuarkusAppInitGeneratorTest.java
@@ -1,0 +1,265 @@
+package io.quarkus.gradle.init;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.file.Directory;
+import org.gradle.buildinit.specs.BuildInitConfig;
+import org.gradle.buildinit.specs.BuildInitParameter;
+import org.gradle.buildinit.specs.BuildInitSpec;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkus.devtools.testing.RegistryClientTest;
+
+class QuarkusAppInitGeneratorTest {
+
+    @RegisterExtension
+    static final RegistryClientTest registryClientTest = new RegistryClientTest();
+
+    @TempDir
+    Path workDir;
+
+    @Test
+    void generatesAQuarkusGradleKotlinDslProject() throws IOException {
+        Path targetDir = generate(configFor("acme-app").groupId("com.example"));
+
+        assertThat(targetDir.resolve("build.gradle.kts")).exists();
+        assertThat(targetDir.resolve("src/main/java")).isDirectory();
+        assertThat(Files.readString(targetDir.resolve("settings.gradle.kts")))
+                .contains("rootProject.name=\"acme-app\"");
+        assertThat(Files.readString(targetDir.resolve("build.gradle.kts")))
+                .contains("group = \"com.example\"");
+    }
+
+    @Test
+    void defaultsGroupIdWhenNotProvided() throws IOException {
+        Path targetDir = generate(configFor("acme-app"));
+
+        assertThat(Files.readString(targetDir.resolve("build.gradle.kts")))
+                .contains("group = \"org.acme\"");
+    }
+
+    @Test
+    void addsRequestedExtensions() throws IOException {
+        Path targetDir = generate(configFor("acme-app").extensions("openapi"));
+
+        assertThat(Files.readString(targetDir.resolve("build.gradle.kts")))
+                .contains("quarkus-smallrye-openapi");
+    }
+
+    @Test
+    void generatesGroovyDslProjectWhenRequested() throws IOException {
+        Path targetDir = generate(configFor("acme-app").dsl("groovy"));
+
+        assertThat(targetDir.resolve("build.gradle")).exists();
+        assertThat(targetDir.resolve("settings.gradle")).exists();
+        assertThat(targetDir.resolve("build.gradle.kts")).doesNotExist();
+    }
+
+    @Test
+    void defaultsToKotlinDslWhenNotRequested() throws IOException {
+        Path targetDir = generate(configFor("acme-app"));
+
+        assertThat(targetDir.resolve("build.gradle.kts")).exists();
+    }
+
+    @Test
+    void failsWithGradleExceptionWhenTargetDirectoryIsNotEmpty() throws IOException {
+        Directory generatedProjectDir = generatedProjectDir();
+        Path targetDir = workDir.resolve("generated-project");
+        Files.createDirectories(targetDir);
+        Files.writeString(targetDir.resolve("pre-existing.txt"), "leftover file");
+
+        assertThatThrownBy(
+                () -> new QuarkusAppInitGenerator().generate(configFor("acme-app").build(), generatedProjectDir))
+                .isInstanceOf(GradleException.class)
+                .hasMessageContaining("Failed to generate the Quarkus project");
+    }
+
+    @Test
+    void appliesCustomVersionWhenProvided() throws IOException {
+        Path targetDir = generate(configFor("acme-app").version("2.0.0"));
+
+        assertThat(Files.readString(targetDir.resolve("build.gradle.kts")))
+                .contains("version = \"2.0.0\"");
+    }
+
+    @Test
+    void defaultsVersionWhenNotProvided() throws IOException {
+        Path targetDir = generate(configFor("acme-app"));
+
+        assertThat(Files.readString(targetDir.resolve("build.gradle.kts")))
+                .contains("version = \"1.0.0-SNAPSHOT\"");
+    }
+
+    @Test
+    void appliesDescriptionToReadmeWhenProvided() throws IOException {
+        Path targetDir = generate(configFor("acme-app").description("A tiny demo app"));
+
+        assertThat(Files.readString(targetDir.resolve("README.md"))).contains("A tiny demo app");
+    }
+
+    @Test
+    void customizesRestResourceClassNameAndPath() throws IOException {
+        Path targetDir = generate(configFor("acme-app").className("Hello").path("/hello"));
+
+        Path resourceFile = targetDir.resolve("src/main/java/org/acme/Hello.java");
+        assertThat(resourceFile).exists();
+        assertThat(Files.readString(resourceFile)).contains("/hello");
+    }
+
+    @Test
+    void skipsDockerfilesWhenRequested() throws IOException {
+        Path targetDir = generate(configFor("acme-app").noDockerfiles());
+
+        assertThat(targetDir.resolve("src/main/docker")).doesNotExist();
+    }
+
+    @Test
+    void generatesDockerfilesByDefault() throws IOException {
+        Path targetDir = generate(configFor("acme-app"));
+
+        assertThat(targetDir.resolve("src/main/docker")).isDirectory();
+    }
+
+    @Test
+    void skipsBuildToolWrapperWhenRequested() throws IOException {
+        Path targetDir = generate(configFor("acme-app").noBuildToolWrapper());
+
+        assertThat(targetDir.resolve("gradlew")).doesNotExist();
+    }
+
+    @Test
+    void skipsCodeGenerationWhenRequested() throws IOException {
+        Path targetDir = generate(configFor("acme-app").noCode());
+
+        try (var javaFiles = Files.walk(targetDir.resolve("src"))) {
+            assertThat(javaFiles.filter(path -> path.toString().endsWith(".java"))).isEmpty();
+        }
+        assertThat(targetDir.resolve("build.gradle.kts")).exists();
+    }
+
+    @Test
+    void selectsKotlinSourceTypeWhenKotlinExtensionRequested() throws IOException {
+        Path targetDir = generate(configFor("acme-app").extensions("quarkus-kotlin"));
+
+        assertThat(targetDir.resolve("src/main/kotlin")).isDirectory();
+        assertThat(Files.readString(targetDir.resolve("build.gradle.kts"))).contains("kotlin(\"jvm\")");
+    }
+
+    @Test
+    void acceptsAnExplicitQuarkusVersion() throws IOException {
+        Path targetDir = generate(configFor("acme-app").quarkusVersion(System.getProperty("project.version")));
+
+        assertThat(Files.readString(targetDir.resolve("gradle.properties")))
+                .contains("quarkusPlatformVersion=" + System.getProperty("project.version"));
+    }
+
+    private Path generate(ConfigBuilder config) throws IOException {
+        Directory generatedProjectDir = generatedProjectDir();
+        new QuarkusAppInitGenerator().generate(config.build(), generatedProjectDir);
+        return workDir.resolve("generated-project");
+    }
+
+    /**
+     * Targets a not-yet-created subdirectory of the {@link ProjectBuilder} project directory, since
+     * {@link ProjectBuilder} writes its own state into whatever directory it's given, which would otherwise trip
+     * the codestart engine's "target directory must be empty" check.
+     */
+    private Directory generatedProjectDir() {
+        return ProjectBuilder.builder().withProjectDir(workDir.toFile()).build()
+                .getLayout().getProjectDirectory().dir("generated-project");
+    }
+
+    private ConfigBuilder configFor(String projectName) {
+        return new ConfigBuilder(projectName);
+    }
+
+    private static final class ConfigBuilder {
+
+        private final Map<BuildInitParameter<?>, Object> arguments = new HashMap<>();
+
+        ConfigBuilder(String projectName) {
+            arguments.put(ProjectNameParameter.INSTANCE, projectName);
+        }
+
+        ConfigBuilder groupId(String groupId) {
+            arguments.put(GroupIdParameter.INSTANCE, groupId);
+            return this;
+        }
+
+        ConfigBuilder extensions(String extensions) {
+            arguments.put(ExtensionsParameter.INSTANCE, extensions);
+            return this;
+        }
+
+        ConfigBuilder dsl(String dsl) {
+            arguments.put(DslParameter.INSTANCE, dsl);
+            return this;
+        }
+
+        ConfigBuilder version(String version) {
+            arguments.put(StringInitParameter.VERSION, version);
+            return this;
+        }
+
+        ConfigBuilder description(String description) {
+            arguments.put(StringInitParameter.DESCRIPTION, description);
+            return this;
+        }
+
+        ConfigBuilder className(String className) {
+            arguments.put(StringInitParameter.CLASS_NAME, className);
+            return this;
+        }
+
+        ConfigBuilder path(String path) {
+            arguments.put(StringInitParameter.PATH, path);
+            return this;
+        }
+
+        ConfigBuilder quarkusVersion(String quarkusVersion) {
+            arguments.put(StringInitParameter.QUARKUS_VERSION, quarkusVersion);
+            return this;
+        }
+
+        ConfigBuilder noDockerfiles() {
+            arguments.put(BooleanInitParameter.NO_DOCKERFILES, Boolean.TRUE);
+            return this;
+        }
+
+        ConfigBuilder noBuildToolWrapper() {
+            arguments.put(BooleanInitParameter.NO_BUILD_TOOL_WRAPPER, Boolean.TRUE);
+            return this;
+        }
+
+        ConfigBuilder noCode() {
+            arguments.put(BooleanInitParameter.NO_CODE, Boolean.TRUE);
+            return this;
+        }
+
+        BuildInitConfig build() {
+            return new BuildInitConfig() {
+                @Override
+                public BuildInitSpec getBuildSpec() {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Map<BuildInitParameter<?>, Object> getArguments() {
+                    return arguments;
+                }
+            };
+        }
+    }
+}

--- a/devtools/gradle/gradle-init-plugin/src/test/java/io/quarkus/gradle/init/QuarkusAppInitSpecTest.java
+++ b/devtools/gradle/gradle-init-plugin/src/test/java/io/quarkus/gradle/init/QuarkusAppInitSpecTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.gradle.init;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class QuarkusAppInitSpecTest {
+
+    @Test
+    void typeIsQuarkusApp() {
+        QuarkusAppInitSpec spec = new QuarkusAppInitSpec();
+
+        assertThat(spec.getType()).isEqualTo("quarkus-app");
+    }
+
+    @Test
+    void declaresAllSupportedParameters() {
+        QuarkusAppInitSpec spec = new QuarkusAppInitSpec();
+
+        assertThat(spec.getParameters()).containsExactly(ProjectNameParameter.INSTANCE, GroupIdParameter.INSTANCE,
+                ExtensionsParameter.INSTANCE, DslParameter.INSTANCE, StringInitParameter.VERSION,
+                StringInitParameter.DESCRIPTION, StringInitParameter.CLASS_NAME, StringInitParameter.PATH,
+                StringInitParameter.QUARKUS_VERSION, BooleanInitParameter.NO_DOCKERFILES,
+                BooleanInitParameter.NO_BUILD_TOOL_WRAPPER, BooleanInitParameter.NO_CODE);
+    }
+}

--- a/devtools/gradle/gradle-init-plugin/src/test/java/io/quarkus/gradle/init/QuarkusInitSpecsPluginTest.java
+++ b/devtools/gradle/gradle-init-plugin/src/test/java/io/quarkus/gradle/init/QuarkusInitSpecsPluginTest.java
@@ -1,0 +1,22 @@
+package io.quarkus.gradle.init;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.gradle.buildinit.specs.BuildInitSpec;
+import org.gradle.buildinit.specs.internal.BuildInitSpecRegistry;
+import org.junit.jupiter.api.Test;
+
+class QuarkusInitSpecsPluginTest {
+
+    @Test
+    void registersQuarkusAppSpecOnApply() {
+        BuildInitSpecRegistry registry = new BuildInitSpecRegistry();
+        QuarkusInitSpecsPlugin plugin = new QuarkusInitSpecsPlugin(registry);
+
+        plugin.apply(null);
+
+        BuildInitSpec registered = registry.getSpecByType("quarkus-app");
+        assertThat(registered).isNotNull();
+        assertThat(registry.getGeneratorForSpec(registered)).isEqualTo(QuarkusAppInitGenerator.class);
+    }
+}

--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -25,6 +25,7 @@
         <module>gradle-model</module>
         <module>gradle-application-plugin</module>
         <module>gradle-extension-plugin</module>
+        <module>gradle-init-plugin</module>
     </modules>
 
     <dependencyManagement>

--- a/devtools/gradle/settings.gradle.kts
+++ b/devtools/gradle/settings.gradle.kts
@@ -24,7 +24,7 @@ develocity {
 
 rootProject.name = "quarkus-gradle-plugins"
 includeBuild("build-logic")
-include("gradle-application-plugin", "gradle-extension-plugin", "gradle-model")
+include("gradle-application-plugin", "gradle-extension-plugin", "gradle-init-plugin", "gradle-model")
 
 @Suppress("UnstableApiUsage")
 dependencyResolutionManagement {

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -60,6 +60,22 @@ The project is generated in a directory named after the passed artifactId.
 A pair of Dockerfiles for native and JVM modes are also generated in `src/main/docker`.
 Instructions to build the image and run the container are written in those Dockerfiles.
 
+[[project-creation-without-cli-or-maven]]
+=== Creating a project without the Quarkus CLI or Maven
+
+If you cannot install the Quarkus CLI and would rather not install Maven just to scaffold a project,
+Gradle's own `init` command can generate one directly, using Gradle's
+link:https://docs.gradle.org/current/userguide/build_init_plugin.html#supported_gradle_build_types[build init specs]:
+
+[source, bash, subs=attributes+]
+----
+gradle init -Dorg.gradle.buildinit.specs=io.quarkus.init:{quarkus-version} --type quarkus-app
+----
+
+NOTE: `org.gradle.buildinit.specs` is still `@Incubating`, so `gradle init` doesn't yet accept custom
+values for its parameters: this always generates `code-with-quarkus`/`org.acme` with the Kotlin DSL. Use the
+xref:cli-tooling.adoc[Quarkus CLI] or the Maven plugin above to customize those values.
+
 [[custom-test-configuration-profile]]
 === Custom test configuration profile in JVM mode
 


### PR DESCRIPTION
Gradle users who can't install the Quarkus CLI (e.g. behind a corporate firewall) have no way to scaffold a Quarkus project without installing Maven first.

Adds a `devtools/gradle/gradle-init-plugin` module (`io.quarkus.init`) implementing Gradle's build init specs mechanism, so `gradle init -Dorg.gradle.buildinit.specs=io.quarkus.init:<version> --type quarkus-app` generates a project standalone. It reuses the existing `CreateProject`/`QuarkusProjectHelper` machinery, and supports the same customization as `quarkus create app` (groupId, extensions, version, description, REST resource className/path, target platform version, DSL, codegen toggles).

Caveat: `org.gradle.buildinit.specs` is `@Incubating` in the current Gradle release, and `gradle init` doesn't collect spec parameter values yet (confirmed via decompilation; tracked upstream in gradle/gradle#1686 with no short-term timeline). So today the command above always uses this plugin's defaults: the parameters are implemented and tested so they activate automatically once Gradle wires that up.

---

Relates to #56252