### PR TITLE
Avoid an internal error when a bean parameter field is not a class type

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -1154,6 +1154,7 @@ public class ResteasyReactiveProcessor {
                                     }
                                     // also remove @BeanParam annotations targeting records
                                     if (field.declaredAnnotation(ResteasyReactiveDotNames.BEAN_PARAM) != null
+                                            && field.type().kind() == Type.Kind.CLASS
                                             && isRecord(resourceScanningResultBuildItem.getResult().getIndex(),
                                                     field.type().asClassType().name())) {
                                         context.remove(a -> a.name().equals(ResteasyReactiveDotNames.BEAN_PARAM));
@@ -1165,7 +1166,7 @@ public class ResteasyReactiveProcessor {
 
                             private boolean isRecord(IndexView index, DotName name) {
                                 ClassInfo classInfo = index.getClassByName(name);
-                                return classInfo.isRecord();
+                                return classInfo != null && classInfo.isRecord();
                             }
                         })));
     }

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/beanparam/BeanParamNonClassTypeFieldTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/beanparam/BeanParamNonClassTypeFieldTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.resteasy.reactive.server.test.beanparam;
+
+import java.util.List;
+
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.RestForm;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class BeanParamNonClassTypeFieldTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClasses(Item.class, Container.class, Resource.class))
+            .assertException(t -> {
+                Throwable root = t;
+                while (root.getCause() != null && root.getCause() != root) {
+                    root = root.getCause();
+                }
+                if (root.getMessage() != null && root.getMessage().contains("Not a class type!")) {
+                    throw new AssertionError("Deployment failed with an internal Jandex error", root);
+                }
+            });
+
+    @Test
+    public void deploymentDoesNotFailWithInternalError() {
+        Assertions.fail();
+    }
+
+    public static class Item {
+
+        @RestForm
+        String name;
+    }
+
+    public static class Container {
+
+        @BeanParam
+        List<Item> items;
+    }
+
+    @Path("/container")
+    public static class Resource {
+
+        @POST
+        @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+        @Produces(MediaType.TEXT_PLAIN)
+        public String post(@BeanParam Container container) {
+            return "ok";
+        }
+    }
+}


### PR DESCRIPTION
A parameter container with a `@BeanParam` field declared as a collection or an array currently fails the build with an internal Jandex error:

```
Build step io.quarkus.arc.deployment.ArcProcessor#registerBeans threw an exception:
java.lang.IllegalArgumentException: Not a class type!
	at org.jboss.jandex.Type.asClassType(Type.java:338)
	at io.quarkus.resteasy.reactive.server.deployment.ResteasyReactiveProcessor$9.accept(...)
```

The message mentions neither the offending field nor the class that declares it, so there is nothing to act on.

The cause is the annotation transformation that removes `@BeanParam` from fields targeting records: it calls `Type.asClassType()` unconditionally, and Jandex throws for anything that is not a class type. Guarding that call leaves the record handling untouched and lets such a field reach the regular deployment error instead of an internal one. The record lookup next to it could also throw a `NullPointerException` for a type that is not in the index, so it now null-checks.

Such fields remain unsupported — this only changes how the failure is reported.

Related to #34800, where this came up while looking at nested form element mapping.
