### PR TITLE
docs: remove duplicate 'the' in OpenTelemetry logging guide

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry-logging.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-logging.adoc
@@ -137,7 +137,7 @@ To configure the connection using the same properties for all signals, please ch
 
 By default all log levels are exported.
 
-If the following configuration is created in the the `application.properties` file, only logs with a level of `ERROR` or higher will be exported:
+If the following configuration is created in the `application.properties` file, only logs with a level of `ERROR` or higher will be exported:
 [source,properties]
 ----
 quarkus.otel.logs.level=ERROR


### PR DESCRIPTION
Remove duplicated word in the OpenTelemetry logging docs: "in the the \`application.properties\`" → "in the \`application.properties\`".

Docs-only grammar fix. I reviewed the surrounding paragraph and confirmed the corrected sentence is the intended wording.