### PR TITLE
docs: remove duplicate 'the' in Dev UI Patterns note

### DIFF
--- a/docs/src/main/asciidoc/dev-ui.adoc
+++ b/docs/src/main/asciidoc/dev-ui.adoc
@@ -1739,7 +1739,7 @@ To do this you can return/produce a `WorkspaceActionBuildItem` in your processor
 <3> Here the code that will execute if the user selects this action. You will receive some input (see the `Input` section below)
 <4> How the result should be displayed (see the `Display` section below)
 <5> What the result type would be (see the `DisplayType` section below)
-<6> Optional filter if this action only applies to certain items. Takes a regex as input, and some predefined regexes exists in the the `Patterns` class
+<6> Optional filter if this action only applies to certain items. Takes a regex as input, and some predefined regexes exists in the `Patterns` class
 
 ==== Input
 


### PR DESCRIPTION
Remove duplicated word in the Dev UI docs: "in the the \`Patterns\` class" → "in the \`Patterns\` class".

Docs-only grammar fix. I reviewed the surrounding list item and confirmed the corrected sentence is the intended wording.