### PR TITLE
Fix 'allows to' grammar in Config programmatic access docs

### DIFF
--- a/docs/src/main/asciidoc/config.adoc
+++ b/docs/src/main/asciidoc/config.adoc
@@ -203,7 +203,7 @@ include::{includes}/devtools/build-native.adoc[]
 
 == Programmatically access the configuration
 
-The `org.eclipse.microprofile.config.ConfigProvider.getConfig()` API allows to access the Config API programmatically.
+The `org.eclipse.microprofile.config.ConfigProvider.getConfig()` API allows access to the Config API programmatically.
 This API is mostly useful in situations where CDI injection is not available.
 
 [source,java]


### PR DESCRIPTION
Tiny docs grammar fix in `docs/src/main/asciidoc/config.adoc`:

"allows to access the Config API" → "allows access to the Config API".

Validated against the surrounding programmatic Config access section. Docs-only; DCO signed-off.