### PR TITLE
Fix 'allows to storage' grammar in MongoDB guide

### DIFF
--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -651,7 +651,7 @@ The link:https://www.mongodb.com/docs/drivers/java/sync/current/fundamentals/dat
 the way a POJO is mapped to a MongoDB collection and this codec is initialized automatically by Quarkus.
 This codec also supports Java records so you can use them for your POJOs or an attribute of your POJOs.
 
-One of these annotations is the `@BsonDiscriminator` annotation that allows to storage multiple Java types in a single MongoDB collection by adding
+One of these annotations is the `@BsonDiscriminator` annotation that allows storing multiple Java types in a single MongoDB collection by adding
 a discriminator field inside the document. It can be useful when working with abstract types or interfaces.
 
 Quarkus will automatically register all the classes annotated with `@BsonDiscriminator` with the POJO codec.


### PR DESCRIPTION
Tiny docs grammar fix in `docs/src/main/asciidoc/mongodb.adoc`:

"allows to storage multiple Java types" → "allows storing multiple Java types".

Validated against the surrounding `@BsonDiscriminator` polymorphism note. Docs-only; DCO signed-off.