### PR TITLE
Preserve the priority order of request filters that read the form body

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/WithFormReadFilterOrderTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/WithFormReadFilterOrderTest.java
@@ -1,0 +1,85 @@
+package io.quarkus.resteasy.reactive.server.test.customproviders;
+
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import org.hamcrest.Matchers;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.server.ServerRequestFilter;
+import org.jboss.resteasy.reactive.server.WithFormRead;
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveContainerRequestContext;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+/**
+ * Filters annotated with {@link WithFormRead} are moved after the form-reading handler.
+ * That relocation must preserve their relative priority order.
+ */
+public class WithFormReadFilterOrderTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(HelloResource.class);
+                }
+            });
+
+    @Test
+    public void filtersRunInPriorityOrderAfterFormRead() {
+        RestAssured.with()
+                .formParam("name", "Quarkus")
+                .post("/hello")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("first(Quarkus)/second(Quarkus)"));
+    }
+
+    @Path("hello")
+    public static class HelloResource {
+
+        @POST
+        public String hello(@RestForm String name, HttpHeaders headers) {
+            return headers.getHeaderString("filter-request");
+        }
+    }
+
+    public static class Filters {
+
+        @WithFormRead
+        @ServerRequestFilter(priority = Priorities.USER + 100)
+        public void first(ResteasyReactiveContainerRequestContext requestContext) {
+            appendMarker(requestContext, "first");
+        }
+
+        @WithFormRead
+        @ServerRequestFilter(priority = Priorities.USER + 200)
+        public void second(ResteasyReactiveContainerRequestContext requestContext) {
+            appendMarker(requestContext, "second");
+        }
+
+        // records the marker together with the form value, which proves the filter ran after the form was read
+        private static void appendMarker(ResteasyReactiveContainerRequestContext requestContext, String marker) {
+            ResteasyReactiveRequestContext rrContext = (ResteasyReactiveRequestContext) requestContext
+                    .getServerRequestContext();
+            Object name = rrContext.getFormParameter("name", true, false);
+            String entry = marker + "(" + name + ")";
+            MultivaluedMap<String, String> headers = requestContext.getHeaders();
+            String previous = headers.getFirst("filter-request");
+            headers.putSingle("filter-request", previous == null ? entry : previous + "/" + entry);
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -312,6 +312,8 @@ public class RuntimeResourceDeployment {
                     }
                 }
             }
+            // the loop above collects the filters from last to first, so restore their original order
+            Collections.reverse(readBodyRequestFilters);
             handlers.addAll(readBodyRequestFilters);
         }
 


### PR DESCRIPTION
Request filters annotated with `@WithFormRead` (or the deprecated `readBody = true`) have to run after the form-reading handler, so `RuntimeResourceDeployment` moves them to the end of the handler chain. The filters were collected by walking the chain from the end towards the start and then appended as collected, which reversed their `@Priority` order: two such filters ran in the opposite order to what the same filters do without `@WithFormRead`, and to what the code comment describes.

This restores the original order before the filters are appended. Applications that happened to rely on the reversed execution order will see the order change to the documented priority order.

Fixes #54947
