### PR TITLE
Restore the correct outer instance after nested test classes with a per-class lifecycle

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestNestedTwoLevelsPerClassLifecycleTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestNestedTwoLevelsPerClassLifecycleTestCase.java
@@ -1,0 +1,52 @@
+package io.quarkus.it.main;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Tests {@link Nested} support of {@link QuarkusTest} with two levels of nesting and the per-class lifecycle.
+ * Notes:
+ * <ul>
+ * <li>to avoid unexpected execution order, don't use surefire's {@code -Dtest=...}, use {@code -Dgroups=nested} instead</li>
+ * </ul>
+ */
+@QuarkusTest
+@Tag("nested")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class QuarkusTestNestedTwoLevelsPerClassLifecycleTestCase {
+
+    @BeforeAll
+    public void beforeAll() {
+        assertThat(this).isExactlyInstanceOf(QuarkusTestNestedTwoLevelsPerClassLifecycleTestCase.class);
+    }
+
+    /**
+     * With two levels of nesting, the outer instance used to be swapped with the intermediate one,
+     * so this method was invoked on a {@link LevelOne} instance.
+     */
+    @AfterAll
+    public void afterAll() {
+        assertThat(this).isExactlyInstanceOf(QuarkusTestNestedTwoLevelsPerClassLifecycleTestCase.class);
+    }
+
+    @Nested
+    class LevelOne {
+
+        @Nested
+        class LevelTwo {
+
+            @Test
+            public void test() {
+                assertThat(LevelOne.this).isExactlyInstanceOf(LevelOne.class);
+            }
+        }
+    }
+}

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -1079,7 +1079,8 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         } finally {
             currentTestClassStack.pop();
             if (!outerInstances.isEmpty()) {
-                actualTestInstance = outerInstances.pop();
+                // outer instances are appended outermost first, so the innermost one is at the end
+                actualTestInstance = outerInstances.removeLast();
             }
         }
     }


### PR DESCRIPTION
`QuarkusTestExtension` keeps the enclosing test instances of `@Nested` classes in a deque. They are appended when a nested class is constructed (outermost first) but restored with `pop()`, which takes from the front. With a single nesting level the deque never holds more than one element, so it did not matter. With two or more levels the outermost instance was restored first, so the outer class's `@AfterAll` ended up being invoked on an intermediate nested instance and failed with `IllegalArgumentException: object is not an instance of declaring class` under `@TestInstance(PER_CLASS)`.

Restore from the end of the deque instead, so the innermost enclosing instance is put back first. The order handed to `QuarkusTestAfterAllCallback`s is unchanged.

- Fixes: #49353
