### PR TITLE
Skip configuration directories that cannot be read when looking for unknown config files

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
@@ -228,6 +228,10 @@ public final class ConfigDiagnostic {
         } catch (NotDirectoryException ignored) {
             log.debugf("File %s is not a directory", configFilesLocation.toAbsolutePath());
             return Collections.emptySet();
+        } catch (IOException e) {
+            // this scan only produces warnings, so a location that cannot be read must not fail the startup
+            log.debugf(e, "Unable to scan %s for configuration files", configFilesLocation.toAbsolutePath());
+            return Collections.emptySet();
         }
         return configFiles;
     }

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigDiagnosticTestCase.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigDiagnosticTestCase.java
@@ -1,0 +1,44 @@
+package io.quarkus.runtime.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+public class ConfigDiagnosticTestCase {
+
+    /**
+     * The scan for unknown configuration files is only there to warn, so a directory that cannot be
+     * read (for example {@code C:\Windows\system32\config} when that is the working directory) must
+     * be skipped rather than fail the startup.
+     */
+    @Test
+    public void unreadableDirectoryIsSkipped() throws IOException {
+        assumeTrue(FileSystems.getDefault().supportedFileAttributeViews().contains("posix"),
+                "POSIX permissions are required");
+        assumeFalse("root".equals(System.getProperty("user.name")), "root ignores permissions");
+
+        Path directory = Files.createTempDirectory("config-diagnostic-");
+        Path applicationProperties = directory.resolve("application.properties");
+        Files.writeString(applicationProperties, "");
+        Set<PosixFilePermission> originalPermissions = Files.getPosixFilePermissions(directory);
+        Files.setPosixFilePermissions(directory, Set.of());
+        try {
+            Set<Path> configFiles = assertDoesNotThrow(() -> ConfigDiagnostic.configFiles(directory));
+            assertTrue(configFiles.isEmpty());
+        } finally {
+            Files.setPosixFilePermissions(directory, originalPermissions);
+            Files.delete(applicationProperties);
+            Files.delete(directory);
+        }
+    }
+}


### PR DESCRIPTION
`ConfigDiagnostic` scans `${user.dir}/config` (and `smallrye.config.locations`) only to warn about `application*` files that were not loaded. When that directory exists but cannot be read, for example `C:\Windows\system32\config` when a process inherits `system32` as its working directory (which happens with MCP servers launched by IDEs), `Files.newDirectoryStream` throws an `AccessDeniedException`. Only `NotDirectoryException` was caught, so the exception escaped and the application failed to start over a diagnostic that could never have produced a warning anyway.

Any `IOException` from the scan is now handled like the existing `NotDirectoryException` case: logged at debug level and the directory skipped. `throws IOException` is kept on the public method so callers keep compiling.

Fixes #53739
