### PR TITLE
Support repeated @MeterTag annotations on a method parameter

### DIFF
--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/runtime/MicrometerCounterInterceptorTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/runtime/MicrometerCounterInterceptorTest.java
@@ -83,6 +83,20 @@ public class MicrometerCounterInterceptorTest {
     }
 
     @Test
+    void testCountRepeatableMeterTags() {
+        counted.countWithRepeatableTags(false);
+        Counter counter = registry.get("metric.repeatable")
+                .tag("method", "countWithRepeatableTags")
+                .tag("class", "io.quarkus.micrometer.test.CountedResource")
+                .tag("tag_a", "prefix_false")
+                .tag("tag_b", "prefix_false")
+                .tag("exception", "none")
+                .tag("result", "success").counter();
+        Assertions.assertNotNull(counter);
+        Assertions.assertEquals(1, counter.count());
+    }
+
+    @Test
     void testCountEmptyMetricName_Success() {
         counted.emptyMetricName(false);
         Counter counter = registry.get("method.counted")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/test/CountedResource.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/test/CountedResource.java
@@ -30,6 +30,15 @@ public class CountedResource {
         }
     }
 
+    // two tags on the same parameter are wrapped in the @MeterTags container by the compiler
+    @Counted(value = "metric.repeatable")
+    public void countWithRepeatableTags(
+            @MeterTag(key = "tag_a", resolver = TestValueResolver.class) @MeterTag(key = "tag_b", resolver = TestValueResolver.class) boolean fail) {
+        if (fail) {
+            throw new NullPointerException("Failed on purpose");
+        }
+    }
+
     @Counted(value = "async.none", recordFailuresOnly = true)
     public CompletableFuture<?> onlyCountAsyncFailures(GuardedResult guardedResult) {
         return supplyAsync(guardedResult::get);

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MeterTagsSupport.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MeterTagsSupport.java
@@ -43,13 +43,15 @@ public class MeterTagsSupport {
         Parameter[] parameters = method.getParameters();
         for (int i = 0; i < parameters.length; i++) {
             Parameter methodParameter = parameters[i];
-            MeterTag annotation = methodParameter.getAnnotation(MeterTag.class);
-            if (annotation != null) {
+            // getAnnotationsByType also finds tags wrapped in the repeatable @MeterTags container
+            MeterTag[] annotations = methodParameter.getAnnotationsByType(MeterTag.class);
+            if (annotations.length > 0) {
                 Object parameterValue = context.getParameters()[i];
-
-                tags.add(Tag.of(
-                        resolveTagKey(annotation, methodParameter.getName()),
-                        resolveTagValue(annotation, parameterValue)));
+                for (MeterTag annotation : annotations) {
+                    tags.add(Tag.of(
+                            resolveTagKey(annotation, methodParameter.getName()),
+                            resolveTagValue(annotation, parameterValue)));
+                }
             }
         }
         return Tags.of(tags);


### PR DESCRIPTION
`@MeterTag` is `@Repeatable`, but `MeterTagsSupport` looked it up on interceptor method parameters with `getAnnotation(MeterTag.class)`. When several tags are declared on the same parameter the compiler wraps them in the `@MeterTags` container, so `getAnnotation` returns `null` and every tag on that parameter was silently dropped from the `@Counted`/`@Timed` meter.

Use `getAnnotationsByType`, which also unwraps the container, and emit one tag per annotation. A single `@MeterTag` behaves exactly as before.

Fixes #47211
