### PR TITLE
Include data written by client writer interceptors after proceed() in the request body

### DIFF
--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/WriterInterceptorBodyTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/WriterInterceptorBodyTest.java
@@ -1,0 +1,80 @@
+package io.quarkus.rest.client.reactive.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.ext.WriterInterceptor;
+import jakarta.ws.rs.ext.WriterInterceptorContext;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+/**
+ * A client {@link WriterInterceptor} may replace the output stream, call {@code proceed()} and only then
+ * write to the original stream (the usual way to log or transform a request body). Everything written
+ * after {@code proceed()} returns must still be sent.
+ */
+public class WriterInterceptorBodyTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClasses(Resource.class, Client.class, CapturingInterceptor.class));
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @Test
+    void bodyWrittenAfterProceedIsSent() {
+        Client client = RestClientBuilder.newBuilder().baseUri(baseUri).register(CapturingInterceptor.class)
+                .build(Client.class);
+        assertThat(client.call("this is a sample body")).isEqualTo("this is a sample body|intercepted");
+    }
+
+    @Path("/")
+    public static class Resource {
+        @POST
+        public String echo(String body) {
+            if ((body == null) || body.isEmpty()) {
+                return "null";
+            }
+            return body;
+        }
+    }
+
+    public interface Client {
+
+        @Path("/")
+        @POST
+        String call(String body);
+    }
+
+    /**
+     * Captures what the writer produces, then writes it to the original stream together with a marker,
+     * so the assertion can only pass if the interceptor ran and its late writes were kept.
+     */
+    public static class CapturingInterceptor implements WriterInterceptor {
+
+        @Override
+        public void aroundWriteTo(WriterInterceptorContext context) throws IOException, WebApplicationException {
+            OutputStream original = context.getOutputStream();
+            ByteArrayOutputStream capture = new ByteArrayOutputStream();
+            context.setOutputStream(capture);
+            context.proceed();
+            original.write(capture.toByteArray());
+            original.write("|intercepted".getBytes(StandardCharsets.UTF_8));
+            context.setOutputStream(original);
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientWriterInterceptorContextImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientWriterInterceptorContextImpl.java
@@ -79,7 +79,6 @@ public class ClientWriterInterceptorContextImpl extends AbstractClientIntercepto
             }
 
             outputStream.close();
-            result = Buffer.buffer(baos.toByteArray());
             done = true;
         } else {
             interceptors[index++].aroundWriteTo(this);
@@ -113,6 +112,9 @@ public class ClientWriterInterceptorContextImpl extends AbstractClientIntercepto
     }
 
     public Buffer getResult() {
+        if (result == null && done) {
+            result = Buffer.buffer(baos.toByteArray());
+        }
         return result;
     }
 


### PR DESCRIPTION
A client `WriterInterceptor` that replaces the output stream, calls `proceed()` and then writes to the original stream (the usual way to log or transform a request body) produced an empty request on the wire. The request buffer was captured at the end of the innermost `proceed()` call, so anything an outer interceptor wrote after `proceed()` returned went into the internal stream after the snapshot had already been taken and was silently dropped. The same interceptor works on the server side, which writes straight to the response stream.

The buffer is now captured in `getResult()`, once the whole interceptor chain has completed. The innermost stream is still closed inside `proceed()`, so wrapper streams such as `GZIPOutputStream` keep working.

Fixes #41051
