### PR TITLE
Drop the stack traces of individual problems from the Qute validation report

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -287,6 +287,7 @@ public class QuteProcessor {
             message.append("\n");
             TemplateException exception = new TemplateException(message.toString());
             for (TemplateException error : errors) {
+                error.setStackTrace(new StackTraceElement[0]);
                 exception.addSuppressed(error);
             }
             throw exception;

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/IncorrectExpressionsReportTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/IncorrectExpressionsReportTest.java
@@ -1,0 +1,63 @@
+package io.quarkus.qute.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.TemplateData;
+import io.quarkus.qute.TemplateException;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * The aggregated validation error keeps one suppressed exception per incorrect expression so that tools can
+ * read their origin, but those exceptions must not carry stack traces: they only add noise to the report.
+ */
+public class IncorrectExpressionsReportTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyClass.class)
+                    .addAsResource(new StringAsset(
+                            "{foo_My:BAZ} {foo_My:QUX}"),
+                            "templates/foo.txt"))
+            .assertException(t -> {
+                Throwable e = t;
+                TemplateException te = null;
+                while (e != null) {
+                    if (e instanceof TemplateException) {
+                        te = (TemplateException) e;
+                        break;
+                    }
+                    e = e.getCause();
+                }
+                assertNotNull(te);
+                assertTrue(te.getMessage().contains("Found incorrect expressions (2)"), te.getMessage());
+                assertEquals(2, te.getSuppressed().length);
+                for (Throwable suppressed : te.getSuppressed()) {
+                    TemplateException problem = assertInstanceOf(TemplateException.class, suppressed);
+                    assertNotNull(problem.getOrigin());
+                    assertEquals(0, problem.getStackTrace().length,
+                            "the individual problems should not carry a stack trace");
+                }
+            });
+
+    @Test
+    public void test() {
+        fail();
+    }
+
+    @TemplateData(namespace = "foo_My")
+    public static class MyClass {
+
+        public static final String FOO = "foo";
+
+    }
+
+}


### PR DESCRIPTION
When template validation fails, `QuteProcessor` throws one `TemplateException` that lists every incorrect expression and adds one suppressed `TemplateException` per problem, so that the dev mode error page and other tools can read the origin of each problem. Those suppressed exceptions also carried a stack trace that only points into the build steps, and the JDK prints it for every problem: with a couple of dozen problems the report grew to several hundred lines (see the gist in the issue).

Clear the stack trace of each individual problem. The aggregated message, the number of suppressed exceptions and their `Origin` are unchanged, so the error page keeps working; each problem now prints as a single `Suppressed:` line.

This addresses the Qute part of the report. The remaining duplication (the builder embedding the full stack trace in the `BuildException` message and again as its cause) is in `core/builder` and would be a separate change.

Fixes #31325
